### PR TITLE
[fix] youtube - send CONSENT Cookie to not be redirected

### DIFF
--- a/searx/engines/youtube_noapi.py
+++ b/searx/engines/youtube_noapi.py
@@ -3,6 +3,7 @@
  Youtube (Videos)
 """
 
+from datetime import datetime
 from functools import reduce
 from json import loads, dumps
 from urllib.parse import quote_plus
@@ -56,6 +57,7 @@ def request(query, params):
         })
         params['headers']['Content-Type'] = 'application/json'
 
+    params['headers']['Cookie'] = "CONSENT=YES+cb.%s-17-p0.en+F+941;" % datetime.now().strftime("%Y%m%d")
     return params
 
 


### PR DESCRIPTION
In the EU there exists a "General Data Protection Regulation" [1] aka GDPR (BTW:
very user friendly!) which requires consent to tracking.  To get the consent
from the user, youtube requests are redirected to confirm and get a CONSENT
Cookie from https://consent.youtube.com

This patch adds a CONSENT Cookie to the youtube request to avoid redirection.

[1] https://en.wikipedia.org/wiki/General_Data_Protection_Regulation

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>
Reported-by: https://github.com/searx/searx/issues/2774

You can test this patch here: https://darmarit.org/searx/search?q=%21yt%20magical%20mystery