### PR TITLE
[enh] add DOI resolver from sci-hub / replace default DOI

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1422,6 +1422,11 @@ doi_resolvers :
   oadoi.org : 'https://oadoi.org/'
   doi.org : 'https://doi.org/'
   doai.io  : 'https://dissem.in/'
-  sci-hub.tw : 'https://sci-hub.tw/'
+  sci-hub.se : 'https://sci-hub.se/'
+  sci-hub.do : 'https://sci-hub.do/'
+  scihubtw.tw : 'https://scihubtw.tw/'
+  sci-hub.st : 'https://sci-hub.st/'
+  sci-hub.bar : 'https://sci-hub.bar/'
+  sci-hub.it.nf : 'https://sci-hub.it.nf/'
 
 default_doi_resolver : 'oadoi.org'

--- a/searx/settings_robot.yml
+++ b/searx/settings_robot.yml
@@ -43,6 +43,11 @@ doi_resolvers :
   oadoi.org : 'https://oadoi.org/'
   doi.org : 'https://doi.org/'
   doai.io  : 'https://dissem.in/'
-  sci-hub.tw : 'https://sci-hub.tw/'
+  sci-hub.se : 'https://sci-hub.se/'
+  sci-hub.do : 'https://sci-hub.do/'
+  scihubtw.tw : 'https://scihubtw.tw/'
+  sci-hub.st : 'https://sci-hub.st/'
+  sci-hub.bar : 'https://sci-hub.bar/'
+  sci-hub.it.nf : 'https://sci-hub.it.nf/'
 
-default_doi_resolver : 'sci-hub.tw'
+default_doi_resolver : 'oadoi.org'


### PR DESCRIPTION
The new sci-hub URLs are comming from @aurora-vasiliev [1].

[1] https://github.com/searx/searx/pull/2706

comment from @dalf: For reference https://github.com/searx/searx/issues/2260#issuecomment-719728346