### PR TITLE
[fix] Fix typo in morty installation instruction

### DIFF
--- a/docs/build-templates/morty.rst
+++ b/docs/build-templates/morty.rst
@@ -32,7 +32,7 @@
        (${SERVICE_USER}) $ mkdir ${SERVICE_HOME}/local
        (${SERVICE_USER}) $ wget --progress=bar -O \"${GO_TAR}\" \\
                    \"${GO_PKG_URL}\"
-       (${SERVICE_USER}) $ tar -C ${SERVICE_HOME}/local/go -xzf \"${GO_TAR}\"
+       (${SERVICE_USER}) $ tar -C ${SERVICE_HOME}/local -xzf \"${GO_TAR}\"
        (${SERVICE_USER}) $ which go
        ${SERVICE_HOME}/local/go/bin/go
 


### PR DESCRIPTION
## What does this PR do?

fixed a typo

fetched from https://github.com/searx/searx/pull/2768