### PR TITLE
Add a search engine for core.ac.uk

### DIFF
--- a/manage
+++ b/manage
@@ -38,6 +38,7 @@ PYLINT_FILES=(
     searx/engines/yahoo_news.py
     searx/engines/apkmirror.py
     searx/engines/artic.py
+    searx/engines/core.py
     searx_extra/update/update_external_bangs.py
     searx/metrics/__init__.py
 )

--- a/searx/engines/core.py
+++ b/searx/engines/core.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
-
-Core Engine (science)
+"""CORE (science)
 
 """
+# pylint: disable=missing-function-docstring
 
 from json import loads
 from datetime import datetime
 from urllib.parse import urlencode
+
+from searx import logger
+from searx.exceptions import SearxEngineAPIException
+
+logger = logger.getChild('CORE engine')
 
 about = {
     "website": 'https://core.ac.uk',
@@ -19,45 +23,60 @@ about = {
 }
 
 categories = ['science']
-
 paging = True
-nb_per_page = 20
+nb_per_page = 10
 
+api_key = 'unset'
 
-# apikey = ''
-apikey = 'MVBozuTX8QF9I1D0GviL5bCn2Ueat6NS'
-
+logger = logger.getChild('CORE engine')
 
 base_url = 'https://core.ac.uk:443/api-v2/search/'
 search_string = '{query}?page={page}&pageSize={nb_per_page}&apiKey={apikey}'
 
-
 def request(query, params):
 
+    if api_key == 'unset':
+        raise SearxEngineAPIException('missing CORE API key')
+
     search_path = search_string.format(
-        query=urlencode({'q': query}),
-        nb_per_page=nb_per_page,
-        page=params['pageno'],
-        apikey=apikey)
-
+        query = urlencode({'q': query}),
+        nb_per_page = nb_per_page,
+        page = params['pageno'],
+        apikey = api_key,
+    )
     params['url'] = base_url + search_path
-    return params
 
+    logger.debug("query_url --> %s", params['url'])
+    return params
 
 def response(resp):
     results = []
-
     json_data = loads(resp.text)
+
     for result in json_data['data']:
-        time = result['_source']['publishedDate']
-        if time is None:
-            date = datetime.now()
-        else:
+
+        source = result['_source']
+        time = source['publishedDate'] or source['depositedDate']
+        if time :
             date = datetime.fromtimestamp(time / 1000)
+        else:
+            date = None
+
+        metadata = []
+        if source['publisher'] and len(source['publisher']) > 3:
+            metadata.append(source['publisher'])
+        if source['topics']:
+            metadata.append(source['topics'][0])
+        if source['doi']:
+            metadata.append(source['doi'])
+        metadata = ' / '.join(metadata)
+
         results.append({
-            'url': result['_source']['urls'][0],
-            'title': result['_source']['title'],
-            'content': result['_source']['description'],
-            'publishedDate': date})
+            'url': source['urls'][0].replace('http://', 'https://', 1),
+            'title': source['title'],
+            'content': source['description'],
+            'publishedDate': date,
+            'metadata' : metadata,
+        })
 
     return results

--- a/searx/engines/core.py
+++ b/searx/engines/core.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+Core Engine (science)
+
+"""
+
+from json import loads
+from datetime import datetime
+from urllib.parse import urlencode
+
+about = {
+    "website": 'https://core.ac.uk',
+    "wikidata_id": 'Q22661180',
+    "official_api_documentation": 'https://core.ac.uk/documentation/api/',
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": 'JSON',
+}
+
+categories = ['science']
+
+paging = True
+nb_per_page = 20
+
+
+# apikey = ''
+apikey = 'MVBozuTX8QF9I1D0GviL5bCn2Ueat6NS'
+
+
+base_url = 'https://core.ac.uk:443/api-v2/search/'
+search_string = '{query}?page={page}&pageSize={nb_per_page}&apiKey={apikey}'
+
+
+def request(query, params):
+
+    search_path = search_string.format(
+        query=urlencode({'q': query}),
+        nb_per_page=nb_per_page,
+        page=params['pageno'],
+        apikey=apikey)
+
+    params['url'] = base_url + search_path
+    return params
+
+
+def response(resp):
+    results = []
+
+    json_data = loads(resp.text)
+    for result in json_data['data']:
+        time = result['_source']['publishedDate']
+        if time is None:
+            date = datetime.now()
+        else:
+            date = datetime.fromtimestamp(time / 1000)
+        results.append({
+            'url': result['_source']['urls'][0],
+            'title': result['_source']['title'],
+            'content': result['_source']['description'],
+            'publishedDate': date})
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -272,14 +272,12 @@ engines:
     categories : images
     shortcut : cce
 
-  - name : core.ac.uk
-    engine : core
-    categories : science
-    shortcut : cor
-    # get your API key from: https://core.ac.uk/api-keys/register/
-    # api_key : "xxxxxxxx"
-    # set api_key and comment out disabled ..
-    disabled: True
+  # - name : core.ac.uk
+  #   engine : core
+  #   categories : science
+  #   shortcut : cor
+  #   # get your API key from: https://core.ac.uk/api-keys/register/
+  #   api_key : 'unset'
 
   - name : crossref
     engine : json_engine
@@ -974,15 +972,13 @@ engines:
 #    query_fields : '' # query fields
 #    enable_http : True
 
-  - name : springer nature
-    engine : springer
-    # get your API key from: https://dev.springernature.com/signup
-    # api_key : "a69685087d07eca9f13db62f65b8f601" # working API key, for test & debug
-    # set api_key and comment out disabled ..
-    disabled: True
-    shortcut : springer
-    categories : science
-    timeout : 6.0
+  # - name : springer nature
+  #   engine : springer
+  #   # get your API key from: https://dev.springernature.com/signup
+  #   api_key : 'unset' # working API key, for test & debug: "a69685087d07eca9f13db62f65b8f601"
+  #   shortcut : springer
+  #   categories : science
+  #   timeout : 6.0
 
   - name : startpage
     engine : startpage

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -272,6 +272,15 @@ engines:
     categories : images
     shortcut : cce
 
+  - name : core.ac.uk
+    engine : core
+    categories : science
+    shortcut : cor
+    # get your API key from: https://core.ac.uk/api-keys/register/
+    # api_key : "xxxxxxxx"
+    # set api_key and comment out disabled ..
+    disabled: True
+
   - name : crossref
     engine : json_engine
     paging : True


### PR DESCRIPTION
## What does this PR do?

Add a search engine for core.ac.uk : https://core.ac.uk/

Initial commit b416231 was fetched-from: https://github.com/searx/searx/pull/2688 / for  the rest see commit messages.
