### PR TITLE
[CI] JamesIves/github-pages-deploy-action SINGLE_COMMIT

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,6 +86,7 @@ jobs:
         BRANCH: gh-pages
         FOLDER: build/gh-pages
         CLEAN: true # Automatically remove deleted files from the deploy branch
+        SINGLE_COMMIT: True
 
   dockers:
     name: Docker


### PR DESCRIPTION
## What does this PR do?

Reduce the commit history of gh-pages to a single commit by setting [`SINGLE_COMMIT: True`](https://github.com/JamesIves/github-pages-deploy-action/tree/3.7.1#optional-choices)

## Why is this change important?

Otherwise repo size will grow up by unneeded content (gh-pages ist just for deploying, no need for a commit history)

## How to test this PR locally?

I tested the switch SINGLE_COMMIT in my fork: https://github.com/return42/searxng/commits/gh-pages

## Author's checklist

The naming of [optional-choices](https://github.com/JamesIves/github-pages-deploy-action/tree/3.7.1#optional-choices) changed in [github-pages-deploy-action v4](https://github.com/JamesIves/github-pages-deploy-action#optional-choices) (ATM we are using v3.7.1)

