### PR TITLE
[CI] JamesIves/github-pages-deploy-action COMMIT_MESSAGE

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,6 +87,7 @@ jobs:
         FOLDER: build/gh-pages
         CLEAN: true # Automatically remove deleted files from the deploy branch
         SINGLE_COMMIT: True
+        COMMIT_MESSAGE: build from commit ${{ github.sha }}
 
   dockers:
     name: Docker


### PR DESCRIPTION
## What does this PR do?

gh-pages: remove rocket symbol from the commit message

## Why is this change important?

The rocket cannot be displayed on simple terminals.  All that's left of it is cryptic fly dirt.

![Bildschirmfoto vom 2021-01-28 20-51-06](https://user-images.githubusercontent.com/554536/106191047-47ac4300-61a2-11eb-863d-64a9b5f06ce8.png)

## How to test this PR locally?

I tested in my fork: https://github.com/return42/searxng/tree/gh-pages

## Author's checklist

Suggested-by: https://github.com/JamesIves/github-pages-deploy-action/pull/576
