### PR TITLE
[fix doc] manage.sh update_packages does not exists anymore

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -39,12 +39,17 @@ install from ``root``, take into account that the scripts are creating a
 these new created users do need read access to the clone of searx, which is not
 the case if you clone into a folder below ``/root``.
 
-
 .. code:: bash
 
    $ cd ~/Downloads
    $ git clone https://github.com/searx/searx searx
    $ cd searx
+
+.. sidebar:: further read
+
+   - :ref:`toolboxing`
+   - :ref:`update searx`
+   - :ref:`inspect searx`
 
 **Install** :ref:`searx service <searx.sh>`
 

--- a/docs/admin/update-searx.rst
+++ b/docs/admin/update-searx.rst
@@ -4,20 +4,56 @@
 How to update
 =============
 
+How to update depends on the :ref:`installation` method.  If you have used the
+:ref:`installation scripts`, use ``update`` command from the scripts.
+
+**Update** :ref:`searx service <searx.sh>`
+
 .. code:: sh
 
-    sudo -H -u searx -i
-    (searx)$ git stash
-    (searx)$ git pull origin master
-    (searx)$ git stash apply
-    (searx)$ ./manage.sh update_packages
+    sudo -H ./utils/searx.sh update searx
 
-Restart uwsgi:
+**Update** :ref:`filtron reverse proxy <filtron.sh>`
 
-.. tabs::
+.. code:: sh
 
-   .. group-tab:: Ubuntu / debian
+    sudo -H ./utils/filtron.sh update filtron
 
-      .. code:: sh
+**Update** :ref:`result proxy <morty.sh>`
 
-         sudo -H systemctl restart uwsgi
+.. code:: bash
+
+   $ sudo -H ./utils/morty.sh update morty
+
+.. _inspect searx:
+
+======================
+How to inspect & debug
+======================
+
+.. sidebar:: further read
+
+   - :ref:`toolboxing`
+   - :ref:`Makefile`
+
+How to debug depends on the :ref:`installation` method.  If you have used the
+:ref:`installation scripts`, use ``inspect`` command from the scripts.
+
+**Inspect** :ref:`searx service <searx.sh>`
+
+.. code:: sh
+
+    sudo -H ./utils/searx.sh inspect service
+
+**Inspect** :ref:`filtron reverse proxy <filtron.sh>`
+
+.. code:: sh
+
+    sudo -H ./utils/filtron.sh inspect service
+
+**Inspect** :ref:`result proxy <morty.sh>`
+
+.. code:: bash
+
+   $ sudo -H ./utils/morty.sh inspect service
+

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -1,9 +1,9 @@
 .. _searx_utils:
 .. _toolboxing:
 
-========================================
-Tooling box ``utils`` for administrators
-========================================
+===================
+Admin's tooling box
+===================
 
 In the folder :origin:`utils/` we maintain some tools useful for administrators.
 


### PR DESCRIPTION
## What does this PR do?

Update documentation about update procedures

## Why is this change important?

`manage.sh update_packages` does not exists anymore

## Related issues

Reported-by: https://github.com/searx/searx/issues/2776
