### PR TITLE
[mod] searx.metrics.error_recorder: store relative file name instead of the full absolute file name.

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -22,6 +22,7 @@ from os.path import realpath, dirname, join, abspath, isfile
 
 
 searx_dir = abspath(dirname(__file__))
+searx_parent_dir = abspath(dirname(dirname(__file__)))
 engine_dir = dirname(realpath(__file__))
 static_path = abspath(join(dirname(__file__), 'static'))
 settings, settings_load_message = searx.settings_loader.load_settings()

--- a/searx/metrics/error_recorder.py
+++ b/searx/metrics/error_recorder.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from httpx import HTTPError, HTTPStatusError
 from searx.exceptions import (SearxXPathSyntaxException, SearxEngineXPathException, SearxEngineAPIException,
                               SearxEngineAccessDeniedException)
-from searx import logger
+from searx import logger, searx_parent_dir
 
 
 errors_per_engines = {}
@@ -117,6 +117,8 @@ def get_exception_classname(exc: Exception) -> str:
 def get_error_context(framerecords, exception_classname, log_message, log_parameters, secondary) -> ErrorContext:
     searx_frame = get_trace(framerecords)
     filename = searx_frame.filename
+    if filename.startswith(searx_parent_dir):
+        filename = filename[len(searx_parent_dir) + 1:]
     function = searx_frame.function
     line_no = searx_frame.lineno
     code = searx_frame.code_context[0].strip()


### PR DESCRIPTION
## What does this PR do?

`/stats?engine=...` and `/stats/errors` display file names.

In the master branch, the full absolute file name is displayed:
`/home/alexandre/code/searx/searx/engines/wikipedia.py`

This PR displays only the relative file name:
`searx/engines/wikipedia.py`

## Why is this change important?

Does not reveal the installation path.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
