### PR TITLE
[fix] manage - fix miss usage of 'set -e'

### DIFF
--- a/manage
+++ b/manage
@@ -343,14 +343,17 @@ pyenv.install() {
     if pyenv.install.OK > /dev/null; then
         return 0
     fi
-    pyenv
-    pyenv.OK || die 42 "error while build pyenv (${PY_ENV_BIN})"
 
     (   set -e
-       build_msg PYENV "[install] pip install -e 'searx${PY_SETUP_EXTRAS}'"
-       "${PY_ENV_BIN}/python" -m pip install -e ".${PY_SETUP_EXTRAS}"
-       buildenv
-    ) || die 42 "error while pip install (${PY_ENV_BIN})"
+        pyenv
+        build_msg PYENV "[install] pip install -e 'searx${PY_SETUP_EXTRAS}'"
+        "${PY_ENV_BIN}/python" -m pip install -e ".${PY_SETUP_EXTRAS}"
+        buildenv
+    )
+    local exit_val=$?
+    if [ ! $exit_val -eq 0 ]; then
+        die 42 "error while pip install (${PY_ENV_BIN})"
+    fi
 }
 
 pyenv.uninstall() {
@@ -462,7 +465,7 @@ themes.simple() {
 PYLINT_FILES=()
 while IFS= read -r line; do
    PYLINT_FILES+=("$line")
-done <<< $(pylint.FILES)
+done <<< "$(pylint.FILES)"
 
 # shellcheck disable=SC2119
 main() {


### PR DESCRIPTION
## What does this PR do?

fix miss usage of `set -e`

The philosophy of set -e is typically that it only exits upon uncaught
errors. Here, the presence of || outside the subshell seems to tell the shell
that the error inside the subshell is 'caught' and therefore set -e does not
cause an exit after false [1].

The shell does not exit if the command that fails is ... part of any command
executed in a && or || list except the command following the final && or ||, any
command in a pipeline but the last, or if the command’s return status is being
inverted with ! [2]

[1] https://unix.stackexchange.com/questions/296526/set-e-in-a-subshell
[2] https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#The-Set-Builtin

BTW: fix error reported by 'make test.shell'

## Why is this change important?

If `pyenv.install` fails it does not stop the script, instead it runs into a installation recursion

## How to test this PR locally?

Modify requirements.txt in a way, that the `make pyenv.install` will fail .. the process should end after the first error / no recursion.
