### PR TITLE
[fix] drop 'idna' from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ certifi==2020.12.05
 babel==2.9.0
 flask-babel==2.0.0
 flask==1.1.2
-idna==2.10
 jinja2==2.11.3
 lxml==4.6.3
 pygments==2.8.1


### PR DESCRIPTION
## What does this PR do?

drop 'idna' from requirements.txt

Requirement idna was added in 181c12ae04ba but I don't know why.  This package
is not directly used by searxng but its a sub-requirement of some other packages
using package `requests` (with different range of supported versions, see
below).  In summary one can say: the version of idna should be depend on package
`requests`::

    ...
    Pallets-Sphinx-Themes==1.2.3
      ...
      - Sphinx [required: Any, installed: 3.5.4]
        ...
        - requests [required: >=2.5.0, installed: 2.25.1]
	  ...
          - idna [required: >=2.5,<3, installed: 2.10]
        ...
    ...
    transifex-client==0.14.2
      - requests [required: >=2.19.1,<3.0.0, installed: 2.25.1]
        ...
        - idna [required: >=2.5,<3, installed: 2.10]
    twine==3.4.1
      ...
      - requests [required: >=2.20, installed: 2.25.1]
        ...
        - idna [required: >=2.5,<3, installed: 2.10]

## Related issues

Closes https://github.com/searxng/searxng/pull/5
