### PR TITLE
[filtron.sh] make filtron rule file configurable

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -40,6 +40,7 @@ fi
 # FILTRON_API="127.0.0.1:4005"
 # FILTRON_LISTEN="127.0.0.1:4004"
 # FILTRON_TARGET="127.0.0.1:8888"
+# FILTRON_RULES_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"
 
 # morty.sh
 # --------

--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -321,7 +321,7 @@ install_rules() {
     choose_one action "What should happen to the rules file? " \
            "keep configuration unchanged" \
            "use origin rules" \
-           "start interactiv shell"
+           "start interactive shell"
     case $action in
         "keep configuration unchanged")
             info_msg "leave rules file unchanged"
@@ -331,7 +331,7 @@ install_rules() {
             info_msg "install origin rules"
             cp "${FILTRON_RULES_TEMPLATE}" "${FILTRON_RULES}"
             ;;
-        "start interactiv shell")
+        "start interactive shell")
             backup_file "${FILTRON_RULES}"
             echo -e "// exit with [${_BCyan}CTRL-D${_creset}]"
             sudo -H -i

--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -461,7 +461,7 @@ install_template() {
         choose_one _reply "choose next step with file $dst" \
                    "replace file" \
                    "leave file unchanged" \
-                   "interactiv shell" \
+                   "interactive shell" \
                    "diff files"
 
         case $_reply in
@@ -474,7 +474,7 @@ install_template() {
             "leave file unchanged")
                 break
                 ;;
-            "interactiv shell")
+            "interactive shell")
                 echo -e "// edit ${_Red}${dst}${_creset} to your needs"
                 echo -e "// exit with [${_BCyan}CTRL-D${_creset}]"
                 sudo -H -u "${owner}" -i

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -436,7 +436,7 @@ install_settings() {
     choose_one action "What should happen to the settings file? " \
            "keep configuration unchanged" \
            "use origin settings" \
-           "start interactiv shell"
+           "start interactive shell"
     case $action in
         "keep configuration unchanged")
             info_msg "leave settings file unchanged"
@@ -446,7 +446,7 @@ install_settings() {
             info_msg "install origin settings"
             cp "${SEARX_SETTINGS_TEMPLATE}" "${SEARX_SETTINGS_PATH}"
             ;;
-        "start interactiv shell")
+        "start interactive shell")
             backup_file "${SEARX_SETTINGS_PATH}"
             echo -e "// exit with [${_BCyan}CTRL-D${_creset}]"
             sudo -H -i


### PR DESCRIPTION
To select a different file with filtron rules, set environment

    FILTRON_RULES_TEMPLATE

the default is

    utils/templates/etc/filtron/rules.json

The installation is done by the new function install_rules() which offers a
multiple choice in case of collisions (known from searx.sh install setup).

update: a local test is not easy, you can do it in a LXC but I tested it on my instance.