### PR TITLE
[mod] engine errors: link to the stats to create an github issue

### DIFF
--- a/searx/templates/oscar/messages/no_results.html
+++ b/searx/templates/oscar/messages/no_results.html
@@ -2,11 +2,14 @@
 {% if unresponsive_engines %}
 <div class="alert alert-danger fade in" role="alert">
     <p><strong class="lead">{{ icon('remove-sign') }} {{ _('Error!') }}</strong> {{ _('Engines cannot retrieve results.') }}</p>
+    {%- for engine_name, error_type in unresponsive_engines -%}
     <p>
-        {% for engine_name, error_type in unresponsive_engines %}
-        {{ engine_name }} ({{ error_type }}){% if not loop.last %}, {% endif %}
-        {% endfor %}
+        {{- engine_name }} (
+        <a href="{{ url_for('stats', engine=engine_name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
+            {{- error_type -}}
+        </a> ){{- '' -}}
     </p>
+    {%- endfor -%}
     <p><small>{{ _('Please, try again later or find another searx instance.') }} (<a href="{{ brand.PUBLIC_INSTANCES }}">{{ _('Public instances') }}</a>)</small></p>
 </div>
 {% else %}

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -12,6 +12,11 @@
     {%- if stats[search_engine.name]['result_count'] -%}
         <p>{{ _('Number of results') }}: {{ stats[search_engine.name]['result_count'] }} ( {{ _('Avg.') }} )</p>{{- "" -}}
     {%- endif -%}
+    {%- if reliabilities[search_engine.name].errors -%}
+        <a href="{{ url_for('stats', engine=search_engine.name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
+          {{ _('View error logs and submit a bug report') }}
+        </a>
+    {%- endif -%}
 </div>
 {%- endif -%}
 {%- endmacro %}
@@ -420,22 +425,22 @@
             </div>
         </div>
 
-	<p class="text-muted">
-	  {{ _('These settings are stored in your cookies, this allows us not to store this data about you.') }}
+        <p class="text-muted">
+          {{ _('These settings are stored in your cookies, this allows us not to store this data about you.') }}
           {{ _("These cookies serve your sole convenience, we don't use these cookies to track you.") }}
         </p>
 
         <p>
-	  {{ _('Search URL of the currently saved preferences') }}
-	  <small class="text-muted">({{ _('Note: specifying custom settings in the search URL can reduce privacy by leaking data to the clicked result sites.') }})</small>:
+          {{ _('Search URL of the currently saved preferences') }}
+          <small class="text-muted">({{ _('Note: specifying custom settings in the search URL can reduce privacy by leaking data to the clicked result sites.') }})</small>:
         </p>
 
-	<div class="tab-pane">
+        <div class="tab-pane">
           <input readonly="" class="form-control select-all-on-click cursor-text" type="url" value="{{ url_for('index', _external=True) }}?preferences={{ preferences_url_params|e }}{% raw %}&amp;q=%s{% endraw %}">
           <input type="submit" class="btn btn-primary" value="{{ _('save') }}" />
         <a href="{{ url_for('index') }}"><div class="btn btn-default">{{ _('back') }}</div></a>
         <a href="{{ url_for('clear_cookies') }}"><div class="btn btn-default">{{ _('Reset defaults') }}</div></a>
-	</div>
+        </div>
     </form>
 </div>
 {% endblock %}

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -50,9 +50,11 @@
 {% endif %}
 {% if checker_result or errors %}
 <td class="{{ css_align_class }} {{ label }}">{{- "" -}}
-    <span aria-labelledby="{{engine_name}}_reliablity">
-        {%- if reliabilities[engine_name].checker %}{{ icon('exclamation-sign', 'The checker fails on the some tests') }}{% endif %} {{ r -}}
-    </span>{{- "" -}}
+    <a href="{{ url_for('stats', engine=engine_name|e) }}">{{- "" -}}
+        <span aria-labelledby="{{engine_name}}_reliablity">
+            {%- if reliabilities[engine_name].checker %}{{ icon('exclamation-sign', 'The checker fails on the some tests') }}{% endif %} {{ r -}}</a>
+        </span>{{- "" -}}
+    </a>{{- "" -}}
     <div class="engine-tooltip text-left" role="tooltip" id="{{engine_name}}_reliablity">
         {%- if checker_result -%}
         <p>{{ _("Failed checker test(s): ") }} {{ ', '.join(checker_result) }}</p>

--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -31,7 +31,12 @@
             <div class="alert alert-danger fade in" role="alert">
                 <p>{{ _('Engines cannot retrieve results') }}:</p>
                 {%- for engine_name, error_type in unresponsive_engines -%}
-                {{- engine_name }} ({{ error_type }}){% if not loop.last %}, {% endif %}{{- "" -}}
+                <p>{{- '' -}}
+                    {{- engine_name }} (
+                    <a href="{{ url_for('stats', engine=engine_name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
+                        {{- error_type -}}
+                    </a> ){{- '' -}}
+                </p>
                 {%- endfor -%}
             </div>
             {%- endif %}

--- a/searx/templates/simple/messages/no_results.html
+++ b/searx/templates/simple/messages/no_results.html
@@ -2,11 +2,15 @@
 {% if unresponsive_engines %}
 <div class="dialog-error" role="alert">
   <p><strong>{{ _('Error!') }}</strong> {{ _('Engines cannot retrieve results.') }}</p>
-  <p>
-    {% for engine_name, error_type in unresponsive_engines %}
-    {{ engine_name }} ({{ error_type }}){% if not loop.last %}, {% endif %}
-    {% endfor %}
+  {% for engine_name, error_type in unresponsive_engines %}
+  <p>{{- '' -}}
+    {{- engine_name }} (
+      <a href="{{ url_for('stats', engine=engine_name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
+          {{- error_type -}}
+      </a> ){{- '' -}}
   </p>
+  {%- endfor %}
+
   <p><small>{{ _('Please, try again later or find another searx instance.') }} (<a href="{{ brand.PUBLIC_INSTANCES }}">{{ _('Public instances') }}</a>) </small></p>
 </div>
 {% else %}

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -63,9 +63,11 @@
 {% endif %}
 {% if checker_result or errors %}
 <td class="{{ label }}">{{- "" -}}
-    <span aria-labelledby="{{engine_name}}_reliablity">
-        {%- if reliabilities[engine_name].checker %}{{ icon('warning', 'The checker fails on the some tests') }}{% endif %} {{ r -}}
-    </span>{{- "" -}}
+    <a href="{{ url_for('stats', engine=engine_name|e) }}">{{- "" -}}
+      <span aria-labelledby="{{engine_name}}_reliablity">
+          {%- if reliabilities[engine_name].checker %}{{ icon('warning', 'The checker fails on the some tests') }}{% endif %} {{ r -}}
+      </span>{{- "" -}}
+    </a>{{- "" -}}
     <div class="engine-tooltip" style="right: 12rem;" role="tooltip" id="{{engine_name}}_reliablity">
         {%- if checker_result -%}
         <p>{{ _("The checker fails on this tests: ") }} {{ ', '.join(checker_result) }}</p>

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -25,6 +25,12 @@
     <p><a href="{{about.website}}" rel="noreferrer">{{about.website}}</a></p>
     {%- if about.wikidata_id -%}<p><a href="https://www.wikidata.org/wiki/{{about.wikidata_id}}" rel="noreferrer">wikidata.org/wiki/{{about.wikidata_id}}</a></p>{%- endif -%}
     {%- if search_engine.enable_http %}<p>{{ icon('exclamation-sign', 'No HTTPS') }}{{ _('No HTTPS')}}</p>{% endif -%}
+    {%- if reliabilities[search_engine.name].errors -%}
+    <a href="{{ url_for('stats', engine=search_engine.name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
+      {{ _('View error logs and submit a bug report') }}
+    </a>
+    {%- endif -%}
+
 </div>
 {%- endif -%}
 {%- endmacro %}

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -43,9 +43,13 @@
         {% if unresponsive_engines and results|length >= 1 %}
 	<div class="dialog-error" role="alert">
 	  <p><strong>{{ _('Error!') }}</strong> {{ _('Engines cannot retrieve results') }}:</p>
-	  <p>{% for engine_name, error_type in unresponsive_engines %}
-	  {{- engine_name }} ({{- error_type -}}){% if not loop.last %}, {% endif %}
-	  {% endfor %}</p>
+    {%- for engine_name, error_type in unresponsive_engines -%}
+    <p>{{- engine_name }} (
+      <a href="{{ url_for('stats', engine=engine_name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
+          {{- error_type -}}
+      </a> ){{- '' -}}
+    </p>
+    {% endfor %}
 	</div>
 	{% endif %}
 


### PR DESCRIPTION
## What does this PR do?

#### Results

The engine name in error boxes are links to `/stats?engine=...` :
![image](https://user-images.githubusercontent.com/1594191/116549384-b1e59880-a8f5-11eb-96fd-8a7c80483ca1.png)

![image](https://user-images.githubusercontent.com/1594191/116549319-9bd7d800-a8f5-11eb-9c54-475be6f022e3.png)

![image](https://user-images.githubusercontent.com/1594191/116550070-916a0e00-a8f6-11eb-9056-49bcb60846e1.png)


#### Worst case scenario:
![image](https://user-images.githubusercontent.com/1594191/116549221-81056380-a8f5-11eb-9e11-e79b5fb8bc6f.png)



#### In the preferences:
![image](https://user-images.githubusercontent.com/1594191/116549490-d6da0b80-a8f5-11eb-91cc-8cd13aef31a7.png)

* The reliability on the right is a link too.
* The tooltip on the engine name contains a link to `/stats?engine=...`


## Why is this change important?

* `/stats?engine=...` displays the detailed error logs.
* It create an incentive to create a bug report.

Note: when there are some results, the error box can be big if a lot of engines crash, but it is more readable.

## How to test this PR locally?

With the simple and oscar theme:
* `!stackoverflow test`
* `!seznam !stackoverflow test`


## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
