### PR TITLE
[themes] /preferences, reliablity: warning icons & error logs link

### DIFF
--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -12,7 +12,7 @@
     {%- if stats[search_engine.name]['result_count'] -%}
         <p>{{ _('Number of results') }}: {{ stats[search_engine.name]['result_count'] }} ( {{ _('Avg.') }} )</p>{{- "" -}}
     {%- endif -%}
-    {%- if reliabilities[search_engine.name].errors -%}
+    {%- if reliabilities.get(search_engine.name, {}).errors or reliabilities.get(search_engine.name, {}).checker -%}
         <a href="{{ url_for('stats', engine=search_engine.name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
           {{ _('View error logs and submit a bug report') }}
         </a>
@@ -56,11 +56,11 @@
 {% if checker_result or errors %}
 <td class="{{ css_align_class }} {{ label }}">{{- "" -}}
     <a href="{{ url_for('stats', engine=engine_name|e) }}">{{- "" -}}
-        <span aria-labelledby="{{engine_name}}_reliablity">
-            {%- if reliabilities[engine_name].checker %}{{ icon('exclamation-sign', 'The checker fails on the some tests') }}{% endif %} {{ r -}}</a>
+        <span aria-labelledby="{{engine_name}}_reliability">
+            {{ icon('exclamation-sign', 'The engine is not reliabled') }} {{ r -}}
         </span>{{- "" -}}
     </a>{{- "" -}}
-    <div class="engine-tooltip text-left" role="tooltip" id="{{engine_name}}_reliablity">
+    <div class="engine-tooltip text-left" role="tooltip" id="{{engine_name}}_reliability">
         {%- if checker_result -%}
         <p>{{ _("Failed checker test(s): ") }} {{ ', '.join(checker_result) }}</p>
         {%- endif -%}

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -25,7 +25,7 @@
     <p><a href="{{about.website}}" rel="noreferrer">{{about.website}}</a></p>
     {%- if about.wikidata_id -%}<p><a href="https://www.wikidata.org/wiki/{{about.wikidata_id}}" rel="noreferrer">wikidata.org/wiki/{{about.wikidata_id}}</a></p>{%- endif -%}
     {%- if search_engine.enable_http %}<p>{{ icon('exclamation-sign', 'No HTTPS') }}{{ _('No HTTPS')}}</p>{% endif -%}
-    {%- if reliabilities[search_engine.name].errors -%}
+    {%- if reliabilities.get(search_engine.name, {}).errors or reliabilities.get(search_engine.name, {}).checker -%}
     <a href="{{ url_for('stats', engine=search_engine.name|e) }}" title="{{ _('View error logs and submit a bug report') }}">
       {{ _('View error logs and submit a bug report') }}
     </a>
@@ -70,13 +70,13 @@
 {% if checker_result or errors %}
 <td class="{{ label }}">{{- "" -}}
     <a href="{{ url_for('stats', engine=engine_name|e) }}">{{- "" -}}
-      <span aria-labelledby="{{engine_name}}_reliablity">
-          {%- if reliabilities[engine_name].checker %}{{ icon('warning', 'The checker fails on the some tests') }}{% endif %} {{ r -}}
+      <span aria-labelledby="{{engine_name}}_reliability">
+          {{ icon('warning', 'The engine is not reliabled') }} {{ r -}}
       </span>{{- "" -}}
     </a>{{- "" -}}
-    <div class="engine-tooltip" style="right: 12rem;" role="tooltip" id="{{engine_name}}_reliablity">
+    <div class="engine-tooltip" style="right: 12rem;" role="tooltip" id="{{engine_name}}_reliability">
         {%- if checker_result -%}
-        <p>{{ _("The checker fails on this tests: ") }} {{ ', '.join(checker_result) }}</p>
+        <p>{{ _("Failed checker test(s): ") }} {{ ', '.join(checker_result) }}</p>
         {%- endif -%}
         {%- if errors %}<p>{{ _('Errors:') }}</p>{% endif -%}
         {%- for error in errors -%}
@@ -85,7 +85,7 @@
     </div>{{- "" -}}
 </td>
 {%- else -%}
-<td class="{{ css_align_class }} {{ label }}"><span>{{ r }}</span></td>
+<td class="{{ label }}"><span>{{ r }}</span></td>
 {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
## What does this PR do?

When there is at least one errors or one failed checker test:
* the warning icon is displayed in the reliability column
* the link "View error logs and submit a bug report" is displayed on engine name tooltip.

![image](https://user-images.githubusercontent.com/1594191/116980166-30f81980-acc6-11eb-9b2e-959c243bf62b.png)
![image](https://user-images.githubusercontent.com/1594191/116980229-44a38000-acc6-11eb-88bb-509035cb968a.png)


Before:
* the warning icon was displayed only when one or more checker test(s) failed.
* the link "View error logs and submit a bug report" was not shown when a checker test failed but there were no error.

## Why is this change important?

* The warning icon is displayed when there is a issue (before it was displayed when there was some specific issues)

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

https://github.com/searxng/searxng/pull/40#discussion_r622995022
