### PR TITLE
[mod] multithreading only in searx.search.* packages

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -167,26 +167,3 @@ def load_engines(engine_list):
         if engine is not None:
             engines[engine.name] = engine
     return engines
-
-
-def initialize_engines(engine_list):
-    load_engines(engine_list)
-    initialize_network(engine_list, settings['outgoing'])
-
-    def engine_init(engine_name, init_fn):
-        try:
-            set_context_network_name(engine_name)
-            init_fn(get_engine_from_settings(engine_name))
-        except SearxEngineResponseException as exc:
-            logger.warn('%s engine: Fail to initialize // %s', engine_name, exc)
-        except Exception:
-            logger.exception('%s engine: Fail to initialize', engine_name)
-        else:
-            logger.debug('%s engine: Initialized', engine_name)
-
-    for engine_name, engine in engines.items():
-        if hasattr(engine, 'init'):
-            init_fn = getattr(engine, 'init')
-            if init_fn:
-                logger.debug('%s engine: Starting background initialization', engine_name)
-                threading.Thread(target=engine_init, args=(engine_name, init_fn)).start()

--- a/searx/search/checker/__main__.py
+++ b/searx/search/checker/__main__.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+# pylint: disable=missing-module-docstring, missing-function-docstring
 
 import sys
 import io

--- a/searx/search/checker/__main__.py
+++ b/searx/search/checker/__main__.py
@@ -8,7 +8,7 @@ import logging
 
 import searx.search
 import searx.search.checker
-from searx.search import processors
+from searx.search import PROCESSORS
 from searx.engines import engine_shortcuts
 
 
@@ -41,13 +41,13 @@ def iter_processor(engine_name_list):
     if len(engine_name_list) > 0:
         for name in engine_name_list:
             name = engine_shortcuts.get(name, name)
-            processor = processors.get(name)
+            processor = PROCESSORS.get(name)
             if processor is not None:
                 yield name, processor
             else:
                 stdout.write(f'{BOLD_SEQ}Engine {name:30}{RESET_SEQ}{RED}Engine does not exist{RESET_SEQ}')
     else:
-        for name, processor in searx.search.processors.items():
+        for name, processor in searx.search.PROCESSORS.items():
             yield name, processor
 
 

--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+# pylint: disable=missing-module-docstring, missing-function-docstring
 
 import json
 import random
@@ -34,7 +36,7 @@ def _get_every():
     return _get_interval(every, 'checker.scheduling.every is not a int or list')
 
 
-def get_result():
+def get_result():  # pylint: disable=inconsistent-return-statements
     serialized_result = storage.get_str(CHECKER_RESULT)
     if serialized_result is not None:
         return json.loads(serialized_result)
@@ -47,7 +49,7 @@ def _set_result(result, include_timestamp=True):
 
 
 def run():
-    if not running.acquire(blocking=False):
+    if not running.acquire(blocking=False): # pylint: disable=consider-using-with
         return
     try:
         logger.info('Starting checker')
@@ -66,7 +68,7 @@ def run():
 
         _set_result(result)
         logger.info('Check done')
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         _set_result({'status': 'error'})
         logger.exception('Error while running the checker')
     finally:
@@ -87,7 +89,7 @@ def _start_scheduling():
         run()
 
 
-def _signal_handler(signum, frame):
+def _signal_handler(_signum, _frame):
     t = threading.Thread(target=run)
     t.daemon = True
     t.start()

--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -9,7 +9,7 @@ import signal
 
 from searx import logger, settings, searx_debug
 from searx.exceptions import SearxSettingsException
-from searx.search.processors import processors
+from searx.search.processors import PROCESSORS
 from searx.search.checker import Checker
 from searx.shared import schedule, storage
 
@@ -55,7 +55,7 @@ def run():
             'status': 'ok',
             'engines': {}
         }
-        for name, processor in processors.items():
+        for name, processor in PROCESSORS.items():
             logger.debug('Checking %s engine', name)
             checker = Checker(processor)
             checker.run()

--- a/tests/unit/test_engines_init.py
+++ b/tests/unit/test_engines_init.py
@@ -23,7 +23,7 @@ class TestEnginesInit(SearxTestCase):
         engine_list = [{'engine': 'dummy', 'name': 'engine1', 'shortcut': 'e1', 'categories': 'general'},
                        {'engine': 'dummy', 'name': 'engine2', 'shortcut': 'e2', 'categories': 'onions'}]
 
-        engines.initialize_engines(engine_list)
+        engines.load_engines(engine_list)
         self.assertEqual(len(engines.engines), 1)
         self.assertIn('engine1', engines.engines)
         self.assertNotIn('onions', engines.categories)
@@ -35,7 +35,7 @@ class TestEnginesInit(SearxTestCase):
                         'timeout': 20.0, 'onion_url': 'http://engine1.onion'},
                        {'engine': 'dummy', 'name': 'engine2', 'shortcut': 'e2', 'categories': 'onions'}]
 
-        engines.initialize_engines(engine_list)
+        engines.load_engines(engine_list)
         self.assertEqual(len(engines.engines), 2)
         self.assertIn('engine1', engines.engines)
         self.assertIn('engine2', engines.engines)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,10 +1,7 @@
-from mock import patch
-
-from searx.search import initialize
+from searx import settings
+from searx.engines import load_engines
 from searx.query import RawTextQuery
 from searx.testing import SearxTestCase
-
-import searx.engines
 
 
 TEST_ENGINES = [
@@ -241,7 +238,7 @@ class TestBang(SearxTestCase):
     THE_QUERY = 'the query'
 
     def test_bang(self):
-        initialize(TEST_ENGINES)
+        load_engines(TEST_ENGINES)
 
         for bang in TestBang.SPECIFIC_BANGS + TestBang.NOT_SPECIFIC_BANGS:
             with self.subTest(msg="Check bang", bang=bang):
@@ -267,12 +264,12 @@ class TestBang(SearxTestCase):
                 self.assertFalse(query.specific)
 
     def test_bang_not_found(self):
-        initialize(TEST_ENGINES)
+        load_engines(TEST_ENGINES)
         query = RawTextQuery('the query !bang_not_found', [])
         self.assertEqual(query.getFullQuery(), 'the query !bang_not_found')
 
     def test_bang_autocomplete(self):
-        initialize(TEST_ENGINES)
+        load_engines(TEST_ENGINES)
         query = RawTextQuery('the query !dum', [])
         self.assertEqual(query.autocomplete_list, ['!dummy_engine'])
 
@@ -281,10 +278,9 @@ class TestBang(SearxTestCase):
         self.assertEqual(query.getQuery(), '!dum the query')
 
     def test_bang_autocomplete_empty(self):
-        with patch.object(searx.engines, 'initialize_engines', searx.engines.load_engines):
-            initialize()
-            query = RawTextQuery('the query !', [])
-            self.assertEqual(query.autocomplete_list, ['!images', '!wikipedia', '!osm'])
+        load_engines(settings['engines'])
+        query = RawTextQuery('the query !', [])
+        self.assertEqual(query.autocomplete_list, ['!images', '!wikipedia', '!osm'])
 
-            query = RawTextQuery('the query ?', ['osm'])
-            self.assertEqual(query.autocomplete_list, ['?images', '?wikipedia'])
+        query = RawTextQuery('the query ?', ['osm'])
+        self.assertEqual(query.autocomplete_list, ['?images', '?wikipedia'])

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -5,14 +5,16 @@ from urllib.parse import ParseResult
 from mock import Mock
 from searx.testing import SearxTestCase
 from searx.search import Search
-import searx.engines
+import searx.search.processors
 
 
 class ViewsTestCase(SearxTestCase):
 
     def setUp(self):
         # skip init function (no external HTTP request)
-        self.setattr4test(searx.engines, 'initialize_engines', searx.engines.load_engines)
+        def dummy(*args, **kwargs):
+            pass
+        self.setattr4test(searx.search.processors, 'initialize_processor', dummy)
 
         from searx import webapp  # pylint disable=import-outside-toplevel
 


### PR DESCRIPTION
## What does this PR do?

This PR prepares the new architecture change, everything about multithreading belong to the searx.search.* packages

previously the call to the "init" function of the engines was done in searx.engines:
* the network was not set (the HTTP request sent without using the defined proxy / configuration).
* it requires to monkey patch the code to avoid HTTP requests during the tests

## Why is this change important?

* keep future async and await in searx.search (not in searx.engines).
* respect network configuration even at the initialization step.

## How to test this PR locally?

* `make run`
* start the checker (embedded and an external tool)

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
