### PR TITLE
[fix] fix KeyError: 'ipv6'

### DIFF
--- a/tests/unit/network/test_network.py
+++ b/tests/unit/network/test_network.py
@@ -4,11 +4,14 @@ from mock import patch
 
 import httpx
 
-from searx.network.network import Network, NETWORKS
+from searx.network.network import Network, NETWORKS, initialize
 from searx.testing import SearxTestCase
 
 
 class TestNetwork(SearxTestCase):
+
+    def setUp(self):
+        initialize()
 
     def test_simple(self):
         network = Network()


### PR DESCRIPTION
## What does this PR do?

tests/units/network/test_network.py requires a call to searx.network.network.initialize
Depending of the test order execution, this function was sometimes call in another test,
sometimes not.

This commit ensure there is a call to initialize()

## Why is this change important?

Bug fix

## How to test this PR locally?

call `make test` multiple time ? I've never had the issue locally.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
