### PR TITLE
[fix] fix usage of docker environment variable INSTANCE_NAME

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -68,7 +68,7 @@ patch_searx_settings() {
 
     # update settings.yml
     sed -i -e "s|base_url : False|base_url : ${BASE_URL}|g" \
-       -e "s/instance_name : \"searx\"/instance_name : \"${INSTANCE_NAME}\"/g" \
+       -e "s/instance_name : \"searxng\"/instance_name : \"${INSTANCE_NAME}\"/g" \
        -e "s/autocomplete : \"\"/autocomplete : \"${AUTOCOMPLETE}\"/g" \
        -e "s/ultrasecretkey/$(openssl rand -hex 32)/g" \
        "${CONF}"


### PR DESCRIPTION
## What does this PR do?

INSTANCE_NAME was ignored.

## Why is this change important?

`docker run --rm -d -v ${PWD}/searx:/etc/searx -p 8080 -e BASE_URL=http://localhost:8080/ -e INSTANCE_NAME=my-instance searxng/searxng`

`INSTANCE_NAME` will be ignored.

This PR fixes that.

## How to test this PR locally?

See above.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

close #65