### PR TITLE
[mod] Dockerfile: upgrade to Alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 ENTRYPOINT ["/sbin/tini","--","/usr/local/searx/dockerfiles/docker-entrypoint.sh"]
 EXPOSE 8080
 VOLUME /etc/searx


### PR DESCRIPTION
## What does this PR do?

Upgrade to Alpine 3.13.

## Why is this change important?

See:
* https://alpinelinux.org/posts/Alpine-3.13.0-released.html
* musl>=1.2.1 have a new malloc implementation (mallocng) :

Also:
* https://musl.libc.org/releases.html
* https://github.com/richfelker/mallocng-draft
* 3 years old post: https://superuser.com/questions/1219609/why-is-the-alpine-docker-image-over-50-slower-than-the-ubuntu-image

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
