### PR TITLE
Revert "[fix] docutils v0.17 incompatibility to previeous v0.16"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ transifex-client==0.14.2
 selenium==3.141.0
 twine==3.4.1
 Pallets-Sphinx-Themes==2.0.0
-docutils==0.16
 Sphinx==4.0.1
 sphinx-issues==1.2.0
 sphinx-jinja==1.1.1


### PR DESCRIPTION

## What does this PR do?

This reverts commit 4557d58919333998bb199653920f1234d67b20b1.

see https://github.com/sphinx-doc/sphinx/issues/9088

## Why is this change important?

Sphinx 4.0 has been released, we do no longer need to pin docutils 
