### PR TITLE
[enh] add offline engine for sqlite database

### DIFF
--- a/searx/engines/sqlite.py
+++ b/searx/engines/sqlite.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+# pylint: disable=missing-function-docstring
+
+"""SQLite database (Offline)
+
+"""
+
+import sqlite3
+
+from searx import logger
+
+logger = logger.getChild('SQLite engine')
+
+engine_type = 'offline'
+database = ""
+query_str = ""
+limit = 10
+paging = True
+result_template = 'key-value.html'
+
+class SQLiteDB:
+    """
+    Implements a `Context Manager`_ for a SQLite.
+
+    usage::
+
+        with SQLiteDB('test.db') as cur:
+            print(cur.execute('select sqlite_version();').fetchall()[0][0])
+
+    .. _Context Manager: https://docs.python.org/3/library/stdtypes.html#context-manager-types
+    """
+
+    def __init__(self, db):
+        self.database = db
+        self.connect = None
+
+    def __enter__(self):
+        self.connect = sqlite3.connect(self.database)
+        self.connect.row_factory = sqlite3.Row
+        return self.connect.cursor()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.connect.commit()
+        self.connect.close()
+
+def init(engine_settings):
+    if 'query_str' not in engine_settings:
+        raise ValueError('query_str cannot be empty')
+
+    if not engine_settings['query_str'].lower().startswith('select '):
+        raise ValueError('only SELECT query is supported')
+
+def search(query, params):
+    global database, query_str, result_template  # pylint: disable=global-statement
+    results = []
+
+    query_params = {
+        'query': query,
+        'wildcard':  r'%' + query.replace(' ',r'%') + r'%',
+        'limit': limit,
+        'offset': (params['pageno'] - 1) * limit
+    }
+    query_to_run = query_str + ' LIMIT :limit OFFSET :offset'
+
+    with SQLiteDB(database) as cur:
+
+        cur.execute(query_to_run, query_params)
+        col_names = [cn[0] for cn in cur.description]
+
+        for row in cur.fetchall():
+            item = dict( zip(col_names, map(str, row)) )
+            item['template'] = result_template
+            logger.debug("append result --> %s", item)
+            results.append(item)
+
+    return results

--- a/searx/engines/sqlite.py
+++ b/searx/engines/sqlite.py
@@ -6,9 +6,8 @@
 
 """
 
-import sqlite3
-
 from searx import logger
+from searx.utils import SQLiteCursor
 
 logger = logger.getChild('SQLite engine')
 
@@ -18,32 +17,6 @@ query_str = ""
 limit = 10
 paging = True
 result_template = 'key-value.html'
-
-class SQLiteDB:
-    """
-    Implements a `Context Manager`_ for a SQLite.
-
-    usage::
-
-        with SQLiteDB('test.db') as cur:
-            print(cur.execute('select sqlite_version();').fetchall()[0][0])
-
-    .. _Context Manager: https://docs.python.org/3/library/stdtypes.html#context-manager-types
-    """
-
-    def __init__(self, db):
-        self.database = db
-        self.connect = None
-
-    def __enter__(self):
-        self.connect = sqlite3.connect(self.database)
-        self.connect.row_factory = sqlite3.Row
-        return self.connect.cursor()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None:
-            self.connect.commit()
-        self.connect.close()
 
 def init(engine_settings):
     if 'query_str' not in engine_settings:
@@ -64,7 +37,7 @@ def search(query, params):
     }
     query_to_run = query_str + ' LIMIT :limit OFFSET :offset'
 
-    with SQLiteDB(database) as cur:
+    with SQLiteCursor(database) as cur:
 
         cur.execute(query_to_run, query_params)
         col_names = [cn[0] for cn in cur.description]

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1003,6 +1003,26 @@ engines:
     timeout : 3.0
     disabled : True
 
+  # For this demo of the sqlite engine download:
+  #   https://liste.mediathekview.de/filmliste-v2.db.bz2
+  # and unpack into searx/data/filmliste-v2.db
+  # Query to test: "!demo concert"
+  #
+  # - name : demo
+  #   engine : sqlite
+  #   shortcut: demo
+  #   categories: general
+  #   result_template: default.html
+  #   database : searx/data/filmliste-v2.db
+  #   query_str :  >-
+  #     SELECT title || ' (' || time(duration, 'unixepoch') || ')' AS title,
+  #            COALESCE( NULLIF(url_video_hd,''), NULLIF(url_video_sd,''), url_video) AS url,
+  #            description AS content
+  #       FROM film
+  #      WHERE title LIKE :wildcard OR description LIKE :wildcard
+  #      ORDER BY duration DESC
+  #   disabled : False
+
   - name : torrentz
     engine : torrentz
     shortcut : tor

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+# pylint: disable=missing-class-docstring, missing-function-docstring
+"""Common utilities
+
+"""
+
 import sys
 import re
 import importlib
@@ -33,13 +40,7 @@ ecma_unescape2_re = re.compile(r'%([0-9a-fA-F]{2})', re.UNICODE)
 xpath_cache = dict()
 lang_to_lc_cache = dict()
 
-
-class NotSetClass:
-    pass
-
-
-NOTSET = NotSetClass()
-
+NOTSET = object()
 
 def searx_useragent():
     """Return the searx User Agent"""
@@ -48,7 +49,7 @@ def searx_useragent():
            suffix=settings['outgoing'].get('useragent_suffix', '')).strip()
 
 
-def gen_useragent(os=None):
+def gen_useragent(os=None):  # pylint: disable=invalid-name
     """Return a random browser User Agent
 
     See searx/data/useragents.json
@@ -147,21 +148,25 @@ def extract_text(xpath_results, allow_none=False):
         for e in xpath_results:
             result = result + extract_text(e)
         return result.strip()
-    elif isinstance(xpath_results, ElementBase):
+
+    if isinstance(xpath_results, ElementBase):
         # it's a element
         text = html.tostring(
             xpath_results, encoding='unicode', method='text', with_tail=False
         )
         text = text.strip().replace('\n', ' ')
         return ' '.join(text.split())
-    elif isinstance(xpath_results, (_ElementStringResult, _ElementUnicodeResult, str, Number, bool)):
+
+    if isinstance(xpath_results, (_ElementStringResult, _ElementUnicodeResult, str, Number, bool)):
         return str(xpath_results)
-    elif xpath_results is None and allow_none:
+
+    if xpath_results is None and allow_none:
         return None
-    elif xpath_results is None and not allow_none:
+
+    if xpath_results is None and not allow_none:
         raise ValueError('extract_text(None, allow_none=False)')
-    else:
-        raise ValueError('unsupported type')
+
+    raise ValueError('unsupported type')
 
 
 def normalize_url(url, base_url):
@@ -253,7 +258,7 @@ def extract_url(xpath_results, base_url):
     return normalize_url(url, base_url)
 
 
-def dict_subset(d, properties):
+def dict_subset(d, properties):  # pylint: disable=invalid-name
     """Extract a subset of a dict
 
     Examples:
@@ -314,8 +319,8 @@ def convert_str_to_int(number_str):
     """Convert number_str to int or 0 if number_str is not a number."""
     if number_str.isdigit():
         return int(number_str)
-    else:
-        return 0
+
+    return 0
 
 
 def int_or_zero(num):
@@ -356,11 +361,11 @@ def is_valid_lang(lang):
             if l[0][:2] == lang:
                 return (True, l[0][:2], l[3].lower())
         return False
-    else:
-        for l in language_codes:
-            if l[1].lower() == lang or l[3].lower() == lang:
-                return (True, l[0][:2], l[3].lower())
-        return False
+
+    for l in language_codes:
+        if l[1].lower() == lang or l[3].lower() == lang:
+            return (True, l[0][:2], l[3].lower())
+    return False
 
 
 def _get_lang_to_lc_dict(lang_list):
@@ -368,7 +373,7 @@ def _get_lang_to_lc_dict(lang_list):
     value = lang_to_lc_cache.get(key, None)
     if value is None:
         value = dict()
-        for lc in lang_list:
+        for lc in lang_list:  # pylint: disable=invalid-name
             value.setdefault(lc.split('-')[0], lc)
         lang_to_lc_cache[key] = value
     return value
@@ -452,9 +457,9 @@ def to_string(obj):
         return obj.__str__()
     if hasattr(obj, '__repr__'):
         return obj.__repr__()
+    return None
 
-
-def ecma_unescape(s):
+def ecma_unescape(s):  # pylint: disable=invalid-name
     """Python implementation of the unescape javascript function
 
     https://www.ecma-international.org/ecma-262/6.0/#sec-unescape-string
@@ -479,10 +484,10 @@ def get_string_replaces_function(replaces):
     rep = {re.escape(k): v for k, v in replaces.items()}
     pattern = re.compile("|".join(rep.keys()))
 
-    def f(text):
+    def func(text):
         return pattern.sub(lambda m: rep[re.escape(m.group(0))], text)
 
-    return f
+    return func
 
 
 def get_engine_from_settings(name):
@@ -600,7 +605,7 @@ def eval_xpath_getindex(elements, xpath_spec, index, default=NOTSET):
         * result (bool, float, list, str): Results.
     """
     result = eval_xpath_list(elements, xpath_spec)
-    if index >= -len(result) and index < len(result):
+    if index >= -len(result) and index < len(result):  # pylint: disable=chained-comparison
         return result[index]
     if default == NOTSET:
         # raise an SearxEngineXPathException instead of IndexError


### PR DESCRIPTION
To test & demonstrate this implementation download:

  https://liste.mediathekview.de/filmliste-v2.db.bz2

and unpack into searx/data/filmliste-v2.db, in your settings.yml define a sqlite engine named "demo"::

    - name : demo
      engine : sqlite
      shortcut: demo
      categories: general
      result_template: default.html
      database : searx/data/filmliste-v2.db
      query_str :  >-
        SELECT title || ' (' || time(duration, 'unixepoch') || ')' AS title,
               COALESCE( NULLIF(url_video_hd,''), NULLIF(url_video_sd,''), url_video) AS url,
               description AS content
          FROM film
         WHERE title LIKE :wildcard OR description LIKE :wildcard
         ORDER BY duration DESC
      disabled : False

Query to test: `!demo concert`

This is a rewrite of the implementation from commit [1]

[1] https://github.com/searx/searx/commit/8e90a214ce5cf60e0640e2ba812fa432d7bdef2f

Suggested-by: @virtadpt https://github.com/searx/searx/issues/2808
