### PR TITLE
[fix] unit test: don't load /etc/searx/settings.yml

### DIFF
--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -40,6 +40,9 @@ def get_user_settings_path():
         # enviroment variable SEARX_SETTINGS_PATH
         return check_settings_yml(environ['SEARX_SETTINGS_PATH'])
 
+    if environ.get('SEARX_DISABLE_ETC_SETTINGS', '').lower() in ('1', 'true'):
+        return None
+
     # if not, get it from searx code base or last solution from /etc/searx
     return check_settings_yml('/etc/searx/settings.yml')
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,5 @@
 import os
+
 os.environ['SEARX_DEBUG'] = '1'
+os.environ['SEARX_DISABLE_ETC_SETTINGS'] = '1'
+os.environ.pop('SEARX_SETTINGS_PATH', None)


### PR DESCRIPTION
## What does this PR do?

Add a new environment variable SEARX_DISABLE_ETC_SETTINGS
to disable loading of /etc/searx/settings.yml

unit tests:
* set SEARX_DISABLE_ETC_SETTINGS to 1
* remove SEARX_SETTINGS_PATH if it exists

## Why is this change important?

Reproducible tests.

## How to test this PR locally?

```sh
source ./local/py3/bin/activate
strace -f -e trace=file python -m nose2 -s tests/unit 2>&1 | grep "/etc/searx"
```

`/etc/searx/settings.yml`  should not appeared.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes: #79
