### PR TITLE
[mod] remove gc.collect() after each user request

### DIFF
--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -1,19 +1,6 @@
-'''
-searx is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-searx is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with searx. If not, see < http://www.gnu.org/licenses/ >.
-
-(C) 2013- by Adam Tauber, <asciimoo@gmail.com>
-'''
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+# pylint: disable=missing-module-docstring, missing-function-docstring
 
 import typing
 import threading
@@ -150,10 +137,11 @@ class Search:
         return requests, actual_timeout
 
     def search_multiple_requests(self, requests):
+        # pylint: disable=protected-access
         search_id = uuid4().__str__()
 
         for engine_name, query, request_params in requests:
-            th = threading.Thread(
+            th = threading.Thread(  # pylint: disable=invalid-name
                 target=PROCESSORS[engine_name].search,
                 args=(query, request_params, self.result_container, self.start_time, self.actual_timeout),
                 name=search_id,
@@ -162,7 +150,7 @@ class Search:
             th._engine_name = engine_name
             th.start()
 
-        for th in threading.enumerate():
+        for th in threading.enumerate():  # pylint: disable=invalid-name
             if th.name == search_id:
                 remaining_time = max(0.0, self.actual_timeout - (default_timer() - self.start_time))
                 th.join(remaining_time)

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -16,11 +16,9 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 '''
 
 import typing
-import gc
 import threading
 from timeit import default_timer
 from uuid import uuid4
-from _thread import start_new_thread
 
 from searx import settings
 from searx.answerers import ask
@@ -182,7 +180,6 @@ class Search:
         # send all search-request
         if requests:
             self.search_multiple_requests(requests)
-            start_new_thread(gc.collect, tuple())
 
         # return results, suggestions, answers and infoboxes
         return True


### PR DESCRIPTION
## What does this PR do?

When searx runs using the docker image, the render time is often high (about 200ms).
When the explicit call to the garbage collector is removed, the render time is often bellow 50ms.

I suspect these causes:
* httpx and its dependencies creates a lot of small objects which change what is kept in the memory or not after a full garbage collector.
* musl from Alpine, since the memory is managed in a different way.

## Why is this change important?

200ms to render a Jinja2 template is high.

## How to test this PR locally?

Run the docker image and check the render time (in the Server-Timing header).

Alternative: switch or at least check with a debian docker image ( [whoogle uses](https://github.com/benbusby/whoogle-search/blob/2bd17bef47af11569d2f524d26f3e14dd6308374/Dockerfile#L1) 3.8-slim )

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues
gc.collect was added in commit ffbee4bb8273e
Timings see:https://github.com/searxng/searxng/pull/60
