### PR TITLE
lint & fix unsplash engine

### DIFF
--- a/searx/engines/unsplash.py
+++ b/searx/engines/unsplash.py
@@ -62,7 +62,8 @@ def response(resp):
                 'url': clean_url(result['links']['html']),
                 'thumbnail_src': clean_url(result['urls']['thumb']),
                 'img_src': clean_url(result['urls']['raw']),
-                'title': result['description'],
-                'content': ''
+                'title': result.get('alt_description') or 'unknown',
+                'content': result.get('description') or ''
             })
+
     return results

--- a/searx/engines/unsplash.py
+++ b/searx/engines/unsplash.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
- Unsplash
+# lint: pylint
+# pylint: disable=missing-function-docstring
+"""Unsplash
+
 """
 
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
 from json import loads
 
+from searx import logger
+
+logger = logger.getChild('unsplash engine')
 # about
 about = {
     "website": 'https://unsplash.com',
@@ -16,8 +21,8 @@ about = {
     "results": 'JSON',
 }
 
-url = 'https://unsplash.com/'
-search_url = url + 'napi/search/photos?'
+base_url = 'https://unsplash.com/'
+search_url = base_url + 'napi/search/photos?'
 categories = ['images']
 page_size = 20
 paging = True
@@ -25,18 +30,24 @@ paging = True
 
 def clean_url(url):
     parsed = urlparse(url)
-    query = [(k, v) for (k, v) in parse_qsl(parsed.query) if k not in ['ixid', 's']]
+    query = [(k, v) for (k, v)
+             in parse_qsl(parsed.query) if k not in ['ixid', 's']]
 
-    return urlunparse((parsed.scheme,
-                       parsed.netloc,
-                       parsed.path,
-                       parsed.params,
-                       urlencode(query),
-                       parsed.fragment))
+    return urlunparse((
+        parsed.scheme,
+        parsed.netloc,
+        parsed.path,
+        parsed.params,
+        urlencode(query),
+        parsed.fragment
+    ))
 
 
 def request(query, params):
-    params['url'] = search_url + urlencode({'query': query, 'page': params['pageno'], 'per_page': page_size})
+    params['url'] = search_url + urlencode({
+        'query': query, 'page': params['pageno'], 'per_page': page_size
+    })
+    logger.debug("query_url --> %s", params['url'])
     return params
 
 
@@ -46,10 +57,12 @@ def response(resp):
 
     if 'results' in json_data:
         for result in json_data['results']:
-            results.append({'template': 'images.html',
-                            'url': clean_url(result['links']['html']),
-                            'thumbnail_src': clean_url(result['urls']['thumb']),
-                            'img_src': clean_url(result['urls']['raw']),
-                            'title': result['description'],
-                            'content': ''})
+            results.append({
+                'template': 'images.html',
+                'url': clean_url(result['links']['html']),
+                'thumbnail_src': clean_url(result['urls']['thumb']),
+                'img_src': clean_url(result['urls']['raw']),
+                'title': result['description'],
+                'content': ''
+            })
     return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1040,7 +1040,6 @@ engines:
 
   - name : unsplash
     engine : unsplash
-    disabled: True
     shortcut : us
 
   - name : yahoo


### PR DESCRIPTION
## What does this PR do?

[pylint] searx/engines/unsplash.py, add logger & norm indentation

- fix messages from pylint
- add logger and log request URL
- normalized various indentation

[fix] unsplash engine - 'searx:result: invalid title:'

- Use result 'alt_description' as title, if not given use
  default title 'unknown'.
- Use result 'description' from unsplash as 'content'

Fix error::

    DEBUG:searx:result: invalid title: {..., 'title': None, 'content': '', 'engine': 'unsplash'}


## How to test this PR locally?

    make run

search e.g. `!unsplash dali`, there should be no more `DEBUG:searx:result: invalid title:` .. and you will see some more results than before .. (those with title 'unknown').
