### PR TITLE
[enh] add settings option to enable/disable search formats

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -18,6 +18,7 @@ search:
     default_lang : "" # Default search language - leave blank to detect from browser information or use codes from 'languages.py'
     ban_time_on_fail : 5 # ban time in seconds after engine errors
     max_ban_time_on_fail : 120 # max ban time in seconds after engine errors
+    formats: [html, csv, json, rss]  # remove format to deny access, use lower case.
 
 server:
     port : 8888

--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -80,9 +80,10 @@
                             <input id="search_url" type="url" class="form-control select-all-on-click cursor-text" name="search_url" value="{{ search_url() }}" readonly>{{- "" -}}
                         </div>{{- "" -}}
                     </form>
+                    {% if search_formats %}
                     <label>{{ _('Download results') }}</label>
                     <div class="clearfix"></div>
-                    {% for output_type in ('csv', 'json', 'rss') %}
+                    {% for output_type in search_formats %}
                     <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="form-inline pull-{% if rtl %}right{% else %}left{% endif %} result_download">
                         {{- search_form_attrs(pageno) -}}
                         <input type="hidden" name="format" value="{{ output_type }}">{{- "" -}}
@@ -90,8 +91,11 @@
                     </form>
                     {% endfor %}
                     <div class="clearfix"></div>
+                    {% if 'rss' in search_formats %}
                     <br /><label><a href="{{ search_url() }}&amp;format=rss">{{ _('RSS subscription') }}</a></label>
+                    {% endif %}
                     <div class="clearfix"></div>
+                    {% endif %}
                 </div>
             </div>
         </div><!-- /#sidebar_results -->

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -85,8 +85,9 @@
             <div class="selectable_url"><pre>{{ url_for('search', _external=True) }}?q={{ q|urlencode }}&amp;language={{ current_language }}&amp;time_range={{ time_range }}&amp;safesearch={{ safesearch }}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if timeout_limit %}&amp;timeout_limit={{ timeout_limit|urlencode }}{% endif %}</pre></div>
         </div>
         <div id="apis">
+          {% if search_formats %}
           <h4 class="title">{{ _('Download results') }}</h4>
-          {% for output_type in ('csv', 'json', 'rss') %}
+          {% for output_type in search_formats %}
 	  <div class="left">
             <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
               <input type="hidden" name="q" value="{{ q|e }}">
@@ -103,6 +104,7 @@
             </form>
 	  </div>
           {% endfor %}
+          {% endif %}
         </div>
     </div>
 

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -505,13 +505,14 @@ NOT_EXISTS = object()
 """Singleton used by :py:obj:`get_value` if a key does not exists."""
 
 
-def get_value(dictionary, keyword, *keys, default=NOT_EXISTS):
+def get_value(dictionary, *keys, default=NOT_EXISTS):
     """Return the value from a *deep* mapping type (e.g. the ``settings`` object
     from yaml).  If the path to the *key* does not exists a :py:obj:`NOT_EXISTS`
     is returned (non ``KeyError`` exception is raised).
 
     .. code: python
 
+       >>> from searx import settings
        >>> from searx.utils import get_value, NOT_EXISTS
        >>> get_value(settings, 'checker', 'additional_tests', 'rosebud', 'result_container')
        ['not_empty', ['one_title_contains', 'citizen kane']]
@@ -519,7 +520,7 @@ def get_value(dictionary, keyword, *keys, default=NOT_EXISTS):
        >>> get_value(settings, 'search', 'xxx') is NOT_EXISTS
        True
        >>> get_value(settings, 'search', 'formats')
-       ['csv', 'json', 'rss']
+       ['html', 'csv', 'json', 'rss']
 
     The list returned from the ``search.format`` key is not a mapping type, you
     can't traverse along non-mapping types.  If you try it, you will get a
@@ -529,7 +530,7 @@ def get_value(dictionary, keyword, *keys, default=NOT_EXISTS):
 
        >>> get_value(settings, 'search', 'format', 'csv') is NOT_EXISTS
        True
-       >>> get_value(settings, 'search', 'formats')[0]
+       >>> get_value(settings, 'search', 'formats')[1]
        'csv'
 
     For convenience you can replace :py:ref:`NOT_EXISTS` by a default value of
@@ -541,20 +542,15 @@ def get_value(dictionary, keyword, *keys, default=NOT_EXISTS):
            print("csv format is denied")
 
     """
-    if not isinstance(dictionary, Mapping):
-        raise TypeError("expected mapping type, got %s" % type(dictionary))
 
-    ret_val = dictionary.get(keyword, default)
-
-    if ret_val is default:
-        return ret_val
-
-    if len(keys):
-        if not isinstance(ret_val, Mapping):
-            ret_val = default
-        else:
-            ret_val = get_value(ret_val, *keys, default=default)
-    return ret_val
+    obj = dictionary
+    for k in keys:
+        if not isinstance(obj, Mapping):
+            raise TypeError("expected mapping type, got %s" % type(obj))
+        obj = obj.get(k, default)
+        if obj is default:
+            return obj
+    return obj
 
 
 def get_xpath(xpath_spec):

--- a/utils/templates/etc/searx/use_default_settings.yml
+++ b/utils/templates/etc/searx/use_default_settings.yml
@@ -8,6 +8,7 @@ search:
     safe_search : 0 # Filter results. 0: None, 1: Moderate, 2: Strict
     autocomplete : "" # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "startpage", "swisscows", "qwant", "wikipedia" - leave blank to turn it off by default
     default_lang : "" # Default search language - leave blank to detect from browser information or use codes from 'languages.py'
+    formats: [html, csv, json, rss]
 
 server:
     port : 8888


### PR DESCRIPTION
## What does this PR do?

- eff337a4 [enh] add settings option to enable/disable search formats

## How to test local

In settings.yml edit

    search:
        ...
        formats: [html]

The denied formats should no longer available in the link box:

![image](https://user-images.githubusercontent.com/554536/119707876-2eaf5800-be4b-11eb-84e8-b989c055c36b.png)

Request a format: ( http://127.0.0.1:8888/search?q=foo&format=csv ) should result in a 403

![image](https://user-images.githubusercontent.com/554536/119708269-85b52d00-be4b-11eb-812f-d061889033a8.png)

## Related issues

Closes #95
