### PR TITLE
[enh] add engine Wikimini (fr.wikimini.org)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1335,6 +1335,26 @@ engines:
     timeout: 5.0
     disabled: True
 
+    # wikimini: online encyclopedia for children
+    # Tthe fulltext and title parameter is necessary for Wikimini because
+    # sometimes it will not show the results and redirect instead
+  - name: wikimini
+    engine: xpath
+    shortcut: wkmn
+    search_url : https://fr.wikimini.org/w/index.php?search={query}&title=Sp%C3%A9cial%3ASearch&fulltext=Search
+    url_xpath : //li/div[@class="mw-search-result-heading"]/a/@href
+    title_xpath : //li//div[@class="mw-search-result-heading"]/a
+    content_xpath : //li/div[@class="searchresult"]
+    categories : general
+    disabled: True
+    about:
+      website: https://wikimini.org/
+      wikidata_id: Q3568032
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name : ubuntuwiki


### PR DESCRIPTION
Online encyclopedia for children (only language fr), merged from [1]

[1] https://github.com/searx/searx/pull/2819

I can't judge (only fr) whether we really need these engine.

@dalf: if you think we don't need it, just close this PR.