### PR TITLE
[mod] the bittorent search engines are available only in the files category

### DIFF
--- a/searx/engines/1337x.py
+++ b/searx/engines/1337x.py
@@ -19,7 +19,7 @@ about = {
 
 url = 'https://1337x.to/'
 search_url = url + 'search/{search_term}/{pageno}/'
-categories = ['videos']
+categories = ['files']
 paging = True
 
 

--- a/searx/engines/btdigg.py
+++ b/searx/engines/btdigg.py
@@ -21,7 +21,7 @@ about = {
 }
 
 # engine dependent config
-categories = ['videos', 'music', 'files']
+categories = ['files']
 paging = True
 
 # search-url

--- a/searx/engines/kickass.py
+++ b/searx/engines/kickass.py
@@ -19,7 +19,7 @@ about = {
 }
 
 # engine dependent config
-categories = ['videos', 'music', 'files']
+categories = ['files']
 paging = True
 
 # search-url

--- a/searx/engines/nyaa.py
+++ b/searx/engines/nyaa.py
@@ -18,7 +18,7 @@ about = {
 }
 
 # engine dependent config
-categories = ['files', 'images', 'videos', 'music']
+categories = ['files']
 paging = True
 
 # search-url

--- a/searx/engines/piratebay.py
+++ b/searx/engines/piratebay.py
@@ -21,7 +21,7 @@ about = {
 }
 
 # engine dependent config
-categories = ["videos", "music", "files"]
+categories = ["files"]
 
 # search-url
 url = "https://thepiratebay.org/"

--- a/searx/engines/tokyotoshokan.py
+++ b/searx/engines/tokyotoshokan.py
@@ -20,7 +20,7 @@ about = {
 }
 
 # engine dependent config
-categories = ['files', 'videos', 'music']
+categories = ['files']
 paging = True
 
 # search-url

--- a/searx/engines/torrentz.py
+++ b/searx/engines/torrentz.py
@@ -20,7 +20,7 @@ about = {
 }
 
 # engine dependent config
-categories = ['files', 'videos', 'music']
+categories = ['files']
 paging = True
 
 # search-url

--- a/searx/engines/yggtorrent.py
+++ b/searx/engines/yggtorrent.py
@@ -21,7 +21,7 @@ about = {
 }
 
 # engine dependent config
-categories = ['videos', 'music', 'files']
+categories = ['files']
 paging = True
 
 # search-url


### PR DESCRIPTION
## What does this PR do?

Dedicate images and videos categories to "instant" results.

## Why is this change important?

Avoid "unexpected" results

(It can still be configured locally)

## How to test this PR locally?

Check the engines in the image and videos categories.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

related to #101