### PR TITLE
/preferences: use simple layout for the oscar theme (Issue 115)

### DIFF
--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -70,6 +70,8 @@ class PluginStore():
                 if not hasattr(plugin, plugin_attr) or not isinstance(getattr(plugin, plugin_attr), plugin_attr_type):
                     setattr(plugin, plugin_attr, plugin_attr_type())
             plugin.id = plugin.name.replace(' ', '_')
+            if not hasattr(plugin, 'preference_section'):
+                plugin.preference_section = 'general'
             self.plugins.append(plugin)
 
     def call(self, ordered_plugin_list, plugin_type, request, *args, **kwargs):

--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -72,6 +72,11 @@ class PluginStore():
             plugin.id = plugin.name.replace(' ', '_')
             if not hasattr(plugin, 'preference_section'):
                 plugin.preference_section = 'general'
+            if plugin.preference_section == 'query':
+                for plugin_attr in ('query_keywords', 'query_examples'):
+                    if not hasattr(plugin, plugin_attr):
+                        logger.critical('missing attribute "{0}", cannot load plugin: {1}'.format(plugin_attr, plugin))
+                        exit(3)
             self.plugins.append(plugin)
 
     def call(self, ordered_plugin_list, plugin_type, request, *args, **kwargs):

--- a/searx/plugins/hash_plugin.py
+++ b/searx/plugins/hash_plugin.py
@@ -23,6 +23,9 @@ import re
 name = "Hash plugin"
 description = gettext("Converts strings to different hash digests.")
 default_on = True
+preference_section = 'query'
+query_keywords = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+query_examples = 'sha512 The quick brown fox jumps over the lazy dog'
 
 parser_re = re.compile('(md5|sha1|sha224|sha256|sha384|sha512) (.*)', re.I)
 

--- a/searx/plugins/self_info.py
+++ b/searx/plugins/self_info.py
@@ -19,7 +19,9 @@ import re
 name = gettext('Self Informations')
 description = gettext('Displays your IP if the query is "ip" and your user agent if the query contains "user agent".')
 default_on = True
-
+preference_section = 'query'
+query_keywords = ['user-agent']
+query_examples = ''
 
 # Self User Agent regex
 p = re.compile('.*user[ -]agent.*', re.IGNORECASE)

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -76,6 +76,16 @@
 {%- endif -%}
 {%- endmacro -%}
 
+{%- macro plugin_of_category(plugin_category) -%}
+{%- for plugin in plugins -%}
+    {%- if plugin.preference_section == plugin_category -%}
+        {{- preferences_item_header(_(plugin.description), _(plugin.name), rtl, 'plugin_' + plugin.id) -}}
+            {{- checkbox_toggle('plugin_' + plugin.id, plugin.id not in allowed_plugins) -}}
+        {{- preferences_item_footer(_(plugin.description), _(plugin.name), rtl) -}}
+    {%- endif -%}
+{%- endfor -%}
+{% endmacro %}
+
 {%- block title %}{{ _('preferences') }} - {% endblock -%}
 
 {% block content %}
@@ -88,9 +98,10 @@
         <!-- Nav tabs -->
         <ul class="nav nav-tabs nav-justified hide_if_nojs" role="tablist">
           <li class="active"><a href="#tab_general" role="tab" data-toggle="tab">{{ _('General') }}</a></li>
+          <li><a href="#tab_ui" role="tab" data-toggle="tab">{{ _('User Interface') }}</a></li>
+          <li><a href="#tab_privacy" role="tab" data-toggle="tab">{{ _('Privacy') }}</a></li>
           <li><a href="#tab_engine" role="tab" data-toggle="tab">{{ _('Engines') }}</a></li>
-          <li><a href="#tab_plugins" role="tab" data-toggle="tab">{{ _('Plugins') }}</a></li>
-          {% if answerers %}<li><a href="#tab_answerers" role="tab" data-toggle="tab">{{ _('Answerers') }}</a></li>{% endif %}
+          <li><a href="#tab_query" role="tab" data-toggle="tab">{{ _('Special Queries') }}</a></li>
           <li><a href="#tab_cookies" role="tab" data-toggle="tab">{{ _('Cookies') }}</a></li>
         </ul>
 
@@ -125,16 +136,16 @@
                     {{ preferences_item_footer(language_info, language_label, rtl) }}
                     {% endif %}
 
-                    {% if 'locale' not in locked_preferences %}
-                    {% set locale_label = _('Interface language') %}
-                    {% set locale_info = _('Change the language of the layout') %}
-                    {{ preferences_item_header(locale_info, locale_label, rtl, 'locale') }}
-                        <select class="form-control {{ custom_select_class(rtl)}}" name="locale" id="locale">
-                            {% for locale_id,locale_name in locales.items() | sort %}
-                            <option value="{{ locale_id }}" {% if locale_id == current_locale %}selected="selected"{% endif %}>{{ locale_name }}</option>
-                            {% endfor %}
+                    {% if 'safesearch' not in locked_preferences %}
+                    {% set safesearch_label = _('SafeSearch') %}
+                    {% set safesearch_info = _('Filter content') %}
+                    {{ preferences_item_header(safesearch_info, safesearch_label, rtl, 'safesearch') }}
+                        <select class="form-control {{ custom_select_class(rtl) }}" name="safesearch" id="safesearch">
+                            <option value="2" {% if safesearch == '2' %}selected="selected"{% endif %}>{{ _('Strict') }}</option>
+                            <option value="1" {% if safesearch == '1' %}selected="selected"{% endif %}>{{ _('Moderate') }}</option>
+                            <option value="0" {% if safesearch == '0' %}selected="selected"{% endif %}>{{ _('None') }}</option>
                         </select>
-                    {{ preferences_item_footer(locale_info, locale_label, rtl) }}
+                    {{ preferences_item_footer(safesearch_info, safesearch_label, rtl) }}
                     {% endif %}
 
                     {% if 'autocomplete' not in locked_preferences %}
@@ -150,81 +161,7 @@
                     {{ preferences_item_footer(autocomplete_info, autocomplete_label, rtl) }}
                     {% endif %}
 
-                    {% if 'image_proxy' not in locked_preferences %}
-                    {% set image_proxy_label = _('Image proxy') %}
-                    {% set image_proxy_info = _('Proxying image results through searx') %}
-                    {{ preferences_item_header(image_proxy_info, image_proxy_label, rtl, 'image_proxy') }}
-                        <select class="form-control {{ custom_select_class(rtl) }}" name="image_proxy" id="image_proxy">
-                            <option value="1" {% if image_proxy  %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
-                            <option value="" {% if not image_proxy %}selected="selected"{% endif %}>{{ _('Disabled')}}</option>
-                        </select>
-                    {{ preferences_item_footer(image_proxy_info, image_proxy_label, rtl) }}
-                    {% endif %}
-
-                    {% if 'method' not in locked_preferences %}
-                    {% set method_label = _('Method') %}
-                    {% set method_info = _('Change how forms are submited, <a href="http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods" rel="external">learn more about request methods</a>') %}
-                    {{ preferences_item_header(method_info, method_label, rtl, 'method') }}
-                        <select class="form-control {{ custom_select_class(rtl) }}" name="method" id="method">
-                            <option value="POST" {% if method == 'POST' %}selected="selected"{% endif %}>POST</option>
-                            <option value="GET" {% if method == 'GET' %}selected="selected"{% endif %}>GET</option>
-                        </select>
-                    {{ preferences_item_footer(method_info, method_label, rtl) }}
-                    {% endif %}
-
-                    {% if 'safesearch' not in locked_preferences %}
-                    {% set safesearch_label = _('SafeSearch') %}
-                    {% set safesearch_info = _('Filter content') %}
-                    {{ preferences_item_header(safesearch_info, safesearch_label, rtl, 'safesearch') }}
-                        <select class="form-control {{ custom_select_class(rtl) }}" name="safesearch" id="safesearch">
-                            <option value="2" {% if safesearch == '2' %}selected="selected"{% endif %}>{{ _('Strict') }}</option>
-                            <option value="1" {% if safesearch == '1' %}selected="selected"{% endif %}>{{ _('Moderate') }}</option>
-                            <option value="0" {% if safesearch == '0' %}selected="selected"{% endif %}>{{ _('None') }}</option>
-                        </select>
-                    {{ preferences_item_footer(safesearch_info, safesearch_label, rtl) }}
-                    {% endif %}
-
-                    {% if 'theme' not in locked_preferences %}
-                    {% set theme_label = _('Themes') %}
-                    {% set theme_info = _('Change searx layout') %}
-                    {{ preferences_item_header(theme_info, theme_label, rtl, 'theme') }}
-                        <select class="form-control {{ custom_select_class(rtl) }}" name="theme" id="theme">
-                            {% for name in themes %}
-                            <option value="{{ name }}" {% if name == theme %}selected="selected"{% endif %}>{{ name }}</option>
-                            {% endfor %}
-                        </select>
-                    {{ preferences_item_footer(theme_info, theme_label, rtl) }}
-                    {% endif %}
-
-                    {% if 'oscar-style' not in locked_preferences %}
-                    {{ preferences_item_header(_('Choose style for this theme'), _('Style'), rtl, 'oscar_style') }}
-                        <select class="form-control {{ custom_select_class(rtl) }}" name="oscar-style" id="oscar_style">
-                            <option value="logicodev" >Logicodev</option>
-                            <option value="pointhi" {% if preferences.get_value('oscar-style') == 'pointhi' %}selected="selected"{% endif %}>Pointhi</option>
-                            <option value="logicodev-dark" {% if preferences.get_value('oscar-style') == 'logicodev-dark' %}selected="selected"{% endif %}>Logicodev dark</option>
-                        </select>
-                    {{ preferences_item_footer(_('Choose style for this theme'), _('Style'), rtl) }}
-                    {% endif %}
-
-                    {% if 'results_on_new_tab' not in locked_preferences %}
-                    {% set label = _('Results on new tabs') %}
-                    {% set info = _('Open result links on new browser tabs') %}
-                    {{ preferences_item_header(info, label, rtl, 'results_on_new_tab') }}
-                        <select class="form-control {{ custom_select_class(rtl) }}" name="results_on_new_tab" id="results_on_new_tab">
-                            <option value="1" {% if results_on_new_tab %}selected="selected"{% endif %}>{{ _('On') }}</option>
-                            <option value="0" {% if not results_on_new_tab %}selected="selected"{% endif %}>{{ _('Off')}}</option>
-                        </select>
-                    {{ preferences_item_footer(info, label, rtl) }}
-                    {% endif %}
-
-                    {% set label = _('Show advanced settings') %}
-                    {% set info = _('Show advanced settings panel in the home page by default') %}
-                    {{ preferences_item_header(info, label, rtl, 'advanced_search') }}
-                        <select class="form-control {{ custom_select_class(rtl) }}" name="advanced_search" id="advanced_search">
-                            <option value="1" {% if preferences.get_value('advanced_search')%}selected="selected"{% endif %}>{{ _('On') }}</option>
-                            <option value="0" {% if not preferences.get_value('advanced_search')%}selected="selected"{% endif %}>{{ _('Off')}}</option>
-                        </select>
-                    {{ preferences_item_footer(info, label, rtl) }}
+                    {{ plugin_of_category('general' )}}
 
                     {% if 'doi_resolver' not in locked_preferences %}
                     {% set label = _('Open Access DOI resolver') %}
@@ -239,6 +176,8 @@
                          </select>
                     {{ preferences_item_footer(info, label, rtl) }}
                     {% endif %}
+
+                    {{ plugin_of_category('onion' )}}
 
                     {% set label = _('Engine tokens') %}
                     {% set info = _('Access tokens for private engines') %}
@@ -344,61 +283,148 @@
                     {% endfor %}
                 </div>
             </div>
-            <div class="tab-pane active_if_nojs" id="tab_plugins">
+            <div class="tab-pane active_if_nojs" id="tab_ui">
                 <noscript>
-                    <h3>{{ _('Plugins') }}</h3>
+                    <h3>{{ _('User Interface') }}</h3>
                 </noscript>
                 <fieldset>
                     <div class="container-fluid">
-                        {% for plugin in plugins %}
-                        {% if plugin.preference_section != 'onions' %}
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3 class="panel-title">{{ _(plugin.name) }}</h3>
-                            </div>
-                            <div class="panel-body">
-                                <div class="col-xs-6 col-sm-4 col-md-6"><label for="{{'plugin_' + plugin.id}}">{{ _(plugin.description) }}</label></div>
-                                <div class="col-xs-6 col-sm-4 col-md-6">
-                                    <div class="onoff-checkbox">
-                                    {{ checkbox_toggle('plugin_' + plugin.id, plugin.id not in allowed_plugins) }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        {% if 'locale' not in locked_preferences %}
+                        {% set locale_label = _('Interface language') %}
+                        {% set locale_info = _('Change the language of the layout') %}
+                        {{ preferences_item_header(locale_info, locale_label, rtl, 'locale') }}
+                            <select class="form-control {{ custom_select_class(rtl)}}" name="locale" id="locale">
+                                {% for locale_id,locale_name in locales.items() | sort %}
+                                <option value="{{ locale_id }}" {% if locale_id == current_locale %}selected="selected"{% endif %}>{{ locale_name }}</option>
+                                {% endfor %}
+                            </select>
+                        {{ preferences_item_footer(locale_info, locale_label, rtl) }}
                         {% endif %}
-                        {% endfor %}
+
+                        {% if 'theme' not in locked_preferences %}
+                        {% set theme_label = _('Themes') %}
+                        {% set theme_info = _('Change searx layout') %}
+                        {{ preferences_item_header(theme_info, theme_label, rtl, 'theme') }}
+                            <select class="form-control {{ custom_select_class(rtl) }}" name="theme" id="theme">
+                                {% for name in themes %}
+                                <option value="{{ name }}" {% if name == theme %}selected="selected"{% endif %}>{{ name }}</option>
+                                {% endfor %}
+                            </select>
+                        {{ preferences_item_footer(theme_info, theme_label, rtl) }}
+                        {% endif %}
+
+                        {% if 'oscar-style' not in locked_preferences %}
+                        {{ preferences_item_header(_('Choose style for this theme'), _('Style'), rtl, 'oscar_style') }}
+                            <select class="form-control {{ custom_select_class(rtl) }}" name="oscar-style" id="oscar_style">
+                                <option value="logicodev" >Logicodev</option>
+                                <option value="pointhi" {% if preferences.get_value('oscar-style') == 'pointhi' %}selected="selected"{% endif %}>Pointhi</option>
+                                <option value="logicodev-dark" {% if preferences.get_value('oscar-style') == 'logicodev-dark' %}selected="selected"{% endif %}>Logicodev dark</option>
+                            </select>
+                        {{ preferences_item_footer(_('Choose style for this theme'), _('Style'), rtl) }}
+                        {% endif %}
+
+                        {% set label = _('Show advanced settings') %}
+                        {% set info = _('Show advanced settings panel in the home page by default') %}
+                        {{ preferences_item_header(info, label, rtl, 'advanced_search') }}
+                            <select class="form-control {{ custom_select_class(rtl) }}" name="advanced_search" id="advanced_search">
+                                <option value="1" {% if preferences.get_value('advanced_search')%}selected="selected"{% endif %}>{{ _('On') }}</option>
+                                <option value="0" {% if not preferences.get_value('advanced_search')%}selected="selected"{% endif %}>{{ _('Off')}}</option>
+                            </select>
+                        {{ preferences_item_footer(info, label, rtl) }}
+
+                        {% if 'results_on_new_tab' not in locked_preferences %}
+                        {% set label = _('Results on new tabs') %}
+                        {% set info = _('Open result links on new browser tabs') %}
+                        {{ preferences_item_header(info, label, rtl, 'results_on_new_tab') }}
+                            <select class="form-control {{ custom_select_class(rtl) }}" name="results_on_new_tab" id="results_on_new_tab">
+                                <option value="1" {% if results_on_new_tab %}selected="selected"{% endif %}>{{ _('On') }}</option>
+                                <option value="0" {% if not results_on_new_tab %}selected="selected"{% endif %}>{{ _('Off')}}</option>
+                            </select>
+                        {{ preferences_item_footer(info, label, rtl) }}
+                        {% endif %}
+
+                        {{ plugin_of_category('ui' )}}
                     </div>
                 </fieldset>
             </div>
-
-            {% if answerers %}
-            <div class="tab-pane active_if_nojs" id="tab_answerers">
+            <div class="tab-pane active_if_nojs" id="tab_privacy">
                 <noscript>
-                    <h3>{{ _('Answerers') }}</h3>
+                    <h3>{{ _('Privacy') }}</h3>
                 </noscript>
-                <p class="text-muted">
-                    {{ _('This is the list of searx\'s instant answering modules.') }}
-                </p>
-                <table class="table table-striped">
-                    <tr>
-                        <th{% if rtl %} class="text-right"{% endif %}>{{ _('Name') }}</th>
-                        <th{% if rtl %} class="text-right"{% endif %}>{{ _('Keywords') }}</th>
-                        <th{% if rtl %} class="text-right"{% endif %}>{{ _('Description') }}</th>
-                        <th{% if rtl %} class="text-right"{% endif %}>{{ _('Examples') }}</th>
-                    </tr>
+                <fieldset>
+                    <div class="container-fluid">
+                        {% if 'method' not in locked_preferences %}
+                        {% set method_label = _('Method') %}
+                        {% set method_info = _('Change how forms are submited, <a href="http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods" rel="external">learn more about request methods</a>') %}
+                        {{ preferences_item_header(method_info, method_label, rtl, 'method') }}
+                            <select class="form-control {{ custom_select_class(rtl) }}" name="method" id="method">
+                                <option value="POST" {% if method == 'POST' %}selected="selected"{% endif %}>POST</option>
+                                <option value="GET" {% if method == 'GET' %}selected="selected"{% endif %}>GET</option>
+                            </select>
+                        {{ preferences_item_footer(method_info, method_label, rtl) }}
+                        {% endif %}
 
-                    {% for answerer in answerers %}
-                    <tr>
-                        <td>{{ answerer.info.name }}</td>
-                        <td>{{ answerer.keywords|join(', ') }}</td>
-                        <td>{{ answerer.info.description }}</td>
-                        <td>{{ answerer.info.examples|join(', ') }}</td>
-                    </tr>
-                    {% endfor %}
-                </table>
+                        {% if 'image_proxy' not in locked_preferences %}
+                        {% set image_proxy_label = _('Image proxy') %}
+                        {% set image_proxy_info = _('Proxying image results through searx') %}
+                        {{ preferences_item_header(image_proxy_info, image_proxy_label, rtl, 'image_proxy') }}
+                            <select class="form-control {{ custom_select_class(rtl) }}" name="image_proxy" id="image_proxy">
+                                <option value="1" {% if image_proxy  %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
+                                <option value="" {% if not image_proxy %}selected="selected"{% endif %}>{{ _('Disabled')}}</option>
+                            </select>
+                        {{ preferences_item_footer(image_proxy_info, image_proxy_label, rtl) }}
+                        {% endif %}
+
+                        {{ plugin_of_category('privacy' )}}
+                    </div>
+                </fieldset>
             </div>
-            {% endif %}
-
+            <div class="tab-pane active_if_nojs" id="tab_query">
+                <noscript>
+                    <h3>{{ _('Query') }}</h3>
+                </noscript>
+                {% if answerers %}
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th{% if rtl %} class="text-right"{% endif %}>{{ _('Allow') }}</th>
+                            <th{% if rtl %} class="text-right"{% endif %}>{{ _('Keywords') }}</th>
+                            <th{% if rtl %} class="text-right"{% endif %}>{{ _('Name') }}</th>
+                            <th{% if rtl %} class="text-right"{% endif %}>{{ _('Description') }}</th>
+                            <th{% if rtl %} class="text-right"{% endif %}>{{ _('Examples') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <td></td>
+                        <th scope="colgroup" colspan="4">{{ _('This is the list of searx\'s instant answering modules.') }}</th>
+                        {% for answerer in answerers %}
+                        <tr>
+                            <td></td>
+                            <td>{{ answerer.keywords|join(', ') }}</td>
+                            <td>{{ answerer.info.name }}</td>
+                            <td>{{ answerer.info.description }}</td>
+                            <td>{{ answerer.info.examples|join(', ') }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                    <tbody>
+                        <td></td>
+                        <th scope="colgroup" colspan="4">{{ _('This is the list of plugins.') }}</th>
+                        {%- for plugin in plugins -%}
+                        {%- if plugin.preference_section == 'query' -%}
+                        <tr>
+                            <td>{{- checkbox_toggle('plugin_' + plugin.id, plugin.id not in allowed_plugins) -}}</td>
+                            <td>{{ plugin.query_keywords|join(', ') }}</td>
+                            <td>{{ _(plugin.name) }}</td>
+                            <td>{{ _(plugin.description) }}</td>
+                            <td>{{ plugin.query_examples }}</td>
+                        </tr>
+                        {%- endif -%}
+                        {%- endfor -%}
+                    </tbody>
+                </table>
+                {% endif %}
+            </div>
             <div class="tab-pane active_if_nojs" id="tab_cookies">
                 <noscript>
                     <h3>{{ _('Cookies') }}</h3>

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -187,102 +187,6 @@
                 </div>
                 </fieldset>
             </div>
-            <div class="tab-pane active_if_nojs" id="tab_engine">
-                <!-- Nav tabs -->
-                <ul class="nav nav-tabs nav-justified hide_if_nojs" role="tablist">
-                    {% for categ in all_categories %}
-                    <li{% if loop.first %} class="active"{% endif %}><a href="#tab_engine_{{ categ|replace(' ', '_') }}" role="tab" data-toggle="tab">{{ _(categ) }}</a></li>
-                    {% endfor %}
-                </ul>
-
-                <noscript>
-                    <h3>{{ _('Engines') }}</h3>
-                </noscript>
-
-                <!-- Tab panes -->
-                <div class="tab-content">
-
-                    <div class="hide_if_nojs">
-                        <p class="text-{% if rtl %}left{% else %}right{% endif %}">
-                            <button type="button" class="btn btn-default btn-success" id="allow-all-engines">{{ _("Allow all") }}</button>
-                            <button type="button" class="btn btn-default btn-danger" id="disable-all-engines">{{ _("Disable all") }}</button>
-                        </p>
-                    </div>
-
-                    {% for categ in all_categories %}
-                    <noscript><label>{{ _(categ) }}</label>
-                    </noscript>
-                    <div class="tab-pane{% if loop.first %} active{% endif %} active_if_nojs" id="tab_engine_{{ categ|replace(' ', '_') }}">
-                        <div class="container-fluid">
-                        <fieldset>
-                          <div class="table-responsive">
-                          <table class="table table-hover table-condensed table-striped">
-                                <tr>
-                                    {% if not rtl %}
-                                    <th scope="col">{{ _("Allow") }}</th>
-                                    <th scope="col">{{ _("Engine name") }}</th>
-                                    <th scope="col">{{ _("Shortcut") }}</th>
-                                    <th scope="col" style="width: 10rem">{{ _("Selected language") }}</th>
-                                    <th scope="col" style="width: 10rem">{{ _("SafeSearch") }}</th>
-                                    <th scope="col" style="width: 10rem">{{ _("Time range") }}</th>
-                                    <th scope="col">{{ _("Response time") }}</th>
-                                    <th scope="col" class="text-right"  style="width: 7rem">{{ _("Max time") }}</th>
-                                    <th scope="col" class="text-right" style="width: 7rem">{{ _("Reliablity") }}</th>
-                                    {% else %}
-                                    <th scope="col">{{ _("Reliablity") }}</th>
-                                    <th scope="col">{{ _("Max time") }}</th>
-                                    <th scope="col" class="text-right">{{ _("Response time") }}</th>
-                                    <th scope="col" class="text-right">{{ _("Time range") }}</th>
-                                    <th scope="col" class="text-right">{{ _("SafeSearch") }}</th>
-                                    <th scope="col" class="text-right">{{ _("Selected language") }}</th>
-                                    <th scope="col" class="text-right">{{ _("Shortcut") }}</th>
-                                    <th scope="col" class="text-right">{{ _("Engine name") }}</th>
-                                    <th scope="col" class="text-right">{{ _("Allow") }}</th>
-                                    {% endif %}
-                                </tr>
-                        {% for search_engine in engines_by_category[categ] %}
-                            {% if not search_engine.private %}
-                                <tr>
-                                    {% if not rtl %}
-                                        <td class="onoff-checkbox">
-                                        {{- checkbox_toggle('engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_'), (search_engine.name, categ) in disabled_engines) -}}
-                                        </td>
-                                        <th scope="row"><span aria-labelledby="{{ 'tooltip_' + categ + '_' + search_engine.name }}">
-                                            {%- if search_engine.enable_http %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif -%}
-                                            {{- search_engine.name -}}</span>
-                                            {{- engine_about(search_engine, 'tooltip_' + categ + '_' + search_engine.name) -}}
-                                        </th>
-                                        <td class="name">{{ shortcuts[search_engine.name] }}</td>
-                                        <td>{{ support_toggle(supports[search_engine.name]['supports_selected_language']) }}</td>
-                                        <td>{{ support_toggle(supports[search_engine.name]['safesearch']) }}</td>
-                                        <td>{{ support_toggle(supports[search_engine.name]['time_range_support']) }}</td>
-                                        {{ engine_time(search_engine.name, 'text-right') }}
-                                        <td class="text-right {{ 'danger' if stats[search_engine.name]['warn_timeout'] else '' }}">{% if stats[search_engine.name]['warn_timeout'] %}{{ icon('exclamation-sign') }} {% endif %}{{ search_engine.timeout }}</td>
-                                        {{ engine_reliability(search_engine.name, 'text-right ') }}
-                                    {% else %}
-                                        {{ engine_reliability(search_engine.name, 'text-left') }}
-                                        <td class="text-left {{ 'danger' if stats[search_engine.name]['warn_timeout'] else '' }}">{{ search_engine.timeout }}{% if stats[search_engine.name]['warn_time'] %} {{ icon('exclamation-sign')}}{% endif %}</td>
-                                        {{ engine_time(search_engine.name, 'text-left') }}
-                                        <td>{{ support_toggle(supports[search_engine.name]['time_range_support']) }}</td>
-                                        <td>{{ support_toggle(supports[search_engine.name]['safesearch']) }}</td>
-                                        <td>{{ support_toggle(supports[search_engine.name]['supports_selected_language']) }}</td>
-                                        <td>{{ shortcuts[search_engine.name] }}</td>
-                                        <th scope="row"><span>{% if search_engine.enable_http %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif %}{{ search_engine.name }}</span>{{ engine_about(search_engine) }}</th>
-                                        <td class="onoff-checkbox">
-                                        {{ checkbox_toggle('engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_'), (search_engine.name, categ) in disabled_engines) }}
-                                        </td>
-                                    {% endif %}
-                                </tr>
-                            {% endif %}
-                        {% endfor %}
-                          </table>
-                          </div>
-                        </fieldset>
-                        </div>
-                    </div>
-                    {% endfor %}
-                </div>
-            </div>
             <div class="tab-pane active_if_nojs" id="tab_ui">
                 <noscript>
                     <h3>{{ _('User Interface') }}</h3>
@@ -378,6 +282,102 @@
                         {{ plugin_of_category('privacy' )}}
                     </div>
                 </fieldset>
+            </div>
+            <div class="tab-pane active_if_nojs" id="tab_engine">
+                <!-- Nav tabs -->
+                <ul class="nav nav-tabs nav-justified hide_if_nojs" role="tablist">
+                    {% for categ in all_categories %}
+                    <li{% if loop.first %} class="active"{% endif %}><a href="#tab_engine_{{ categ|replace(' ', '_') }}" role="tab" data-toggle="tab">{{ _(categ) }}</a></li>
+                    {% endfor %}
+                </ul>
+
+                <noscript>
+                    <h3>{{ _('Engines') }}</h3>
+                </noscript>
+
+                <!-- Tab panes -->
+                <div class="tab-content">
+
+                    <div class="hide_if_nojs">
+                        <p class="text-{% if rtl %}left{% else %}right{% endif %}">
+                            <button type="button" class="btn btn-default btn-success" id="allow-all-engines">{{ _("Allow all") }}</button>
+                            <button type="button" class="btn btn-default btn-danger" id="disable-all-engines">{{ _("Disable all") }}</button>
+                        </p>
+                    </div>
+
+                    {% for categ in all_categories %}
+                    <noscript><label>{{ _(categ) }}</label>
+                    </noscript>
+                    <div class="tab-pane{% if loop.first %} active{% endif %} active_if_nojs" id="tab_engine_{{ categ|replace(' ', '_') }}">
+                        <div class="container-fluid">
+                        <fieldset>
+                          <div class="table-responsive">
+                          <table class="table table-hover table-condensed table-striped">
+                                <tr>
+                                    {% if not rtl %}
+                                    <th scope="col">{{ _("Allow") }}</th>
+                                    <th scope="col">{{ _("Engine name") }}</th>
+                                    <th scope="col">{{ _("Shortcut") }}</th>
+                                    <th scope="col" style="width: 10rem">{{ _("Selected language") }}</th>
+                                    <th scope="col" style="width: 10rem">{{ _("SafeSearch") }}</th>
+                                    <th scope="col" style="width: 10rem">{{ _("Time range") }}</th>
+                                    <th scope="col">{{ _("Response time") }}</th>
+                                    <th scope="col" class="text-right"  style="width: 7rem">{{ _("Max time") }}</th>
+                                    <th scope="col" class="text-right" style="width: 7rem">{{ _("Reliablity") }}</th>
+                                    {% else %}
+                                    <th scope="col">{{ _("Reliablity") }}</th>
+                                    <th scope="col">{{ _("Max time") }}</th>
+                                    <th scope="col" class="text-right">{{ _("Response time") }}</th>
+                                    <th scope="col" class="text-right">{{ _("Time range") }}</th>
+                                    <th scope="col" class="text-right">{{ _("SafeSearch") }}</th>
+                                    <th scope="col" class="text-right">{{ _("Selected language") }}</th>
+                                    <th scope="col" class="text-right">{{ _("Shortcut") }}</th>
+                                    <th scope="col" class="text-right">{{ _("Engine name") }}</th>
+                                    <th scope="col" class="text-right">{{ _("Allow") }}</th>
+                                    {% endif %}
+                                </tr>
+                        {% for search_engine in engines_by_category[categ] %}
+                            {% if not search_engine.private %}
+                                <tr>
+                                    {% if not rtl %}
+                                        <td class="onoff-checkbox">
+                                        {{- checkbox_toggle('engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_'), (search_engine.name, categ) in disabled_engines) -}}
+                                        </td>
+                                        <th scope="row"><span aria-labelledby="{{ 'tooltip_' + categ + '_' + search_engine.name }}">
+                                            {%- if search_engine.enable_http %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif -%}
+                                            {{- search_engine.name -}}</span>
+                                            {{- engine_about(search_engine, 'tooltip_' + categ + '_' + search_engine.name) -}}
+                                        </th>
+                                        <td class="name">{{ shortcuts[search_engine.name] }}</td>
+                                        <td>{{ support_toggle(supports[search_engine.name]['supports_selected_language']) }}</td>
+                                        <td>{{ support_toggle(supports[search_engine.name]['safesearch']) }}</td>
+                                        <td>{{ support_toggle(supports[search_engine.name]['time_range_support']) }}</td>
+                                        {{ engine_time(search_engine.name, 'text-right') }}
+                                        <td class="text-right {{ 'danger' if stats[search_engine.name]['warn_timeout'] else '' }}">{% if stats[search_engine.name]['warn_timeout'] %}{{ icon('exclamation-sign') }} {% endif %}{{ search_engine.timeout }}</td>
+                                        {{ engine_reliability(search_engine.name, 'text-right ') }}
+                                    {% else %}
+                                        {{ engine_reliability(search_engine.name, 'text-left') }}
+                                        <td class="text-left {{ 'danger' if stats[search_engine.name]['warn_timeout'] else '' }}">{{ search_engine.timeout }}{% if stats[search_engine.name]['warn_time'] %} {{ icon('exclamation-sign')}}{% endif %}</td>
+                                        {{ engine_time(search_engine.name, 'text-left') }}
+                                        <td>{{ support_toggle(supports[search_engine.name]['time_range_support']) }}</td>
+                                        <td>{{ support_toggle(supports[search_engine.name]['safesearch']) }}</td>
+                                        <td>{{ support_toggle(supports[search_engine.name]['supports_selected_language']) }}</td>
+                                        <td>{{ shortcuts[search_engine.name] }}</td>
+                                        <th scope="row"><span>{% if search_engine.enable_http %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif %}{{ search_engine.name }}</span>{{ engine_about(search_engine) }}</th>
+                                        <td class="onoff-checkbox">
+                                        {{ checkbox_toggle('engine_' + search_engine.name|replace(' ', '_') + '__' + categ|replace(' ', '_'), (search_engine.name, categ) in disabled_engines) }}
+                                        </td>
+                                    {% endif %}
+                                </tr>
+                            {% endif %}
+                        {% endfor %}
+                          </table>
+                          </div>
+                        </fieldset>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
             </div>
             <div class="tab-pane active_if_nojs" id="tab_query">
                 <noscript>

--- a/tests/robot/__init__.py
+++ b/tests/robot/__init__.py
@@ -57,6 +57,7 @@ def test_preferences_locale(browser):
     browser.visit(url)
     browser.click_link_by_text('preferences')
 
+    browser.find_by_xpath('//a[@href="#tab_ui"]').first.click()
     browser.select('locale', 'hu')
     browser.find_by_xpath('//input[@value="save"]').first.click()
 


### PR DESCRIPTION
## What does this PR do?

#### General tab

![image](https://user-images.githubusercontent.com/1594191/122258333-38b7fa00-ced1-11eb-83fd-60423f5d5e4d.png)

#### User Interface tab

![image](https://user-images.githubusercontent.com/1594191/122258424-4e2d2400-ced1-11eb-8f57-b19e8786e7c2.png)

#### Privacy tab

![image](https://user-images.githubusercontent.com/1594191/122258443-54230500-ced1-11eb-8a69-163c6380ce7c.png)

#### Special queries tab

![image](https://user-images.githubusercontent.com/1594191/122258463-59804f80-ced1-11eb-888d-8a25decdbd3a.png)

#### Cookies tab

![image](https://user-images.githubusercontent.com/1594191/122258483-5edd9a00-ced1-11eb-80b5-a637c0ecef2f.png)



## Why is this change important?

From the usability point of view, for an user who is not the admin of the instance, the plugin tab should not exist.

For plugin with `plugin_category="query"`, there are two new values 
  * `query_keywords` 
  * `query_examples` 

## How to test this PR locally?

* `make run`
* check the preferences are saved with the selected choices.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #115

## Notes

* the engine currency, mymemory translated and dictzone should also be listed in the "Special Queries" tab.
* the "On / Off" select should be replace by a toggle (for example "Show advanced settings")
