### PR TITLE
[fix] utils/morty.sh - PUBLIC_URL_MORTY is based on PUBLIC_URL

### DIFF
--- a/utils/morty.sh
+++ b/utils/morty.sh
@@ -18,7 +18,7 @@ in_container && lxc_set_suite_env
 MORTY_LISTEN="${MORTY_LISTEN:-127.0.0.1:3000}"
 PUBLIC_URL_PATH_MORTY="${PUBLIC_URL_PATH_MORTY:-/morty/}"
 
-PUBLIC_URL_MORTY="${PUBLIC_URL_MORTY:-$(echo "$SEARX_URL" |  sed -e's,^\(.*://[^/]*\).*,\1,g')${PUBLIC_URL_PATH_MORTY}}"
+PUBLIC_URL_MORTY="${PUBLIC_URL_MORTY:-$(echo "$PUBLIC_URL" |  sed -e's,^\(.*://[^/]*\).*,\1,g')${PUBLIC_URL_PATH_MORTY}}"
 
 # shellcheck disable=SC2034
 MORTY_TIMEOUT=5


### PR DESCRIPTION
## What does this PR do?

It fixes a bug with the morty proxy URL.

## Why is this change important?

LXC container suite generates wrong proxy URLs

## How to test this PR locally?

- Prepare a LXC container for development as described here: https://searxng.github.io/searxng/dev/lxcdev.html#summary
- Open http://10.174.184.156/searx (or whatever is the IP of your container)
- do a search and have a look at the URL of the _proxied_ link in the right bottom corner .. 
 
The link should be `http://10.174.184.176/morty/?mortyurl=...&mortyhash=...` (or whatever is the IP of your container) 
If you see a `http://searx-archlinux/..` URL the bug resists.