### PR TITLE
Fix google news

### DIFF
--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -94,8 +94,8 @@ def request(query, params):
     ceid = "%s:%s" % (lang_info['country'], lang_info['language'])
 
     # google news redirects en to en-US
-    if lang_info['hl'] == 'en':
-        lang_info['hl'] = 'en-US'
+    if lang_info['params']['hl'] == 'en':
+        lang_info['params']['hl'] = 'en-US'
 
     # Very special to google-news compared to other google engines, the time
     # range is included in the search term.

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -19,6 +19,7 @@ Definitions`_.  Not all parameters can be appied:
 # pylint: disable=invalid-name, missing-function-docstring
 
 import binascii
+from datetime import datetime
 import re
 from urllib.parse import urlencode
 from base64 import b64decode
@@ -115,6 +116,7 @@ def request(query, params):
     params['headers']['Accept'] = (
         'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
         )
+    params['headers']['Cookie'] = "CONSENT=YES+cb.%s-14-p0.en+F+941;" % datetime.now().strftime("%Y%m%d")
 
     return params
 


### PR DESCRIPTION
## What does this PR do?

fixes two issues with google-news engine:

- [fix] google-news engine - KeyError: 'hl in request
- [fix] google news - send CONSENT Cookie to not be redirected

## How to test this PR locally?

Start instance `make run` and test some `!google_news ...`  queries.

## Related issues

Closes #154

