### PR TITLE
[fix] node.clean - ignore npm dependencies when npm is not installed

### DIFF
--- a/manage
+++ b/manage
@@ -313,6 +313,10 @@ node.env() {
 }
 
 node.clean() {
+    if ! required_commands npm 2>/dev/null; then
+        build_msg CLEAN "npm is not installed / ignore npm dependencies"
+        return 0
+    fi
     build_msg CLEAN "locally installed npm dependencies"
     (   set -e
         npm --prefix searx/static/themes/oscar run clean


### PR DESCRIPTION
## What does this PR do?

[fix] node.clean - ignore npm dependencies when npm is not installed

## Why is this change important?

error pattern::

    $ make clean
    CLEAN     pyenv
    PYENV     [virtualenv] drop local/py3
    CLEAN     docs -- build/docs dist/docs
    CLEAN     locally installed npm dependencies
    ./manage: line 318: npm: command not found
    ERROR: node.clean exit with error (127)
    make: *** [Makefile:90: node.clean] Error 127