### PR TITLE
[fix] py.build - fix small typo in the build message

### DIFF
--- a/manage
+++ b/manage
@@ -326,7 +326,7 @@ node.clean() {
 }
 
 py.build() {
-    build_msg BUILD "[pylint] python package ${PYDIST}"
+    build_msg BUILD "python package ${PYDIST}"
     pyenv.cmd python setup.py \
               sdist -d "${PYDIST}" \
               bdist_wheel --bdist-dir "${PYBUILD}" -d "${PYDIST}"


### PR DESCRIPTION
## What does this PR do?

target `py.build`: fix small typo in the build message
