### PR TITLE
[fix] tidy up ignore lists .gitignore & .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,6 @@
 */*/*/*~
 */*/*/*/*~
 
-#
-local/
-
 # Git
 .git
 .gitignore
@@ -26,19 +23,6 @@ __pycache__/
 */*/*.py[cod]
 */*/*/*.py[cod]
 
-# to sync with .gitignore
-.coverage
-coverage/
-.installed.cfg
-engines.cfg
-env
-searx-ve
-robot_log.html
-robot_output.xml
-robot_report.html
-test_basic/
-setup.cfg
-
 # node_modules
 node_modules/
 */node_modules/
@@ -48,9 +32,13 @@ node_modules/
 
 .tx/
 
-#
+# to sync with .gitignore
+geckodriver.log
+.coverage
+coverage/
+cache/
 build/
 dist/
 local/
 gh-pages/
-searx.egg-info/
+*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,17 @@
 # to sync with .dockerignore
-.coverage
-coverage/
-cache/
-.installed.cfg
-engines.cfg
-env
-searx-ve
-robot_log.html
-robot_output.xml
-robot_report.html
-test_basic/
-setup.cfg
 
 *.pyc
 */*.pyc
 *~
 *.swp
+geckodriver.log
 
-/node_modules
+.coverage
+coverage/
 
-.tx/
-
+cache/
 build/
 dist/
 local/
 gh-pages/
-searx.egg-info/
+*.egg-info/


### PR DESCRIPTION
## What does this PR do?

tidy up ignore lists `.gitignore` & `.dockerignore`

@dalf: could you have a look at the `.dockerignore` list please / we have the new ignore files at:

- https://github.com/searxng/searxng/blob/master/searx/static/themes/oscar/.gitignore and
- https://github.com/searxng/searxng/blob/master/searx/static/themes/simple/.gitignore

Is there anything we have to consider?