### PR TITLE
[emacs] .dir-locals.el: add setup for json-mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -83,6 +83,11 @@
 
                (flycheck-checker . yaml-yamllint)))))
 
+ (json-mode
+  . ((eval . (progn
+               (setq-local js-indent-level 2)
+               (flycheck-checker . json-python-json)))))
+
  (python-mode
   . ((eval . (progn
 


### PR DESCRIPTION
## What does this PR do?

.dir-locals.el: add setup for json-mode
