### PR TITLE
[mod] utils/lxc.sh: detect conflict of docker & LXC in the iptables

### DIFF
--- a/docs/dev/lxcdev.rst
+++ b/docs/dev/lxcdev.rst
@@ -52,7 +52,12 @@ software:
 and the script :ref:`lxc.sh`, with we can scale our installation, maintenance or
 even development tasks over a stack of isolated containers / what we call the:
 
-  **searxNG LXC suite**
+  **SearxNG LXC suite**
+
+.. hint::
+
+   If you see any problems with the internet connectivity of your
+   containers read section :ref:`internet connectivity docker`.
 
 
 Gentlemen, start your engines!

--- a/docs/utils/lxc.sh.rst
+++ b/docs/utils/lxc.sh.rst
@@ -40,8 +40,14 @@ take some time**::
 
 A cup of coffee later, your LXC suite is build up and you can run whatever task
 you want / in a selected or even in all :ref:`LXC suite containers <lxc.sh
-help>`.  If you do not want to build all containers, **you can build just
-one**::
+help>`.
+
+.. hint::
+
+   If you see any problems with the internet connectivity of your
+   containers read section :ref:`internet connectivity docker`.
+
+If you do not want to build all containers, **you can build just one**::
 
   $ sudo -H ./utils/lxc.sh build searx-ubu1804
 
@@ -65,6 +71,49 @@ If there comes the time you want to **get rid off all** the containers and
 
   $ sudo -H ./utils/lxc.sh remove
   $ sudo -H ./utils/lxc.sh remove images
+
+.. _internet connectivity docker:
+
+Internet Connectivity & Docker
+==============================
+
+.. sidebar::  further read
+
+   - `Docker blocking network of existing LXC containers <https://github.com/docker/for-linux/issues/103>`__
+   - `Docker and IPtables (fralef.me) <https://fralef.me/docker-and-iptables.html>`__
+   - `Docker and iptables (docker.com) <https://docs.docker.com/network/iptables/#docker-on-a-router/>`__
+
+There is a conflict in the ``iptables`` setup of Docker & LXC.  If you have
+docker installed, you may find that the internet connectivity of your LXD
+containers no longer work.
+
+Whenever docker is started (reboot) it sets the iptables policy for the
+``FORWARD`` chain to ``DROP`` `[ref]
+<https://docs.docker.com/network/iptables/#docker-on-a-router>`__::
+
+  $ sudo -H iptables-save | grep FORWARD
+  :FORWARD ACCEPT [7048:7851230]
+  :FORWARD DROP [7048:7851230]
+
+A handy solution of this problem might be to reset the policy for the
+``FORWARD`` chain after the network has been initialized.  For this create a
+file in the ``if-up`` section of the network (``/etc/network/if-up.d/iptable``)
+and insert the following lines::
+
+  #!/bin/sh
+  iptables -F FORWARD
+  iptables -P FORWARD ACCEPT
+
+Don't forget to set the execution bit::
+
+  sudo chmod ugo+x /etc/network/if-up.d/iptable
+
+Reboot your system and check the iptables rules::
+
+  $ sudo -H iptables-save | grep FORWARD
+  :FORWARD ACCEPT [7048:7851230]
+  :FORWARD ACCEPT [7048:7851230]
+
 
 .. _lxc.sh install suite:
 

--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -5,6 +5,8 @@
 # shellcheck source=utils/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 source_dot_config
+# shellcheck source=utils/brand.env
+source "${REPO_ROOT}/utils/brand.env"
 
 # load environment of the LXC suite
 LXC_ENV="${LXC_ENV:-${REPO_ROOT}/utils/lxc-searx.env}"
@@ -535,6 +537,9 @@ lxc_install_boilerplate() {
     if lxc start -q "${container_name}" &>/dev/null; then
         sleep 5 # guest needs some time to come up and get an IP
     fi
+    if ! check_connectivity "${container_name}"; then
+        die 42 "Container ${container_name} has no internet connectivity!"
+    fi
     lxc_init_container_env "${container_name}"
     info_msg "[${_BBlue}${container_name}${_creset}] install /.lxcenv.mk .."
     cat <<EOF | lxc exec "${container_name}" -- bash | prefix_stdout "[${_BBlue}${container_name}${_creset}] "
@@ -554,6 +559,20 @@ EOF
     fi
 }
 
+check_connectivity() {
+    local ret_val=0
+    info_msg "check internet connectivity ..."
+    if ! lxc exec "${1}" -- ping -c 1 8.8.8.8 &>/dev/null; then
+        ret_val=1
+        err_msg "no internet connectivity!"
+        info_msg "Most often the connectivity is blocked by a docker installation:"
+        info_msg "Whenever docker is started (reboot) it sets the iptables policy "
+        info_msg "for the FORWARD chain to DROP, see:"
+        info_msg "    ${DOCS_URL}/utils/lxc.sh.html#internet-connectivity-docker"
+        iptables-save | grep ":FORWARD"
+    fi
+    return $ret_val
+}
 
 # ----------------------------------------------------------------------------
 main "$@"


### PR DESCRIPTION
## What does this PR do?

Docker is blocking network of existing LXC containers / there is a conflict in
the iptables setup of Docker & LXC.  With this patch:

- utils/lxc.sh checks internet connectivity (instead of silently hang)
- Chapter "Internet Connectivity & Docker" describes the problem and made a
  suggestion for a solution a solution
