### PR TITLE
Set use_mobile_ui to false for Google engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -584,7 +584,7 @@ engines:
     engine: google
     shortcut: go
     # see https://searxng.github.io/searxng/src/searx.engines.google.html#module-searx.engines.google
-    use_mobile_ui: true
+    use_mobile_ui: false
     # additional_tests:
     #   android: *test_android
 


### PR DESCRIPTION
## What does this PR do?

It set use_mobile_ui to false for the Google engine.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

The mobile UI of Google serve an HTML page that is different from the original Google search HTML page. For example, the number of results is not given.

I don't think we want to offer a default experience with fewer features, and also we haven't received enough feedback to consider this mobile UI stable for general usage.

## How to test this PR locally?

Run searx with use_mobile_ui to false.

## Author's checklist

N/A

## Related issues

N/A
