### PR TITLE
[fix] decoding of saved preferences in the URL

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -437,10 +437,10 @@ class Preferences:
 
     def parse_encoded_data(self, input_data):
         """parse (base64) preferences from request (``flask.request.form['preferences']``)"""
-        decoded_data = decompress(urlsafe_b64decode(input_data.encode()))
+        bin_data = decompress(urlsafe_b64decode(input_data))
         dict_data = {}
-        for x, y in parse_qs(decoded_data).items():
-            dict_data[x.decode()] = y[0].decode()
+        for x, y in parse_qs(bin_data.decode('ascii')).items():
+            dict_data[x] = y[0]
         self.parse_dict(dict_data)
 
     def parse_dict(self, input_data):

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1456,7 +1456,7 @@ engines:
     timeout: 5.0
     disabled: true
 
-  - name: slownik jezyka polskiego
+  - name: słownik języka polskiego
     engine: sjp
     shortcut: sjp
     base_url: https://sjp.pwn.pl/


### PR DESCRIPTION
## What does this PR do?

[fix] decoding of saved preferences in the URL

To compress saved preferences in the URL was introduced in 5f758b2d3 and
slightly fixed in 8f4401462.  But the main fail was not fixed; The decompress
function returns a binary string and this binary should first be decoded to a
string before it is passed to urllib.parse_qs.

BTW: revert the hot-fix from 5973491

Related-to: https://github.com/searxng/searxng/issues/166
