### PR TITLE
[fix] utils/lib.sh: prefix_stdout show cursor (ANSI escape \e[?25h)

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -270,6 +270,8 @@ prefix_stdout () {
     (while IFS= read line; do
         echo -e "${prefix}$line"
     done)
+    # some piped commands hide the cursor, show cursory when the stream ends
+    echo -en "\e[?25h"
 }
 
 append_line() {


### PR DESCRIPTION
## What does this PR do?

Some piped commands hide the cursor, show cursory when the stream ends.

Most often this is a bug of the command which is piped.  The command should not
hide the cursor when it writes to a pipe.  I have seen this bug with the package
manager (pacman) from ArchLinux.