### PR TITLE
[fix] .config.sh: typo SEARX_INTERNAL_URL --> SEARX_INTERNAL_HTTP

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -25,7 +25,7 @@ fi
 # searx.sh
 # ---------
 
-# SEARX_INTERNAL_URL="127.0.0.1:8888"
+# SEARX_INTERNAL_HTTP="127.0.0.1:8888"
 # SEARX_SETTINGS_TEMPLATE="${REPO_ROOT}/utils/templates/etc/searx/use_default_settings.yml"
 
 # Only change, if you maintain a searx brand in your searx fork (GIT_URL) which

--- a/docs/build-templates/searx.rst
+++ b/docs/build-templates/searx.rst
@@ -176,7 +176,7 @@ ${fedora_build}
        # disable debug
        $ sudo -H sed -i -e \"s/debug : True/debug : False/g\" \"$SEARX_SETTINGS_PATH\"
 
-Open WEB browser and visit http://$SEARX_INTERNAL_URL .  If you are inside a
+Open WEB browser and visit http://$SEARX_INTERNAL_HTTP .  If you are inside a
 container or in a script, test with curl:
 
 .. tabs::
@@ -185,13 +185,13 @@ container or in a script, test with curl:
 
     .. code-block:: sh
 
-       $ xdg-open http://$SEARX_INTERNAL_URL
+       $ xdg-open http://$SEARX_INTERNAL_HTTP
 
   .. group-tab:: curl
 
     .. code-block:: none
 
-       $ curl --location --verbose --head --insecure $SEARX_INTERNAL_URL
+       $ curl --location --verbose --head --insecure $SEARX_INTERNAL_HTTP
 
        *   Trying 127.0.0.1:8888...
        * TCP_NODELAY set


### PR DESCRIPTION
## What does this PR do?

There is a typo in .config.sh that causes confusion more and more often.
SEARX_INTERNAL_HTTP should be the correct name of the environment variable.
First mentioned in [1] and also discussed in [2].

[1] searx PR 2273
[2] searx discussions 2863
