### PR TITLE
[fix] brave engine: shows descriptions with their correct URLs

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1510,8 +1510,14 @@ engines:
     search_url: https://search.brave.com/search?q={query}
     url_xpath: //div[@class="snippet fdb"]/a/@href
     title_xpath: //span[@class="snippet-title"]
-    content_xpath: //div[@class="snippet-content"]
+    content_xpath: //p[1][@class="snippet-description"]
     categories: general
+    about:
+      website: https://brave.com/search/
+      wikidata_id: Q22906900
+      use_official_api: false
+      require_api_key: false
+      results: HTML
 
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.


### PR DESCRIPTION
## What does this PR do?

It now shows descriptions with their correct URLs when there are videos in the
search results, pulling content_xpath from snippet-description instead of
snippet-content.

BTW add about section to the YAML configuration

Suggested-by: @eagle-dogtooth https://github.com/searx/searx/issues/2857#issuecomment-869119968
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>