### PR TITLE
Add woxikon.de synonyme (XPath)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1477,6 +1477,23 @@ engines:
     timeout: 5.0
     disabled: true
 
+  - name: woxikon.de synonyme
+    engine: xpath
+    shortcut: woxi
+    categories: general
+    timeout: 5.0
+    disabled: true
+    search_url: https://synonyme.woxikon.de/synonyme/{query}.php
+    url_xpath: //div[@class="upper-synonyms"]/a/@href
+    content_xpath: //div[@class="synonyms-list-group"]
+    title_xpath: //div[@class="upper-synonyms"]/a
+    about:
+      website: https://www.woxikon.de/
+      wikidata_id: # No Wikidata ID
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name: słownik języka polskiego
     engine: sjp
     shortcut: sjp

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1384,7 +1384,8 @@ engines:
     engine: json_engine
     paging: true
     # This API Token is needed to work
-    search_url: https://search.whaleslide.com/api/v1/search_v2/web/{pageno}?q={query}&api_token=f8OhUDEYKUICHDnIxEgI7Cb4uYyTBqT4nO8iueNbfTO3devS24yElGqM7nCm
+    search_url:
+      https://search.whaleslide.com/api/v1/search_v2/web/{pageno}?q={query}&api_token=f8OhUDEYKUICHDnIxEgI7Cb4uYyTBqT4nO8iueNbfTO3devS24yElGqM7nCm
     url_query: url
     title_query: title
     title_html_to_text: true
@@ -1394,7 +1395,7 @@ engines:
     disabled: true
     about:
       website: https://whaleslide.com/
-      wikidata_id: # No Wikidata page
+      wikidata_id:  # No Wikidata page
       official_api_documentation: false
       use_official_api: false
       require_api_key: false
@@ -1489,7 +1490,7 @@ engines:
     title_xpath: //div[@class="upper-synonyms"]/a
     about:
       website: https://www.woxikon.de/
-      wikidata_id: # No Wikidata ID
+      wikidata_id:  # No Wikidata ID
       use_official_api: false
       require_api_key: false
       results: HTML


### PR DESCRIPTION
## What does this PR do?

Add woxikon.de synonyme (Xpath)

Merge from https://github.com/searx/searx/pull/2883 (and slightly modified)

The second commit fixes just some minor warnings from yamllint.