### PR TITLE
[fix] drop engine dogpile

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1536,26 +1536,6 @@ engines:
       require_api_key: false
       results: HTML
 
-  - name: dogpile
-    shortcut: dp
-    engine: xpath
-    paging: true
-    page_size: 9
-    # Doesn't work without the 'sc' parameter
-    search_url: https://www.dogpile.com/serp?q={query}&page={pageno}&sc=Gp0GqqlRVflv20
-    url_xpath: //span[@class="web-bing__url"]
-    title_xpath: //a[@class="web-bing__title"]
-    content_xpath: //span[@class="web-bing__description"]
-    categories: general
-    timeout: 3.0
-    disabled: true
-    about:
-      website: https://www.dogpile.com
-      wikidata_id: Q3595363
-      use_official_api: false
-      require_api_key: false
-      results: html
-
   - name: brave
     shortcut: brave
     engine: xpath


### PR DESCRIPTION
## What does this PR do?

Drop XPath engine `dogpile`.

The engine was added in commit a4b07460 but now it shows new issues [1].

In the 90'th of the last century, dogpile had its own WEB index, but nowadays it
is a meta-search engine [2]

    Powered by technology, Dogpile returns all the best results from leading
    search engines including Google and Yahoo!

Using dogpile as an engine in SearXNG needs more investigation, a XPath solution
like we have is not enough.   It is questionable whether it still makes sense to
investigate more into a meta-search engine with a ReCAPTCHA in front.

With this patch the dogpile engine is removed

[1] https://github.com/searxng/searxng/issues/202
[2] https://www.dogpile.com/support/aboutus

Closes: #202 