### PR TITLE
Add missing parameter for mobile UI search

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -287,6 +287,7 @@ def request(query, params):
     additional_parameters = {}
     if use_mobile_ui:
         additional_parameters = {
+            'asearch': 'arc',
             'async': 'use_ac:true,_fmt:pc',
         }
 


### PR DESCRIPTION
## What does this PR do?

It adds the `asearch=arc` parameter for the mobile UI search.

## Why is this change important?

The parameter was removed in https://github.com/searxng/searxng/commit/f096d68ec6c8ae3efc6656181570791115746d5d.
But it is important in order to make the request through the Google internal network, without it we are just sending the request normally and we don't bypass the rate limiting system.

## How to test this PR locally?

Run searx

## Author's checklist

N/A

## Related issues
N/A
