### PR TITLE
[fix] /preferences: remove the empty engine category "social medias"(it is "social media")

### DIFF
--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -30,7 +30,7 @@ CATEGORY_ORDER = [
     'it',
     'science',
     'files',
-    'social medias',
+    'social media',
 ]
 STR_TO_BOOL = {
     '0': False,


### PR DESCRIPTION
## What does this PR do?

Remove the "social medias" category:
![image](https://user-images.githubusercontent.com/1594191/126758375-44fcf25c-a74b-4443-9cf9-48f38984030a.png)

it is "social media".

## Why is this change important?

Bug fix

## How to test this PR locally?

* `make run`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
