### PR TITLE
[fix] peertube: update _fetch_supported_languages

### DIFF
--- a/searx/engines/peertube.py
+++ b/searx/engines/peertube.py
@@ -97,6 +97,6 @@ def _fetch_supported_languages(resp):
     import re
 
     # https://docs.python.org/3/howto/regex.html#greedy-versus-non-greedy
-    videolanguages = re.search(r"videoLanguages \(\) \{(.*?)\]", resp.text, re.DOTALL)
+    videolanguages = re.search(r"videoLanguages \(\)[^\n]+(.*?)\]", resp.text, re.DOTALL)
     peertube_languages = [m.group(1) for m in re.finditer(r"\{ id: '([a-z]+)', label:", videolanguages.group(1))]
     return peertube_languages


### PR DESCRIPTION
## What does this PR do?

update the regex to match the changes in peertube source code
fix "make data.languages"

## Why is this change important?

currently "make data.languages" crash.

## How to test this PR locally?

`make data.languages`
`git diff`

peertube languages are fetched, since it is the same language list it doesn't appear in the diff:

```diff
diff --git a/searx/data/engines_languages.json b/searx/data/engines_languages.json
index a6491895..2e861e1e 100644
--- a/searx/data/engines_languages.json
+++ b/searx/data/engines_languages.json
@@ -26142,6 +26142,10 @@
       "english_name": "Danish",
       "name": "Dansk"
     },
+    "dag": {
+      "english_name": "Dagbani",
+      "name": "Dagbanli"
+    },
     "de": {
       "english_name": "German",
       "name": "Deutsch"
@@ -26866,6 +26870,10 @@
       "english_name": "Serbo-Croatian",
       "name": "Srpskohrvatski / \u0421\u0440\u043f\u0441\u043a\u043e\u0445\u0440\u0432\u0430\u0442\u0441\u043a\u0438"
     },
+    "shi": {
+      "english_name": "Tachelhit",
+      "name": "Tacl\u1e25it"
+    },
     "shn": {
       "english_name": "Shan",
       "name": "\u101c\u102d\u1075\u103a\u1088\u1010\u1086\u1038"
@@ -27384,6 +27392,10 @@
       "english_name": "Danish",
       "name": "Dansk"
     },
+    "dag": {
+      "english_name": "Dagbani",
+      "name": "Dagbanli"
+    },
     "de": {
       "english_name": "German",
       "name": "Deutsch"
@@ -28108,6 +28120,10 @@
       "english_name": "Serbo-Croatian",
       "name": "Srpskohrvatski / \u0421\u0440\u043f\u0441\u043a\u043e\u0445\u0440\u0432\u0430\u0442\u0441\u043a\u0438"
     },
+    "shi": {
+      "english_name": "Tachelhit",
+      "name": "Tacl\u1e25it"
+    },
     "shn": {
       "english_name": "Shan",
       "name": "\u101c\u102d\u1075\u103a\u1088\u1010\u1086\u1038"
diff --git a/searx/languages.py b/searx/languages.py
index f9c9f65e..7db692a9 100644
--- a/searx/languages.py
+++ b/searx/languages.py
@@ -2,9 +2,7 @@
 # list of language codes
 # this file is generated automatically by utils/fetch_languages.py
 language_codes = \
-(   ('af-ZA', 'Afrikaans', '', 'Afrikaans'),
-    ('ar-EG', 'العربية', '', 'Arabic'),
-    ('be-BY', 'Беларуская', '', 'Belarusian'),
+(   ('ar-EG', 'العربية', '', 'Arabic'),
     ('bg-BG', 'Български', '', 'Bulgarian'),
     ('ca-ES', 'Català', '', 'Catalan'),
     ('cs-CZ', 'Čeština', '', 'Czech'),
@@ -28,7 +26,6 @@ language_codes = \
     ('es-ES', 'Español', 'España', 'Spanish'),
     ('es-MX', 'Español', 'México', 'Spanish'),
     ('et-EE', 'Eesti', '', 'Estonian'),
-    ('fa-IR', 'فارسی', '', 'Persian'),
     ('fi-FI', 'Suomi', '', 'Finnish'),
     ('fr', 'Français', '', 'French'),
     ('fr-BE', 'Français', 'Belgique', 'French'),
@@ -38,9 +35,7 @@ language_codes = \
     ('he-IL', 'עברית', '', 'Hebrew'),
     ('hr-HR', 'Hrvatski', '', 'Croatian'),
     ('hu-HU', 'Magyar', '', 'Hungarian'),
-    ('hy-AM', 'Հայերեն', '', 'Armenian'),
     ('id-ID', 'Indonesia', '', 'Indonesian'),
-    ('is-IS', 'Íslenska', '', 'Icelandic'),
     ('it-IT', 'Italiano', '', 'Italian'),
     ('ja-JP', '日本語', '', 'Japanese'),
     ('ko-KR', '한국어', '', 'Korean'),
@@ -58,12 +53,9 @@ language_codes = \
     ('ru-RU', 'Русский', '', 'Russian'),
     ('sk-SK', 'Slovenčina', '', 'Slovak'),
     ('sl-SI', 'Slovenščina', '', 'Slovenian'),
-    ('sr-RS', 'Srpski', '', 'Serbian'),
     ('sv-SE', 'Svenska', '', 'Swedish'),
-    ('sw-TZ', 'Kiswahili', '', 'Swahili'),
     ('th-TH', 'ไทย', '', 'Thai'),
     ('tr-TR', 'Türkçe', '', 'Turkish'),
-    ('uk-UA', 'Українська', '', 'Ukrainian'),
     ('vi-VN', 'Tiếng Việt', '', 'Vietnamese'),
     ('zh', '中文', '', 'Chinese'),
     ('zh-CN', '中文', '中国', 'Chinese'),
```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
