### PR TITLE
[mod] hardening SearXNG instances by default (formats)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -27,7 +27,9 @@ search:
   # max ban time in seconds after engine errors
   max_ban_time_on_fail: 120
   # remove format to deny access, use lower case.
-  formats: [html, csv, json, rss]
+  # formats: [html, csv, json, rss]
+  formats:
+    - html
 
 server:
   port: 8888

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,6 @@
+import os
+from os.path import dirname, sep, abspath
+
+# In unit tests the user settings from unit/settings/test_settings.yml are used.
+os.environ['SEARX_SETTINGS_PATH'] = abspath(
+    dirname(__file__) + sep + 'settings' + sep + 'test_settings.yml')

--- a/tests/unit/settings/test_settings.yml
+++ b/tests/unit/settings/test_settings.yml
@@ -1,0 +1,5 @@
+# This SearXNG setup is used in unit tests
+
+use_default_settings: true
+search:
+  formats: [html, csv, json, rss]


### PR DESCRIPTION
## What does this PR do?

Deny formats has been implemented in 6ed4616d.

To harden SearXNG instances by default, other formats than HTML should be
denied.  Most of JSON, RSS and CSV requests are bots [1]::

    Bots are the only users of this feature on a public instance, and they abuse
    it too much that the engines rate limit pretty quickly the IP address of the
    instance.

[1] https://github.com/searxng/searxng/issues/95

## Why is this change important?

hardening SearXNG instances by default (formats)

## How to test this PR locally?

Can't be tested local, but it is obviously that disabling those formats only used by bots is hardening the instance.

## Hint ##

Flask app in unit tests now uses the `unit/settings/test_settings.yml`  (e02b5469)
