### PR TITLE
manage script: remove unused reference to utils/brand.env and .config.sh

### DIFF
--- a/manage
+++ b/manage
@@ -5,9 +5,6 @@
 
 # shellcheck source=utils/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/utils/lib.sh"
-# shellcheck source=utils/brand.env
-source "${REPO_ROOT}/utils/brand.env"
-source_dot_config
 
 # shellcheck source=utils/lib_static.sh
 source "$(dirname "${BASH_SOURCE[0]}")/utils/lib_static.sh"
@@ -121,17 +118,6 @@ buildenv() {
             | prefix_stdout "${_Blue}BUILDENV${_creset}  "
     )
     return "${PIPESTATUS[0]}"
-}
-
-buildenv.unset_env(){
-    # Some defaults in the settings.yml are taken from the environment,
-    # e.g. SEARX_BIND_ADDRESS (:py:obj:`searx.settings_defaults.SHEMA`).  In
-    # some tasks (e.g. test.robot) we do not want these envorionment applied.
-    unset GIT_URL
-    unset GIT_BRANCH
-    unset SEARX_URL
-    unset SEARX_PORT
-    unset SEARX_BIND_ADDRESS
 }
 
 babel.compile() {
@@ -474,7 +460,6 @@ test.coverage() {
 
 test.robot() {
     build_msg TEST 'robot'
-    buildenv.unset_env
     gecko.driver
     PYTHONPATH=. pyenv.cmd python searx/testing.py robot
     dump_return $?

--- a/utils/build_env.py
+++ b/utils/build_env.py
@@ -22,10 +22,9 @@ def _env(*arg, **kwargs):
         val = ''
     return val
 
-# If you add or remove variables here, do not forgett to update:
+# If you add or remove variables here, do not forget to update:
 # - ./docs/admin/engines/settings.rst
 # - ./docs/dev/makefile.rst (section make buildenv)
-# - ./manage function buildenv.unset_env()
 
 name_val = [
 


### PR DESCRIPTION
## What does this PR do?

`./utils/brand.env` defines 
* SEARX_URL
* SEARX_PORT
* SEARX_BIND_ADDRESS
* GIT_URL
* GIT_BRANCH

`.config.sh` defines some variables for the scripts in the `utils` directory.

None of these values are referenced by:
* `./utils/makefile.include`
* `./manage`
* `./lib/lib.sh`
* `./utils/lib_static.sh`

In this PR, `manage` includes neither `./utils/brand.env` nor `./config.sh`.

Did I miss something?

## Why is this change important?

Decouple installation ( ./utils/*.sh) from the repository (./manage and Makefile)

## How to test this PR locally?

try the different `Makefile` targets.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
