### PR TITLE
[mod] simple theme - add ESLint

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -91,9 +91,9 @@
  (js-mode
   . ((eval . (progn
                (setq-local js-indent-level 2)
-               ;; flycheck should use the jshint checker from simple theme
-               (setq-local flycheck-javascript-jshint-executable
-                           (expand-file-name "searx/static/themes/simple/node_modules/.bin/jshint" prj-root))
+               ;; flycheck should use the eslint checker from simple theme
+               (setq-local flycheck-javascript-eslint-executable
+                           (expand-file-name "searx/static/themes/simple/node_modules/.bin/eslint" prj-root))
                (flycheck-mode)
                ))))
 

--- a/manage
+++ b/manage
@@ -665,8 +665,6 @@ themes.oscar() {
 themes.simple() {
     build_msg GRUNT "theme: simple"
     npm --prefix searx/static/themes/simple run build
-    # just report eslint issues but do not break the build (--force)
-    npm --prefix searx/static/themes/simple run eslint --force
     dump_return $?
 }
 

--- a/manage
+++ b/manage
@@ -665,6 +665,8 @@ themes.oscar() {
 themes.simple() {
     build_msg GRUNT "theme: simple"
     npm --prefix searx/static/themes/simple run build
+    # just report eslint issues but do not break the build (--force)
+    npm --prefix searx/static/themes/simple run eslint --force
     dump_return $?
 }
 

--- a/searx/static/themes/simple/.eslintrc.json
+++ b/searx/static/themes/simple/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12,
+        "sourceType": "module"
+    },
+    "rules": {
+    }
+}

--- a/searx/static/themes/simple/.eslintrc.json
+++ b/searx/static/themes/simple/.eslintrc.json
@@ -5,8 +5,7 @@
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module"
+        "ecmaVersion": 12
     },
     "rules": {
     }

--- a/searx/static/themes/simple/gruntfile.js
+++ b/searx/static/themes/simple/gruntfile.js
@@ -9,15 +9,13 @@ module.exports = function(grunt) {
     watch: {
       scripts: {
         files: ['src/**'],
-        tasks: ['jshint', 'copy', 'concat', 'uglify', 'less:development', 'less:production']
+        tasks: ['eslint', 'copy', 'concat', 'uglify', 'less:development', 'less:production']
       }
-    },
-    jshint: {
-      files: ['src/js/main/*.js', 'src/js/head/*.js', '../__common__/js/*.js'],
     },
     eslint: {
       options: {
-        configFile: '.eslintrc.json'
+        configFile: '.eslintrc.json',
+        failOnError: false
       },
       target: [
         'src/js/main/*.js',
@@ -204,8 +202,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['jshint']);
 
   grunt.registerTask('default', [
-    // 'eslint',
-    'jshint',
+    'eslint',
     'stylelint',
     'copy',
     'concat',

--- a/searx/static/themes/simple/gruntfile.js
+++ b/searx/static/themes/simple/gruntfile.js
@@ -15,6 +15,16 @@ module.exports = function(grunt) {
     jshint: {
       files: ['src/js/main/*.js', 'src/js/head/*.js', '../__common__/js/*.js'],
     },
+    eslint: {
+      options: {
+        configFile: '.eslintrc.json'
+      },
+      target: [
+        'src/js/main/*.js',
+        'src/js/head/*.js',
+        '../__common__/js/*.js'
+      ],
+    },
     stylelint: {
       options: {
         formatter: 'unix',
@@ -189,10 +199,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-webfont');
   grunt.loadNpmTasks('grunt-stylelint');
+  grunt.loadNpmTasks('grunt-eslint');
 
   grunt.registerTask('test', ['jshint']);
 
   grunt.registerTask('default', [
+    // 'eslint',
     'jshint',
     'stylelint',
     'copy',

--- a/searx/static/themes/simple/package.json
+++ b/searx/static/themes/simple/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "eslint": "^7.32.0",
     "grunt-cli": "^1.4.3",
     "grunt": "~1.4.1",
     "grunt-contrib-copy": "^1.0.0",
@@ -10,6 +11,7 @@
     "grunt-contrib-uglify": "~5.0.1",
     "grunt-contrib-watch": "~1.1.0",
     "grunt-stylelint": "^0.16.0",
+    "grunt-eslint": "^23.0.0",
     "grunt-webfont": "^1.7.2",
     "ionicons-npm": "^2.0.1",
     "jslint": "^0.12.1",
@@ -26,6 +28,7 @@
   "scripts": {
     "all": "npm install && grunt",
     "build": "grunt",
+    "eslint": "grunt eslint",
     "watch": "grunt watch",
     "webfont": "grunt webfont",
     "clean": "rm -Rf node_modules package-lock.json ion.less",

--- a/searx/static/themes/simple/package.json
+++ b/searx/static/themes/simple/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "eslint": "^7.32.0",
     "grunt-cli": "^1.4.3",
     "grunt": "~1.4.1",
     "grunt-contrib-copy": "^1.0.0",
@@ -14,7 +13,7 @@
     "grunt-eslint": "^23.0.0",
     "grunt-webfont": "^1.7.2",
     "ionicons-npm": "^2.0.1",
-    "jslint": "^0.12.1",
+    "eslint": "^7.32.0",
     "less": "^4.1.1",
     "less-plugin-clean-css": "^1.5.1",
     "stylelint": "^13.13.1",


### PR DESCRIPTION
## What does this PR do?

Add ESLint to the simple theme (npm and grunt)

BTW: add ESLint to the flycheck mode of emacs

[1] https://eslint.org/
[2] https://eslint.org/docs/user-guide/configuring/
[3] https://eslint.org/docs/user-guide/command-line-interface

## How to test this PR locally?

    make node.env
    make themes.simple

.. and have a look at the reported issues.

```
Running "eslint:target" (eslint) task

/800GBPCIex4/share/searx/searx/static/themes/simple/src/js/main/00_searx_toolkit.js
   73:38  error  'callback' is defined but never used     no-unused-vars
  151:5   error  'element' is not defined                 no-undef
  159:9   error  'el' is assigned a value but never used  no-unused-vars

/800GBPCIex4/share/searx/searx/static/themes/simple/src/js/main/searx_keyboard.js
    1:1   error  'searx' is not defined                                                     no-undef
    3:3   error  'searx' is not defined                                                     no-undef
    7:3   error  'searx' is not defined                                                     no-undef
  119:3   error  'searx' is not defined                                                     no-undef
  121:17  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
  221:21  error  '$' is not defined                                                         no-undef
  311:2   error  Mixed spaces and tabs                                                      no-mixed-spaces-and-tabs
  343:1   error  Mixed spaces and tabs                                                      no-mixed-spaces-and-tabs
  350:1   error  Mixed spaces and tabs                                                      no-mixed-spaces-and-tabs
  352:3   error  Mixed spaces and tabs                                                      no-mixed-spaces-and-tabs
  359:1   error  Mixed spaces and tabs                                                      no-mixed-spaces-and-tabs

/800GBPCIex4/share/searx/searx/static/themes/simple/src/js/main/searx_mapresult.js
  38:27  error  'L' is not defined                                 no-undef
  39:27  error  'L' is not defined                                 no-undef
  40:24  error  'L' is not defined                                 no-undef
  44:19  error  'L' is not defined                                 no-undef
  48:29  error  'L' is not defined                                 no-undef
  51:13  error  'osmWikimedia' is assigned a value but never used  no-unused-vars
  51:32  error  'L' is not defined                                 no-undef
  63:29  error  'L' is not defined                                 no-undef
  65:29  error  'L' is not defined                                 no-undef
  76:9   error  'L' is not defined                                 no-undef
  79:11  error  'L' is not defined                                 no-undef

/800GBPCIex4/share/searx/searx/static/themes/simple/src/js/main/searx_results.js
  24:49  error  'event' is defined but never used  no-unused-vars
  40:49  error  'event' is defined but never used  no-unused-vars

/800GBPCIex4/share/searx/searx/static/themes/simple/src/js/main/searx_search.js
   59:35  error  'e' is defined but never used  no-unused-vars
   74:30  error  'AutoComplete' is not defined  no-undef
  101:56  error  'e' is defined but never used  no-unused-vars

/800GBPCIex4/share/searx/searx/static/themes/simple/src/js/head/00_init.js
  29:81  error  'DocumentTouch' is not defined  no-undef

✖ 31 problems (31 errors, 0 warnings)
```

## Author's checklist

- ~~Initial ESLint is just to report issues. On the long run we can replace jshint by ESLint.~~ Replaces jshint, see https://github.com/searxng/searxng/pull/244#issuecomment-904410790
- ESLint has also a [`--fix` option](https://eslint.org/docs/user-guide/command-line-interface) 
