### PR TITLE
[mod] "npm run webfont" require fontforge & ttfautohint packages

### DIFF
--- a/docs/dev/quickstart.rst
+++ b/docs/dev/quickstart.rst
@@ -5,6 +5,8 @@ Development Quickstart
 ======================
 
 .. _npm: https://www.npmjs.com/
+.. _fontforge: https://github.com/fontforge/fontforge
+.. _ttfautohint: https://www.freetype.org/ttfautohint/doc/ttfautohint.html
 
 Searx loves developers, just clone and start hacking.  All the rest is done for
 you simply by using :ref:`make <makefile>`.
@@ -31,7 +33,12 @@ If you implement themes, you will need to compile styles and JavaScript before
 
    make themes.all
 
-Don't forget to install npm_ first.
+Don't forget to install npm_, ttfautohint_ and fontforge_ first.  To install
+all system requirements of a :ref:`buildhosts` use::
+
+  sudo -H ./utils/searx.sh install buildhost
+
+Otherwise, install only what you need at least:
 
 .. tabs::
 
@@ -39,19 +46,19 @@ Don't forget to install npm_ first.
 
       .. code:: sh
 
-         sudo -H apt-get install npm
+         sudo -H apt-get install npm ttfautohint fontforge
 
    .. group-tab:: Arch Linux
 
       .. code-block:: sh
 
-         sudo -H pacman -S npm
+         sudo -H pacman -S npm ttfautohint fontforge
 
    .. group-tab::  Fedora / RHEL
 
       .. code-block:: sh
 
-	 sudo -H dnf install npm
+	 sudo -H dnf install npm ttfautohint fontforge
 
 If you finished your *tests* you can start to commit your changes.  To separate
 the changed code from the build products first run:

--- a/manage
+++ b/manage
@@ -343,10 +343,10 @@ node.env() {
     (   set -e
 
         build_msg INSTALL "searx/static/themes/oscar/package.json"
-        npm --prefix searx/static/themes/oscar install
+        pyenv.cmd npm --prefix searx/static/themes/oscar install
 
         build_msg INSTALL "searx/static/themes/simple/package.json"
-        npm --prefix searx/static/themes/simple install
+        pyenv.cmd npm --prefix searx/static/themes/simple install
     )
     dump_return $?
 }

--- a/manage
+++ b/manage
@@ -334,7 +334,7 @@ gecko.driver() {
 }
 
 node.env() {
-    if ! required_commands npm; then
+    if ! required_commands npm fontforge ttfautohint; then
         info_msg "to install build tools use::"
         info_msg "   sudo -H ./utils/searx.sh install buildhost"
         die 1 "install needed build tools first"

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -43,7 +43,7 @@ shellcheck"
 BUILD_PACKAGES_debian="\
 firefox graphviz imagemagick texlive-xetex librsvg2-bin
 texlive-latex-recommended texlive-extra-utils fonts-dejavu
-latexmk
+latexmk fontforge ttfautohint
 npm"
 
 # pacman packages
@@ -55,7 +55,7 @@ shellcheck"
 
 BUILD_PACKAGES_arch="\
 firefox graphviz imagemagick texlive-bin extra/librsvg
-texlive-core texlive-latexextra ttf-dejavu
+texlive-core texlive-latexextra ttf-dejavu fontforge ttfautohint
 npm"
 
 # dnf packages
@@ -69,7 +69,7 @@ BUILD_PACKAGES_fedora="\
 firefox graphviz graphviz-gd ImageMagick librsvg2-tools
 texlive-xetex-bin texlive-collection-fontsrecommended
 texlive-collection-latex dejavu-sans-fonts dejavu-serif-fonts
-dejavu-sans-mono-fonts
+dejavu-sans-mono-fonts fontforge ttfautohint
 npm"
 
 # yum packages
@@ -89,7 +89,7 @@ BUILD_PACKAGES_centos="\
 firefox graphviz graphviz-gd ImageMagick librsvg2-tools
 texlive-xetex-bin texlive-collection-fontsrecommended
 texlive-collection-latex dejavu-sans-fonts dejavu-serif-fonts
-dejavu-sans-mono-fonts"
+dejavu-sans-mono-fonts fontforge ttfautohint"
 
 case $DIST_ID-$DIST_VERS in
     ubuntu-16.04|ubuntu-18.04)


### PR DESCRIPTION
## What does this PR do?

Add documentation & buildhost packages needed by:

    "npm run webfont" require fontforge & ttfautohint packages

See commit dca3bcca9::

     [mod] simple theme: include fonts

     "npm run webfont" to build the fonts directory.
     It requires fontforge and ttfautohint distro packages

     partial revert of commit 7137d28

I don't know why, but the same commit dca3bcca9 [removes](https://github.com/searxng/searxng/commit/dca3bcca9e1917dd3874ba9e40e1055e32caba34#diff-ffd563c55bf191e4f0f3bdc162add389733738c2e88c5a3e9c22d54585f7be69) the fontforge &
ttfautohint packages which has been added in 7137d28.  I assume it was an
mistake of the *partial revert of commit 7137d28*.

## How to test this PR locally?

    make clean node.env

## Author's checklist

Lets have a look if github integration ...

https://github.com/searxng/searxng/blob/34ffd08187d49b2e5de387f63662c18fda800064/.github/workflows/integration.yml#L51-L60

.. continues to have an [issue with gyp](https://github.com/searxng/searxng/runs/3219005909?check_suite_focus=true#step:4:48)

With commit e09fd43 d60f957  [issue with gyp still exists](https://github.com/searxng/searxng/pull/248/checks?check_run_id=3231685008#step:4:418)

## Related issues

Related-to:  https://github.com/searxng/searxng/pull/157#discussion_r654836723
