### PR TITLE
[docs] admin/engines/settings.rst remove 'locales' section

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -219,30 +219,6 @@ Communication with search engines.
 ``max_redirects`` :
   30 by default. Maximum redirect before it is an error.
 
-
-``locales:``
-------------
-
-.. code:: yaml
-
-   locales:
-     en: English
-     de: Deutsch
-     he: Hebrew
-     hu: Magyar
-     fr: Français
-     es: Español
-     it: Italiano
-     nl: Nederlands
-     ja: 日本語 (Japanese)
-     tr: Türkçe
-     ru: Russian
-     ro: Romanian
-
-``locales`` :
-  Locales codes and their names.  Available translations of searx interface.
-
-
 .. _settings engine:
 
 Engine settings


### PR DESCRIPTION
## What does this PR do?

[docs] admin/engines/settings.rst remove 'locales' section

'locales' setting has been removed in:

- f30d01ff [mod] settings.yml: remove locales

## Related issues

I forgot to remove the documentation in #247