### PR TITLE
[fix] searx.search.checker.get_result() always return a dict

### DIFF
--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -36,10 +36,11 @@ def _get_every():
     return _get_interval(every, 'checker.scheduling.every is not a int or list')
 
 
-def get_result():  # pylint: disable=inconsistent-return-statements
+def get_result():
     serialized_result = storage.get_str(CHECKER_RESULT)
     if serialized_result is not None:
         return json.loads(serialized_result)
+    return {'status': 'unknown'}
 
 
 def _set_result(result, include_timestamp=True):


### PR DESCRIPTION
## What does this PR do?

searx.search.checker.get_result() always return a dict `{ 'status': '....' ... }`
So `checker_results['status'] == 'ok'` is enough to check the checker result.
See https://github.com/searxng/searxng/blob/9667142d5c45ae52f19b361e69a61900e09fe005/searx/webapp.py#L981

## Why is this change important?

`/preferences` endpoint: avoid crash in some rare cases.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
