### PR TITLE
[mod] searx.webapp.get_locale: read locale from the preferences

### DIFF
--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -220,6 +220,24 @@ class ViewsTestCase(SearxTestCase):
             'Search language ignored browser preference.'
         )
 
+    def test_brower_empty_locale(self):
+        result = self.app.get('/preferences', headers={'Accept-Language': ''})
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(
+            b'<option value="en" selected="selected">',
+            result.data,
+            'Interface locale ignored browser preference.'
+        )
+
+    def test_locale_occitan(self):
+        result = self.app.get('/preferences?locale=oc')
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(
+            b'<option value="oc" selected="selected">',
+            result.data,
+            'Interface locale ignored browser preference.'
+        )
+
     def test_stats(self):
         result = self.app.get('/stats')
         self.assertEqual(result.status_code, 200)


### PR DESCRIPTION
## What does this PR do?

pre_request already set the locale.
simplify `searx.webapp.get_locale` function.

## Why is this change important?

Read the preferences in one place: pre_request function.

## How to test this PR locally?

* clear the cookie: locale and language must follow the browser preferences.
* save the preferences with a different locale: check the locale has changed.
* make a request with `?locale=oc`: check the locale has changed to `oc`.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
