### PR TITLE
[fix] utils/searx.sh install settings - do not eval the template

### DIFF
--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -302,6 +302,12 @@ install_rules() {
         return
     fi
 
+    if cmp --silent "${FILTRON_RULES}" "${FILTRON_RULES_TEMPLATE}"; then
+        info_msg "${FILTRON_RULES} is up to date with"
+        info_msg "${FILTRON_RULES_TEMPLATE}"
+        return
+    fi
+
     rst_para "Diff between origin's rules file (+) and current (-):"
     echo "${FILTRON_RULES}" "${FILTRON_RULES_TEMPLATE}"
     $DIFF_CMD "${FILTRON_RULES}" "${FILTRON_RULES_TEMPLATE}"

--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -437,7 +437,8 @@ install_template() {
 
     if [[ "$do_eval" == "1" ]]; then
         template_file="${CACHE}${dst}${variant}"
-        info_msg "BUILD template ${template_file}"
+	info_msg "BUILD ${template_file}"
+	info_msg "BUILD using template ${template_origin}"
         if [[ -n ${SUDO_USER} ]]; then
             sudo -u "${SUDO_USER}" mkdir -p "$(dirname "${template_file}")"
         else

--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -621,7 +621,7 @@ install_settings() {
     fi
 
     mkdir -p "$(dirname "${SEARX_SETTINGS_PATH}")"
-    install_template \
+    install_template --no-eval \
         "${SEARX_SETTINGS_PATH}" \
         "${SERVICE_USER}" "${SERVICE_GROUP}"
     configure_searx


### PR DESCRIPTION

## What does this PR do?

The settings template in utils/templates/etc/searx/settings.yml
does not include any replacements (shell environment variables).

BTW: utils/filtron.sh & utils/lib.sh
  Add some more messages to installation procedures, to be more clear.

## Why is this change important?

Evaluate templates needs some quoting e.g. of the quotation marks / without `--no-eval` these quotation marks get lost

## How to test this PR locally?

run the following command twice and in the second run there should be no diff (no missing quotation marks)

    utils/searx.sh install settings

