### PR TITLE
[enh] new issue: include information from searx.version

### DIFF
--- a/searx/templates/__common__/new_issue.html
+++ b/searx/templates/__common__/new_issue.html
@@ -6,6 +6,13 @@
     <textarea name="body" class="issue-hide">{{- '' -}}
 
 **Version of SearXNG, commit number if you are using on master branch and stipulate if you forked SearXNG**
+{% if searx_git_url and searx_git_url != 'unknow' %}
+Repository: {{ searx_git_url }}
+Branch: {{ searx_git_branch }}
+Version: {{ searx_version }}
+<!-- Check if these values are correct -->
+
+{% else %}
 <!-- If you are running on master branch using git execute this command
 in order to fetch the latest commit ID:
 ```
@@ -17,6 +24,7 @@ and check for the version after "Powered by SearXNG"
 Please also stipulate if you are using a forked version of SearxNG and
 include a link to the fork source code.
 -->
+{% endif %}
 **How did you install SearXNG?**
 <!-- Did you install SearXNG using the official wiki or using searx-docker
 or manually by executing the searx/webapp.py file? -->

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1191,6 +1191,7 @@ def stats():
         engine_stats = engine_stats,
         engine_reliabilities = engine_reliabilities,
         selected_engine_name = selected_engine_name,
+        searx_git_branch = GIT_BRANCH,
     )
 
 


### PR DESCRIPTION
## What does this PR do?

In /stats, when the user clicks on "Submit a new issue on Github including the above information", the form in GitHub contains:
* the git URL
* the git branch
* the version (tag-distance-commit)

Example:
```
**Version of SearXNG, commit number if you are using on master branch and stipulate if you forked SearXNG**
Repository: https://github.com/searxng/searxng
Branch: master
Version: 1.0.0-640-9667142d-dirty
<!-- Check if these values are correct -->

**How did you install SearXNG?**
...
```

If the git URL is unknown, then the previous version is displayed:
```
**Version of SearXNG, commit number if you are using on master branch and stipulate if you forked SearXNG**
<!-- If you are running on master branch using git execute this command
in order to fetch the latest commit ID:

git log -1

If you are using searx-docker then look at the bottom of the SearXNG page
and check for the version after "Powered by SearXNG"

Please also stipulate if you are using a forked version of SearxNG and
include a link to the fork source code.
-->
```

## Why is this change important?

The user doesn't need to look for an information that is already known.

## How to test this PR locally?

* `!digg test`
* click on the error
* click on "Submit a new issue on Github including the above information"

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
