### PR TITLE
[enh] Add Packagist search engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -938,6 +938,26 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name: packagist
+    engine: json_engine
+    paging: true
+    search_url: https://packagist.org/search.json?q={query}&page={pageno}
+    results_query: results
+    url_query: url
+    title_query: name
+    content_query: description
+    categories: it
+    disabled: true
+    timeout: 5.0
+    shortcut: pack
+    about:
+      website: https://packagist.org
+      wikidata_id: Q108311377
+      official_api_documentation: https://packagist.org/apidoc
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
   - name: pdbe
     engine: pdbe
     shortcut: pdb


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/915514/131233533-2471e44b-7b5f-4395-ac80-1549f0349674.png)

## What does this PR do?

This adds [Packagist](https://packagist.org) as a search engine. I based this engine on the existing Docker Hub engine, the engine's favicon was downloaded from the Packagist website with `wget` and converted to a PNG with ImageMagick, and the shortcut was plucked from [DDG's bangs database](https://duckduckgo.com/bang?q=packagist). It supports the parsing of URLs, titles, content, and published dates of Composer packages.

## Why is this change important?

<!-- MANDATORY -->

As a regular user of the Packagist repository myself, I'm sure many developers would find the direct ability to search for Composer packages very convenient.

## How to test this PR locally?

This PR is fully compatible with `make test`. To see it in action:

- `make run`
- query `!pack polyfill-php80`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
