### PR TITLE
[fix] remove minimum length of content for XPath engine

### DIFF
--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -194,7 +194,7 @@ def response(resp):
 
             url = extract_url(eval_xpath_list(result, url_xpath, min_len=1), search_url)
             title = extract_text(eval_xpath_list(result, title_xpath, min_len=1))
-            content = extract_text(eval_xpath_list(result, content_xpath, min_len=1))
+            content = extract_text(eval_xpath_list(result, content_xpath))
             tmp_result = {'url': url, 'title': title, 'content': content}
 
             # add thumbnail if available


### PR DESCRIPTION
## What does this PR do?

Instead of raising an exception and therefore hiding all results of the engine, 
remove minimum length of content for XPath engine

It make sense to remove that requirement in order to allow the implementation of
search engines that do not always have a description.  In fact some search
engines that in 99% of the case have a description like Brave Search or Mojeek
crash completely if they for some reason included a result with no description.

Suggested-by: 0xhtml in https://github.com/searx/searx/discussions/2933
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>

## How to test this PR locally?

To test this patch try Mojeek:

    !mjk xyz

before and after the patch.
