### PR TITLE
one logger per engine

### DIFF
--- a/manage
+++ b/manage
@@ -37,7 +37,7 @@ PYLINT_SEARX_DISABLE_OPTION="\
 I,C,R,\
 W0105,W0212,W0511,W0603,W0613,W0621,W0702,W0703,W1401,\
 E1136"
-PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES="supported_languages,language_aliases"
+PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES="supported_languages,language_aliases,logger"
 PYLINT_OPTIONS="-m pylint -j 0 --rcfile .pylintrc"
 
 help() {
@@ -588,6 +588,7 @@ test.pylint() {
     (   set -e
         build_msg TEST "[pylint] \$PYLINT_FILES"
         pyenv.cmd python ${PYLINT_OPTIONS} ${PYLINT_VERBOSE} \
+            --additional-builtins="${PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES}" \
             "${PYLINT_FILES[@]}"
 
         build_msg TEST "[pylint] searx/engines"

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -111,6 +111,7 @@ def load_engine(engine_data):
     if is_missing_required_attributes(engine):
         return None
 
+    engine.logger = logger.getChild(engine_name)
     return engine
 
 

--- a/searx/engines/apkmirror.py
+++ b/searx/engines/apkmirror.py
@@ -8,14 +8,11 @@
 from urllib.parse import urlencode
 from lxml import html
 
-from searx import logger
 from searx.utils import (
     eval_xpath_list,
     eval_xpath_getindex,
     extract_text,
 )
-
-logger = logger.getChild('APKMirror engine')
 
 about = {
     "website": 'https://www.apkmirror.com',

--- a/searx/engines/artic.py
+++ b/searx/engines/artic.py
@@ -13,9 +13,6 @@ Explore thousands of artworks from The Art Institute of Chicago.
 from json import loads
 from urllib.parse import urlencode
 
-from searx import logger
-logger = logger.getChild('APKMirror engine')
-
 about = {
     "website": 'https://www.artic.edu',
     "wikidata_id": 'Q239303',

--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -6,10 +6,7 @@
 import re
 from urllib.parse import urlencode
 from lxml import html
-from searx import logger
 from searx.utils import eval_xpath, extract_text, match_language
-
-logger = logger.getChild('bing engine')
 
 # about
 about = {

--- a/searx/engines/core.py
+++ b/searx/engines/core.py
@@ -9,10 +9,7 @@ from json import loads
 from datetime import datetime
 from urllib.parse import urlencode
 
-from searx import logger
 from searx.exceptions import SearxEngineAPIException
-
-logger = logger.getChild('CORE engine')
 
 about = {
     "website": 'https://core.ac.uk',
@@ -28,8 +25,6 @@ paging = True
 nb_per_page = 10
 
 api_key = 'unset'
-
-logger = logger.getChild('CORE engine')
 
 base_url = 'https://core.ac.uk:443/api-v2/search/'
 search_string = '{query}?page={page}&pageSize={nb_per_page}&apiKey={apikey}'

--- a/searx/engines/duckduckgo_definitions.py
+++ b/searx/engines/duckduckgo_definitions.py
@@ -9,14 +9,11 @@ import json
 from urllib.parse import urlencode, urlparse, urljoin
 from lxml import html
 
-from searx import logger
 from searx.data import WIKIDATA_UNITS
 from searx.engines.duckduckgo import language_aliases
 from searx.engines.duckduckgo import _fetch_supported_languages, supported_languages_url  # NOQA # pylint: disable=unused-import
 from searx.utils import extract_text, html_to_text, match_language, get_string_replaces_function
 from searx.external_urls import get_external_url, get_earth_coordinates_url, area_to_osm_zoom
-
-logger = logger.getChild('duckduckgo_definitions')
 
 # about
 about = {

--- a/searx/engines/flickr_noapi.py
+++ b/searx/engines/flickr_noapi.py
@@ -7,10 +7,7 @@ from json import loads
 from time import time
 import re
 from urllib.parse import urlencode
-from searx.engines import logger
 from searx.utils import ecma_unescape, html_to_text
-
-logger = logger.getChild('flickr-noapi')
 
 # about
 about = {

--- a/searx/engines/genius.py
+++ b/searx/engines/genius.py
@@ -9,9 +9,6 @@ from json import loads
 from urllib.parse import urlencode
 from datetime import datetime
 
-from searx import logger
-logger = logger.getChild('genius engine')
-
 # about
 about = {
     "website": 'https://genius.com/',

--- a/searx/engines/gigablast.py
+++ b/searx/engines/gigablast.py
@@ -8,7 +8,6 @@
 import re
 from json import loads
 from urllib.parse import urlencode
-# from searx import logger
 from searx.network import get
 
 # about

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -29,11 +29,8 @@ The google WEB engine itself has a special setup option:
 
 from urllib.parse import urlencode
 from lxml import html
-from searx import logger
 from searx.utils import match_language, extract_text, eval_xpath, eval_xpath_list, eval_xpath_getindex
 from searx.exceptions import SearxEngineCaptchaException
-
-logger = logger.getChild('google engine')
 
 # about
 about = {

--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -16,7 +16,6 @@
 from urllib.parse import urlencode, unquote
 from lxml import html
 
-from searx import logger
 from searx.utils import (
     eval_xpath,
     eval_xpath_list,
@@ -36,8 +35,6 @@ from searx.engines.google import (
     ,  _fetch_supported_languages
 )
 # pylint: enable=unused-import
-
-logger = logger.getChild('google images')
 
 # about
 about = {

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -20,7 +20,6 @@ from urllib.parse import urlencode
 from base64 import b64decode
 from lxml import html
 
-from searx import logger
 from searx.utils import (
     eval_xpath,
     eval_xpath_list,
@@ -49,8 +48,6 @@ about = {
     "require_api_key": False,
     "results": 'HTML',
 }
-
-logger = logger.getChild('google news')
 
 # compared to other google engines google-news has a different time range
 # support.  The time range is included in the search term.

--- a/searx/engines/google_scholar.py
+++ b/searx/engines/google_scholar.py
@@ -14,7 +14,6 @@ Definitions`_.
 from urllib.parse import urlencode
 from datetime import datetime
 from lxml import html
-from searx import logger
 
 from searx.utils import (
     eval_xpath,
@@ -52,8 +51,6 @@ language_support = True
 use_locale_domain = True
 time_range_support = True
 safesearch = False
-
-logger = logger.getChild('google scholar')
 
 def time_range_url(params):
     """Returns a URL query component for a google-Scholar time range based on

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -20,7 +20,6 @@ import re
 from urllib.parse import urlencode
 from lxml import html
 
-from searx import logger
 from searx.utils import (
     eval_xpath,
     eval_xpath_list,
@@ -58,8 +57,6 @@ about = {
     "require_api_key": False,
     "results": 'HTML',
 }
-
-logger = logger.getChild('google video')
 
 # engine dependent config
 

--- a/searx/engines/solidtorrents.py
+++ b/searx/engines/solidtorrents.py
@@ -8,9 +8,6 @@
 
 from json import loads
 from urllib.parse import urlencode
-from searx import logger
-
-logger = logger.getChild('solidtor engine')
 
 about = {
     "website": 'https://www.solidtorrents.net/',

--- a/searx/engines/soundcloud.py
+++ b/searx/engines/soundcloud.py
@@ -8,7 +8,6 @@ from json import loads
 from lxml import html
 from dateutil import parser
 from urllib.parse import quote_plus, urlencode
-from searx import logger
 from searx.network import get as http_get
 
 # about

--- a/searx/engines/springer.py
+++ b/searx/engines/springer.py
@@ -10,10 +10,7 @@ from datetime import datetime
 from json import loads
 from urllib.parse import urlencode
 
-from searx import logger
 from searx.exceptions import SearxEngineAPIException
-
-logger = logger.getChild('Springer Nature engine')
 
 about = {
     "website": 'https://www.springernature.com/',

--- a/searx/engines/sqlite.py
+++ b/searx/engines/sqlite.py
@@ -9,11 +9,6 @@
 import sqlite3
 import contextlib
 
-from searx import logger
-
-
-logger = logger.getChild('SQLite engine')
-
 engine_type = 'offline'
 database = ""
 query_str = ""

--- a/searx/engines/unsplash.py
+++ b/searx/engines/unsplash.py
@@ -8,9 +8,6 @@
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
 from json import loads
 
-from searx import logger
-
-logger = logger.getChild('unsplash engine')
 # about
 about = {
     "website": 'https://unsplash.com',

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -10,14 +10,11 @@ from json import loads
 from dateutil.parser import isoparse
 from babel.dates import format_datetime, format_date, format_time, get_datetime_format
 
-from searx import logger
 from searx.data import WIKIDATA_UNITS
 from searx.network import post, get
 from searx.utils import match_language, searx_useragent, get_string_replaces_function
 from searx.external_urls import get_external_url, get_earth_coordinates_url, area_to_osm_zoom
 from searx.engines.wikipedia import _fetch_supported_languages, supported_languages_url  # NOQA # pylint: disable=unused-import
-
-logger = logger.getChild('wikidata')
 
 # about
 about = {

--- a/searx/engines/wordnik.py
+++ b/searx/engines/wordnik.py
@@ -4,11 +4,8 @@
 """
 
 from lxml.html import fromstring
-from searx import logger
 from searx.utils import extract_text
 from searx.network import raise_for_httperror
-
-logger = logger.getChild('Wordnik engine')
 
 # about
 about = {

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -23,9 +23,6 @@ from urllib.parse import urlencode
 
 from lxml import html
 from searx.utils import extract_text, extract_url, eval_xpath, eval_xpath_list
-from searx import logger
-
-logger = logger.getChild('XPath engine')
 
 search_url = None
 """

--- a/searx/engines/yahoo_news.py
+++ b/searx/engines/yahoo_news.py
@@ -14,7 +14,6 @@ from datetime import datetime, timedelta
 from dateutil import parser
 from lxml import html
 
-from searx import logger
 from searx.utils import (
     eval_xpath_list,
     eval_xpath_getindex,
@@ -22,8 +21,6 @@ from searx.utils import (
 )
 
 from searx.engines.yahoo import parse_url
-
-logger = logger.getChild('yahoo_news engine')
 
 # about
 about = {


### PR DESCRIPTION
## What does this PR do?

Implements _one logger per engine_ requested in https://github.com/searxng/searxng/issues/98 

## How to test this PR locally?

    make run

Run some queries and have a look at the debug messages..

`!google_videos foo` (python module)

    DEBUG:searx.engines.google videos:HTTP header Accept-Language --> de-DE,de;q=0.8,,en;q=0.6,*;q=0.5

`!brave foo` (XPath engine)

    DEBUG:searx.engines.brave:found 20 results


## Related issues

Rleated: https://github.com/searxng/searxng/issues/98
