### PR TITLE
debug mode: more readable logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ run:  install
 	sleep 2 ; \
 	xdg-open http://127.0.0.1:8888/ ; \
 	) &
-	SEARX_DEBUG=1 ./manage pyenv.cmd python ./searx/webapp.py
+	SEARX_DEBUG=1 ./manage pyenv.cmd python -m searx.webapp
 
 PHONY += install uninstall
 install uninstall:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ linuxdoc==20210324
 aiounittest==1.4.0
 yamllint==1.26.3
 wlc==1.12
+coloredlogs==15.0.1

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -2,12 +2,22 @@
 # lint: pylint
 # pylint: disable=missing-module-docstring
 
+import sys
+import os
 from os.path import dirname, abspath
+
 import logging
 
 import searx.unixthreadname
 import searx.settings_loader
 from searx.settings_defaults import settings_set_defaults
+
+
+# Debug
+LOG_FORMAT_DEBUG = '%(levelname)-7s %(name)-30.30s: %(message)s'
+
+# Production
+LOG_FORMAT_PROD = '%(asctime)-15s %(levelname)s:%(name)s: %(message)s'
 
 searx_dir = abspath(dirname(__file__))
 searx_parent_dir = abspath(dirname(dirname(__file__)))
@@ -15,22 +25,6 @@ settings, settings_load_message = searx.settings_loader.load_settings()
 
 if settings is not None:
     settings = settings_set_defaults(settings)
-
-searx_debug = settings['general']['debug']
-if searx_debug:
-    logging.basicConfig(level=logging.DEBUG)
-else:
-    logging.basicConfig(level=logging.WARNING)
-
-logger = logging.getLogger('searx')
-logger.info(settings_load_message)
-
-# log max_request_timeout
-max_request_timeout = settings['outgoing']['max_request_timeout']
-if max_request_timeout is None:
-    logger.info('max_request_timeout=%s', repr(max_request_timeout))
-else:
-    logger.info('max_request_timeout=%i second(s)', max_request_timeout)
 
 _unset = object()
 
@@ -53,3 +47,61 @@ def get_setting(name, default=_unset):
             break
 
     return value
+
+
+def is_color_terminal():
+    if os.getenv('TERM') in ('dumb', 'unknown'):
+        return False
+    return sys.stdout.isatty()
+
+
+def logging_config_debug():
+    try:
+        import coloredlogs  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        coloredlogs = None
+
+    log_level = os.environ.get('SEARX_DEBUG_LOG_LEVEL', 'DEBUG')
+    if coloredlogs and is_color_terminal():
+        level_styles = {
+            'spam': {'color': 'green', 'faint': True},
+            'debug': {},
+            'notice': {'color': 'magenta'},
+            'success': {'bold': True, 'color': 'green'},
+            'info': {'bold': True, 'color': 'cyan'},
+            'warning': {'color': 'yellow'},
+            'error': {'color': 'red'},
+            'critical': {'bold': True, 'color': 'red'},
+        }
+        field_styles = {
+            'asctime': {'color': 'green'},
+            'hostname': {'color': 'magenta'},
+            'levelname': {'color': 8},
+            'name': {'color': 8},
+            'programname': {'color': 'cyan'},
+            'username': {'color': 'yellow'}
+        }
+        coloredlogs.install(
+            level=log_level,
+            level_styles=level_styles,
+            field_styles=field_styles,
+            fmt=LOG_FORMAT_DEBUG
+        )
+    else:
+        logging.basicConfig(level=logging.getLevelName(log_level), format=LOG_FORMAT_DEBUG)
+
+
+searx_debug = settings['general']['debug']
+if searx_debug:
+    logging_config_debug()
+else:
+    logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT_PROD)
+logger = logging.getLogger('searx')
+logger.info(settings_load_message)
+
+# log max_request_timeout
+max_request_timeout = settings['outgoing']['max_request_timeout']
+if max_request_timeout is None:
+    logger.info('max_request_timeout=%s', repr(max_request_timeout))
+else:
+    logger.info('max_request_timeout=%i second(s)', max_request_timeout)

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -18,6 +18,7 @@ LOG_FORMAT_DEBUG = '%(levelname)-7s %(name)-30.30s: %(message)s'
 
 # Production
 LOG_FORMAT_PROD = '%(asctime)-15s %(levelname)s:%(name)s: %(message)s'
+LOG_LEVEL_PROD = logging.WARNING
 
 searx_dir = abspath(dirname(__file__))
 searx_parent_dir = abspath(dirname(dirname(__file__)))
@@ -95,7 +96,9 @@ searx_debug = settings['general']['debug']
 if searx_debug:
     logging_config_debug()
 else:
-    logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT_PROD)
+    logging.basicConfig(level=LOG_LEVEL_PROD, format=LOG_FORMAT_PROD)
+    logging.root.setLevel(level=LOG_LEVEL_PROD)
+    logging.getLogger('werkzeug').setLevel(level=LOG_LEVEL_PROD)
 logger = logging.getLogger('searx')
 logger.info(settings_load_message)
 

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -173,7 +173,6 @@ def request(query, params):
 
     params['url'] = search_url.format(**fargs)
     params['soft_max_redirects'] = soft_max_redirects
-    logger.debug("query_url --> %s", params['url'])
 
     return params
 

--- a/searx/metrics/error_recorder.py
+++ b/searx/metrics/error_recorder.py
@@ -5,7 +5,8 @@ from urllib.parse import urlparse
 from httpx import HTTPError, HTTPStatusError
 from searx.exceptions import (SearxXPathSyntaxException, SearxEngineXPathException, SearxEngineAPIException,
                               SearxEngineAccessDeniedException)
-from searx import logger, searx_parent_dir
+from searx import searx_parent_dir
+from searx.engines import engines
 
 
 errors_per_engines = {}
@@ -47,7 +48,7 @@ class ErrorContext:
 def add_error_context(engine_name: str, error_context: ErrorContext) -> None:
     errors_for_engine = errors_per_engines.setdefault(engine_name, {})
     errors_for_engine[error_context] = errors_for_engine.get(error_context, 0) + 1
-    logger.debug('%s: %s', engine_name, str(error_context))
+    engines[engine_name].logger.warning('%s', str(error_context))
 
 
 def get_trace(traces):

--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -194,7 +194,7 @@ def new_client(
         # pylint: disable=too-many-arguments
         enable_http, verify, enable_http2,
         max_connections, max_keepalive_connections, keepalive_expiry,
-        proxies, local_address, retries, max_redirects  ):
+        proxies, local_address, retries, max_redirects, hook_log_response  ):
     limit = httpx.Limits(
         max_connections=max_connections,
         max_keepalive_connections=max_keepalive_connections,
@@ -221,7 +221,17 @@ def new_client(
         mounts['http://'] = AsyncHTTPTransportNoHttp()
 
     transport = get_transport(verify, enable_http2, local_address, None, limit, retries)
-    return httpx.AsyncClient(transport=transport, mounts=mounts, max_redirects=max_redirects)
+
+    event_hooks = None
+    if hook_log_response:
+        event_hooks = {'response': [ hook_log_response ]}
+
+    return httpx.AsyncClient(
+        transport=transport,
+        mounts=mounts,
+        max_redirects=max_redirects,
+        event_hooks=event_hooks,
+    )
 
 
 def get_loop():
@@ -231,7 +241,7 @@ def get_loop():
 
 def init():
     # log
-    for logger_name in ('hpack.hpack', 'hpack.table'):
+    for logger_name in ('hpack.hpack', 'hpack.table', 'httpx._client'):
         logging.getLogger(logger_name).setLevel(logging.WARNING)
 
     # loop

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -147,7 +147,7 @@ class Search:
                 if th.is_alive():
                     th._timeout = True
                     self.result_container.add_unresponsive_engine(th._engine_name, 'timeout')
-                    logger.warning('engine timeout: {0}'.format(th._engine_name))
+                    PROCESSORS[th._engine_name].logger.error('engine timeout')
 
     def search_standard(self):
         """

--- a/searx/search/processors/__init__.py
+++ b/searx/search/processors/__init__.py
@@ -65,6 +65,6 @@ def initialize(engine_list):
             processor = get_processor(engine, engine_name)
             initialize_processor(processor)
             if processor is None:
-                logger.error('Error get processor for engine %s', engine_name)
+                engine.logger.error('Error get processor for engine %s', engine_name)
             else:
                 PROCESSORS[engine_name] = processor

--- a/searx/search/processors/offline.py
+++ b/searx/search/processors/offline.py
@@ -5,10 +5,8 @@
 
 """
 
-from searx import logger
 from .abstract import EngineProcessor
 
-logger = logger.getChild('searx.search.processor.offline')
 
 class OfflineProcessor(EngineProcessor):
     """Processor class used by ``offline`` engines"""
@@ -24,7 +22,7 @@ class OfflineProcessor(EngineProcessor):
             self.extend_container(result_container, start_time, search_results)
         except ValueError as e:
             # do not record the error
-            logger.exception('engine {0} : invalid input : {1}'.format(self.engine_name, e))
+            self.logger.exception('engine {0} : invalid input : {1}'.format(self.engine_name, e))
         except Exception as e: # pylint: disable=broad-except
             self.handle_exception(result_container, e)
-            logger.exception('engine {0} : exception : {1}'.format(self.engine_name, e))
+            self.logger.exception('engine {0} : exception : {1}'.format(self.engine_name, e))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ import os
 import aiounittest
 
 os.environ['SEARX_DEBUG'] = '1'
+os.environ['SEARX_DEBUG_LOG_LEVEL'] = 'WARNING'
 os.environ['SEARX_DISABLE_ETC_SETTINGS'] = '1'
 os.environ.pop('SEARX_SETTINGS_PATH', None)
 


### PR DESCRIPTION
## What does this PR do?

* In development add a new dependency: [coloredlogs](https://pypi.org/project/coloredlogs/) (declared in `requirements-dev.txt` but optional in the code, see `searx/__init__.py`)
* Logs about an engine always use the engine logger ( #296 ), include log from `searx.search.processors` and `searx.metrics`.
* HTTP request are logged with the network name: a wikipedia HTTP request is logged with `searx.network.wikipedia` instead of `httpx._client`.

Make the debug log more readable:

![image](https://user-images.githubusercontent.com/1594191/132256887-e7c9333e-4d1a-4839-b9a1-b33052476824.png)

## Why is this change important?

A lot of information are logged in debug mode, which are not easy to read.

But it makes messages more difficult to find in the code:
![image](https://user-images.githubusercontent.com/1594191/132257210-3a37a49f-7512-4607-be09-a786f072f9a6.png)

But a `git grep` is easy:
```
$ git grep "engine time"
searx/search/__init__.py:        # max of all selected engine timeout
searx/search/__init__.py:                    PROCESSORS[th._engine_name].logger.error('engine timeout')
```

## How to test this PR locally?

* `make run`
* production mode:
   * change the secret key
   * start in production mode
* check the log with uwsgi
* check the log with docker

Draft because 
* HTTP redirection are not logged (fixed in https://github.com/encode/httpx/pull/1806 --> we need to upgrade httpx to a new version).
* HTTP timeout doesn't log the URL (it was not the case before ?).
* it may requires some adjustment (or close the PR).

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
