### PR TITLE
[fix] fix openstreetmap engine

### DIFF
--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -439,3 +439,8 @@ def get_key_label(key_name, lang):
         if labels is None:
             return None
     return get_label(labels, lang)
+
+
+def init(_):
+    import searx.engines.wikidata  # pylint: disable=import-outside-toplevel
+    searx.engines.wikidata.logger = logger


### PR DESCRIPTION
## What does this PR do?

This is a workaround: inside engine code, any call to function in another engine can crash
since the logger won't be initialized except if it is done explicitly.

For example:
https://github.com/searxng/searxng/blob/b57d776edb65665cb514d5f8197c6f1960c80412/searx/engines/google_images.py#L26-L30

"Luckily" these functions don't use the `logger`.

## Why is this change important?

Fix OSM engine.
This is a workaround: the initialization of the `logger` should be done in a different way.

## How to test this PR locally?

search for anything using osm engine.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

close #298
