### PR TITLE
[fix] drop useless pylint: disable=undefined-variable

### DIFF
--- a/manage
+++ b/manage
@@ -37,7 +37,7 @@ PYLINT_SEARX_DISABLE_OPTION="\
 I,C,R,\
 W0105,W0212,W0511,W0603,W0613,W0621,W0702,W0703,W1401,\
 E1136"
-PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES="supported_languages,language_aliases,logger"
+PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES="supported_languages,language_aliases,logger,categories"
 PYLINT_OPTIONS="-m pylint -j 0 --rcfile .pylintrc"
 
 help() {

--- a/searx/engines/duckduckgo_definitions.py
+++ b/searx/engines/duckduckgo_definitions.py
@@ -64,7 +64,7 @@ def request(query, params):
     params['url'] = URL.format(query=urlencode({'q': query}))
     language = match_language(
         params['language'],
-        supported_languages,   # pylint: disable=undefined-variable
+        supported_languages,
         language_aliases
     )
     language = language.split('-')[0]

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -277,7 +277,6 @@ def request(query, params):
     offset = (params['pageno'] - 1) * 10
 
     lang_info = get_lang_info(
-        # pylint: disable=undefined-variable
         params, supported_languages, language_aliases, True
     )
 

--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -92,7 +92,6 @@ def request(query, params):
     """Google-Video search request"""
 
     lang_info = get_lang_info(
-        # pylint: disable=undefined-variable
         params, supported_languages, language_aliases, False
     )
     logger.debug(

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -75,7 +75,6 @@ def request(query, params):
     """Google-News search request"""
 
     lang_info = get_lang_info(
-        # pylint: disable=undefined-variable
         params, supported_languages, language_aliases, False
     )
     logger.debug(

--- a/searx/engines/google_scholar.py
+++ b/searx/engines/google_scholar.py
@@ -73,7 +73,6 @@ def request(query, params):
 
     offset = (params['pageno'] - 1) * 10
     lang_info = get_lang_info(
-        # pylint: disable=undefined-variable
         params, supported_languages, language_aliases, False
     )
     logger.debug(

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -110,7 +110,6 @@ def request(query, params):
     """Google-Video search request"""
 
     lang_info = get_lang_info(
-        # pylint: disable=undefined-variable
         params, supported_languages, language_aliases, False
     )
     logger.debug(

--- a/searx/engines/peertube.py
+++ b/searx/engines/peertube.py
@@ -34,7 +34,6 @@ def request(query, params):
     search_url = sanitized_url + "/api/v1/search/videos/?pageno={pageno}&{query}"
     query_dict = {"search": query}
     language = params["language"].split("-")[0]
-    # pylint: disable=undefined-variable
     if "all" != language and language in supported_languages:
         query_dict["languageOneOf"] = language
     params["url"] = search_url.format(

--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -89,7 +89,6 @@ def request(query, params):
     else:
         language = match_language(
             params['language'],
-            # pylint: disable=undefined-variable
             supported_languages,
             language_aliases,
         )

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -184,7 +184,7 @@ def response(resp):
     '''
     results = []
     dom = html.fromstring(resp.text)
-    is_onion = 'onions' in categories  # pylint: disable=undefined-variable
+    is_onion = 'onions' in categories
 
     if results_xpath:
         for result in eval_xpath_list(dom, results_xpath):


### PR DESCRIPTION
## What does this PR do?

Since 7b235a1 (see line 591) it is no longer needed to disable `undefined-variable` for names defined in::

    PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES

Suggested-by: @dalf https://github.com/searxng/searxng/issues/102#issuecomment-914068609

## How to test this PR locally?

    make test.pylint

## Related issues

Closes: https://github.com/searxng/searxng/issues/102