### PR TITLE
[mod] plugin: call on_result for each result of each engines.

### DIFF
--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -26,8 +26,8 @@ Example plugin
    # attach callback to the post search hook
    #  request: flask request object
    #  ctx: the whole local context of the post search hook
-   def post_search(request, ctx):
-       ctx['search'].suggestions.add('example')
+   def post_search(request, search):
+       search.result_container.suggestions.add('example')
        return True
 
 External plugins
@@ -50,20 +50,52 @@ Plugin entry points
 
 Entry points (hooks) define when a plugin runs. Right now only three hooks are
 implemented. So feel free to implement a hook if it fits the behaviour of your
-plugin.
+plugin. A plugin doesn't need to implement all the hooks.
 
-Pre search hook
----------------
 
-Runs BEFORE the search request. Function to implement: ``pre_search``
+.. py:function:: pre_search(request, search) -> bool
 
-Post search hook
-----------------
+   Runs BEFORE the search request.
 
-Runs AFTER the search request. Function to implement: ``post_search``
+   `search.result_container` can be changed.
 
-Result hook
------------
+   Return a boolean:
 
-Runs when a new result is added to the result list. Function to implement:
-``on_result``
+   * True to continue the search
+   * False to stop the search
+
+   :param flask.request request:
+   :param searx.search.SearchWithPlugins search:
+   :return: False to stop the search
+   :rtype: bool
+
+
+.. py:function:: post_search(request, search) -> None
+
+   Runs AFTER the search request.
+
+   :param flask.request request: Flask request.
+   :param searx.search.SearchWithPlugins search: Context.
+
+
+.. py:function:: on_result(request, search, result) -> bool
+
+   Runs for each result of each engine.
+
+   `result` can be changed.
+
+   If `result["url"]` is defined, then `result["parsed_url"] = urlparse(result['url'])`
+
+   .. warning::
+      `result["url"]` can be changed, but `result["parsed_url"]` must be updated too.
+
+   Return a boolean:
+
+   * True to keep the result
+   * False to remove the result
+
+   :param flask.request request:
+   :param searx.search.SearchWithPlugins search:
+   :param typing.Dict result: Result, see - :ref:`engine results`
+   :return: True to keep the result
+   :rtype: bool

--- a/docs/src/searx.search.rst
+++ b/docs/src/searx.search.rst
@@ -1,0 +1,38 @@
+.. _searx.search:
+
+======
+Search
+======
+
+.. autoclass:: searx.search.EngineRef
+  :members:
+
+.. autoclass:: searx.search.SearchQuery
+  :members:
+
+.. autoclass:: searx.search.Search
+
+  .. attribute:: search_query
+    :type: searx.search.SearchQuery
+
+  .. attribute:: result_container
+    :type: searx.results.ResultContainer
+
+  .. automethod:: search() -> searx.results.ResultContainer
+
+.. autoclass:: searx.search.SearchWithPlugins
+  :members:
+
+  .. attribute:: search_query
+    :type: searx.search.SearchQuery
+
+  .. attribute:: result_container
+    :type: searx.results.ResultContainer
+
+  .. attribute:: ordered_plugin_list
+    :type: typing.List
+
+  .. attribute:: request
+    :type: flask.request
+
+  .. automethod:: search() -> searx.results.ResultContainer

--- a/searx/plugins/ahmia_filter.py
+++ b/searx/plugins/ahmia_filter.py
@@ -20,14 +20,8 @@ def get_ahmia_blacklist():
     return ahmia_blacklist
 
 
-def not_blacklisted(result):
+def on_result(request, search, result):
     if not result.get('is_onion') or not result.get('parsed_url'):
         return True
     result_hash = md5(result['parsed_url'].hostname.encode()).hexdigest()
     return result_hash not in get_ahmia_blacklist()
-
-
-def post_search(request, search):
-    filtered_results = list(filter(not_blacklisted, search.result_container._merged_results))
-    search.result_container._merged_results = filtered_results
-    return True

--- a/searx/plugins/oa_doi_rewrite.py
+++ b/searx/plugins/oa_doi_rewrite.py
@@ -11,8 +11,6 @@ description = gettext('Avoid paywalls by redirecting to open-access versions of 
 default_on = False
 preference_section = 'general'
 
-doi_resolvers = settings['doi_resolvers']
-
 
 def extract_doi(url):
     match = regex.search(url.path)
@@ -25,13 +23,12 @@ def extract_doi(url):
     return None
 
 
-def get_doi_resolver(args, preference_doi_resolver):
+def get_doi_resolver(preferences):
     doi_resolvers = settings['doi_resolvers']
-    doi_resolver = args.get('doi_resolver', preference_doi_resolver)[0]
-    if doi_resolver not in doi_resolvers:
-        doi_resolver = settings['default_doi_resolver']
-    doi_resolver_url = doi_resolvers[doi_resolver]
-    return doi_resolver_url
+    selected_resolver = preferences.get_value('doi_resolver')[0]
+    if selected_resolver not in doi_resolvers:
+        selected_resolver = settings['default_doi_resolver']
+    return doi_resolvers[selected_resolver]
 
 
 def on_result(request, search, result):
@@ -43,6 +40,6 @@ def on_result(request, search, result):
         for suffix in ('/', '.pdf', '.xml', '/full', '/meta', '/abstract'):
             if doi.endswith(suffix):
                 doi = doi[:-len(suffix)]
-        result['url'] = get_doi_resolver(request.args, request.preferences.get_value('doi_resolver')) + doi
+        result['url'] = get_doi_resolver(request.preferences) + doi
         result['parsed_url'] = urlparse(result['url'])
     return True

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # lint: pylint
-# pylint: disable=missing-module-docstring
+# pylint: disable=missing-module-docstring, too-few-public-methods
 
 import typing
 import threading
@@ -179,7 +179,18 @@ class SearchWithPlugins(Search):
     def __init__(self, search_query, ordered_plugin_list, request):
         super().__init__(search_query)
         self.ordered_plugin_list = ordered_plugin_list
-        self.request = request
+        self.result_container.on_result = self._on_result
+        # pylint: disable=line-too-long
+        # get the "real" request to use it outside the Flask context.
+        # see
+        # * https://github.com/pallets/flask/blob/d01d26e5210e3ee4cbbdef12f05c886e08e92852/src/flask/globals.py#L55
+        # * https://github.com/pallets/werkzeug/blob/3c5d3c9bd0d9ce64590f0af8997a38f3823b368d/src/werkzeug/local.py#L548-L559
+        # * https://werkzeug.palletsprojects.com/en/2.0.x/local/#werkzeug.local.LocalProxy._get_current_object
+        # pylint: enable=line-too-long
+        self.request = request._get_current_object()
+
+    def _on_result(self, result):
+        return plugins.call(self.ordered_plugin_list, 'on_result', self.request, self, result)
 
     def search(self):
         if plugins.call(self.ordered_plugin_list, 'pre_search', self.request, self):
@@ -187,9 +198,6 @@ class SearchWithPlugins(Search):
 
         plugins.call(self.ordered_plugin_list, 'post_search', self.request, self)
 
-        results = self.result_container.get_ordered_results()
-
-        for result in results:
-            plugins.call(self.ordered_plugin_list, 'on_result', self.request, self, result)
+        self.result_container.close()
 
         return self.result_container

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -39,7 +39,7 @@ class Search:
 
     __slots__ = "search_query", "result_container", "start_time", "actual_timeout"
 
-    def __init__(self, search_query):
+    def __init__(self, search_query: SearchQuery):
         # init vars
         super().__init__()
         self.search_query = search_query
@@ -163,7 +163,7 @@ class Search:
         return True
 
     # do search-request
-    def search(self):
+    def search(self) -> ResultContainer:
         self.start_time = default_timer()
         if not self.search_external_bang():
             if not self.search_answerers():
@@ -172,11 +172,11 @@ class Search:
 
 
 class SearchWithPlugins(Search):
-    """Similar to the Search class but call the plugins."""
+    """Inherit from the Search class, add calls to the plugins."""
 
     __slots__ = 'ordered_plugin_list', 'request'
 
-    def __init__(self, search_query, ordered_plugin_list, request):
+    def __init__(self, search_query: SearchQuery, ordered_plugin_list, request: "flask.Request"):
         super().__init__(search_query)
         self.ordered_plugin_list = ordered_plugin_list
         self.result_container.on_result = self._on_result
@@ -192,7 +192,7 @@ class SearchWithPlugins(Search):
     def _on_result(self, result):
         return plugins.call(self.ordered_plugin_list, 'on_result', self.request, self, result)
 
-    def search(self):
+    def search(self) -> ResultContainer:
         if plugins.call(self.ordered_plugin_list, 'pre_search', self.request, self):
             super().search()
 

--- a/searx/search/models.py
+++ b/searx/search/models.py
@@ -4,6 +4,7 @@ import typing
 
 
 class EngineRef:
+    """Reference by names to an engine and category"""
 
     __slots__ = 'name', 'category'
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1040,9 +1040,7 @@ def preferences():
         themes = themes,
         plugins = plugins,
         doi_resolvers = settings['doi_resolvers'],
-        current_doi_resolver = get_doi_resolver(
-            request.args, request.preferences.get_value('doi_resolver')
-        ),
+        current_doi_resolver = get_doi_resolver(request.preferences),
         allowed_plugins = allowed_plugins,
         theme = get_current_theme_name(),
         preferences_url_params = request.preferences.get_as_url_params(),


### PR DESCRIPTION
## What does this PR do?

Currently, searx.search.Search calls on_result once the engine results have been merged
(ResultContainer.order_results).

on_result plugins can rewrite the results: once the URL(s) are modified, even they can be merged,
it won't be the case since ResultContainer.order_results has already be called.

This commit call on_result for each result of each engines.
In addition the on_result function can return False to remove the result.

Note: the on_result function now run on the engine thread instead of the Flask thread.

## Why is this change important?

With an implementation of https://github.com/searxng/searxng/issues/284 some identical results won't be merged.
It is already the case in the science category when the "Open Access DOI rewrite" plugin is enabled.

---

Alternative to filter out some result:
https://github.com/searxng/searxng/blob/a3789b3bb44fd929a730518da678b7754a2c18cb/searx/plugins/ahmia_filter.py#L23-L33

With this PR: https://github.com/dalf/searxng/blob/2b96ace61118d0a94eb74f6d078728a0c73276de/searx/plugins/ahmia_filter.py : 
```python
def on_result(request, search, result):
    if not result.get('is_onion') or not result.get('parsed_url'):
        return True
    result_hash = md5(result['parsed_url'].hostname.encode()).hexdigest()
    return result_hash not in get_ahmia_blacklist()
```

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
