### PR TITLE
[fix] logger per engine: make .logger is always initialized

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -110,8 +110,24 @@ def load_engine(engine_data):
     if is_missing_required_attributes(engine):
         return None
 
-    engine.logger = logger.getChild(engine_name)
+    set_loggers(engine, engine_name)
+
     return engine
+
+
+def set_loggers(engine, engine_name):
+    # set the logger for engine
+    engine.logger = logger.getChild(engine_name)
+    # the engine may have load some other engines
+    # may sure the logger is initialized
+    for module_name, module in sys.modules.items():
+        if (
+            module_name.startswith("searx.engines")
+            and module_name != "searx.engines.__init__"
+            and not hasattr(module, "logger")
+        ):
+            module_engine_name = module_name.split(".")[-1]
+            module.logger = logger.getChild(module_engine_name)
 
 
 def update_engine_attributes(engine, engine_data):

--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -438,8 +438,3 @@ def get_key_label(key_name, lang):
         if labels is None:
             return None
     return get_label(labels, lang)
-
-
-def init(_):
-    import searx.engines.wikidata  # pylint: disable=import-outside-toplevel
-    searx.engines.wikidata.logger = logger


### PR DESCRIPTION
## What does this PR do?
the openstreetmap engine imports code from the wikidata engine.
before this commit, specific code make sure to copy the logger variable to the wikidata engine.

with this commit `searx.engines.load_engine` makes sure the `logger` is initialized.
The implementation scans `sys.modules` for module name starting with `searx.engines`.

## Why is this change important?

Without this PR, `import searx.engines.an_engine` may not work:
* `searx.engines.an_engine.logger` won't be initialized
* as soon as code in `searx.engines.an_engine` makes a reference to `searx.engines.an_engine.logger` the engine crash.

With this PR, `searx.engines.load_engine` makes sure the .logger is initialized.

See the result of `git grep "from searx.engines"`

---

About this line
https://github.com/searxng/searxng/blob/1973e4ecf691f173299fb11abc61750009bdef84/searx/engines/__init__.py#L95

For example the azlyrics engine, loads the `xpath` module.
The name in `sys.module` is `xpath` without the prefix `searx.engines`.

So, this line
https://github.com/searxng/searxng/blob/1973e4ecf691f173299fb11abc61750009bdef84/searx/engines/ebay.py#L7
imports a new copy of the `xpath` module.

That's why even if the logger for the wikidata engine is initialized (`engine.logger = ...`), when the OSM engine imports code from the wikidata engine, the logger is not initialized without special care.

## How to test this PR locally?

* `!osm somewhere`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
