### PR TITLE
[enh] add hostname_replace plugin

### DIFF
--- a/docs/dev/search_api.rst
+++ b/docs/dev/search_api.rst
@@ -100,17 +100,17 @@ Parameters
   :default: ``HTTPS_rewrite``, ``Self_Informations``,
     ``Search_on_category_select``, ``Tracker_URL_remover``
 
-  :values: [ ``DOAI_rewrite``, ``HTTPS_rewrite``, ``Infinite_scroll``,
+  :values: ``DOAI_rewrite``, ``HTTPS_rewrite``, ``Infinite_scroll``,
     ``Vim-like_hotkeys``, ``Self_Informations``, ``Tracker_URL_remover``,
-    ``Search_on_category_select`` ]
+    ``Search_on_category_select``, ``Hostname_replace``
 
 ``disabled_plugins``: optional
   List of disabled plugins.
 
-  :default: ``DOAI_rewrite``, ``Infinite_scroll``, ``Vim-like_hotkeys``
+  :default: ``DOAI_rewrite``, ``Infinite_scroll``, ``Vim-like_hotkeys``, ``Hostname_replace``
   :values: ``DOAI_rewrite``, ``HTTPS_rewrite``, ``Infinite_scroll``,
     ``Vim-like_hotkeys``, ``Self_Informations``, ``Tracker_URL_remover``,
-    ``Search_on_category_select``
+    ``Search_on_category_select``, ``Hostname_replace``
 
 ``enabled_engines`` : optional : *all* :origin:`engines <searx/engines>`
   List of enabled engines.

--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -31,6 +31,7 @@ from searx.plugins import (oa_doi_rewrite,
                            hash_plugin,
                            infinite_scroll,
                            self_info,
+                           hostname_replace,
                            search_on_category_select,
                            tracker_url_remover,
                            vim_hotkeys)
@@ -182,6 +183,7 @@ plugins.register(oa_doi_rewrite)
 plugins.register(hash_plugin)
 plugins.register(infinite_scroll)
 plugins.register(self_info)
+plugins.register(hostname_replace)
 plugins.register(search_on_category_select)
 plugins.register(tracker_url_remover)
 plugins.register(vim_hotkeys)

--- a/searx/plugins/hostname_replace.py
+++ b/searx/plugins/hostname_replace.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import re
+from urllib.parse import urlunparse
+from searx import settings
+from searx.plugins import logger
+from flask_babel import gettext
+
+name = gettext('Hostname replace')
+description = gettext('Rewrite result hostnames or remove results based on the hostname')
+default_on = False
+preference_section = 'general'
+
+plugin_id = 'hostname_replace'
+
+replacements = {re.compile(p): r for (p, r) in settings[plugin_id].items()} if plugin_id in settings else {}
+
+logger = logger.getChild(plugin_id)
+parsed = 'parsed_url'
+
+
+def on_result(request, search, result):
+    if parsed not in result:
+        return True
+    for (pattern, replacement) in replacements.items():
+        if pattern.search(result[parsed].netloc):
+            if not replacement:
+                return False
+            result[parsed] = result[parsed]._replace(netloc=pattern.sub(replacement, result[parsed].netloc))
+            result['url'] = urlunparse(result[parsed])
+
+    return True

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -150,7 +150,17 @@ outgoing:
 #
 # enabled_plugins:
 #   - "HTTPS rewrite"
-#   - ...
+#   - "Hostname replace"  # see configuration below
+
+# "Hostname replace" plugin configuration example:
+# hostname_replace:
+#   '(.*\.)?youtube\.com$':           'invidious.example.com'
+#   '(.*\.)?youtu\.be$':              'invidious.example.com'
+#   '(.*\.)?youtube-noocookie\.com$': 'yotter.example.com'
+#   '(.*\.)?reddit\.com$':            'teddit.example.com'
+#   '(.*\.)?redd\.it$':               'teddit.example.com'
+#   '(www\.)?twitter\.com$':          'nitter.example.com'
+#   'spam\.example\.com':             false  # remove results from spam.example.com
 
 checker:
   # disable checker when in debug mode


### PR DESCRIPTION
## What does this PR do?

* backport of https://github.com/searx/searx/pull/2724
* allow to remove result if the replacement is the boolean value false

## Why is this change important?

Same as the original PR: Useful for redirecting sites to alternative frontends.

## How to test this PR locally?

Add this section to settings.yml
```
enabled_plugins:
  - 'Hostname replace'
hostname_replace:
  '(.*\.)?youtube\.com$':           'invidious.example.com'
  '(.*\.)?youtu\.be$':              'invidious.example.com'
  '(.*\.)?youtube-noocookie\.com$': 'yotter.example.com'
  '(.*\.)?reddit\.com$':            'teddit.example.com'
  '(.*\.)?redd\.it$':               'teddit.example.com'
  '(www\.)?twitter\.com$':          'nitter.example.com'
  'www\.libhunt\.com':              false  # www.libhunt.com
```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* Close #284
* Related to #304
