### PR TITLE
[ci] add Python 3.10.0-rc.2

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version:  ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2"]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
## What does this PR do?

See https://www.python.org/dev/peps/pep-0619/

* 3.10.0 candidate 2: Monday, 2021-09-06 (if necessary)
* 3.10.0 final: Monday, 2021-10-04

## Why is this change important?

Make sure searxng is compatible with the last version of Python.

## How to test this PR locally?

N/A

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
