### PR TITLE
[fix] searx/results.py: strip result['content'] only if it exists

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -255,7 +255,8 @@ class ResultContainer:
             result['url'] = result['parsed_url'].geturl()
 
         # strip multiple spaces and cariage returns from content
-        result['content'] = WHITESPACE_REGEX.sub(' ', result['content'])
+        if result.get('content'):
+            result['content'] = WHITESPACE_REGEX.sub(' ', result['content'])
 
         return True
 


### PR DESCRIPTION
## What does this PR do?

fix PR #302

## Why is this change important?

otherwise an exception is raised, and the results of the engine are ignored.

code before PR #302 
https://github.com/searxng/searxng/blob/ec834935381e5cfb4ebc3820ed2f668d0fc7855d/searx/results.py#L239-L241

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
