### PR TITLE
Engine stats link

### DIFF
--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -85,6 +85,7 @@
                     {{ _('Powered by') }} <a href="{{ get_setting('brand.docs_url') }}">SearXNG</a> - {{ searx_version }} - {{ _('a privacy-respecting, hackable metasearch engine') }}<br/>
                     <a href="{{ searx_git_url }}">{{ _('Source code') }}</a> |
                     <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a> |
+                    <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a> |
                     <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>{% if get_setting('general.contact_url') %} |
                     <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact instance maintainer') }}</a>{% endif %}
                 </small>

--- a/searx/templates/oscar/stats.html
+++ b/searx/templates/oscar/stats.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 <div class="container-fluid">
-    <h1>{{ _('Engine stats') }}{% if selected_engine_name %} - {{ selected_engine_name }}{% endif %}</h1>
+    <h1>{% if selected_engine_name %}<a href="{{ url_for('stats') }}">{% endif %}{{ _('Engine stats') }}{% if selected_engine_name %}</a> - {{ selected_engine_name }}{% endif %}</h1>
     <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-12">
             <div class="table-responsive">

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -53,6 +53,7 @@
     {{ _('Powered by') }} <a href="{{ url_for('about') }}">searxng</a> - {{ searx_version }} — {{ _('a privacy-respecting, hackable metasearch engine') }}<br/>
         <a href="{{ searx_git_url }}">{{ _('Source code') }}</a> |
         <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a> |
+        <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a> |
         <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>{% if get_setting('general.contact_url') %} |
         <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact instance maintainer') }}</a>{% endif %}
     </p>

--- a/searx/templates/simple/stats.html
+++ b/searx/templates/simple/stats.html
@@ -18,7 +18,7 @@
 
 <a href="{{ url_for('index') }}"><h1><span>searx</span></h1></a>
 
-<h2>{{ _('Engine stats') }}{% if selected_engine_name %} - {{ selected_engine_name }}{% endif %}</h2>
+<h2>{% if selected_engine_name %}<a href="{{ url_for('stats') }}">{% endif %}{{ _('Engine stats') }}{% if selected_engine_name %}</a> - {{ selected_engine_name }}{% endif %}</h2>
 
 {% if not engine_stats.get('time') %}
 {{ _('There is currently no data available. ') }}


### PR DESCRIPTION
## What does this PR do?

This PR adds a new Engine stats link to the footer and makes the engine stats headline clickable (when viewing stats by one specific engine).

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this PR important?

This makes makes it easier for people to find the stats page (which can right now only be accessed by knowing the /stats path or when an engine had an error through the info boxes; and even then it does not show the full stats page).

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

```make run```

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
