### PR TITLE
[fix] manage help(): commands babel.* has been renamed to weblate.*

### DIFF
--- a/manage
+++ b/manage
@@ -44,9 +44,9 @@ help() {
     cat <<EOF
 buildenv:
   rebuild ./utils/brand.env
-babel.:
-  master.to.translations: update the translations branch from the messages of the master branch.
-  translations.to.master: copy change from the translations branch to the master branch.
+weblate.:
+  push.translations: push translation changes from SearXNG to Weblate's counterpart
+  to.translations: Update 'translations' branch with last additions from Weblate.
 data.:
   all       : update searx/languages.py and ./data/*
   languages : update searx/data/engines_languages.json & searx/languages.py


### PR DESCRIPTION
## What does this PR do?

Fix manage help(). In commit 97355672c the functions named babel.* has been renamed to weblate.*
but it was forgotten to change it also in the help().

## How to test this PR locally?

    ./mange --help
