### PR TITLE
[brand] docs - normalize project name to SearXNG

### DIFF
--- a/docs/admin/api.rst
+++ b/docs/admin/api.rst
@@ -83,7 +83,7 @@ Embed search bar
 ================
 
 The search bar can be embedded into websites.  Just paste the example into the
-HTML of the site.  URL of the searx instance and values are customizable.
+HTML of the site.  URL of the SearXNG instance and values are customizable.
 
 .. code:: html
 

--- a/docs/admin/architecture.rst
+++ b/docs/admin/architecture.rst
@@ -14,10 +14,10 @@ Architecture
    - Searx: :ref:`installation basic`
 
 Herein you will find some hints and suggestions about typical architectures of
-searx infrastructures.
+SearXNG infrastructures.
 
 We start with a contribution from :pull-searx:`@dalf <1776#issuecomment-567917320>`.
-It shows a *reference* setup for public searx instances which can build up and
+It shows a *reference* setup for public SearXNG instances which can build up and
 maintained by the scripts from our :ref:`toolboxing`.
 
 .. _arch public:
@@ -25,4 +25,4 @@ maintained by the scripts from our :ref:`toolboxing`.
 .. kernel-figure:: arch_public.dot
    :alt: arch_public.dot
 
-   Reference architecture of a public searx setup.
+   Reference architecture of a public SearXNG setup.

--- a/docs/admin/engines/nosql-engines.rst
+++ b/docs/admin/engines/nosql-engines.rst
@@ -42,7 +42,7 @@ Extra Dependencies
 ------------------
 
 For using :ref:`engine redis_server` or :ref:`engine mongodb` you need to
-install additional packages in Python's Virtual Environment of your SearxNG
+install additional packages in Python's Virtual Environment of your SearXNG
 instance.  To switch into the environment (:ref:`searx-src`) you can use
 :ref:`searx.sh`::
 

--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -27,7 +27,7 @@ The initial ``settings.yml`` we be load from these locations:
 1. the full path specified in the ``SEARX_SETTINGS_PATH`` environment variable.
 2. ``/etc/searx/settings.yml``
 
-If these files don't exist (or are empty or can't be read), searx uses the
+If these files don't exist (or are empty or can't be read), SearXNG uses the
 :origin:`searx/settings.yml` file.  Read :ref:`settings use_default_settings` to
 see how you can simplify your *user defined* ``settings.yml``.
 
@@ -71,11 +71,11 @@ Global Settings
 
    general:
      debug: false               # Debug mode, only for development
-     instance_name:  "searxng"  # displayed name
+     instance_name:  "SearXNG"  # displayed name
      contact_url: false         # mailto:contact@example.com
 
 ``debug`` : ``$SEARX_DEBUG``
-  Allow a more detailed log if you run searx directly. Display *detailed* error
+  Allow a more detailed log if you run SearXNG directly. Display *detailed* error
   messages in the browser too, so this must be deactivated in production.
 
 ``contact_url``:
@@ -110,29 +110,29 @@ Global Settings
    rebuild instance's environment :ref:`utils/brand.env <make buildenv>`.
 
 ``base_url`` : :ref:`buildenv SEARX_URL <make buildenv>`
-  The base URL where searx is deployed.  Used to create correct inbound links.
+  The base URL where SearXNG is deployed.  Used to create correct inbound links.
   If you change the value, don't forget to rebuild instance's environment
   (:ref:`utils/brand.env <make buildenv>`)
 
 ``port`` & ``bind_address``: :ref:`buildenv SEARX_PORT & SEARX_BIND_ADDRESS <make buildenv>`
-  Port number and *bind address* of the searx web application if you run it
-  directly using ``python searx/webapp.py``.  Doesn't apply to searx running on
+  Port number and *bind address* of the SearXNG web application if you run it
+  directly using ``python searx/webapp.py``.  Doesn't apply to SearXNG running on
   Apache or Nginx.
 
 ``secret_key`` : ``$SEARX_SECRET``
   Used for cryptography purpose.
 
 ``image_proxy`` :
-  Allow your instance of searx of being able to proxy images.  Uses memory space.
+  Allow your instance of SearXNG of being able to proxy images.  Uses memory space.
 
 ``default_locale`` :
-  Searx interface language.  If blank, the locale is detected by using the
+  SearXNG interface language.  If blank, the locale is detected by using the
   browser language.  If it doesn't work, or you are deploying a language
   specific instance of searx, a locale can be defined using an ISO language
   code, like ``fr``, ``en``, ``de``.
 
 ``default_theme`` :
-  Name of the theme you want to use by default on your searx instance.
+  Name of the theme you want to use by default on your SearXNG instance.
 
 .. _HTTP headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
 
@@ -171,11 +171,11 @@ Communication with search engines.
 ``request_timeout`` :
   Global timeout of the requests made to others engines in seconds.  A bigger
   timeout will allow to wait for answers from slow engines, but in consequence
-  will slow searx reactivity (the result page may take the time specified in the
+  will slow SearXNG reactivity (the result page may take the time specified in the
   timeout to load). Can be override by :ref:`settings engine`
 
 ``useragent_suffix`` :
-  Suffix to the user-agent searx uses to send requests to others engines.  If an
+  Suffix to the user-agent SearXNG uses to send requests to others engines.  If an
   engine wish to block you, a contact info here may be useful to avoid that.
 
 ``keepalive_expiry``:
@@ -201,7 +201,7 @@ Communication with search engines.
   * ``[ 192.168.0.1, fe80::/126 ]``
 
 ``retries`` :
-  Number of retry in case of an HTTP error.  On each retry, searx uses an
+  Number of retry in case of an HTTP error.  On each retry, SearXNG uses an
   different proxy and source ip.
 
 ``retry_on_http_error`` :
@@ -271,7 +271,7 @@ engine is shown.  Most of the options have a default value or even are optional.
          - socks5h://user:password@proxy4:1080
 
 ``name`` :
-  Name that will be used across searx to define this engine.  In settings, on
+  Name that will be used across SearXNG to define this engine.  In settings, on
   the result page...
 
 ``engine`` :
@@ -361,7 +361,7 @@ and can relied on the default configuration :origin:`searx/settings.yml` using:
 ``engines:``
   With ``use_default_settings: true``, each settings can be override in a
   similar way, the ``engines`` section is merged according to the engine
-  ``name``.  In this example, searx will load all the engine and the arch linux
+  ``name``.  In this example, SearXNG will load all the engine and the arch linux
   wiki engine has a :ref:`token <private engines>`:
 
   .. code-block:: yaml
@@ -375,7 +375,7 @@ and can relied on the default configuration :origin:`searx/settings.yml` using:
 
 ``engines:`` / ``remove:``
   It is possible to remove some engines from the default settings. The following
-  example is similar to the above one, but searx doesn't load the the google
+  example is similar to the above one, but SearXNG doesn't load the the google
   engine:
 
   .. code-block:: yaml
@@ -392,7 +392,7 @@ and can relied on the default configuration :origin:`searx/settings.yml` using:
 
 ``engines:`` / ``keep_only:``
   As an alternative, it is possible to specify the engines to keep. In the
-  following example, searx has only two engines:
+  following example, SearXNG has only two engines:
 
   .. code-block:: yaml
 

--- a/docs/admin/engines/sql-engines.rst
+++ b/docs/admin/engines/sql-engines.rst
@@ -10,7 +10,7 @@ SQL Engines
    - `PostgreSQL <https://www.postgresql.org>`_
    - `MySQL <https://www.mysql.com>`_
 
-With the *SQL engines* you can bind SQL databases into SearxNG.  The following
+With the *SQL engines* you can bind SQL databases into SearXNG.  The following
 Relational Database Management System (RDBMS) are supported:
 
 - :ref:`engine sqlite`
@@ -98,7 +98,7 @@ Extra Dependencies
 ------------------
 
 For using :ref:`engine postgresql` or :ref:`engine mysql_server` you need to
-install additional packages in Python's Virtual Environment of your SearxNG
+install additional packages in Python's Virtual Environment of your SearXNG
 instance.  To switch into the environment (:ref:`searx-src`) you can use
 :ref:`searx.sh`::
 

--- a/docs/admin/filtron.rst
+++ b/docs/admin/filtron.rst
@@ -18,7 +18,7 @@ How to protect an instance
 
 .. _filtron: https://github.com/asciimoo/filtron
 
-Searx depends on external search services.  To avoid the abuse of these services
+SearXNG depends on external search services.  To avoid the abuse of these services
 it is advised to limit the number of requests processed by searx.
 
 An application firewall, filtron_ solves exactly this problem.  Filtron is just
@@ -187,5 +187,5 @@ Use it along with ``nginx`` with the following example configuration.
 
 
 Requests are coming from port 4004 going through filtron and then forwarded to
-port 8888 where a searx is being run. For a complete setup see: :ref:`nginx
+port 8888 where a SearXNG is being run. For a complete setup see: :ref:`nginx
 searx site`.

--- a/docs/admin/installation-apache.rst
+++ b/docs/admin/installation-apache.rst
@@ -170,13 +170,13 @@ Apache Reverse Proxy
 
 .. sidebar:: public to the internet?
 
-   If your searx instance is public, stop here and first install :ref:`filtron
+   If your SearXNG instance is public, stop here and first install :ref:`filtron
    reverse proxy <filtron.sh>` and :ref:`result proxy morty <morty.sh>`, see
-   :ref:`installation scripts`.  If already done, follow setup: *searx via
+   :ref:`installation scripts`.  If already done, follow setup: *SearXNG via
    filtron plus morty*.
 
 To setup a Apache revers proxy you have to enable the *headers* and *proxy*
-modules and create a `Location`_ configuration for the searx site.  In most
+modules and create a `Location`_ configuration for the SearXNG site.  In most
 distributions you have to un-comment the lines in the main configuration file,
 except in :ref:`The Debian Layout`.
 
@@ -234,7 +234,7 @@ proxied host.
 
 .. tabs::
 
-   .. group-tab:: searx via filtron plus morty
+   .. group-tab:: SearXNG via filtron plus morty
 
       Use this setup, if your instance is public to the internet, compare
       figure: :ref:`architecture <arch public>` and :ref:`installation scripts`.

--- a/docs/admin/installation-docker.rst
+++ b/docs/admin/installation-docker.rst
@@ -98,7 +98,7 @@ stoped.  To get rid of a container use ``container rm``:
 
 .. sidebar:: Warning
 
-   This might remove all docker items, not only those from searxng.
+   This might remove all docker items, not only those from SearXNG.
 
 If you won't use docker anymore and want to get rid of all conatiners & images
 use the following *prune* command:

--- a/docs/admin/installation-nginx.rst
+++ b/docs/admin/installation-nginx.rst
@@ -128,17 +128,17 @@ depends on the linux distribution:
 
 .. _nginx searx site:
 
-A nginx searx site
-==================
+A nginx SearXNG site
+====================
 
 .. sidebar:: public to the internet?
 
-   If your searx instance is public, stop here and first install :ref:`filtron
+   If your SearXNG instance is public, stop here and first install :ref:`filtron
    reverse proxy <filtron.sh>` and :ref:`result proxy morty <morty.sh>`, see
-   :ref:`installation scripts`.  If already done, follow setup: *searx via
+   :ref:`installation scripts`.  If already done, follow setup: *SearXNG via
    filtron plus morty*.
 
-Now you have to create a configuration for the searx site.  If nginx_ is new to
+Now you have to create a configuration for the SearXNG site.  If nginx_ is new to
 you, the `nginx beginners guide`_ is a good starting point and the `Getting
 Started wiki`_ is always a good resource *to keep in the pocket*.
 
@@ -167,7 +167,7 @@ Started wiki`_ is always a good resource *to keep in the pocket*.
 
 .. tabs::
 
-   .. group-tab:: searx via filtron plus morty
+   .. group-tab:: SearXNG via filtron plus morty
 
       Use this setup, if your instance is public to the internet, compare
       figure: :ref:`architecture <arch public>` and :ref:`installation scripts`.
@@ -292,7 +292,7 @@ Started wiki`_ is always a good resource *to keep in the pocket*.
 
       Be warned, with these setups, your instance isn't :ref:`protected <searx
       filtron>`.  The examples are just here to demonstrate how to export the
-      searx application from a subdirectory URL ``https://example.org/searx/``.
+      SearXNG application from a subdirectory URL ``https://example.org/searx/``.
 
       .. code:: nginx
 
@@ -313,7 +313,7 @@ Started wiki`_ is always a good resource *to keep in the pocket*.
              alias /usr/local/searx/searx-src/searx/static/;
          }
 
-      The ``X-Script-Name /searx`` is needed by the searx implementation to
+      The ``X-Script-Name /searx`` is needed by the SearXNG implementation to
       calculate relative URLs correct.  The next example shows a uWSGI
       configuration.  Since there are no HTTP headers in a (u)WSGI protocol, the
       value is shipped via the SCRIPT_NAME_ in the WSGI environment.
@@ -332,7 +332,7 @@ Started wiki`_ is always a good resource *to keep in the pocket*.
              alias /usr/local/searx/searx-src/searx/;
          }
 
-      For searx to work correctly the ``base_url`` must be set in the
+      For SearXNG to work correctly the ``base_url`` must be set in the
       :origin:`searx/settings.yml`.
 
       .. code:: yaml

--- a/docs/admin/installation-searx.rst
+++ b/docs/admin/installation-searx.rst
@@ -36,8 +36,8 @@ Create user
 
 .. _searx-src:
 
-install searx & dependencies
-============================
+Install SearXNG & dependencies
+==============================
 
 Start a interactive shell from new created user and clone searx:
 
@@ -51,7 +51,7 @@ In the same shell create *virtualenv*:
    :start-after: START create virtualenv
    :end-before: END create virtualenv
 
-To install searx's dependencies, exit the searx *bash* session you opened above
+To install searx's dependencies, exit the SearXNG *bash* session you opened above
 and restart a new.  Before install, first check if your *virtualenv* was sourced
 from the login (*~/.profile*):
 
@@ -106,8 +106,8 @@ For a *minimal setup*, configure like shown below – replace ``searx@$(uname
 Check
 =====
 
-To check your searx setup, optional enable debugging and start the *webapp*.
-Searx looks at the exported environment ``$SEARX_SETTINGS_PATH`` for a
+To check your SearXNG setup, optional enable debugging and start the *webapp*.
+SearXNG looks at the exported environment ``$SEARX_SETTINGS_PATH`` for a
 configuration file.
 
 .. kernel-include:: $DOCS_BUILD/includes/searx.rst
@@ -115,6 +115,6 @@ configuration file.
    :end-before: END check searx installation
 
 If everything works fine, hit ``[CTRL-C]`` to stop the *webapp* and disable the
-debug option in ``settings.yml``. You can now exit searx user bash (enter exit
-command twice).  At this point searx is not demonized; uwsgi allows this.
+debug option in ``settings.yml``. You can now exit SearXNG user bash (enter exit
+command twice).  At this point SearXNG is not demonized; uwsgi allows this.
 

--- a/docs/admin/installation-uwsgi.rst
+++ b/docs/admin/installation-uwsgi.rst
@@ -40,7 +40,7 @@ recommend two methods
     unit template    -->  /usr/lib/systemd/system/uwsgi@.service
     uwsgi ini files  -->  /etc/uwsgi/searx.ini
 
-  The searx app can be maintained as know from common systemd units::
+  The SearXNG app can be maintained as know from common systemd units::
 
     systemctl enable  uwsgi@searx
     systemctl start   uwsgi@searx
@@ -57,7 +57,7 @@ The `uWSGI Emperor`_ mode which fits for maintaining a large range of uwsgi apps
   instance is started, reload or stopped.  Take Fedora and a searx.ini as
   example::
 
-    to start a new searx instance create   --> /etc/uwsgi.d/searx.ini
+    to start a new SearXNG instance create --> /etc/uwsgi.d/searx.ini
     to reload the instance edit timestamp  --> touch /etc/uwsgi.d/searx.ini
     to stop instance remove ini            --> rm /etc/uwsgi.d/searx.ini
 

--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -11,7 +11,7 @@ Installation
 - :ref:`installation basic`
 
 The :ref:`installation basic` is good enough for intranet usage and it is a
-excellent illustration of *how a searx instance is build up*.  If you place your
+excellent illustration of *how a SearXNG instance is build up*.  If you place your
 instance public to the internet you should really consider to install a
 :ref:`filtron reverse proxy <filtron.sh>` and for privacy a :ref:`result proxy
 <morty.sh>` is mandatory.
@@ -51,9 +51,9 @@ the case if you clone into a folder below ``/root``.
    - :ref:`update searx`
    - :ref:`inspect searx`
 
-**Install** :ref:`searx service <searx.sh>`
+**Install** :ref:`SearXNG service <searx.sh>`
 
-This installs searx as described in :ref:`installation basic`.
+This installs SearXNG as described in :ref:`installation basic`.
 
 .. code:: bash
 
@@ -80,8 +80,8 @@ If all services are running fine, you can add it to your HTTP server:
 
 **Install** :ref:`external plugins <dev plugin>`
 
-Use searx's ``shell`` to install external plugins.  In the example below we
-install the searx plugins from **The Green Web Foundation** `[ref]
+Use SearXNG's ``shell`` to install external plugins.  In the example below we
+install the SearXNG plugins from **The Green Web Foundation** `[ref]
 <https://www.thegreenwebfoundation.org/news/searching-the-green-web-with-searx/>`__:
 
 .. code:: bash

--- a/docs/admin/morty.rst
+++ b/docs/admin/morty.rst
@@ -12,7 +12,7 @@ How to setup result proxy
 .. _morty: https://github.com/asciimoo/morty
 .. _morty's README: https://github.com/asciimoo/morty
 
-By default searx can only act as an image proxy for result images, but it is
+By default SearXNG can only act as an image proxy for result images, but it is
 possible to proxify all the result URLs with an external service, morty_.
 
 To use this feature, morty has to be installed and activated in searx's
@@ -29,7 +29,7 @@ Note that the example above (``http://127.0.0.1:3000``) is only for single-user
 instances without a HTTP proxy.  If your morty service is public, the url is the
 address of the reverse proxy (e.g ``https://example.org/morty``).
 
-For more information about *result proxy* have a look at *"searx via filtron
+For more information about *result proxy* have a look at *"SearXNG via filtron
 plus morty"* in the :ref:`nginx <nginx searx via filtron plus morty>` and
 :ref:`apache <apache searx via filtron plus morty>` sections.
 

--- a/docs/admin/update-searx.rst
+++ b/docs/admin/update-searx.rst
@@ -7,7 +7,7 @@ How to update
 How to update depends on the :ref:`installation` method.  If you have used the
 :ref:`installation scripts`, use ``update`` command from the scripts.
 
-**Update** :ref:`searx service <searx.sh>`
+**Update** :ref:`SearXNG service <searx.sh>`
 
 .. code:: sh
 
@@ -39,7 +39,7 @@ How to inspect & debug
 How to debug depends on the :ref:`installation` method.  If you have used the
 :ref:`installation scripts`, use ``inspect`` command from the scripts.
 
-**Inspect** :ref:`searx service <searx.sh>`
+**Inspect** :ref:`SearXNG service <searx.sh>`
 
 .. code:: sh
 

--- a/docs/build-templates/searx.rst
+++ b/docs/build-templates/searx.rst
@@ -118,7 +118,7 @@ ${fedora_build}
        pip install -U wheel
        pip install -U pyyaml
 
-       # jump to searx's working tree and install searx into virtualenv
+       # jump to searx's working tree and install SearXNG into virtualenv
        (${SERVICE_USER})$ cd \"$SEARX_SRC\"
        (${SERVICE_USER})$ pip install -e .
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ copyright = '2021 SearXNG team, 2015-2021 Adam Tauber, Noémi Ványi'
 author = '2021 SearXNG team, 2015-2021 Adam Tauber'
 release, version = VERSION_STRING, VERSION_STRING
 
-SEARX_URL = get_setting('server.base_url') or 'https://example.org/searx'
+SEARX_URL = get_setting('server.base_url') or 'https://example.org/searxng'
 ISSUE_URL = get_setting('brand.issue_url')
 DOCS_URL = get_setting('brand.docs_url')
 PUBLIC_INSTANCES = get_setting('brand.public_instances')
@@ -132,7 +132,7 @@ html_sidebars = {
 singlehtml_sidebars = {"index": ["project.html", "localtoc.html"]}
 html_static_path = ["static"]
 html_logo = "static/img/searx_logo_small.png"
-html_title = "Searx Documentation ({})".format(VERSION_STRING)
+html_title = "SearXNG Documentation ({})".format(VERSION_STRING)
 html_show_sourcelink = False
 
 # LaTeX ----------------------------------------------------------------

--- a/docs/dev/contribution_guide.rst
+++ b/docs/dev/contribution_guide.rst
@@ -12,21 +12,21 @@ How to contribute
 Prime directives: Privacy, Hackability
 ======================================
 
-Searx has two prime directives, **privacy-by-design and hackability** .  The
+SearXNG has two prime directives, **privacy-by-design and hackability** .  The
 hackability comes in three levels:
 
 - support of search engines
 - plugins to alter search behaviour
-- hacking searx itself
+- hacking SearXNG itself
 
-Note the lack of "world domination" among the directives.  Searx has no
+Note the lack of "world domination" among the directives.  SearXNG has no
 intention of wide mass-adoption, rounded corners, etc.  The prime directive
 "privacy" deserves a separate chapter, as it's quite uncommon unfortunately.
 
 Privacy-by-design
 -----------------
 
-Searx was born out of the need for a **privacy-respecting** search tool which
+SearXNG was born out of the need for a **privacy-respecting** search tool which
 can be extended easily to maximize both, its search and its privacy protecting
 capabilities.
 
@@ -46,7 +46,7 @@ Submitting a bugreport to the vendor of the tool that misbehaves might be a good
 feedback to reconsider the disrespect to its customers (e.g. ``GET`` vs ``POST``
 requests in various browsers).
 
-Remember the other prime directive of searx is to be hackable, so if the above
+Remember the other prime directive of SearXNG is to be hackable, so if the above
 privacy concerns do not fancy you, simply fork it.
 
   *Happy hacking.*
@@ -99,7 +99,7 @@ In order to submit a patch, please follow the steps below:
 
 - Create a pull request.
 
-For more help on getting started with searx development, see :ref:`devquickstart`.
+For more help on getting started with SearXNG development, see :ref:`devquickstart`.
 
 
 Translation

--- a/docs/dev/engine_overview.rst
+++ b/docs/dev/engine_overview.rst
@@ -15,11 +15,11 @@ Engine Overview
    :depth: 3
    :backlinks: entry
 
-searx is a metasearch-engine_, so it uses different search engines to provide
+SearXNG is a metasearch-engine_, so it uses different search engines to provide
 better results.
 
 Because there is no general search API which could be used for every search
-engine, an adapter has to be built between searx and the external search
+engine, an adapter has to be built between SearXNG and the external search
 engines.  Adapters are stored under the folder :origin:`searx/engines`.
 
 .. _general engine configuration:
@@ -27,7 +27,7 @@ engines.  Adapters are stored under the folder :origin:`searx/engines`.
 General Engine Configuration
 ============================
 
-It is required to tell searx the type of results the engine provides. The
+It is required to tell SearXNG the type of results the engine provides. The
 arguments can be set in the engine file or in the settings file (normally
 ``settings.yml``). The arguments in the settings file override the ones in the
 engine file.
@@ -88,7 +88,7 @@ Overrides
 A few of the options have default values in the namespace of engine's python
 modul, but are often overwritten by the settings.  If ``None`` is assigned to an
 option in the engine file, it has to be redefined in the settings, otherwise
-searx will not start with that engine (global names with a leading underline can
+SearXNG will not start with that engine (global names with a leading underline can
 be ``None``).
 
 Here is an very simple example of the global names in the namespace of engine's

--- a/docs/dev/lxcdev.rst
+++ b/docs/dev/lxcdev.rst
@@ -52,7 +52,7 @@ software:
 and the script :ref:`lxc.sh`, with we can scale our installation, maintenance or
 even development tasks over a stack of isolated containers / what we call the:
 
-  **SearxNG LXC suite**
+  **SearXNG LXC suite**
 
 .. hint::
 
@@ -211,7 +211,7 @@ To debug services from filtron and morty analogous use:
         $ ./utils/filtron.sh inspect service
         $ ./utils/morty.sh inspect service
 
-Another point we have to notice is that each service (:ref:`searx <searx.sh>`,
+Another point we have to notice is that each service (:ref:`SearXNG <searx.sh>`,
 :ref:`filtron <filtron.sh>` and :ref:`morty <morty.sh>`) runs under dedicated
 system user account with the same name (compare :ref:`create searx user`).  To
 get a shell from theses accounts, simply call one of the scripts:
@@ -266,7 +266,7 @@ suite.  For this, we have to keep an eye on the :ref:`installation basic`:
 - virtualenv in: ``/usr/local/searx/searx-pyenv``
 - SearXNG software in: ``/usr/local/searx/searx-src``
 
-With the use of the :ref:`searx.sh` the searx service was installed as
+With the use of the :ref:`searx.sh` the SearXNG service was installed as
 :ref:`uWSGI application <searx uwsgi>`.  To maintain this service, we can use
 ``systemctl`` (compare :ref:`service architectures on distributions <uwsgi
 configuration>`).
@@ -280,7 +280,7 @@ configuration>`).
         $ sudo -H ./utils/lxc.sh cmd searx-archlinux \
           systemctl stop uwsgi@searx
 
-With the command above, we stopped the searx uWSGI-App in the archlinux
+With the command above, we stopped the SearXNG uWSGI-App in the archlinux
 container.
 
 The uWSGI-App for the archlinux dsitros is configured in
@@ -316,7 +316,7 @@ of the container:
           ln -s /share/searx/ /usr/local/searx/searx-src
 
 Now we can develop as usual in the working tree of our desktop system.  Every
-time the software was changed, you have to restart the searx service (in the
+time the software was changed, you have to restart the SearXNG service (in the
 conatiner):
 
 .. tabs::

--- a/docs/dev/makefile.rst
+++ b/docs/dev/makefile.rst
@@ -38,7 +38,7 @@ Python Environment (``make install``)
 
 We do no longer need to build up the virtualenv manually.  Jump into your git
 working tree and release a ``make install`` to get a virtualenv with a
-*developer install* of searx (:origin:`setup.py`). ::
+*developer install* of SearXNG (:origin:`setup.py`). ::
 
    $ cd ~/searx-clone
    $ make install
@@ -193,7 +193,7 @@ commit.
 .. _Pylint: https://www.pylint.org/
 
 Pylint_ is known as one of the best source-code, bug and quality checker for the
-Python programming language.  The pylint profile we use at searx project is
+Python programming language.  The pylint profile used in the SearXNG project is
 found in project's root folder :origin:`.pylintrc`.
 
 .. _make search.checker:

--- a/docs/dev/offline_engines.rst
+++ b/docs/dev/offline_engines.rst
@@ -11,7 +11,7 @@ Offline Engines
    - :ref:`engine command`
    - :origin:`Redis <searx/engines/redis_server.py>`
 
-To extend the functionality of SearxNG, offline engines are going to be
+To extend the functionality of SearXNG, offline engines are going to be
 introduced.  An offline engine is an engine which does not need Internet
 connection to perform a search and does not use HTTP to communicate.
 
@@ -47,14 +47,14 @@ Engine representation in ``/config``
 Extra Dependencies
 ==================
 
-If an offline engine depends on an external tool, SearxNG does not install it by
+If an offline engine depends on an external tool, SearXNG does not install it by
 default.  When an administrator configures such engine and starts the instance,
 the process returns an error with the list of missing dependencies.  Also,
 required dependencies will be added to the comment/description of the engine, so
 admins can install packages in advance.
 
 If there is a need to install additional packages in *Python's Virtual
-Environment* of your SearxNG instance you need to switch into the environment
+Environment* of your SearXNG instance you need to switch into the environment
 (:ref:`searx-src`) first, for this you can use :ref:`searx.sh`::
 
   $ sudo utils/searx.sh shell
@@ -66,7 +66,7 @@ Private engines (Security)
 
 To limit the access to offline engines, if an instance is available publicly,
 administrators can set token(s) for each of the :ref:`private engines`.  If a
-query contains a valid token, then SearxNG performs the requested private
+query contains a valid token, then SearXNG performs the requested private
 search.  If not, requests from an offline engines return errors.
 
 

--- a/docs/dev/quickstart.rst
+++ b/docs/dev/quickstart.rst
@@ -6,7 +6,7 @@ Development Quickstart
 
 .. _npm: https://www.npmjs.com/
 
-Searx loves developers, just clone and start hacking.  All the rest is done for
+SearXNG loves developers, just clone and start hacking.  All the rest is done for
 you simply by using :ref:`make <makefile>`.
 
 .. code:: sh

--- a/docs/dev/reST.rst
+++ b/docs/dev/reST.rst
@@ -6,10 +6,10 @@ reST primer
 
 .. sidebar:: KISS_ and readability_
 
-   Instead of defining more and more roles, we at searx encourage our
+   Instead of defining more and more roles, we at SearXNG encourage our
    contributors to follow principles like KISS_ and readability_.
 
-We at searx are using reStructuredText (aka reST_) markup for all kind of
+We at SearXNG are using reStructuredText (aka reST_) markup for all kind of
 documentation, with the builders from the Sphinx_ project a HTML output is
 generated and deployed at :docs:`github.io <.>`.  For build prerequisites read
 :ref:`docs build`.
@@ -78,7 +78,7 @@ User's POV: :origin:`docs/user`
 
 Admin's POV: :origin:`docs/admin`
   A typical Admin knows about setting up services on a linux system, but he does
-  not know all the pros and cons of a searx setup.
+  not know all the pros and cons of a SearXNG setup.
 
 Developer's POV: :origin:`docs/dev`
   Depending on the readability_ of code, a typical developer is able to read and
@@ -900,7 +900,7 @@ primer>`.
 
    .. sidebar:: KISS_ and readability_
 
-      Instead of defining more and more roles, we at searx encourage our
+      Instead of defining more and more roles, we at SearXNG encourage our
       contributors to follow principles like KISS_ and readability_.
 
 Generic admonition
@@ -1280,7 +1280,7 @@ Templating
 
 Templating is suitable for documentation which is created generic at the build
 time.  The sphinx-jinja_ extension evaluates jinja_ templates in the :ref:`make
-install` (with searx modules installed).  We use this e.g. to build chapter:
+install` (with SearXNG modules installed).  We use this e.g. to build chapter:
 :ref:`configured engines`.  Below the jinja directive from the
 :origin:`docs/admin/engines.rst` is shown:
 

--- a/docs/dev/search_api.rst
+++ b/docs/dev/search_api.rst
@@ -24,7 +24,7 @@ Parameters
 
 ``q`` : required
   The search query.  This string is passed to external search services.  Thus,
-  searx supports syntax of each search service.  For example, ``site:github.com
+  SearXNG supports syntax of each search service.  For example, ``site:github.com
   searx`` is a valid query for Google.  However, if simply the query above is
   passed to any search engine which does not filter its results based on this
   syntax, you might not get the results you wanted.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 ==================
-Welcome to searxng
+Welcome to SearXNG
 ==================
 
     *Search without being tracked.*
@@ -8,12 +8,12 @@ Welcome to searxng
 
    This is not searx, but searxng.
 
-Searxng is a free internet metasearch engine which aggregates results from more
+SearXNG is a free internet metasearch engine which aggregates results from more
 than 70 search services.  Users are neither tracked nor profiled.  Additionally,
-searxng can be used over Tor for online anonymity.
+SearXNG can be used over Tor for online anonymity.
 
-Get started with searxng by using one of the Searx-instances_.  If you don't trust
-anyone, you can set up your own, see :ref:`installation`.
+Get started with SearXNG by using one of the instances listed at searx.space_.
+If you don't trust anyone, you can set up your own, see :ref:`installation`.
 
 .. sidebar::  Features
 
@@ -36,4 +36,4 @@ anyone, you can set up your own, see :ref:`installation`.
    utils/index
    src/index
 
-.. _Searx-instances: https://searx.space
+.. _searx.space: https://searx.space

--- a/docs/user/own-instance.rst
+++ b/docs/user/own-instance.rst
@@ -4,22 +4,22 @@ Why use a private instance?
 
   *"Is it worth to run my own instance?"*
 
-\.\. is a common question among searx users.  Before answering this question,
-see what options a searx user has.
+\.\. is a common question among SearXNG users.  Before answering this question,
+see what options a SearXNG user has.
 
 Public instances are open to everyone who has access to its URL.  Usually, these
 are operated by unknown parties (from the users' point of view).  Private
-instances can be used by a select group of people.  It is for example a searx of
+instances can be used by a select group of people.  It is for example a SearXNG of
 group of friends or a company which can be accessed through VPN.  Also it can be
 single user one which runs on the user's laptop.
 
-To gain more insight on how these instances work let's dive into how searx
+To gain more insight on how these instances work let's dive into how SearXNG
 protects its users.
 
-How does searx protect privacy?
-===============================
+How does SearXNG protect privacy?
+=================================
 
-Searx protects the privacy of its users in multiple ways regardless of the type
+SearXNG protects the privacy of its users in multiple ways regardless of the type
 of the instance (private, public).  Removal of private data from search requests
 comes in three forms:
 
@@ -31,11 +31,11 @@ comes in three forms:
 Removing private data means not sending cookies to external search engines and
 generating a random browser profile for every request.  Thus, it does not matter
 if a public or private instance handles the request, because it is anonymized in
-both cases.  IP addresses will be the IP of the instance.  But searx can be
+both cases.  IP addresses will be the IP of the instance.  But SearXNG can be
 configured to use proxy or Tor.  `Result proxy
 <https://github.com/asciimoo/morty>`__ is supported, too.
 
-Searx does not serve ads or tracking content unlike most search services.  So
+SearXNG does not serve ads or tracking content unlike most search services.  So
 private data is not forwarded to third parties who might monetize it.  Besides
 protecting users from search services, both referring page and search query are
 hidden from visited result pages.
@@ -61,7 +61,7 @@ control: the source code, logging settings and private data.  Unknown instance
 administrators do not have to be trusted.
 
 Furthermore, as the default settings of their instance is editable, there is no
-need to use cookies to tailor searx to their needs.  So preferences will not be
+need to use cookies to tailor SearXNG to their needs.  So preferences will not be
 reset to defaults when clearing browser cookies.  As settings are stored on
 their computer, it will not be accessible to others as long as their computer is
 not compromised.
@@ -70,10 +70,10 @@ Conclusion
 ==========
 
 Always use an instance which is operated by people you trust.  The privacy
-features of searx are available to users no matter what kind of instance they
+features of SearXNG are available to users no matter what kind of instance they
 use.
 
-If someone is on the go or just wants to try searx for the first time public
+If someone is on the go or just wants to try SearXNG for the first time public
 instances are the best choices.  Additionally, public instance are making a
 world a better place, because those who cannot or do not want to run an
 instance, have access to a privacy respecting search service.

--- a/docs/user/search_syntax.rst
+++ b/docs/user/search_syntax.rst
@@ -5,7 +5,7 @@
 Search syntax
 =============
 
-Searx allows you to modify the default categories, engines and search language
+SearXNG allows you to modify the default categories, engines and search language
 via the search query.
 
 Prefix ``!``
@@ -44,11 +44,11 @@ Custom language in wikipedia:
 Multilingual Search
 ===================
 
-Searx does not support true multilingual search.
+SearXNG does not support true multilingual search.
 You have to use the language prefix in your search query when searching in a different language.
 
 But there is a workaround:
-By adding a new search engine with a different language, Searx will search in your default and other language.
+By adding a new search engine with a different language, SearXNG will search in your default and other language.
 
 Example configuration in settings.yml for a German and English speaker:
  .. code-block:: yaml

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -35,7 +35,7 @@ Scripts to maintain services often dispose of common commands and environments.
 ``FORCE_TIMEOUT`` : environment
   Sets timeout for interactive prompts. If you want to run a script in batch
   job, with defaults choices, set ``FORCE_TIMEOUT=0``.  By example; to install a
-  reverse proxy for filtron on all containers of the :ref:`searx suite
+  reverse proxy for filtron on all containers of the :ref:`SearXNG suite
   <lxc-searx.env>` use ::
 
     sudo -H ./utils/lxc.sh cmd -- FORCE_TIMEOUT=0 ./utils/filtron.sh apache install

--- a/docs/utils/lxc.sh.rst
+++ b/docs/utils/lxc.sh.rst
@@ -22,7 +22,7 @@
    - `LXD@github`_
 
 With the use of *Linux Containers* (LXC_) we can scale our tasks over a stack of
-containers, what we call the: *lxc suite*.  The *searx suite*
+containers, what we call the: *lxc suite*.  The *SearXNG suite*
 (:origin:`lxc-searx.env <utils/lxc-searx.env>`) is loaded by default, every time
 you start the ``lxc.sh`` script (*you do not need to care about*).
 
@@ -32,7 +32,7 @@ once::
   $ snap install lxd
   $ lxd init --auto
 
-To make use of the containers from the *searx suite*, you have to build the
+To make use of the containers from the *SearXNG suite*, you have to build the
 :ref:`LXC suite containers <lxc.sh help>` initial.  But be warned, **this might
 take some time**::
 
@@ -120,12 +120,12 @@ Reboot your system and check the iptables rules::
 Install suite
 =============
 
-To install the complete :ref:`searx suite (includes searx, morty & filtron)
+To install the complete :ref:`SearXNG suite (includes searx, morty & filtron)
 <lxc-searx.env>` into all LXC_ use::
 
   $ sudo -H ./utils/lxc.sh install suite
 
-The command above installs a searx suite (see :ref:`installation scripts`).  To
+The command above installs a SearXNG suite (see :ref:`installation scripts`).  To
 get the IP (URL) of the filtron service in the containers use ``show suite``
 command.  To test instances from containers just open the URLs in your
 WEB-Browser::
@@ -156,10 +156,10 @@ Makefile target ``test`` in the archlinux_ container::
   sudo -H ./utils/lxc.sh cmd searx-archlinux make test
 
 
-Setup searx buildhost
-=====================
+Setup SearXNG buildhost
+=======================
 
-You can **install the searx buildhost environment** into one or all containers.
+You can **install the SearXNG buildhost environment** into one or all containers.
 The installation procedure to set up a :ref:`build host<buildhosts>` takes its
 time.  Installation in all containers will take more time (time for another cup
 of coffee).::
@@ -191,8 +191,8 @@ The ``--help`` output of the script is largely self-explanatory:
 
 .. _lxc-searx.env:
 
-searx suite
-===========
+SearXNG suite
+=============
 
 .. literalinclude:: ../../utils/lxc-searx.env
    :language: bash

--- a/docs/utils/morty.sh.rst
+++ b/docs/utils/morty.sh.rst
@@ -37,7 +37,7 @@ into this user account:
 
 .. hint::
 
-   To add morty to your searx instance read chapter :ref:`searx morty`.
+   To add morty to your SearXNG instance read chapter :ref:`searx morty`.
 
 Create user
 ===========

--- a/docs/utils/searx.sh.rst
+++ b/docs/utils/searx.sh.rst
@@ -12,13 +12,13 @@
    - :ref:`installation nginx`
    - :ref:`installation apache`
 
-To simplify installation and maintenance of a searx instance you can use the
+To simplify installation and maintenance of a SearXNG instance you can use the
 script :origin:`utils/searx.sh`.
 
 Install
 =======
 
-In most cases you will install searx simply by running the command:
+In most cases you will install SearXNG simply by running the command:
 
 .. code::  bash
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1,6 +1,6 @@
 general:
   debug: false              # Debug mode, only for development
-  instance_name: "searxng"  # displayed name
+  instance_name: "SearXNG"  # displayed name
   contact_url: false        # mailto:contact@example.com
 
 brand:

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -99,7 +99,7 @@ class ViewsTestCase(SearxTestCase):
     def test_search_empty_html(self):
         result = self.app.post('/search', data={'q': ''})
         self.assertEqual(result.status_code, 200)
-        self.assertIn(b'<span class="instance pull-left"><a href="/">searxng</a></span>', result.data)
+        self.assertIn(b'<span class="instance pull-left"><a href="/">SearXNG</a></span>', result.data)
 
     def test_search_empty_json(self):
         result = self.app.post('/search', data={'q': '', 'format': 'json'})


### PR DESCRIPTION
## What does this PR do?

In the documentation, normalize project name to SearXNG.
