### PR TITLE
plugins: refactor initialization

### DIFF
--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -234,9 +234,9 @@ def plugin_module_names():
     yield_plugins = set()
 
     # embedded plugins
-    for module_name in iter_modules(path=[dirname(__file__)]):
-        yield (module_name, False)
-        yield_plugins.add(module_name)
+    for module in iter_modules(path=[dirname(__file__)]):
+        yield (__name__ + "." + module.name, False)
+        yield_plugins.add(module.name)
     # external plugins
     for module_name in settings['plugins']:
         if module_name not in yield_plugins:
@@ -246,6 +246,6 @@ def plugin_module_names():
 
 def initialize(app):
     for module_name, external in plugin_module_names():
-        plugin = load_and_initialize_plugin(__name__ + "." + module_name.name, external, (app, settings))
+        plugin = load_and_initialize_plugin(module_name, external, (app, settings))
         if plugin:
             plugins.register(plugin)

--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -59,7 +59,6 @@ def sync_resource(base_path, resource_path, name, target_dir, plugin_dir):
 
 
 def prepare_package_resources(plugin, plugin_module_name):
-    # pylint: disable=consider-using-generator
     plugin_base_path = dirname(abspath(plugin.__file__))
 
     plugin_dir = plugin_module_name
@@ -80,24 +79,19 @@ def prepare_package_resources(plugin, plugin_module_name):
 
     if hasattr(plugin, "js_dependencies"):
         resources.extend(map(basename, plugin.js_dependencies))
-        plugin.js_dependencies = tuple(
-            [
-                sync_resource(
-                    plugin_base_path, x, plugin_module_name, target_dir, plugin_dir
-                )
-                for x in plugin.js_dependencies
-            ]
-        )
+        plugin.js_dependencies = ([
+            sync_resource(
+                plugin_base_path, x, plugin_module_name, target_dir, plugin_dir
+            ) for x in plugin.js_dependencies
+            ])
+
     if hasattr(plugin, "css_dependencies"):
         resources.extend(map(basename, plugin.css_dependencies))
-        plugin.css_dependencies = tuple(
-            [
-                sync_resource(
-                    plugin_base_path, x, plugin_module_name, target_dir, plugin_dir
-                )
-                for x in plugin.css_dependencies
-            ]
-        )
+        plugin.css_dependencies = ([
+            sync_resource(
+                plugin_base_path, x, plugin_module_name, target_dir, plugin_dir
+            ) for x in plugin.css_dependencies
+            ])
 
     for f in listdir(target_dir):
         if basename(f) not in resources:

--- a/searx/plugins/ahmia_filter.py
+++ b/searx/plugins/ahmia_filter.py
@@ -13,15 +13,17 @@ preference_section = 'onions'
 ahmia_blacklist = None
 
 
-def get_ahmia_blacklist():
-    global ahmia_blacklist
-    if not ahmia_blacklist:
-        ahmia_blacklist = ahmia_blacklist_loader()
-    return ahmia_blacklist
-
-
 def on_result(request, search, result):
     if not result.get('is_onion') or not result.get('parsed_url'):
         return True
     result_hash = md5(result['parsed_url'].hostname.encode()).hexdigest()
-    return result_hash not in get_ahmia_blacklist()
+    return result_hash not in ahmia_blacklist
+
+
+def init(app, settings):
+    global ahmia_blacklist  # pylint: disable=global-statement
+    if not settings['outgoing']['using_tor_proxy']:
+        # disable the plugin
+        return False
+    ahmia_blacklist = ahmia_blacklist_loader()
+    return True

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -200,8 +200,8 @@ SCHEMA = {
         'networks': {
         },
     },
-    'plugins': SettingsValue((None, list), None),
-    'enabled_plugins': SettingsValue(list, []),
+    'plugins': SettingsValue(list, []),
+    'enabled_plugins': SettingsValue((None, list), None),
     'checker': {
         'off_when_debug': SettingsValue(bool, True),
     },

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -10,6 +10,12 @@ def get_search_mock(query, **kwargs):
                 result_container=Mock(answers=dict()))
 
 
+class PluginMock():
+    default_on = False
+    name = 'Default plugin'
+    description = 'Default plugin description'
+
+
 class PluginStoreTest(SearxTestCase):
 
     def test_PluginStore_init(self):
@@ -18,14 +24,14 @@ class PluginStoreTest(SearxTestCase):
 
     def test_PluginStore_register(self):
         store = plugins.PluginStore()
-        testplugin = plugins.Plugin()
+        testplugin = PluginMock()
         store.register(testplugin)
 
         self.assertTrue(len(store.plugins) == 1)
 
     def test_PluginStore_call(self):
         store = plugins.PluginStore()
-        testplugin = plugins.Plugin()
+        testplugin = PluginMock()
         store.register(testplugin)
         setattr(testplugin, 'asdf', Mock())
         request = Mock()
@@ -40,8 +46,9 @@ class PluginStoreTest(SearxTestCase):
 class SelfIPTest(SearxTestCase):
 
     def test_PluginStore_init(self):
+        plugin = plugins.load_and_initialize_plugin('searx.plugins.self_info', False, (None, {}))
         store = plugins.PluginStore()
-        store.register(plugins.self_info)
+        store.register(plugin)
 
         self.assertTrue(len(store.plugins) == 1)
 
@@ -89,7 +96,8 @@ class HashPluginTest(SearxTestCase):
 
     def test_PluginStore_init(self):
         store = plugins.PluginStore()
-        store.register(plugins.hash_plugin)
+        plugin = plugins.load_and_initialize_plugin('searx.plugins.hash_plugin', False, (None, {}))
+        store.register(plugin)
 
         self.assertTrue(len(store.plugins) == 1)
 


### PR DESCRIPTION
## What does this PR do?

Add a new function "init" call when the app starts.
The function can:
* return False to disable the plugin (case of ahmia_filter plugin).
* modify the Flask app.

See https://github.com/dalf/searxng/blob/mod-plugins/searx/plugins/ahmia_filter.py

Reference to the plugins are by Python module names instead of plugin names (related to https://github.com/searxng/searxng/issues/315)

The function `searx.plugins.load_plugin` looks like `searx.engines.load_engines`.

BREAKING CHANGE: the user preferences (cookies) about the plugins will be lost.

Embedded plugins are automatically detected.

## Why is this change important?

With this change a plugin can change the web application:
* add / remove / replace some HTTP endpoints
* add middleware, etc...

Draft:
* ~if would be nice if the `init` could replace the application: `app = Flask_Babel(app)`.~
* ~perhaps implement a temporary workaround to avoid a breaking change about the cookies.~ (it just requires to go the preferences and make some changes and save)

## How to test this PR locally?

* `make run`
* check it works with an external plugin including static resources

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #315
