### PR TITLE
[fix] checker: fix memory usage

### DIFF
--- a/searx/search/checker/impl.py
+++ b/searx/search/checker/impl.py
@@ -85,7 +85,10 @@ def _download_and_check_if_image(image_url: str) -> bool:
             })
             r = next(stream)
             r.close()
-            is_image = r.headers["content-type"].startswith('image/')
+            if r.status_code == 200:
+                is_image = r.headers.get('content-type', '').startswith('image/')
+            else:
+                is_image = False
             del r
             del stream
             return is_image


### PR DESCRIPTION
## What does this PR do?

* download images using the "image_proxy" network (HTTP/1 instead of HTTP/2)
* don't cache data: URL (reduce memory usage)

## Why is this change important?

Drastically reduce the memory usage when the checker is enabled.
 
## How to test this PR locally?

* enable the checker in settings.yml
* `kill -USR1 <pid>`
* check the memory usage
* `kill -USR1 <pid>` again
* check the memory usage : it shouldn't be similar to the previous value

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
