### PR TITLE
[fix] openstreetmap engine: map "all" language to English

### DIFF
--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -220,6 +220,7 @@ def fetch_wikidata(nominatim_json, user_langage):
                 wd_to_results.setdefault(wd_id, []).append(result)
 
     if wikidata_ids:
+        user_langage = 'en' if user_langage == 'all' else user_langage
         wikidata_ids_str = " ".join(wikidata_ids)
         query = wikidata_image_sparql.replace('%WIKIDATA_IDS%', sparql_string_escape(wikidata_ids_str)).replace(
             '%LANGUAGE%', sparql_string_escape(user_langage)

--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -42,6 +42,7 @@ route_re = re.compile('(?:from )?(.+) to (.+)')
 wikidata_image_sparql = """
 select ?item ?itemLabel ?image ?sign ?symbol ?website ?wikipediaName
 where {
+  hint:Query hint:optimizer "None".
   values ?item { %WIKIDATA_IDS% }
   OPTIONAL { ?item wdt:P18|wdt:P8517|wdt:P4291|wdt:P5252|wdt:P3451|wdt:P4640|wdt:P5775|wdt:P2716|wdt:P1801|wdt:P4896 ?image }
   OPTIONAL { ?item wdt:P1766|wdt:P8505|wdt:P8667 ?sign }


### PR DESCRIPTION
## What does this PR do?

* without this PR `!osm :all tokyo`, the wikipedia link is https://ja.wikipedia.org/wiki/%E6%9D%B1%E4%BA%AC%E9%83%BD
* with this PR, the wikipedia link is https://en.wikipedia.org/wiki/Tokyo

* also, this PR includes a small optimization of the SPARQL query.

## Why is this change important?

The "expected" fallback for `all` language is English.
With this PR, the osm returns the expected results.
 
## How to test this PR locally?

* search for `!osm :all tokyo`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
