### PR TITLE
[mod] /image_proxy: fix memory leak

### DIFF
--- a/searx/network/__init__.py
+++ b/searx/network/__init__.py
@@ -219,8 +219,7 @@ def stream(method, url, **kwargs):
     """Replace httpx.stream.
 
     Usage:
-    stream = poolrequests.stream(...)
-    response = next(stream)
+    response, stream = poolrequests.stream(...)
     for chunk in stream:
         ...
 
@@ -236,6 +235,5 @@ def stream(method, url, **kwargs):
 
     response._generator = generator  # pylint: disable=protected-access
     response.close = MethodType(_close_response_method, response)
-    yield response
 
-    yield from generator
+    return response, generator


### PR DESCRIPTION
## What does this PR do?

`/image_proxy`: 
* make sure to close the httpx response
* use [`direct_passthrough`](https://werkzeug.palletsprojects.com/en/2.0.x/wrappers/#werkzeug.wrappers.Response) for a slight improvement of the performance.

## Why is this change important?

No memory leak.

## How to test this PR locally?

* `make run`
* enable the image proxy
* watch the RSS (`watch ps -o vsz=,rss= <pid>`)

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
