### PR TITLE
[fix] make weblate.push.translations

### DIFF
--- a/manage
+++ b/manage
@@ -266,7 +266,7 @@ weblate.push.translations() {
     if [ "$exitcode" -eq 42 ]; then
         return 0
     fi
-    if [ "$exitcode" ]; then
+    if [ "$exitcode" -gt 0 ]; then
        return $exitcode
     fi
     (


### PR DESCRIPTION
## What does this PR do?

Even when there are changes, the function exit without pushing them.

Not tested, see log:
https://github.com/searxng/searxng/runs/3783399235?check_suite_focus=true#step:6:235

Extract:
```
extracting messages from searx/templates/simple/result_templates/images.html (extensions="jinja2.ext.autoescape,jinja2.ext.with_")
extracting messages from searx/templates/simple/result_templates/key-value.html (extensions="jinja2.ext.autoescape,jinja2.ext.with_")
extracting messages from searx/templates/simple/result_templates/map.html (extensions="jinja2.ext.autoescape,jinja2.ext.with_")
extracting messages from searx/templates/simple/result_templates/torrent.html (extensions="jinja2.ext.autoescape,jinja2.ext.with_")
extracting messages from searx/templates/simple/result_templates/videos.html (extensions="jinja2.ext.autoescape,jinja2.ext.with_")
writing PO template file to /home/runner/work/searxng/searxng/cache/translations/searx/translations/messages.pot
```

The log stops without anymore.

Which lead me to think this condition is always true:
https://github.com/searxng/searxng/blob/47eb836c657f581fab12d68c978d9520e2e14417/manage#L269-L271

This PR change line 269 to
```sh
if [ "$exitcode" -gt 0 ]; the
```

Local dumb tests:
```sh
[ "0" ] && echo "a"
[ "0" -gt 0 ] && echo "b"
```

## Why is this change important?

Bug fix

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
