### PR TITLE
[fix] commit message of 'make weblate.push.translations'

### DIFF
--- a/manage
+++ b/manage
@@ -240,7 +240,7 @@ weblate.push.translations() {
     # 5. Notify Weblate to pull updated 'master' & 'translations' branch.
 
     local messages_pot diff_messages_pot last_commit_hash last_commit_detail \
-          last_commit_message exitcode
+          exitcode
     messages_pot="${TRANSLATIONS_WORKTREE}/searx/translations/messages.pot"
     (   set -e
         pyenv.activate
@@ -301,11 +301,12 @@ weblate.push.translations() {
         # git add/commit/push
         last_commit_hash=$(git log -n1  --pretty=format:'%h')
         last_commit_detail=$(git log -n1 --pretty=format:'%h - %as - %aN <%ae>' "${last_commit_hash}")
-        last_commit_message="[translations] update messages.pot and messages.po files\nFrom ${last_commit_detail}"
 
         pushd "${TRANSLATIONS_WORKTREE}"
         git add searx/translations
-        git commit -m "${last_commit_message}"
+        git commit \
+            -m "[translations] update messages.pot and messages.po files" \
+            -m "From ${last_commit_detail}"
         git push
         popd
 


### PR DESCRIPTION
## What does this PR do?

Fix `\n` issue in the commit message [1] by using multiple `-m` options [2]::

    7d9ffd680 translations     [translations] update messages.pot and messages.po files\nFrom cebc0e39 - 2021-10-04 - Markus Heiser <markus.heiser@darmarIT.de>

## Related issues

[1] https://github.com/searxng/searxng/pull/379#issuecomment-933242702
[2] https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--mltmsggt
