### PR TITLE
Fix match_language issue to make zh-TW match to zh-Hant-TW

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -92,6 +92,14 @@ class TestUtils(SearxTestCase):
         self.assertEqual(utils.match_language('es', [], fallback='fallback'), 'fallback')
         self.assertEqual(utils.match_language('ja', ['jp'], {'ja': 'jp'}), 'jp')
 
+        # handle script tags
+        self.assertEqual(utils.match_language('zh-CN', ['zh-Hans-CN', 'zh-Hant-TW']), 'zh-Hans-CN')
+        self.assertEqual(utils.match_language('zh-TW', ['zh-Hans-CN', 'zh-Hant-TW']), 'zh-Hant-TW')
+        self.assertEqual(utils.match_language('zh-Hans-CN', ['zh-CN', 'zh-TW']), 'zh-CN')
+        self.assertEqual(utils.match_language('zh-Hant-TW', ['zh-CN', 'zh-TW']), 'zh-TW')
+        self.assertEqual(utils.match_language('zh-Hans', ['zh-CN', 'zh-TW', 'zh-HK']), 'zh-CN')
+        self.assertEqual(utils.match_language('zh-Hant', ['zh-CN', 'zh-TW', 'zh-HK']), 'zh-TW')
+
         aliases = {'en-GB': 'en-UK', 'he': 'iw'}
 
         # guess country


### PR DESCRIPTION
## What does this PR do?

This fixes the issue in #380 where setting `'Accept-Language': 'zh-tw;q=0.8` fails to pick `zh_Hant_TW` as the locale.

The issue is that PyBabel separates locales with underscores but we use hyphens everywhere else.

I haven't tested this thoroughly yet. It looks like it shouldn't break anything else but I don't know anymore...

## How to test this PR locally?

1. Set `'Accept-Language': 'zh-tw;q=0.8`
2. Go to `/preferences`.
3. Verify that both search language and UI locale are in `zh-TW` or `zh_Hant_TW`.
4. Check with other locales to make sure I didn't break something else.

## Related issues
Part of #380