### PR TITLE
SearXNG: docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
 FROM alpine:3.14
-ENTRYPOINT ["/sbin/tini","--","/usr/local/searx/dockerfiles/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini","--","/usr/local/searxng/dockerfiles/docker-entrypoint.sh"]
 EXPOSE 8080
 VOLUME /etc/searx
+VOLUME /etc/searxng
 VOLUME /var/log/uwsgi
 
-ARG SEARX_GID=977
-ARG SEARX_UID=977
+ARG SEARXNG_GID=977
+ARG SEARXNG_UID=977
 
-RUN addgroup -g ${SEARX_GID} searx && \
-    adduser -u ${SEARX_UID} -D -h /usr/local/searx -s /bin/sh -G searx searx
+RUN addgroup -g ${SEARXNG_GID} searxng && \
+    adduser -u ${SEARXNG_UID} -D -h /usr/local/searxng -s /bin/sh -G searxng searxng
 
 ENV INSTANCE_NAME=searxng \
     AUTOCOMPLETE= \
     BASE_URL= \
     MORTY_KEY= \
     MORTY_URL= \
-    SEARXNG_SETTINGS_PATH=/etc/searx/settings.yml \
-    UWSGI_SETTINGS_PATH=/etc/searx/uwsgi.ini
+    SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml \
+    UWSGI_SETTINGS_PATH=/etc/searxng/uwsgi.ini
 
-WORKDIR /usr/local/searx
+WORKDIR /usr/local/searxng
 
 
 COPY requirements.txt ./requirements.txt
@@ -51,38 +52,38 @@ RUN apk upgrade --no-cache \
  && apk del build-dependencies \
  && rm -rf /root/.cache
 
-COPY --chown=searx:searx . .
+COPY --chown=searxng:searxng . .
 
 ARG TIMESTAMP_SETTINGS=0
 ARG TIMESTAMP_UWSGI=0
 ARG VERSION_GITCOMMIT=unknown
 
-RUN su searx -c "/usr/bin/python3 -m compileall -q searx"; \
+RUN su searxng -c "/usr/bin/python3 -m compileall -q searx"; \
     touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml; \
     touch -c --date=@${TIMESTAMP_UWSGI} dockerfiles/uwsgi.ini; \
-    find /usr/local/searx/searx/static -a \( -name '*.html' -o -name '*.css' -o -name '*.js' \
+    find /usr/local/searxng/searx/static -a \( -name '*.html' -o -name '*.css' -o -name '*.js' \
     -o -name '*.svg' -o -name '*.ttf' -o -name '*.eot' \) \
     -type f -exec gzip -9 -k {} \+ -exec brotli --best {} \+
 
 # Keep these arguments at the end to prevent redundant layer rebuilds
 ARG LABEL_DATE=
 ARG GIT_URL=unknown
-ARG SEARX_GIT_VERSION=unknown
+ARG SEARXNG_GIT_VERSION=unknown
 ARG LABEL_VCS_REF=
 ARG LABEL_VCS_URL=
 LABEL maintainer="searxng <${GIT_URL}>" \
       description="A privacy-respecting, hackable metasearch engine." \
-      version="${SEARX_GIT_VERSION}" \
+      version="${SEARXNG_GIT_VERSION}" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.name="searxng" \
-      org.label-schema.version="${SEARX_GIT_VERSION}" \
+      org.label-schema.version="${SEARXNG_GIT_VERSION}" \
       org.label-schema.url="${LABEL_VCS_URL}" \
       org.label-schema.vcs-ref=${LABEL_VCS_REF} \
       org.label-schema.vcs-url=${LABEL_VCS_URL} \
       org.label-schema.build-date="${LABEL_DATE}" \
       org.label-schema.usage="https://github.com/searxng/searxng-docker" \
       org.opencontainers.image.title="searxng" \
-      org.opencontainers.image.version="${SEARX_GIT_VERSION}" \
+      org.opencontainers.image.version="${SEARXNG_GIT_VERSION}" \
       org.opencontainers.image.url="${LABEL_VCS_URL}" \
       org.opencontainers.image.revision=${LABEL_VCS_REF} \
       org.opencontainers.image.source=${LABEL_VCS_URL} \

--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 # Who will run the code
-uid = searx
-gid = searx
+uid = searxng
+gid = searxng
 
 # Number of workers (usually CPU count)
 workers = 4
@@ -20,8 +20,8 @@ enable-threads = true
 module = searx.webapp
 
 # Virtualenv and python path
-pythonpath = /usr/local/searx/
-chdir = /usr/local/searx/searx/
+pythonpath = /usr/local/searxng/
+chdir = /usr/local/searxng/searx/
 
 # Disable logging for privacy
 disable-logging=True
@@ -38,10 +38,10 @@ add-header = Connection: close
 
 # uwsgi serves the static files
 # expires set to one day as Flask does
-static-map = /static=/usr/local/searx/searx/static
+static-map = /static=/usr/local/searxng/searx/static
 static-expires = /* 864000
 static-gzip-all = True
 offload-threads = %k
 
 # Cache
-cache2 = name=searxcache,items=2000,blocks=2000,blocksize=4096,bitmap=1
+cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1

--- a/docs/admin/installation-docker.rst
+++ b/docs/admin/installation-docker.rst
@@ -63,7 +63,7 @@ instance using `docker run <https://docs.docker.com/engine/reference/run/>`_:
    $ docker pull searxng/searxng
    $ docker run --rm \
                 -d -p ${PORT}:8080 \
-                -v "${PWD}/searx:/etc/searx" \
+                -v "${PWD}/searxng:/etc/searxng" \
                 -e "BASE_URL=http://localhost:$PORT/" \
                 -e "INSTANCE_NAME=my-instance" \
                 searxng/searxng
@@ -75,7 +75,7 @@ Open your WEB browser and visit the URL:
 
    $ xdg-open "http://localhost:$PORT"
 
-Inside ``${PWD}/searx``, you will find ``settings.yml`` and ``uwsgi.ini``.  You
+Inside ``${PWD}/searxng``, you will find ``settings.yml`` and ``uwsgi.ini``.  You
 can modify these files according to your needs and restart the Docker image.
 
 .. code:: sh
@@ -139,7 +139,7 @@ Build the image
 It's also possible to build SearXNG from the embedded :origin:`Dockerfile`::
 
    $ git clone https://github.com/searxng/searxng.git
-   $ cd searx
+   $ cd searxng
    $ make docker.build
    ...
    Successfully built 49586c016434

--- a/manage
+++ b/manage
@@ -390,10 +390,10 @@ docker.buildx() {
 docker.build() {
     pyenv.install
 
-    local SEARX_GIT_VERSION
+    local SEARXNG_GIT_VERSION
     local VERSION_GITCOMMIT
     local GITHUB_USER
-    local SEARX_IMAGE_NAME
+    local SEARXNG_IMAGE_NAME
     local BUILD
 
     build_msg DOCKER build
@@ -427,35 +427,35 @@ docker.build() {
 
         # define the docker image name
         GITHUB_USER=$(echo "${GIT_URL}" | sed 's/.*github\.com\/\([^\/]*\).*/\1/')
-        SEARX_IMAGE_NAME="${SEARX_IMAGE_NAME:-${GITHUB_USER:-searxng}/searxng}"
+        SEARXNG_IMAGE_NAME="${SEARXNG_IMAGE_NAME:-${GITHUB_USER:-searxng}/searxng}"
 
         BUILD="build"
         if [ "$1" = "buildx" ]; then
             # buildx includes the push option
-            CACHE_TAG="${SEARX_IMAGE_NAME}:latest-build-cache"
+            CACHE_TAG="${SEARXNG_IMAGE_NAME}:latest-build-cache"
             BUILD="buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push --cache-from=type=registry,ref=$CACHE_TAG --cache-to=type=registry,ref=$CACHE_TAG,mode=max"
             shift
         fi
         build_msg DOCKER "Build command: ${BUILD}"
 
         # build Docker image
-        build_msg DOCKER "Building image ${SEARX_IMAGE_NAME}:${SEARX_GIT_VERSION}"
+        build_msg DOCKER "Building image ${SEARXNG_IMAGE_NAME}:${SEARXNG_GIT_VERSION}"
         # shellcheck disable=SC2086
         docker $BUILD \
          --build-arg BASE_IMAGE="${DEPENDENCIES_IMAGE_NAME}" \
          --build-arg GIT_URL="${GIT_URL}" \
-         --build-arg SEARX_GIT_VERSION="${VERSION_STRING}" \
+         --build-arg SEARXNG_GIT_VERSION="${VERSION_STRING}" \
          --build-arg VERSION_GITCOMMIT="${VERSION_GITCOMMIT}" \
          --build-arg LABEL_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
          --build-arg LABEL_VCS_REF="$(git rev-parse HEAD)" \
          --build-arg LABEL_VCS_URL="${GIT_URL}" \
          --build-arg TIMESTAMP_SETTINGS="$(git log -1 --format="%cd" --date=unix -- searx/settings.yml)" \
          --build-arg TIMESTAMP_UWSGI="$(git log -1 --format="%cd" --date=unix -- dockerfiles/uwsgi.ini)" \
-         -t "${SEARX_IMAGE_NAME}:latest" -t "${SEARX_IMAGE_NAME}:${VERSION_STRING}" .
+         -t "${SEARXNG_IMAGE_NAME}:latest" -t "${SEARXNG_IMAGE_NAME}:${VERSION_STRING}" .
 
         if [ "$1" = "push" ]; then
-	        docker push "${SEARX_IMAGE_NAME}:latest"
-	        docker push "${SEARX_IMAGE_NAME}:${SEARX_GIT_VERSION}"
+	        docker push "${SEARXNG_IMAGE_NAME}:latest"
+	        docker push "${SEARXNG_IMAGE_NAME}:${SEARXNG_GIT_VERSION}"
 	    fi
     )
     dump_return $?


### PR DESCRIPTION
## What does this PR do?

SearXNG brand: the docker image
* installs the file in `usr/local/searxng` (inside the image)
* uses `searxng` user
* uses the volume `/etc/searxng`. 

searx compatibility:
* If `/etc/searx/settings.yml` exists, it is copied to `/etc/searxng`
* If `/etc/searx/uwsgi.ini` exists, is it ignored (the content requires some updates)
* If `/etc/searx/settings.yml` or `/etc/searx/uwsgi.ini` exist:
   * a warning is logged
   * the file `/etc/searx/deprecated_volume_read_me.txt` is created, and notice the administrator.

The documentation is updated accordingly.

## Why is this change important?

See https://github.com/searxng/searxng/pull/358

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
