### PR TITLE
[mod] set 'engine.supported_languages' from the origin python module

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -601,6 +601,17 @@ engines:
     # additional_tests:
     #   android: *test_android
 
+  # - name: google italian
+  #   engine: google
+  #   shortcut: goit
+  #   use_mobile_ui: false
+  #   language: it
+
+  # - name: google mobile ui
+  #   engine: google
+  #   shortcut: gomui
+  #   use_mobile_ui: true
+
   - name: google images
     engine: google_images
     shortcut: goi


### PR DESCRIPTION
## What does this PR do?

Set `engine.supported_languages` from the origin python module

The key of the dictionary 'searx.data.ENGINES_LANGUAGES' is the *engine name*
configured in settings.xml.  When multiple engines are configured to use the
same origin engine (e.g. `engine: google`)::

    - name: google
      engine: google
      use_mobile_ui: false
      ...

    - name: google italian
      engine: google
      use_mobile_ui: false
      language: it
      ...

    - name: google mobile ui
      engine: google
      shortcut: gomui
      use_mobile_ui: true

There exists no entry for ENGINES_LANGUAGES[engine.name] (e.g. `name: google
mobile ui` or `name: google italian`).  This issue can be solved by recreate the
ENGINES_LANGUAGES::

    make data.languages

But this is nothing an SearXNG admin would like to do when just configuring
additional engines, since this just doubles entries in ENGINES_LANGUAGES and
BTW: `make data.languages` has various external requirements which might be not
installed or not available, on a production host.

With this patch, if engine.name fails, ENGINES_LANGUAGES[engine.engine] is used
to get the engine.supported_languages (e.g. `google` for the engine named
`google mobile`).

For an engine, when there is `language: ...` in the YAML settings, the engine
supports only one language, in this case engine.supported_languages should
contains this value defined in settings.yml (e.g. `it` for the engine named
`google italian`).

## How to test this PR locally?

Activate the engines shown above in the settings.yml, call `make run` and do some queries e.g.  `!goit foo`, `!goit foo :en`, `!gomui foo :en`, `!gomui foo :it` and `foo`

## Related issues

Closes: https://github.com/searxng/searxng/issues/384
