### PR TITLE
[nix] searxng recipe for installation via nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 local/
 gh-pages/
 *.egg-info/
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,126 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix-src": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1629464241,
+        "narHash": "sha256-DLAVO2fyj5VxDf/7FoBsXZTQcz1/deJ9EFRqO9BD0tI=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "d223656fc0eff33f4da77d69db19752edc9a5ba5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1622797669,
+        "narHash": "sha256-xIyWeoYExzF0KNaKcqfxEX58fN4JTIQxTJWbsAujllc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1ca6b0a0cc38dbba0441202535c92841dd39d1ae",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1631135948,
+        "narHash": "sha256-Awt0CTDsECS4Z1Iqn4bkH9CAfPcECOniOXazomMGUnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "95bfcf1e2475b780dd7dbba503fc06ac8e1faa79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622970040,
+        "narHash": "sha256-u//RFnae/XMIhoy83G2uH2Qu/1LiUhVCdwwY1xj4Ufs=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "be6591698c67a86a69c81fef72167e38d038a9fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "mach-nix-src": "mach-nix-src",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -50,7 +50,9 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs",
-        "pypi-deps-db": "pypi-deps-db"
+        "pypi-deps-db": [
+          "pypi-deps-db"
+        ]
       },
       "locked": {
         "lastModified": 1629464241,
@@ -99,11 +101,11 @@
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1622970040,
-        "narHash": "sha256-u//RFnae/XMIhoy83G2uH2Qu/1LiUhVCdwwY1xj4Ufs=",
+        "lastModified": 1634243405,
+        "narHash": "sha256-mopV8eg7VChFcdS0V74wpyWLXBpl5E4zPaKHq/CcgUQ=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "be6591698c67a86a69c81fef72167e38d038a9fc",
+        "rev": "c00afed61c57a09ba931c4dc264195570db4e943",
         "type": "github"
       },
       "original": {
@@ -117,7 +119,8 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "mach-nix-src": "mach-nix-src",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "pypi-deps-db": "pypi-deps-db"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "SearXNG";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    mach-nix-src.url = "github:DavHau/mach-nix";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  inputs.flake-compat = {
+    url = "github:edolstra/flake-compat";
+    flake = false;
+  };
+
+  outputs = { self, nixpkgs, flake-utils, mach-nix-src, ... }:
+    let
+      # TODO : for some reason `nix flake show` results in error:
+      # ```error: a 'aarch64-darwin' with features {} is required to build '/nix/store/s79ixgs3xy250x1b9vyy90g7dzd6bsh4-conda-channels.json.drv',
+      #   but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test}```
+      # Some internal part of mach-nix attempts to build derivation into target system and cross-build fails
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      #
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      python = "python38";
+      pypiDataRev = "18250538b9eeb9484c4e3bdf135bc1f3a2ccd949";
+      pypiDataSha256 = "01hdjy5rpcjm92fyp8n6lci773rgbsa81h2n08r49zjhk9michrb";
+      requirements = builtins.readFile ./requirements.txt;
+
+      nixpkgsFor = forAllSystems (
+        system:
+          import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
+          }
+      );
+    in
+      {
+
+        overlay = final: prev:
+          let
+            mach-nix = import mach-nix-src {
+              pkgs = prev;
+              inherit python pypiDataRev pypiDataSha256;
+            };
+          in
+            {
+              searxng = (
+                mach-nix.buildPythonPackage {
+                  inherit requirements;
+                  pname = "SearXNG";
+                  version = "1.0";
+                  src = ./.;
+                }
+              );
+              dev-python =
+                  mach-nix.mkPython {
+                    inherit python;
+                    requirements = requirements;
+                  };
+            };
+        packages = forAllSystems (
+          system:
+            {
+              inherit (nixpkgsFor.${system}) searxng;
+            }
+        );
+
+        # The default package for 'nix build'. This makes sense if the
+        # flake provides only one package or there is a clear "main"
+        # package.
+        # Returns Searx with plugin enabled
+        defaultPackage = forAllSystems (system: self.packages.${system}.searxng);
+
+        # To use as `nix develop`
+        # will provide shell with
+        # - make utility for `make run` and `make test`
+        # - python with dependencies, to run searx built with nix
+        # - env var pointing to default repository searx config
+        devShell = forAllSystems (
+          system: nixpkgsFor.${system}.mkShell
+            rec {
+              buildInputs = with nixpkgsFor.${system}; [
+                dev-python
+                gnumake
+              ];
+              settingsFile = builtins.readFile ./searx/settings.yml;
+              SEARX_SETTINGS_PATH = "${settingsFile}";
+            }
+        );
+
+        nixosModules.searxng = { pkgs, ... }:
+          {
+            nixpkgs.overlays = [ self.overlay ];
+          };
+      };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
This PR adds recipe for installing searxng via nix package manager, so that admins that use searx service on their nix managed servers could easily change it to searxng


## What does this PR do?

Adds:
- searxng package : "searxng" python description that's created with [mach-nix](https://github.com/DavHau/mach-nix), i.e extracts dependencies from `requirements.txt` of the project
- overlay for easier installation into nix configuration
- development shell with make & python with dependencies for local execution of built artifact

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
Searx is packaged for Nix, and can be installed & configured easily, [here sample](https://github.com/efim/nix-searx-container-example/blob/master/flake.nix)
This change would allow admins to easily use SearXNG with minimal modification of the configurations on their side.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

If Nix is installed (available for Linux & MacOS), then
- modify `./searx/settings.yml` secret value to non-default
- `nix build` would build the project, and symlink it to `./result`
- `nix-shell` would create subshell with env var SEARX_SETTINGS_PATH pointing to `./searx/settings.yml` and add `searx-run` to PATH
- `searx-run` would launch built project


## Author's checklist

<!-- additional notes for reviewiers -->
Using `mach-nix` to create recipe for SearXNG is different from the way Searx is packaged currently.
Mach nix takes exact versions of python dependencies from the `requirements.txt`, while [Searx definition](https://github.com/NixOS/nixpkgs/blob/nixos-21.05/pkgs/servers/web-apps/searx/default.nix#L71) takes versions of python libraries that are available in "nix store" and not necessarily match requirements (as I understand)

Also using mach-nix allows for easier maintaining of the nix recipe.
- `nix flake lock --update-input nixpkgs ` would pin "nixpkgs" to latest version
- any change to "requirements.txt" would automatically get picked up by the `nix build`

Downside: I spent quite a while trying to figure out how to add plugins to SearXNG that is packaged this way and wasn't successful, yet hopeful that will be able to figure it out in the future.
For now [nix packaged external Searx plugin](https://github.com/return42/tgwf-searx-plugins/pull/1) would only work with Searx

I suspect that writing more extensive documentation on SearXNG installation with nix would be useful,
but I created this PR with code first, to get the feedback and comments

## Related issues

<!--
Closes #234
-->
