### PR TITLE
[fix] don't mix loaded modules with imported modules (sys.modules)

### DIFF
--- a/searx/utils.py
+++ b/searx/utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
 import re
 import importlib
 
@@ -427,13 +426,10 @@ def match_language(locale_code, lang_list=[], custom_aliases={}, fallback='en-US
 
 def load_module(filename, module_dir):
     modname = splitext(filename)[0]
-    if modname in sys.modules:
-        del sys.modules[modname]
     filepath = join(module_dir, filename)
     # and https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
     spec = importlib.util.spec_from_file_location(modname, filepath)
     module = importlib.util.module_from_spec(spec)
-    sys.modules[modname] = module
     spec.loader.exec_module(module)
     return module
 


### PR DESCRIPTION
## What does this PR do?

Don't mix loaded modules with imported modules (sys.modules)

## Why is this change important?

The utils.load_module() function is used to load a python file (aka module) and
return the module's namespace.  SearXNG uses this function to load *engines and
answerers* from arbitrary locations with arbitrary modifications.  These are not
real python modules and it is not intended to mix this *engines and answerers*
with the python modules registered in sys.modules.

## Related issues

Suggested-by: @dalf in https://github.com/searxng/searxng/issues/312
Closes: https://github.com/searxng/searxng/issues/312
