### PR TITLE
Zlibrary engine support

### DIFF
--- a/searx/engines/zlibrary.py
+++ b/searx/engines/zlibrary.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Z-Library
+
+Z-Library uses regional domains (see https://z-lib.org). Known ``base_url:``
+
+- base_url: https://b-ok.cc
+- base_url: https://de1lib.org
+- base_url: https://booksc.eu does not have cover preview
+- base_url: https://booksc.org does not have cover preview
+
+"""
+
+from urllib.parse import quote
+from lxml import html
+
+from searx.utils import extract_text, eval_xpath
+from searx.network import get as http_get
+
+# about
+about = {
+    "website": "https://z-lib.org",
+    "wikidata_id": "Q104863992",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+
+categories = ['files']
+paging = True
+base_url = ''
+
+def init(engine_settings=None):
+    global base_url # pylint: disable=global-statement
+
+    if "base_url" not in engine_settings:
+        resp = http_get('https://z-lib.org', timeout=5.0)
+        if resp.ok:
+            dom = html.fromstring(resp.text)
+            base_url = "https:" + extract_text(eval_xpath(dom,
+                './/a[contains(@class, "domain-check-link") and @data-mode="books"]/@href'
+            ))
+    logger.debug("using base_url: %s" % base_url)
+
+
+def request(query, params):
+    search_url = base_url + '/s/{search_query}/?page={pageno}'
+    params['url'] = search_url.format(
+        search_query=quote(query),
+        pageno=params['pageno']
+    )
+    return params
+
+
+def response(resp):
+    results = []
+    dom = html.fromstring(resp.text)
+
+    for item in dom.xpath('//div[@id="searchResultBox"]//div[contains(@class, "resItemBox")]'):
+        result = {}
+
+        result["url"] = base_url + \
+            item.xpath('(.//a[starts-with(@href, "/book/")])[1]/@href')[0]
+
+        result["title"] = extract_text(eval_xpath(item, './/*[@itemprop="name"]'))
+
+        year = extract_text(eval_xpath(
+            item, './/div[contains(@class, "property_year")]//div[contains(@class, "property_value")]'))
+        if year:
+            year = '(%s) ' % year
+
+        result["content"] = "{year}{authors}. {publisher}. Language: {language}. {file_type}. \
+            Book rating: {book_rating}, book quality: {book_quality}".format(
+                year = year,
+                authors = extract_text(eval_xpath(item, './/div[@class="authors"]')),
+                publisher = extract_text(eval_xpath(item, './/div[@title="Publisher"]')),
+                file_type = extract_text(
+                    eval_xpath(
+                        item,
+                        './/div[contains(@class, "property__file")]//div[contains(@class, "property_value")]')),
+                language = extract_text(
+                    eval_xpath(
+                        item,
+                        './/div[contains(@class, "property_language")]//div[contains(@class, "property_value")]')),
+                book_rating = extract_text(
+                    eval_xpath(
+                        item, './/span[contains(@class, "book-rating-interest-score")]')),
+                book_quality = extract_text(
+                    eval_xpath(
+                        item, './/span[contains(@class, "book-rating-quality-score")]')),
+            )
+
+        result["img_src"] = extract_text(eval_xpath(item, './/img[contains(@class, "cover")]/@data-src'))
+
+        results.append(result)
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -801,6 +801,17 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name: z-library
+    engine: zlibrary
+    shortcut: zlib
+    categories: files
+    timeout: 3.0
+    # choose base_url, otherwise engine will do it at initialization time
+    # base_url: https://b-ok.cc
+    # base_url: https://de1lib.org
+    # base_url: https://booksc.eu   # does not have cover preview
+    # base_url: https://booksc.org  # does not have cover preview
+
   - name: library of congress
     engine: loc
     shortcut: loc


### PR DESCRIPTION
## What does this PR do?

Add support for a zlibrary engine.
I used a python file insead of the xpath engine in order to display a more descriptive content with authors, publisher, year, file type, dimension, language and ratings.

## Why is this change important?
According to Wikipedia:

`As of 15 September 2021, Z-Library states that it provides access to more than 8,533,000 books and 84,837,000 articles.[1] According to Z-Library, it is "the world's largest ebook library" for eBooks`

So it would be awesome to query this large library directly from SearXNG.

## How to test this PR locally?

Pull and search for a book using `!zlib`.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

## Additional context
Zlibrary supports filtering by language but a list of supported languages is found only nested inside a dificult to scrape html script tag in a search result page. For the moment I did not bother to add language support but ideas are welcome.
