### PR TITLE
[fix] qwant engine - only get results from categories

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -138,6 +138,9 @@ def response(resp):
     for row in mainline:
 
         mainline_type = row.get('type', 'web')
+        if mainline_type != keyword:
+            continue
+
         if mainline_type == 'ads':
             # ignore adds
             continue


### PR DESCRIPTION
## What does this PR do?

fix qwant engine - only get results from categories

## Patch ##

Reported-by: https://github.com/searx/searx/issues/3014
Cherry-picked: https://github.com/searx/searx/commit/3bcca43
