### PR TITLE
[fix] language param for qwant

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -85,14 +85,14 @@ def request(query, params):
 
     # add language tag
     if params['language'] == 'all':
-        params['url'] += '&locale=en_us'
+        params['url'] += '&locale=en_US'
     else:
         language = match_language(
             params['language'],
             supported_languages,
             language_aliases,
         )
-        params['url'] += '&locale=' + language.replace('-', '_').lower()
+        params['url'] += '&locale=' + language.replace('-', '_')
 
     params['raise_for_httperror'] = False
     return params


### PR DESCRIPTION
## What does this PR do?

Qwant returns low quality results in the wrong language, when the language is set to en-US (the request is done as `en_us`). This PR fixes this issue by returning the language with an uppercase country code like this: `en_US`. (If found this out after trying around with https://www.qwant.com/?locale=en_US&q=c%2B%2B+arrays&t=web; so on the Qwant site itself its the en_US syntax; so its probably the same for the API?)

## Why is this change important?

Higher quality results with Qwant when using en-US language.

## How to test this PR locally?

```make run```

## Author's checklist

Before this PR:
![image](https://user-images.githubusercontent.com/38733246/137316314-21076592-640a-47a4-b83a-d747395ef449.png)


With this PR applied:
![image](https://user-images.githubusercontent.com/38733246/137316175-47f2fe33-1f4d-4ab5-9909-797f5afb51d6.png)


## Related issues

Related to fe67f1478f2f6b0939f378e7a1c65b7303f35763
