### PR TITLE
[enh] reduce the available language list

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -10,14 +10,11 @@ from zlib import compress, decompress
 from urllib.parse import parse_qs, urlencode
 
 from searx import settings, autocomplete
-from searx.languages import language_codes as languages
 from searx.locales import LOCALE_NAMES
 from searx.webutils import VALID_LANGUAGE_CODE
 
 
 COOKIE_MAX_AGE = 60 * 60 * 24 * 365 * 5  # 5 years
-LANGUAGE_CODES = [l[0] for l in languages]
-LANGUAGE_CODES.append('all')
 DISABLED = 0
 ENABLED = 1
 DOI_RESOLVERS = list(settings['doi_resolvers'])
@@ -336,7 +333,7 @@ class Preferences:
             'language': SearchLanguageSetting(
                 settings['search']['default_lang'],
                 is_locked('language'),
-                choices=list(LANGUAGE_CODES) + ['']
+                choices=settings['search']['languages'] + ['']
             ),
             'locale': EnumStringSetting(
                 settings['ui']['default_locale'],

--- a/searx/query.py
+++ b/searx/query.py
@@ -3,6 +3,7 @@
 from abc import abstractmethod, ABC
 import re
 
+from searx import settings
 from searx.languages import language_codes
 from searx.engines import categories, engines, engine_shortcuts
 from searx.external_bang import get_bang_definition_and_autocomplete
@@ -120,11 +121,17 @@ class LanguageParser(QueryPartParser):
     def _autocomplete(self, value):
         if not value:
             # show some example queries
-            for lang in [":en", ":en_us", ":english", ":united_kingdom"]:
-                self.raw_text_query.autocomplete_list.append(lang)
+            if len(settings['search']['languages']) < 10:
+                for lang in settings['search']['languages']:
+                    self.raw_text_query.autocomplete_list.append(':' + lang)
+            else:
+                for lang in [":en", ":en_us", ":english", ":united_kingdom"]:
+                    self.raw_text_query.autocomplete_list.append(lang)
             return
 
         for lc in language_codes:
+            if lc[0] not in settings['search']['languages']:
+                continue
             lang_id, lang_name, country, english_name = map(str.lower, lc)
 
             # check if query starts with language-id

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -20,6 +20,13 @@ search:
   # Default search language - leave blank to detect from browser information or
   # use codes from 'languages.py'
   default_lang: ""
+  # Available languages
+  # languages:
+  #  - all
+  #  - es
+  #  - de
+  #  - it-IT
+  #  - en-GB
   # ban time in seconds after engine errors
   ban_time_on_fail: 5
   # max ban time in seconds after engine errors

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -17,7 +17,7 @@ searx_dir = abspath(dirname(__file__))
 
 logger = logging.getLogger('searx')
 OUTPUT_FORMATS = ['html', 'csv', 'json', 'rss']
-LANGUAGE_CODES = ('', 'all') + tuple(l[0] for l in languages)
+LANGUAGE_CODES = ['all'] + list(l[0] for l in languages)
 OSCAR_STYLE = ('logicodev', 'logicodev-dark', 'pointhi')
 CATEGORY_ORDER = [
     'general',
@@ -98,6 +98,18 @@ class SettingsValue:
         self.check_type_definition(value)
         return value
 
+
+class SettingSublistValue(SettingsValue):
+    """Check the value is a sublist of type definition.
+    """
+
+    def check_type_definition(self, value: typing.Any) -> typing.Any:
+        if not isinstance(value, list):
+            raise ValueError('The value has to a list')
+        for item in value:
+            if not item in self.type_definition[0]:
+                raise ValueError('{} not in {}'.format(item, self.type_definition))
+
 class SettingsDirectoryValue(SettingsValue):
     """Check and update a setting value that is a directory path
     """
@@ -148,7 +160,8 @@ SCHEMA = {
     'search': {
         'safe_search': SettingsValue((0,1,2), 0),
         'autocomplete': SettingsValue(str, ''),
-        'default_lang': SettingsValue(LANGUAGE_CODES, ''),
+        'default_lang': SettingsValue(tuple(LANGUAGE_CODES + ['']), ''),
+        'languages': SettingSublistValue(LANGUAGE_CODES, LANGUAGE_CODES),
         'ban_time_on_fail': SettingsValue(numbers.Real, 5),
         'max_ban_time_on_fail': SettingsValue(numbers.Real, 120),
         'formats': SettingsValue(list, OUTPUT_FORMATS),

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -90,7 +90,6 @@ from searx.plugins.oa_doi_rewrite import get_doi_resolver
 from searx.preferences import (
     Preferences,
     ValidationException,
-    LANGUAGE_CODES,
 )
 from searx.answerers import (
     answerers,
@@ -432,7 +431,7 @@ def render(template_name, override_theme=None, **kwargs):
     kwargs['categories'] = _get_enable_categories(kwargs['all_categories'])
 
     # i18n
-    kwargs['language_codes'] = languages  # from searx.languages
+    kwargs['language_codes'] = [ l for l in languages if l[0] in settings['search']['languages'] ]
     kwargs['translations'] = json.dumps(get_translations(), separators=(',', ':'))
 
     locale = request.preferences.get_value('locale')
@@ -442,7 +441,7 @@ def render(template_name, override_theme=None, **kwargs):
         kwargs['rtl'] = True
     if 'current_language' not in kwargs:
         kwargs['current_language'] = match_language(
-            request.preferences.get_value('language'), LANGUAGE_CODES )
+            request.preferences.get_value('language'), settings['search']['languages'] )
 
     # values from settings
     kwargs['search_formats'] = [
@@ -524,7 +523,7 @@ def pre_request():
     # language is defined neither in settings nor in preferences
     # use browser headers
     if not preferences.get_value("language"):
-        language =  _get_browser_language(request, LANGUAGE_CODES)
+        language =  _get_browser_language(request, settings['search']['languages'])
         preferences.parse_dict({"language": language})
 
     # locale is defined neither in settings nor in preferences
@@ -807,7 +806,7 @@ def search():
         ),
         current_language = match_language(
             search_query.lang,
-            LANGUAGE_CODES,
+            settings['search']['languages'],
             fallback=request.preferences.get_value("language")
         ),
         theme = get_current_theme_name(),


### PR DESCRIPTION
## What does this PR do?

In settings.yml:
```yml
search:
  languages:
   - es
   - en-GB
```

Reduce the language list:
![image](https://user-images.githubusercontent.com/1594191/138243201-a4bae214-6358-4409-b231-35499631d3a4.png)


![image](https://user-images.githubusercontent.com/1594191/138243290-272c6c65-aa3b-4675-9c7d-11dafd5dd60b.png)

Note: `all` is always included.

## Why is this change important?

A locale instance, it can be easier to have a small set of language choices.

## How to test this PR locally?

* in `settings.yml`, uncomment the `search.languages` section
* `make run`
* check the language list
* select the default language in the preference, save the preferences, check the right value is saved.
* select another language, save the preferences, check the right value is saved.

## Author's checklist

Note: in the master branch, I don't know how the `all` choice get accepted by `searx.preferences.SearchLanguageSetting` (I had to add `['all', '']` instead of `['']` in `searx.preferences.Preferences.__init__`this PR can 

Alternative: the API can accept all the language, only the UI shows a reduced list.

## Related issues

close #406