### PR TITLE
[mod] settings_defaults.py: default values for the brand section

### DIFF
--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -139,11 +139,11 @@ SCHEMA = {
         'contact_url': SettingsValue((None, False, str), None),
     },
     'brand': {
-        'issue_url': SettingsValue(str, None),
-        'new_issue_url': SettingsValue(str, None),
-        'docs_url': SettingsValue(str, None),
-        'public_instances': SettingsValue(str, None),
-        'wiki_url': SettingsValue(str, None),
+        'issue_url': SettingsValue(str, 'https://github.com/searxng/searxng/issues'),
+        'new_issue_url': SettingsValue(str, 'https://github.com/searxng/searxng/issues/new'),
+        'docs_url': SettingsValue(str, 'https://searxng.github.io/searxng'),
+        'public_instances': SettingsValue(str, 'https://searx.space'),
+        'wiki_url': SettingsValue(str, 'https://github.com/searxng/searxng/wiki'),
     },
     'search': {
         'safe_search': SettingsValue((0,1,2), 0),


### PR DESCRIPTION
## What does this PR do?

Currently `brand.new_issue_url` must be a `str` but there is no default value:
https://github.com/searxng/searxng/blob/cec9ded2e664da501955396a2d6c438ae8c117f3/searx/settings_defaults.py#L143

This PR provides default values for the `brand` section.

## Why is this change important?

Default values from the `brand` section makes the migration from searx easier.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

A possible extension: make external links optional (link to searx.space, issues, etc...), so there are not displayed in the UI.

## Related issues

Related to https://github.com/searxng/searxng/pull/383#issuecomment-948453913
