### PR TITLE
[mod] simple theme: autocompletion doesn't use the style attribute.

### DIFF
--- a/searx/static/themes/simple/src/js/main/search.js
+++ b/searx/static/themes/simple/src/js/main/search.js
@@ -67,13 +67,10 @@
           },
           MinChars: 4,
           Delay: 300,
+          _Position:function() {
+            this.DOMResults.setAttribute("class", "autocomplete");
+          },
         }, "#" + qinput_id);
-
-        // hack, see : https://github.com/autocompletejs/autocomplete.js/issues/37
-        w.addEventListener('resize', function() {
-          var event = new CustomEvent("position");
-          qinput.dispatchEvent(event);
-        });
       }
 
       qinput.addEventListener('focus', placeCursorAtEndOnce, false);

--- a/searx/static/themes/simple/src/less/autocomplete.less
+++ b/searx/static/themes/simple/src/less/autocomplete.less
@@ -2,10 +2,13 @@
 
 .autocomplete {
   position: absolute;
+  width: 44.7rem;
+  margin-top: 2.4rem;
   max-height: 0;
   overflow-y: hidden;
   text-align: left;
-  .rounded-corners;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
 
   &:active,
   &:focus,
@@ -24,7 +27,7 @@
 
     > li {
       cursor: pointer;
-      padding: 8px 0 8px 8px;
+      padding: 8px 0 8px 0.75rem;
 
       &.active,
       &:active,
@@ -50,9 +53,15 @@
     background-color: var(--color-autocomplete-background);
     color: var(--color-autocomplete-font);
     border: 1px solid var(--color-autocomplete-border);
+    border-top: none;
     max-height: 500px;
     overflow-y: auto;
-    z-index: 100;
+    z-index: 100000000;
+
+    li:first-child {
+      margin-top: 0.475rem;
+      border-top: 1px solid var(--color-autocomplete-border);
+    }
 
     &:empty {
       display: none;
@@ -62,7 +71,11 @@
 
 @media screen and (max-width: @phone) {
   .autocomplete {
+    position: absolute;
+    width: calc(100% - 0.5rem);
+    top: 2.9rem;
     bottom: 0;
+    margin-top: 0;
   }
 
   .autocomplete > ul > li {

--- a/searx/static/themes/simple/src/less/autocomplete.less
+++ b/searx/static/themes/simple/src/less/autocomplete.less
@@ -7,8 +7,7 @@
   max-height: 0;
   overflow-y: hidden;
   text-align: left;
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
+  .rounded-bottom-corners;
 
   &:active,
   &:focus,

--- a/searx/static/themes/simple/src/less/mixins.less
+++ b/searx/static/themes/simple/src/less/mixins.less
@@ -18,6 +18,11 @@
   border-radius: @radius;
 }
 
+.rounded-bottom-corners (@radius: 10px) {
+  border-bottom-left-radius: @radius;
+  border-bottom-right-radius: @radius;
+}
+
 .rounded-corners-tiny (@radius: 5px) {
   border-radius: @radius;
 }


### PR DESCRIPTION
## What does this PR do?

Simple theme: change the autocompletion css and js not to use the style attribute.

The implementation has different issues:
* the right border can have a small gap.
* when the mouse is over the magnifier on the right, the 

![image](https://user-images.githubusercontent.com/1594191/138333191-7a70f9ae-542e-4c0c-8522-a3b1007ea32c.png)

![image](https://user-images.githubusercontent.com/1594191/138333336-1cfc3e84-bf15-4895-87b7-fd68e74e6166.png)

![image](https://user-images.githubusercontent.com/1594191/138333989-4f7a0945-c180-4235-a335-af9b0e5f2c5d.png)

## Why is this change important?

* remove `style` attributes.
* if the two above issues are fixed, cleaner UI.

## How to test this PR locally?

* `make themes`
* `make run`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

close #352