### PR TITLE
healthcheck endpoint from https://github.com/searx/searx/pull/2992

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -618,6 +618,11 @@ def index():
     )
 
 
+@app.route('/healthz', methods=['GET'])
+def health():
+    return Response('OK', mimetype='text/plain')
+
+
 @app.route('/search', methods=['GET', 'POST'])
 def search():
     """Search query in q and return results.

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -191,6 +191,11 @@ class ViewsTestCase(SearxTestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn(b'<h1>About <a href="/">searxng</a></h1>', result.data)
 
+    def test_health(self):
+        result = self.app.get('/healthz')
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(b'OK', result.data)
+
     def test_preferences(self):
         result = self.app.get('/preferences')
         self.assertEqual(result.status_code, 200)


### PR DESCRIPTION
## What does this PR do?

This PR adds a `/healthz` endpoint which does nothing more than returning plaintext `OK` response. (We could build on this by implementing healthcheck in the `Dockerfile` of this repo or in the `docker-compose.yml` of searxng/searxng-docker)

## Why is this change important?

It is useful for service discovery tools (consul/kubernetes etc.), to quickly say, that service is alive and running.

## How to test this PR locally?

```make run```

```curl https://127.0.0.1:8080/healtz -i```

## Author's checklist

## Related issues

From https://github.com/searx/searx/pull/2992
