### PR TITLE
[fix] filtron.sh: fix filtron proxy error

### DIFF
--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -42,7 +42,7 @@ SERVICE_GROUP="${SERVICE_USER}"
 SERVICE_GROUP="${SERVICE_USER}"
 
 GO_ENV="${SERVICE_HOME}/.go_env"
-GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz"
+GO_PKG_URL="https://golang.org/dl/go1.17.2.linux-amd64.tar.gz"
 GO_TAR=$(basename "$GO_PKG_URL")
 
 APACHE_FILTRON_SITE="searx.conf"

--- a/utils/morty.sh
+++ b/utils/morty.sh
@@ -28,7 +28,7 @@ SERVICE_GROUP="${SERVICE_USER}"
 SERVICE_ENV_DEBUG=false
 
 GO_ENV="${SERVICE_HOME}/.go_env"
-GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz"
+GO_PKG_URL="https://golang.org/dl/go1.17.2.linux-amd64.tar.gz"
 GO_TAR=$(basename "$GO_PKG_URL")
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
## What does this PR do?

build filtron with the golang version 1.17.2

## Why is this change important?

#443 is fixed by upgrading the golang version.

## How to test this PR locally?

In a new VM:
* follow https://searxng.github.io/searxng/admin/installation.html
* check filtron is working.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

close  #443