### PR TITLE
[fix] morty & filtron: don't use golang installed by package manager

### DIFF
--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -340,7 +340,7 @@ EOF
 
     cat > "$GO_ENV" <<EOF
 export GOPATH=\$HOME/go-apps
-export PATH=\$PATH:\$HOME/local/go/bin:\$GOPATH/bin
+export PATH=\$HOME/local/go/bin:\$GOPATH/bin:\$PATH
 EOF
     echo "Environment $GO_ENV has been setup."
 
@@ -359,7 +359,7 @@ install_filtron() {
     rst_title "Install filtron in user's ~/go-apps" section
     echo
     tee_stderr <<EOF | sudo -i -u "$SERVICE_USER" 2>&1 | prefix_stdout "$_svcpr"
-go get -v -u github.com/asciimoo/filtron
+go install -v github.com/asciimoo/filtron@latest
 EOF
 }
 
@@ -367,7 +367,7 @@ update_filtron() {
     rst_title "Update filtron" section
     echo
     tee_stderr <<EOF | sudo -i -u "$SERVICE_USER" 2>&1 | prefix_stdout "$_svcpr"
-go get -v -u github.com/asciimoo/filtron
+go install -v github.com/asciimoo/filtron@latest
 EOF
 }
 

--- a/utils/morty.sh
+++ b/utils/morty.sh
@@ -340,7 +340,7 @@ EOF
 
     cat > "$GO_ENV" <<EOF
 export GOPATH=\$HOME/go-apps
-export PATH=\$PATH:\$HOME/local/go/bin:\$GOPATH/bin
+export PATH=\$HOME/local/go/bin:\$GOPATH/bin:\$PATH
 EOF
     echo "Environment $GO_ENV has been setup."
 
@@ -359,12 +359,7 @@ install_morty() {
     rst_title "Install morty in user's ~/go-apps" section
     echo
     tee_stderr <<EOF | sudo -i -u "$SERVICE_USER" 2>&1 | prefix_stdout "$_svcpr"
-go get -v -u github.com/asciimoo/morty
-EOF
-    tee_stderr <<EOF | sudo -i -u "$SERVICE_USER" 2>&1 | prefix_stdout "$_svcpr"
-cd \$GOPATH/src/github.com/asciimoo/morty
-go test
-go test -benchmem -bench .
+go install -v github.com/asciimoo/morty@latest
 EOF
 }
 
@@ -372,12 +367,7 @@ update_morty() {
     rst_title "Update morty" section
     echo
     tee_stderr <<EOF | sudo -i -u "$SERVICE_USER" 2>&1 | prefix_stdout "$_svcpr"
-go get -v -u github.com/asciimoo/morty
-EOF
-    tee_stderr <<EOF | sudo -i -u "$SERVICE_USER" 2>&1 | prefix_stdout "$_svcpr"
-cd \$GOPATH/src/github.com/asciimoo/morty
-go test
-go test -benchmem -bench .
+go install -v github.com/asciimoo/morty@latest
 EOF
 }
 


### PR DESCRIPTION
## What does this PR do?

When golang is installed via a package manager the local version, which filtron
downloads, is ignored.

BTW: With the new go1.17.2 (cfea51f4), `go get` is deprecated::

    go get: installing executables with 'go get' in module mode is deprecated.
      Use 'go install pkg@version' instead.
      For more information, see https://golang.org/doc/go-get-install-deprecation

## How to test this PR locally?

Install filtron & morty

## Related issues

Reported-by: @tiekoetter https://github.com/searxng/searxng/pull/455#issuecomment-954918411

