### PR TITLE
[fix] make reddit only in social media category avail.

### DIFF
--- a/searx/engines/reddit.py
+++ b/searx/engines/reddit.py
@@ -18,7 +18,7 @@ about = {
 }
 
 # engine dependent config
-categories = ['general', 'images', 'news', 'social media']
+categories = ['social media']
 page_size = 25
 
 # search-url


### PR DESCRIPTION
## What does this PR do?

Make reddit only in social media category available.

## Why is this change important?

Fix #470 and also reddit has really slow load times sometimes so it should not be in the general category and news category as well in my opinion....

## How to test this PR locally?

```make run```

* enable reddit in /preferences -> engines -> social media

* search for something

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes #470
