### PR TITLE
[fix] Dockerfile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ RUN apk upgrade --no-cache \
     uwsgi \
     uwsgi-python3 \
     brotli \
- && pip3 install --upgrade pip \
- && pip3 install --no-cache -r requirements.txt \
+ && pip3 install --upgrade pip wheel setuptools \
+ && pip3 install --no-cache  --no-binary :all: -r requirements.txt \
  && apk del build-dependencies \
  && rm -rf /root/.cache
 


### PR DESCRIPTION
## What does this PR do?

ignore existing wheels, rebuild all of them
fix an issue the lxml wheel for the muslc

The build time may increase.

## Why is this change important?

Fix #482

## How to test this PR locally?

* `make docker`
* check the build image name, may be this is not `searxng/searxng` (for me `dalf/searxng`).
* `docker run --rm              -d -p ${PORT}:8080              -e "BASE_URL=http://localhost:$PORT/"              -e "INSTANCE_NAME=my-instance"              searxng/searxng` 

## Author's checklist

Alternative (?): use the Debian slim image.

## Related issues

Close #482