### PR TITLE
[mod] new preference: query_in_title

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -405,6 +405,17 @@ class Preferences:
                     'on': True,
                 }
             ),
+            'query_in_title': MapSetting(
+                settings['ui']['query_in_title'],
+                is_locked('query_in_title'),
+                map={
+                    '': settings['ui']['query_in_title'],
+                    '0': False,
+                    '1': True,
+                    'True': True,
+                    'False': False
+                }
+            ),
         }
 
         self.engines = EnginesSetting('engines', choices=engines)

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -66,6 +66,9 @@ ui:
   static_path: ""
   # Custom templates path - leave it blank if you didn't change
   templates_path: ""
+  # query_in_title: When true, the result page's titles contains the query
+  # it decreases the privacy, since the browser can records the page titles.
+  query_in_title: false
   # ui theme
   default_theme: oscar
   # Default interface locale - leave blank to detect from browser information or
@@ -91,6 +94,7 @@ ui:
 #     - language
 #     - autocomplete
 #     - method
+#     - query_in_title
 
 # searx supports result proxification using an external service:
 # https://github.com/asciimoo/morty uncomment below section if you have running

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -186,6 +186,7 @@ SCHEMA = {
         },
         'results_on_new_tab': SettingsValue(bool, False),
         'advanced_search': SettingsValue(bool, False),
+        'query_in_title': SettingsValue(bool, False),
         'categories_order': SettingsValue(list, CATEGORY_ORDER),
     },
     'preferences': {

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -280,6 +280,17 @@
                         {{ preferences_item_footer(image_proxy_info, image_proxy_label, rtl) }}
                         {% endif %}
 
+                        {% if 'query_in_title' not in locked_preferences %}
+                        {% set query_in_title_label = _('Query in the page\'s title') %}
+                        {% set query_in_title_info = _('When enabled, the result page\'s title contains your query. Your browser can record this title') %}
+                        {{ preferences_item_header(query_in_title_info, query_in_title_label, rtl, 'query_in_title') }}
+                            <select class="form-control {{ custom_select_class(rtl) }}" name="query_in_title" id="query_in_title">
+                                <option value="1" {% if query_in_title  %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
+                                <option value="" {% if not query_in_title %}selected="selected"{% endif %}>{{ _('Disabled')}}</option>
+                            </select>
+                        {{ preferences_item_footer(query_in_title_info, query_in_title_label, rtl) }}
+                        {% endif %}
+
                         {{ plugin_of_category('privacy' )}}
                     </div>
                 </fieldset>

--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -16,7 +16,7 @@
 {%- endmacro %}
 {%- macro search_url() %}{{ url_for('search', _external=True) }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}{% if time_range %}&amp;time_range={{ time_range }}{% endif %}{% if current_language != 'all' %}&amp;language={{ current_language }}{% endif %}{% endmacro -%}
 
-{% block title %}{{ q|e }} - {% endblock %}
+{% block title %}{% if query_in_title %}{{- q|e -}} - {% endif %}{% endblock %}
 {% block meta %}{{"    "}}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ search_url() }}&amp;format=rss">{% endblock %}
 {% block content %}
     {% include 'oscar/search.html' %}

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -237,6 +237,18 @@
       <div class="description">{{ _('Proxying image results through SearXNG') }}</div>
     </fieldset>
     {% endif %}
+    {% if 'query_in_title' not in locked_preferences %}
+    <fieldset>
+      <legend>{{ _('Query in the page\'s title') }}</legend>
+      <p class="value">
+        <select name='query_in_title'>
+          <option value="1" {% if query_in_title %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
+          <option value="" {% if not query_in_title %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>
+        </select>
+      </p>
+      <div class="description">{{ _('When enabled, the result page\'s title contains your query. Your browser can record this title.') }}</div>
+    </fieldset>
+    {% endif %}
     {{ plugin_preferences('privacy') }}
   {{ tab_footer() }}
 

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -7,7 +7,7 @@
         {% endfor %}
     {% endfor %}
 {%- endmacro %}
-{% block title %}{% if method == 'GET' %}{{- q|e -}} -{% endif %}{% endblock %}
+{% block title %}{% if query_in_title %}{{- q|e -}} - {% endif %}{% endblock %}
 {% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('search', _external=True) }}?q={{ q|urlencode }}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}&amp;pageno={{ pageno }}&amp;time_range={{ time_range }}&amp;language={{ current_language }}&amp;safesearch={{ safesearch }}&amp;format=rss">{% endblock %}
 {% block content %}
 <nav id="linkto_preferences"><a href="{{ url_for('preferences') }}">{{ icon('navicon-round') }}</a></nav>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -425,6 +425,7 @@ def render(template_name, override_theme=None, **kwargs):
     kwargs['autocomplete'] = request.preferences.get_value('autocomplete')
     kwargs['results_on_new_tab'] = request.preferences.get_value('results_on_new_tab')
     kwargs['advanced_search'] = request.preferences.get_value('advanced_search')
+    kwargs['query_in_title'] = request.preferences.get_value('query_in_title')
     kwargs['safesearch'] = str(request.preferences.get_value('safesearch'))
     kwargs['theme'] = get_current_theme_name(override=override_theme)
     kwargs['all_categories'] = _get_ordered_categories()


### PR DESCRIPTION
## What does this PR do?

* disable by default
* settings.yml: ui.query_in_title
* in /preferences: privacy tab

when enabled, the result page's title contains the user query.

previously:
* oscar theme: the query was always included
* simple theme: the query was included with the GET method

![image](https://user-images.githubusercontent.com/1594191/140608059-17d3c445-fcd8-4ebc-80cc-6cb62c4a5756.png)

![image](https://user-images.githubusercontent.com/1594191/140608065-27efb01a-556a-4ecd-8ecd-119bb1ba5c30.png)

## Why is this change important?

Some browser records the page history using the HTML title pages.

See https://github.com/searxng/searxng/issues/434#issuecomment-962023693

## How to test this PR locally?

With the simple and oscar themes:
* make a query : check there is NO title
* change the preferences: check there is a title
* reset the preferences
* in settings.yml: set `ui.query_in_title: true`
* check there is a title
* in settings.yml: set `lock: - query_in_title`
* `/preferences`: check the option has disappeared.

## Author's checklist


## Related issues

Related to #434