### PR TITLE
[fix] make test.shell - ./manage line 80

### DIFF
--- a/manage
+++ b/manage
@@ -77,7 +77,7 @@ pyenv.:
 pypi.upload:
   Upload python packages to PyPi (to test use pypi.upload.test)
 test.:
-  yamllint  : lint YAML files: $YAMLLINT_FILES
+  yamllint  : lint YAML files (YAMLLINT_FILES)
   pylint    : lint PYLINT_FILES, searx/engines, searx & tests
   pep8      : pycodestyle (pep8) for all files except PYLINT_FILES
   unit      : run unit tests


### PR DESCRIPTION
`make test.shell` reports an issue that has been added in [PR-500]::

    In ./manage line 80:
      yamllint  : lint YAML files: $YAMLLINT_FILES
                                   ^-------------^
                                   SC2128: Expanding an array without an
                                   index only gives the first element.

[PR-500] https://github.com/searxng/searxng/pull/500