### PR TITLE
[engines] move library of genesis from general to files category

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -806,7 +806,7 @@ engines:
     url_xpath: //a[contains(@href,"bookfi.net/md5")]/@href
     title_xpath: //a[contains(@href,"book/")]/text()[1]
     content_xpath: //td/a[1][contains(@href,"=author")]/text()
-    categories: general
+    categories: files
     timeout: 7.0
     disabled: true
     shortcut: lg


### PR DESCRIPTION
## What does this PR do?

Move library of genesis from general to files category (maybe science would be better?).

## Why is this change important?

I think it fits better in files and also: https://github.com/paulgoio/searxng/issues/13

## How to test this PR locally?

```make run```

## Author's checklist

(Also it says on engines page that the engine does not support HTTPS; but in settings.yml the search url is HTTPS !?)

## Related issues

<!--
Closes #234
-->
