### PR TITLE
[fix] Qwant search query string

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -59,7 +59,7 @@ category_to_keyword = {
 }
 
 # search-url
-url = 'https://api.qwant.com/v3/search/{keyword}?q={query}&count={count}&offset={offset}'
+url = 'https://api.qwant.com/v3/search/{keyword}?{query}&count={count}&offset={offset}'
 
 def request(query, params):
     """Qwant search request"""


### PR DESCRIPTION
## What does this PR do?
Search string: "!qwant time"
Resulting request URL: https://api.qwant.com/v3/search/web?q=q=time&count=10&offset=0&device=desktop&safesearch=1&locale=en_US
Notice the double `q=`

Resulting request URL after fix: https://api.qwant.com/v3/search/web?q=time&count=10&offset=0&device=desktop&safesearch=1&locale=en_US

## Why is this change important?
Improve qwant search result quality.
Currently the search string is prefixed with `q=` resulting in unwanted search results.

## How to test this PR locally?
`make run`

## Author's checklist

## Related issues
