### PR TITLE
[mod] engines - add Onesearch engine

### DIFF
--- a/searx/data/engine_descriptions.json
+++ b/searx/data/engine_descriptions.json
@@ -16,7 +16,7 @@
   "wikinews":"Wikinews es un projècte de la Wikimedia Foundation visant a establir una font d'informacions liura resumissent d'actualitats e seguissent un punt de vista neutra. Son contengut es liurament distribuible segon los tèrmes de la licéncia Creative Commons Attribution 2.5. Lo nom del projècte a per originas la tecnologia utilizada e lo tèrme anglés « news », que se traduch per « actualitats » o « informacions ». Son foncionament es basat sul jornalisme ciutadan.",
   "wiktionary":"Lo wikiccionari es un projècte de la Wikimedia Foundation de diccionari liure, a gratís e escrich amb la collaboracion de totes. La version occitana a començat lo 14 d'abril de 2005. Lo nom anglés es Wiktionary."
  },
- "nl_BE":{
+ "nl-BE":{
   "archive is":"archive.today is een Engelstalige niet-commerciële website, die tot doel heeft schermafbeeldingen van webpagina's te archiveren, zodat de inhoud ervan beschikbaar blijft wanneer de oorspronkelijke pagina is verdwenen. Archive.today archiveert op verzoek. De website werd opgericht in 2012. Archive.today is geregistreerd bij de Amerikaanse registrar Enom.",
   "artic":"Het Art Institute of Chicago (AIC) is een museum voor beeldende kunsten aan 111 South Michigan Avenue in Grant Park, Chicago (Illinois).",
   "arxiv":"arXiv is een verzameling van elektronische vooruitgaven van wetenschappelijke artikelen in de wiskunde, natuurkunde, sterrenkunde, informatica, mathematische biologie, statistiek en mathematische economie, die online geraadpleegd kunnen worden. In bepaalde deelgebieden van de wis- en natuurkunde kunnen bijna alle wetenschappelijke artikelen op arXiv gevonden worden. arXiv is opgericht op 14 augustus 1991 en passeerde de grens van een half miljoen artikelen op 3 oktober 2008. In 2012 werden er meer dan 7000 artikelen per maand op arXiv geplaatst.",
@@ -24,7 +24,7 @@
   "wikipedia":"Wikipedia is een meertalige internetencyclopedie, die door vrijwillige auteurs wordt geschreven. Wikipedia wordt gepubliceerd onder een vrije licentie, waardoor de inhoud elders gratis mits met bronvermelding opnieuw te gebruiken is. De website is eigendom van de Amerikaanse Wikimedia Foundation. Het is het oudste en bekendste project van deze organisatie.",
   "bing":"Bing, codenaam Kumo, is een zoekmachine van Microsoft, die op 3 juni 2009 werd gelanceerd. Het is de op een na grootste zoekmachine op het internet na Google. Bing heeft elk jaar een groeiend aantal gebruikers. Bing heeft in 2019 een wereldwijd marktaandeel van ongeveer 2,5%. Het programma is vooral populair in de Verenigde Staten en in India. Op 15 november 2011 werd de bètatag ervan verwijderd.",
   "bing images":[
-   "bing:nl_BE",
+   "bing:nl-BE",
    "ref"
   ],
   "bitbucket":[
@@ -32,21 +32,20 @@
    "wikidata"
   ],
   "crossref":"CrossRef is een samenwerking tussen uitgevers om de standaardisatie van digitale objecten online mogelijk te maken.",
-  "currency":"DuckDuckGo is een zoekmachine die informatie van veelbezochte sites zoals Wikipedia gebruikt om traditionele internet-zoekresultaten te verbeteren. De zoekmachine beoogt een betere privacy voor gebruikers te geven en poogt ook vooringenomenheid te voorkomen. Er wordt niet gekeken naar het zoekgedrag van de gebruiker. Elke gebruiker krijgt dezelfde zoekresultaten te zien voor dezelfde zoekopdracht.",
+  "currency":"DuckDuckGo is een zoekmachine die informatie van veelbezochte sites zoals Wikipedia gebruikt om traditionele internet-zoekresultaten te verbeteren. De zoekmachine beoogt een betere privacy voor gebruikers te geven en poogt vooringenomenheid te voorkomen. Er wordt niet gekeken naar het zoekgedrag van de gebruiker. Elke gebruiker krijgt dezelfde zoekresultaten te zien voor dezelfde zoekopdracht.",
   "deezer":"Deezer is een web-streaming service voor muziek. De dienst laat gebruikers onbeperkt luisteren naar nummers van muzieklabels zoals Sony Music Entertainment, Universal Music Group, en Warner Music Group. Deezer is beschikbaar in browsers, op Android, BlackBerry, iOS, Windows Phone en Symbian. Naast afspeelmogelijkheden in browsers zijn er met Deezer ook mogelijkheden tot afspelen via streaming speakers zoals onder andere die van HEOS by Denon. Ook is er een Windows 8 en een Windows 10 desktop app.",
   "deviantart":"DeviantART is een Engelstalige internet-community waar gebruikers zelfgemaakte kunstwerken tentoonstellen. De website ging van start op 7 augustus 2000 op initiatief van Scott Jarkoff, Matthew Stephens en Angelo Sotira. Het bedrijf deviantArt, Inc. is in Hollywood gevestigd.",
   "ddg definitions":[
-   "currency:nl_BE",
+   "currency:nl-BE",
    "ref"
   ],
-  "digg":"Digg is een Amerikaanse website die (nieuws)artikelen publiceert op het gebied van wetenschap en technologie, politiek en amusement.",
   "wikidata":"Wikidata is een project van de Wikimedia Foundation dat een gezamenlijk bewerkte database biedt, op basis van RDF technologie, die onder andere wordt gebruikt om Wikipedia te ondersteunen. Het project werd in 2012 door Wikimedia Duitsland gestart. Wikidata is net zoals de andere projecten van de Wikimedia Foundation gericht op kennisoverdracht.",
   "duckduckgo":[
-   "currency:nl_BE",
+   "currency:nl-BE",
    "ref"
   ],
   "duckduckgo images":[
-   "currency:nl_BE",
+   "currency:nl-BE",
    "ref"
   ],
   "flickr":"Flickr is een website voor het delen van foto's en videofragmenten. Net als Delicious wordt het gezien als een Web 2.0-applicatie die tagging (trefwoorden) gebruikt om een niet-hiërarchische classificering mogelijk te maken (folksonomie).",
@@ -61,10 +60,11 @@
   "google scholar":"Google Scholar is een gratis toegankelijke internet-zoekmachine die de volledige tekst of metadata van wetenschappelijke literatuur indexeert in een scala aan publicatie-indelingen en disciplines. De Google Scholar-index, die in november 2004 als bètaversie werd uitgebracht, bevat de meeste door vakgenoten beoordeelde online academische boeken en tijdschriften, conferentiedocumenten, scripties en proefschriften, preprints, samenvattingen, technische rapporten en andere wetenschappelijke literatuur, waaronder rechterlijke adviezen en patenten. Hoewel Google niet de omvang van de Google Scholar-database publiceert, schatten scientometrische onderzoekers dat deze ongeveer 389 miljoen documenten bevat, inclusief artikelen, citaten en patenten, waardoor het in januari 2018 's werelds grootste academische zoekmachine is. Eerder werd de omvang geschat op 160 miljoen documenten vanaf mei 2014. Een eerdere statistische schatting gepubliceerd in PLOS ONE met behulp van een Mark and recapture-methode schatte ongeveer 80-90% dekking van alle in het Engels gepubliceerde artikelen met een schatting van 100 miljoen. Deze schatting bepaalde ook hoeveel documenten vrij beschikbaar waren op het internet.",
   "google play apps":"Google Play, voorheen Android Market, is de applicatie en website waarmee apps kunnen worden geïnstalleerd op mobiele telefoons die draaien op Android. Het is de Android-tegenhanger van App Store van Apple. Google Play wordt beheerd door Google. Om apps te kunnen downloaden en/of installeren is een Google-account noodzakelijk. Tijdens het aanmaken van een Google-account moet een e-mailadres opgegeven worden.",
   "google play movies":[
-   "google play apps:nl_BE",
+   "google play apps:nl-BE",
    "ref"
   ],
   "hoogle":"Haskell is een functionele programmeertaal vernoemd naar de wiskundige Haskell Brooks Curry.",
+  "imdb":"De Internet Movie Database is een online databank met films, televisieseries, acteurs en videogames. IMDb werd in 1990 opgericht door Col Needham en is sinds 1998 in handen van Amazon.com.",
   "kickass":"KickassTorrents is een website die BitTorrent-bestanden en magneetlinks indexeert. Volgens Alexa behoorde de website in november 2014 tot de meest bezochte websites ter wereld.",
   "library genesis":"Library Genesis of LibGen is een zoekmachine voor artikels en boeken over verschillende onderwerpen. Library Genesis maakt de gratis toegang mogelijk tot inhoud waar anders voor betaald moet worden of nog niet is gedigitaliseerd. Het bevat onder meer PDF's met inhoud van de ScienceDirect-webportal van Elsevier.",
   "library of congress":"De Library of Congress in Washington D.C. is de nationale bibliotheek van de Verenigde Staten en een van de belangrijkste bibliotheken ter wereld. Formeel is de Library of Congress een agentschap van het Amerikaans Congres.",
@@ -75,19 +75,27 @@
    "wikidata"
   ],
   "openairepublications":[
-   "openairedatasets:nl_BE",
+   "openairedatasets:nl-BE",
    "ref"
   ],
   "openstreetmap":"OpenStreetMap (OSM) is een project dat als doel heeft om vrij beschikbare en bewerkbare geografische gegevens te verzamelen, zodat daaruit landkaarten en andere diensten kunnen gemaakt worden. Eenieder die zich inschrijft, kan eraan meewerken. Het invoeren en aanpassen van de geografische data steunt volledig op vrijwilligers. Het is mede opgericht uit onvrede met de hoge kosten die commerciële kaartbedrijven vragen voor hun producten. Reeds meer dan 20 miljoen kilometer wegen, fiets- en voetpaden werden in kaart gebracht door middel van het overnemen van gegevens van luchtfoto's en zelf op pad te gaan met een GPS-apparaat. In juni 2020 waren elke dag gemiddeld zo'n 6300 vrijwilligers actief aan het bijdragen.",
   "piratebay":"The Pirate Bay is een website die torrentlinks indexeert. Volgens Alexa stond de website in maart 2013 op plaats 73 van de meest bezochte websites ter wereld. In december 2014 ging de Pirate Bay een paar maanden offline nadat de Zweedse politie tijdens een inval een groot aantal servers van de website in beslag nam.",
   "reddit":"Reddit is een Amerikaanse sociale nieuwswebsite. Advance Magazine Publishers Inc. heeft hierin een meerderheidsbelang.",
   "soundcloud":"SoundCloud is een online audioplatform dat geluidsproducenten de mogelijkheid geeft hun origineel gecreëerde geluiden te uploaden, op te nemen, promoten en delen.",
-  "stackoverflow":"Stack Overflow is een website met vragen en antwoorden over een breed scala van programmeeronderwerpen. Het werd opgericht in 2008 en is onderdeel van het Stack Exchange-netwerk van sites waar bijvoorbeeld ook 'Ask Ubuntu' deel van uitmaakt. Sinds juni 2021 is de website eigendom van de internationale investeringsgroep Prosus.",
+  "stackoverflow":"Stack Exchange is een netwerk van websites waar mensen vragen kunnen stellen en beantwoorden over verschillende onderwerpen. Stack Exchange is onderverdeeld in verschillende websites, die elk een aparte categorie behandelen. Deze categorieën zijn voornamelijk gericht op de ict en het programmeren.",
+  "askubuntu":[
+   "stackoverflow:nl-BE",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:nl-BE",
+   "ref"
+  ],
   "startpage":"Startpage is een zoekmachine gevestigd in Nederland en eigendom van de Nederlandse vennootschap Startpage B.V. in Den Haag De zoekmachine heeft de privacy van de gebruiker hoog in haar vaandel staan.",
   "youtube":"YouTube is een website van YouTube LLC, een dochteronderneming van Google LLC. Het is een website waar gebruikers kosteloos video's kunnen publiceren en voorzien van advertenties kunnen bekijken. YouTube is na Google.com de meest bezochte website ter wereld. Per dag worden er ongeveer 300.000 nieuwe video's geplaatst (2016).",
   "dailymotion":"Dailymotion is een website waarop kosteloos video's geplaatst en bekeken kunnen worden. Het motto van de website is Share Your Videos.",
   "vimeo":"Vimeo is een videowebsite waar gebruikers video's kunnen uploaden, delen en bekijken. Voor het uploaden moet men houder zijn van de rechten van het beeldmateriaal en alle andere inhoud.",
-  "wikibooks":"Wikibooks is een kennisproject van de Wikimedia Foundation en is bedoeld als een verzameling vrije (gratis) leerboeken.",
+  "wikibooks":"Wikibooks is een kennisproject van de Wikimedia Foundation en is bedoeld als een verzameling vrije (gratis) studieboeken.",
   "wikinews":"Wikinieuws, in het Engels en veel andere talen Wikinews genoemd, is een nieuwsbron van vrije informatie, in de vorm van een wiki waarin iedereen nieuwsartikelen kan publiceren over een breed scala van onderwerpen. Het is een project van de Wikimedia Foundation en werd formeel gestart in november 2004.",
   "wikiquote":"Wikiquote is een van de deelprojecten van de Wikimedia Foundation. Het doel van Wikiquote is het verzamelen van citaten van en over bekende personen. Daarnaast zijn er aparte pagina's voor citaten over een bepaald thema, zoals films, series, fictieve personages, boeken en meer algemene zaken zoals het weer. Ook is er ruimte voor het verzamelen van spreekwoorden in een bepaalde taal.",
   "wikisource":"Wikisource is een project van de Wikimedia Foundation dat zich richt op het verzamelen van bronmateriaal. Het project heeft hiermee als doel om een vrij wikiwikicompendium van primaire bronnen in elke taal te worden en om vertalingen van deze bronteksten te creëren. Alle teksten die op Wikisource worden gepubliceerd, dienen onder een vrije licentie te staan of bij het publiek domein te horen.",
@@ -128,7 +136,6 @@
    "currency:ar",
    "ref"
   ],
-  "digg":"ديغ ‏ موقع ويب 2.0 يقدم خدمة المفضلات الاجتماعية. يتيح الموقع للمستخدمين إضافة وتقييم مواضيع الأخبار والمدونات وغيرها، يضيف المستخدمون وصلات لصفحات الأخبار والمدونات من الإنترنت إلى الموقع. ديغ يشبه لحد كبير موقع رديت.",
   "wikidata":"ويكي بيانات مشروع يهدف لإنشاء قاعدة بيانات حرة للمعلومات عن العالم يمكن للإنسان والآلة قراءتها وتعديلها على حد سواء. إذ ستزود ببيانات بجميع لغات مشاريع ويكيميديا، وتتيح الوصول المركزي إلى البيانات مثلما يعمل مشروع ويكيميديا كومنز للملفات. المشروع تشغله وتستضيفه مؤسسة ويكيميديا وهو أحد المشاريع الشقيقة لويكيبيديا الموسوعة الحرة. أنشئ المشروع بتمويل من التبرعات المقدمة من معهد ألين للذكاء الاصطناعي، ومؤسسة غوردون وبيتي موور، وشركة جوجل، تصل إلى إجمالي 1.3 مليون دولار.",
   "duckduckgo":[
    "currency:ar",
@@ -157,6 +164,7 @@
    "ref"
   ],
   "hoogle":"هاسكل هي لغة برمجة مطابقة للمعايير، للأغراض العامة، وهي لغة وظيفية إلى حد كبير، دون دلالات ألفاظ ملزمة وبكتابة ثابتة وقوية. وقد سُميت بـ هاسكل علي اسم عالم المنطق \" هاسكل كوري \". وفي اللغة هاسكل، \"تمثل الوظيفة مواطن من الدرجة الأولى\" من لغة البرمجة. ولكونها لغة برمجة وظيفية فإن بنية التحكم الرئيسية هي الوظيفة. وترجع أصول اللغة إلى ملاحظات هاسكل كوري وأتباعه من المفكرين، بأن \" الإثبات هو برنامج؛ والمعادلة التي يثبتها هي نوع للبرنامج\".",
+  "imdb":"قاعدة بيانات الأفلام على الإنترنت وتُعرف اختصارًا بـ آي إم دي بي ‏ هي قاعدة بيانات عبر الإنترنت للمعلومات المتعلقة بالأفلام والبرامج التلفزيونية ومقاطع الفيديو المنزلية وألعاب الفيديو والمحتوى المتدفق عبر الإنترنت - بما في ذلك الممثلون وطاقم الإنتاج والسير الذاتية الشخصية وملخصات الحبكة، التقييمات وآراء المعجبين وكذا المراجعات النقدية. كان موقع قاعدة بيانات الأفلام على الإنترنت في الأصل موقع ويب يُديره المعجبون إلى أن سيطرت عليهِ شركة آي إم دي بي دوت كوم إنكوايرر ‏ وهي شركةٌ تابعةٌ لشركة أمازون. بدأ الموقع كقاعدة بيانات أفلام على مجموعة يوزنت ‏ على المسار ريك دوت آرتس دوت موفيز ‏ في عام 1990 وانتقلَ إلى الويب في عام 1993.",
   "kickass":"كيك اس تورنت ‏ هو موقع على شبكة الانترنت، تأسس في عام 2008، يوفر ملفات وروابط تورنت لتسهيل تبادل الملفات الند للند باستخدام بروتوكول بت تورنت. وتوقف الموقع عن الخدمة في 20 يوليوز عام 2016، بعد أن تم الحجز على اسم نطاقه من قبل حكومة الولايات المتحدة. وأغلقت خوادم بروكسي الموقع من طرف موظفيه في نفس الوقت.",
   "library genesis":"مكتبة التكوين ‏ وتُدعى اختصارًا LibGen هي محرك بحث للمقالات والكتب حول مواضيع مختلفة، والتي تتيح الوصول المجاني إلى المحتوى الذي يتم توصيله بطريقة أخرى أو عدم ترقيمه في مكان آخر. من بين أمور أخرى، تتضمن ملفات بي دي اف محتوى من بوابة إلزيفير المعروفة باسم سيانس دايركت",
   "library of congress":"مكتبة الكونغرس ‏ تعرف اختصاراً LOC هي مكتبة الأبحاث والتي تخص رسمياً كونغرس الولايات المتحدة وهي المكتبة الوطنية للولايات المتحدة بحكم الأمر الواقع .وهي أقدم مؤسسة ثقافية اتحادية في الولايات المتحدة. تقع المكتبة في ثلاثة مبان في كابيتول هيل في واشنطن دي سي .كما أنها تحتفظ بالمركز الوطني للمحافظة على السمعيات والبصريات في كولبيبر بولاية فيرجينيا. يشرف أمين مكتبة الكونغرس على وظائف المكتبة، ويحافظ مهندس مبنى الكابيتول على مبانيها. تعد مكتبة الكونجرس من أكبر المكتبات في العالم. \"مجموعاتها عالمية ولا تقتصر على الموضوع أو التنسيق أو الحدود الوطنية، وتتضمن مواد بحثية من جميع أنحاء العالم وبأكثر من 450 لغة.\"",
@@ -166,7 +174,15 @@
   "pubmed":"مدلاين ‏ هي قاعدة بيانات ببليوغرافية في علوم الحياة والعلوم الحيوية الطبية. تحتوي على معلومات ببليوغرافية حول المجلات الأكاديمية في علوم الطب والتمريض والصيدلة وطب الأسنان والطب البيطري والرعاية الصحية. كما يحتوي مدلاين على مواضيع في علم الأحياء والكيمياء الحيوية وكذلك مجالات التطور الجزيئي والطب الحيوي.",
   "reddit":"ريديت ‏ هو مجتمع إخباري على الإنترنت، إلا أنه يعتبر أيضا من مواقع مشاركة الروابط ومناقشتها حتى بات يشبه المنتديات، يعرف ريديت بالصفحة الرئيسية للإنترنت.",
   "soundcloud":"ساوند كلاود هو موقع ويب للموسيقى والصوتيات يمكن لأي شخص من خلاله إنشاء الأصوات ومشاركتها. يتيح ساوند كلاود تسجيل الأصوات وتحميلها بسهولة، ومشاركة الصوت في إطار خاص مع أصدقائهم أو بشكل عام على المدونات ومواقع الويب والشبكات الاجتماعية، يزور الموقع حوالي 175 مليون شخص كل شهر، كما انه متوفر كتطبيق للهواتف الذكية.",
-  "stackoverflow":"ستاك أوفرفلو ‏ هو الموقع الرئيسي لستاك إكستشينج، أنشأ في عام 2008 من قِبل جيف أتوود وجويل سبولسكي. اختير الاسم من قبل رواد مدونة البرمجة الشهيرة كودينق هورر عام 2008.",
+  "stackoverflow":"ستاك إكستشينج Stack Exchange هي شبكة من مواقع الأسئلة والأجوبة التي يهتم كل منها باختصاص معين، ويقوم المستخدمون فيها بطرح الأسئلة، الإجابة عليها، وتقييم الأسئلة والأجوبة بشكل تعاوني غير مركزي.",
+  "askubuntu":[
+   "stackoverflow:ar",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:ar",
+   "ref"
+  ],
   "semantic scholar":"سيمانتك سكولر هو مشروعٌ طُور في معهد ألن للذكاء الاصطناعي، وصدر للجمهور في نوفمبر 2015، وهو مصممٌ ليكون محرك بحث مدعومًا بالذكاء الاصطناعي للمنشورات الأكاديمية. يستخدم المشروع مزيجًا من التعلم الآلي ومعالجة اللغة الطبيعية والرؤية الآلية لإضافة طبقة من التحليل الدلالي إلى الأساليب التقليدية لتحليل الاقتباس واستخراج الأشكال والكيانات والأماكن ذات الصلة من الأوراق. مقارنةً مع جوجل سكولار وببمد، فإنَّ سيمانتك سكولر مصممٌ لإبراز أهم الأوراق والأكثر تأثيرًا، وتحديد الروابط بينهما.",
   "yahoo news":"ياهو! نيوز بالإنجليزية موقع أخباري تابع لشركة ياهو الأمريكية تقوم بجمع الأخبار من جميع الوكلات والصحف ووضعها في الموقع.",
   "youtube":"يوتيوب ‏ هو موقع ويب يسمح لمستخدميه برفع التسجيلات المرئية مجانًا ومشاهدتها عبر البث الحي ومشاركتها والتعليق عليها وغير ذلك. أسسه في 14 فبراير سنة 2005م ثلاث موظفين سابقين من شركة باي بال هم تشاد هيرلي وستيف تشين وجاود كريم، في مدينة سان برونو، وكان يستخدم تقنية برنامج أدوبي فلاش لعرض المقاطع المتحركة، أما الآن فيعتمد تقنية إتش تي إم إل 5. ومحتوى الموقع يتنوع بين مقاطع الأفلام، والتلفاز، والموسيقى، وكذلك الفيديو المنتج من قبل الهواة، وغيرها. وهو حاليًا مزود بأكثر من ألفي موظف. وفي أكتوبر 2006 أعلنت شركة Google التوصل لاتفاقية لشراء الموقع مقابل 1.65 مليار دولار أمريكي، أي ما يعادل 1.31 مليار يورو. ويعتبر الموقع من مواقع ويب 2.0.",
@@ -190,7 +206,7 @@
  "bg":{
   "arxiv":"arXiv е Интернет архив със свободен достъп за статии от областта на физиката, математиката, компютърните науки и биологията.",
   "wikipedia":"Уикипедия е многоезична, уеб базирана енциклопедия със свободно съдържание. Тя е динамичен продукт на сътрудничещи си доброволци от цял свят, позволяваща на всеки човек с достъп до интернет да участва в редактирането ѝ. Проектът започва на 15 януари 2001 г. като допълнение към Нюпедия, която се съставя от експерти. Към 2020 г. Уикипедия се управлява от Фондация Уикимедия, организация с нестопанска цел. В Уикипедия има над 40 милиона статии, включително над 250 000 в българоезичната ѝ версия, създадени от над 100 000 доброволци. През годините на своето съществуване Уикипедия завоюва голяма популярност, насърчавайки зараждането на други сродни проекти като Уикиречник, Уикикниги и други.",
-  "bing":"Bing е онлайн търсачка на Microsoft.",
+  "bing":"Microsoft Bing е онлайн търсачка на Microsoft.",
   "bing images":[
    "bing:bg",
    "ref"
@@ -204,12 +220,11 @@
    "https://www.bing.com/videos"
   ],
   "deviantart":"deviantArt е онлайн общност, в която се качват различни видове „произведения на изкуството“, направени от потребителите. Отворен е на 7 август, 2000 от Скот Джаркоф, Матю Стивънс, Анджело Сотира и други. Дружеството на deviantArt се намира в Холивуд, Лос Анджелис, Съединени щати.",
-  "digg":"Digg е социална мрежа за новини създадена от Кевин Роуз, чиято идея е да предостави на хората възможност да откриват и споделят съдържание отнякъде в интернет, чрез публикуване на връзки към новини, както и гласуването и коментирането им. Гласуването на връзки нагоре и надолу, е основна функция на сайта и носи неговото име, съответно „изкопай“ и „закопай“. Много връзки са публикувани всеки ден, но само „най-изкопаните“ връзки се появяват на първа страница. Популярността на Digg подтиква към създаването на други сайтове за социални контакти.",
   "wikidata":"Уикиданни е уики проект – база знания създадена от Фондация Уикимедия. Съдържанието е свободно и подобно на повечето проекти на фондацията е достъпно под лицензи „Криейтив Комънс – Признание – Споделяне на споделеното“ (CC-BY-SA) и обществено достояние (CC0).",
   "github":"GitHub e уеб базирана услуга за разполагане на софтуерни проекти и техни съвместни разработки върху отдалечен интернет сървър в т.нар. хранилище. Базира се на Git системите за контрол и управление на версиите. Услугата може да бъде както платена за частни проекти, така и безплатна за т.нар. проекти с общодостъпен код, като и в двата случая потребителите могат да ползват всички възможности на услугата. Към май 2011 г. GitHub се счита за най-популярния сайт за разполагане на съвместни проекти с общодостъпен или наречен още отворен код.",
   "google":"Гугъл търсачката е интернет търсачка, притежание на едноименната компания Гугъл.",
   "google images":[
-   "Google Изображения. Най-резултатното търсене на изображения в мрежата.Google Изображения. Най-резултатното търсене на изображения в мрежата.",
+   "Google Изображения. Най-резултатното търсене на изображения в мрежата.",
    "https://images.google.com"
   ],
   "google news":[
@@ -223,12 +238,21 @@
    "ref"
   ],
   "hoogle":"Haskell (Ха̀скъл) е функционален език за програмиране. В частност, той е полиморфично статично-типизиран, „мързелив“, чисто функционален език, доста различен от повечето езици за програмиране. Името му е в чест на логика Хаскел Къри, чийто труд в областта на математическата логика е в основата на създаването на функционалните езици. Haskell е базиран на ламбда смятане, следователно ламбда се използва за негово лого. Поради близостта си с математиката и богатството от математически библиотеки езикът е широко използван за решаване на кратки математически задачи.",
+  "imdb":"Internet Movie Database е онлайн база от данни с информация за актьори, филми, телевизионни предавания, телевизионни звезди, видеоигри и технически персонал (кинаджии).",
   "library of congress":"Библиотеката на Конгреса е фактически национална библиотека на Съединените щати. Тя е най-старото федерално културно учреждение в САЩ.",
   "openstreetmap":"„Оупън Стрийт Мап“, съкратено ОСМ, е сътруднически проект за създаване на свободна и редактируема карта на света.",
   "piratebay":"The Pirate Bay е известен шведски уеб сайт, най-големият BitTorrent тракер в света, позволяващ надежден трансфер на големи файлове, с повече от 22 млн. потребители. Той също служи като индекс за торент файлове.",
   "reddit":"Reddit е новинарски сайт, позволяващ създаването на отделни общности, наречени „subreddits“, в които потребители да споделят снимки, видео, линкове и текстове по определена тема, които могат да се обсъждат и да бъдат гласувани.",
   "soundcloud":"SoundCloud е онлайн платформа за разпространение на аудио и музика, базирана в Берлин, Германия, която позволява на потребителите да качват и споделят звукови файлове.",
-  "stackoverflow":"Stack Overflow е уебсайт, създаден от Джеф Атууд и Джоел Сполски през 2008 г.",
+  "stackoverflow":"Stack Exchange е мрежа от сайтове за въпроси и отговори по различни тематики в различни сфери, като всеки сайт покрива определена тематика. В тези сайтове потребителите се ползват с ограничение/възнаграждаване на техните онлайн действия в зависимост от активността им онлайн и „репутацията“, която получават в тези сайтове като резултат от тяхната онлайн активност. Тези сайтове са моделирани по примера на популярния сайт Stack Overflow, интернет форум за компютърно програмиране и въпроси по тази тематика, като това е оригиналният начален сайт в тази мрежа. Идеята на системата с онлайн репутацията е сайтовете да са само-модериращи се.",
+  "askubuntu":[
+   "stackoverflow:bg",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:bg",
+   "ref"
+  ],
   "youtube":"YouTube е видео хостинг услуга, притежавана от Google Inc. Тя предоставя уебсайт за видеосподеляне, на който потребителите могат да качват, споделят и гледат видеоклипове. След нова актуализация е предоставена възможността за споделяне на снимки, както и „истории“, видими за 24-часов период.",
   "wikibooks":"Уикикниги (Wikibooks), в миналото наричан „Wikimedia Free Textbook Project“ и „Wikimedia-Textbooks“ (Уикимедия-учебници), е сроден на Уикипедия проект и част от Фондация Уикимедия. Проектът стартира на 10 юли, 2003 г.",
   "wikinews":"Уикиновини (Wikinews) е новинарски сайт, базиран на уики-технологията, и един от проектите на Фондация Уикимедия. Подобно на останалите проекти на Фондацията, сайтът се поддържа от доброволци. Общността на тези доброволци, както и принципите на работа обаче са различни от тези на Уикипедия. Проектът стартира на 26 октомври 2004 г., а на български – на 6 февруари 2005 г.",
@@ -276,7 +300,6 @@
    "currency:ca",
    "ref"
   ],
-  "digg":"Digg és un lloc web en anglès on els usuaris registrats són qui envien notícies o històries i amb els vots de la resta d'usuaris trien quines arriben a eixir a la portada. Està en actiu des del 2004.",
   "wikidata":"Wikidata és una base de dades editada de manera col·laborativa, part de la Fundació Wikimedia, amb l'objectiu de proporcionar una font comuna per a certs tipus de dades, com dates de naixement, que poden ser usats per projectes Wikimedia com Viquipèdia. Això és similar a la manera com Wikimedia Commons proporciona emmagatzematge per a fitxers multimèdia i accés a aquests fitxers en tots els projectes Wikimedia.",
   "duckduckgo":[
    "currency:ca",
@@ -306,30 +329,14 @@
    "ref"
   ],
   "hoogle":"Haskell és un llenguatge de programació funcional estandarditzat de semàntica no estricta i avaluació tardana de les expressions en el moment que se'n demana el valor i pren el nom del matemàtic Haskell Curry.",
+  "imdb":"La IMDb, Internet Movie Database és una base de dades en línia amb informació sobre actors, pel·lícules, programes de televisió i videojocs. Fundada el 17 d'octubre de 1990, és propietat d'Amazon des de 1998. Inclou ressenyes, votacions populars i comentaris dels usuaris, per tal d'orientar els gustos cinèfils dels visitants o recopilar dades sobre el món audiovisual.",
   "library genesis":"Library Genesis o LibGen és un motor de cerca que permet el lliure accés a continguts que, d'altra manera, són de pagament o no digitalitzats en altres llocs, generalment articles científics o llibres acadèmics, i en menor proporció de ficció. Posseeix contingut lliure en formats PDF, EPUB, MOBI, DJVU, etc. accessible en portals de nombroses editorials acadèmiques com Oxford University Press, Cambridge University Press, ScienceDirect d'Elsevier, Springer, etc.",
   "library of congress":"La Biblioteca del Congrés dels Estats Units, situada a Washington DC, és la biblioteca nacional del país i arxiu administratiu del Congrés. Va ser fundada pel president John Adams el 24 d'abril de l'any 1800, al mateix temps que es traslladava la seu del govern des de Filadèlfia a Washington, i es troba distribuïda en tres edificis: l'Edifici Thomas Jefferson, l'Edifici John Adams i l'Edifici James Madison. És una de les biblioteques més grans del món amb més de 138 milions de documents, dels quals més de deu milions són en llengua catalana.",
   "openstreetmap":"OpenStreetMap és un projecte col·laboratiu per crear mapes de contingut lliure usant dades obtingudes mitjançant dispositius GPS mòbils, ortofotografies i altres fonts de dades. Les dades dels mapes (coordenades) i les imatges obtingudes amb elles es lliuren sota la llicència Open Database License.",
   "piratebay":"The Pirate Bay (TPB) és un directori de torrents suec que data del novembre de 2003. The Pirate Bay serveix com a motor de cerca i, alhora, de rastrejador amb el qual es pot cercar qualsevol tipus de contingut multimèdia.",
   "pubmed":"MEDLINE és una base de dades bibliogràfica de ciències de la vida i d'informació biomèdica. Inclou la informació bibliogràfica d'articles de revistes acadèmiques que cobreixen medicina, infermeria, farmàcia, odontologia, veterinària i assistència sanitària. MEDLINE també cobreix gran part de literatura en biologia i bioquímica, així com camps com ara l'evolució molecular.",
-  "qwant":[
-   "Qwant és un cercador que respecta la teva privadesa alhora que estimula i facilita la descoberta i la participació des d'un enfoc social.",
-   "https://www.qwant.com/"
-  ],
-  "qwant news":[
-   "qwant:ca",
-   "ref"
-  ],
-  "qwant images":[
-   "qwant:ca",
-   "ref"
-  ],
-  "qwant videos":[
-   "qwant:ca",
-   "ref"
-  ],
   "reddit":"Reddit és un lloc web de marcadors socials i agregador de notícies on els usuaris poden compartir enllaços a continguts web. El contingut s'organitza en comunitats anomenades «subreddits» que són creats i moderats pels mateixos usuaris. Aquestes comunitats cobreixen una gran varietat de temàtiques com ara notícies, ciència, pel·lícules, videojocs, música, gastronomia... Les contribucions a cada «subreddit» poden ser votades positivament o negativament pels usuaris de la comunitat per tal que aquestes apareguin més o menys destacades.",
   "soundcloud":"SoundCloud és una plataforma de distribució d'àudio en línia on els usuaris poden col·laborar, promocionar i distribuir els seus projectes musicals.",
-  "stackoverflow":"Stack Overflow és una pàgina web, el principal lloc web de la Xarxa Stack Exchange, creada el 2008 per Jeff Atwood i Joel Spolsky. Va ser creat per ser una alternativa més oberta als fòrums com Experts-Exchange. El nom per la pàgina web va ser escollit en votació l'abril 2008 per lectors de Coding Horror, un blog de programació popular d'Atwood.",
   "startpage":"Ixquick és un metacercador web fundat per David Bodnick el 1998. Els seus servidors es troben a Nova York i als Països Baixos. Des de l'any 2000 forma part de l'empresa Surfboard Holding BV.",
   "unsplash":"Unsplash és una pàgina web dedicada a compartir fotografia de stock sota llicència pròpia d'Unsplash. L'any 2021 fou adquirida per Getty Imatges. Les peticiones de la pàgina web s'eleven a 207.000 aportacions de fotògrafs i genera més de 17 bilions d'impressions de fotos per mes en la seva biblioteca que conté a una mida total de més de 2 milions de fotos. Unsplash ha estat citada com una de les pàgines web de fotografia davantera del món per Forbes, Entrepreneur Magazine, CNET, Medium i The Next Web.",
   "yahoo news":"Yahoo! Inc. és una empresa global de mitjans amb seu als Estats Units d'Amèrica que té per missió: \"ser el servei global d'Internet més essencial per a consumidors i negocis\". Posseeix un portal d'Internet, un directori Web i una sèrie de serveis, incloent-hi el popular correu electrònic Yahoo!. Fou fundada el gener de 1994 per dos estudiants de postgrau de la Universitat de Stanford, Jerry Yang i David Filo. Yahoo! es va constituir com empresa el 2 de març de 1995 i va començar a cotitzar a borsa el 12 d'abril de 1996. L'empresa té la seu corporativa a Sunnyvale, Califòrnia, Estats Units.",
@@ -392,7 +399,7 @@
   ],
   "fdroid":"F-Droid je softwarový repozitář pro operační systém Android, stejně jako Google Play. Hlavní repozitář, poskytovaný vývojáři, obsahuje jen svobodný software. Aplikace mohou být prohledávány a instalovány na webu F-Droidu nebo pomocí klientské aplikace bez nutnosti registrace. „Anti-vlastnosti“ jako reklamy, sledování uživatelů, nebo závislost na nesvobodném softwaru jsou označeny v popisu aplikací. Webové stránky nabízejí také zdrojový kód aplikací které hostí i softwaru který pohání server, což umožňuje komukoliv vytvořit si vlastní repozitář.",
   "flickr":"Flickr je komunitní web pro sdílení fotografií. Byl také jedním z prvních serverů Web 2.0, který umožňoval používat štítky (tagy). Uživatelé mohou také své fotografie umístit do mapy. V září 2010 bylo oznámeno, že Flickr sdílí více než 5 miliard obrázků.",
-  "gitlab":"GitLab je webový Git repositář s wiki a s podporou sledování chyb. GitLab hostuje účty podobně jako GitHub, ale také umožňuje aby byl jejich software použit na serveru třetích stran. Je dostupný jako balíček Omnibus.",
+  "gitlab":"GitLab je webový Git repozitář s wiki a s podporou sledování chyb. GitLab hostuje účty podobně jako GitHub, ale také umožňuje aby byl jejich software použit na serveru třetích stran. Je dostupný jako balíček Omnibus.",
   "github":"GitHub je webová služba podporující vývoj softwaru za pomoci verzovacího nástroje Git. GitHub nabízí bezplatný Webhosting pro open source projekty. Od 7. ledna 2019 je možné ukládat bezplatně i soukromé repositáře. Projekt byl spuštěn v roce 2008, zakladatelé byli Tom Preston-Werner, Chris Wanstrath a PJ Hyett.",
   "google":"Vyhledávání Google je v současnosti nejpoužívanější internetový vyhledávač, který vlastní společnost Google.",
   "google images":"Obrázky Google je vyhledávací služba, pomocí které Google umožňuje uživatelům vyhledávat na internetu obrázky. Byla zveřejněna v roce 2001 a existuje ve všech jazykových verzích, v nichž existuje samotný vyhledávač. Klíčová slova při hledání obrázků jsou založena na názvu souboru, slovech, která na daný obrázek odkazují a textu, který je na dané stránce u obrázku. Na stránce s výsledky vyhledávání jsou zobrazeny miniatury obrázků. Po kliknutí na některou z nich je obrázek zobrazen nahoře a o něco níže je zobrazen obsah stránky, na níž se obrázek nachází. Díky tomu můžeme snadno zjistit, z jaké stránky obrázek pochází.",
@@ -405,6 +412,7 @@
    "ref"
   ],
   "hoogle":"Haskell je standardizovaný funkcionální programovací jazyk používající líné vyhodnocování, pojmenovaný na počest logika Haskella Curryho. Jazyk se rychle vyvíjí, především díky svým implementacím Hugs a GHC.",
+  "imdb":"Internet Movie Database (IMDb) je on-line databáze informací o filmech, televizních pořadech, hercích, herečkách, režisérech a všem ostatním, co s filmovou tvorbou souvisí.",
   "invidious":[
    "alternativní frontend pro YouTube",
    "wikidata"
@@ -428,7 +436,19 @@
    "ref"
   ],
   "reddit":"Reddit je otevřenou internetovou sociální sítí, založenou na principu předkládání obsahu uživateli a jeho následného hodnocení pomocí hlasování. Název serveru je anglickou slovní hříčkou ze slovního spojení „I read it“. Reddit má celosvětovou komunitu čítající každý měsíc více než 540 milionů jedinečných uživatelů z více než dvou set zemí.",
-  "soundcloud":"SoundCloud je internetová stránka pro online distribuci hudby. Je často využívána méně známými interprety ke sdílení jejich tvorby. V současné době[kdy?] se k němu však na úkor mySpace obrací i známí interpreti. Například Sonic Youth využila odkazy na SoundCloud z Twitteru ke streamování jejich posledního alba. Moby zde zveřejňuje své nejnovější singly. A když se Beck rozhodl skončit se svými zastaralými webovými stránkami a chtěl jednoduché stránky založené na vysoce kvalitním obsahu, také přešel k SoundCloudu.",
+  "soundcloud":"SoundCloud je internetová stránka pro online distribuci hudby. Je často využívána méně známými interprety ke sdílení jejich tvorby. Například Sonic Youth využila odkazy na SoundCloud z Twitteru ke streamování jejich posledního alba. Moby zde zveřejňuje své nejnovější singly. A když se Beck rozhodl skončit se svými zastaralými webovými stránkami a chtěl jednoduché stránky založené na vysoce kvalitním obsahu, také přešel k SoundCloudu.",
+  "stackoverflow":[
+   "síť webů pro otázky a odpovědi",
+   "wikidata"
+  ],
+  "askubuntu":[
+   "stackoverflow:cs",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:cs",
+   "ref"
+  ],
   "startpage":"Startpage.com je webový vyhledávač, který jako svoji hlavní přednost prezentuje zachování soukromí uživatelů. Dříve byl známý jako metavyhledávací systém Ixquick, Startpage v té době byla jiná služba. Obě stránky byly sloučeny v roce 2016.",
   "youtube":"YouTube [ju:tu:b] je největší internetový server pro sdílení videosouborů. Založili jej v únoru 2005 zaměstnanci PayPalu Chad Hurley, Steve Chen a Jawed Karim. Nynější generální ředitelkou společnosti je Susan Wojcicki. V listopadu 2006 byl zakoupen společností Google za 1,65 miliardy dolarů. Google nyní provozuje tuto stránku jako dceřinou společnost, uživatelské účty mezi těmito společnostmi jsou propojené.",
   "vimeo":"Vimeo je webový projekt určený pro sdílení audiovizuální tvorby. Nacházejí se zde převážně díla autorská a umělecká. Vimeo je primárně určen filmovým nadšencům a experimentátorům, kteří se mohou zaregistrovat a sdílet názory a postřehy s ostatními. Charakter Vimea je zcela odlišný od charakteru YouTube, Vimeo je zaměřeno na uměleckou komunitu, kdežto YouTube směřuje k zájmům masové společnosti.",
@@ -456,13 +476,14 @@
   "wikidata":"Prosiect cydweithredol, byd-eang ydy Wicidata gan gymuned Wicimedia ; fe'i bwriedir i ganoli data ar gyfer prosiectau megis Wicipedia, fel a wneir gyda Comin Wicimedia. Mae'r cynnwys, fel gyda gweddill y teulu \"Wici\" wedi'i drwyddedu ar ffurf cynnwys rhydd, agored tebyg i'r CC-BY-SA a ddefnyddir ar y wici hwn.",
   "flickr":"Gwefan sy'n cynnal lluniau a fideos gan gymuned ar y we yw Flickr.",
   "google images":[
-   "Lluniau Google.Y chwiliad lluniau mwya cynhwysfawr ar y we.Lluniau Google.Y chwiliad lluniau mwya cynhwysfawr ar y we.",
+   "Lluniau Google.Y chwiliad lluniau mwya cynhwysfawr ar y we.",
    "https://images.google.com"
   ],
   "google news":[
    "Cyn i chi barhau",
    "https://news.google.com"
   ],
+  "imdb":"Cronfa ddata ar-lein o ffilmiau, rhaglenni teledu, a gemau fideos yw'r Internet Movie Database (IMDb). Cafodd ei greu gan Col Needham ym 1990.",
   "ina":[
    "amgueddfa yn Ffrainc",
    "wikidata"
@@ -516,7 +537,7 @@
   "flickr":"Flickr er et foto-delings-website, hvor private brugere kan uploade digitale fotografier. Det fungerer dels som et online fotoalbum, dels som et community. Populariteten er stadigt stigende, og der er i øjeblikket lagt over 4 milliarder billeder ind på Flickr. [kilde mangler]",
   "google":"Google eller Google Search, på dansk Google-søgning, er en søgemaskine på internettet. Den ejes af Google Inc. og er i dag den største søgemaskine på internettet.",
   "google images":[
-   "Google Billeder. Den mest omfattende billedsøgning på nettet.Google Billeder. Den mest omfattende billedsøgning på nettet.",
+   "Google Billeder. Den mest omfattende billedsøgning på nettet.",
    "https://images.google.com"
   ],
   "google news":[
@@ -531,9 +552,10 @@
    "ref"
   ],
   "hoogle":"Haskell er navnet på et rent funktionsprogrammeringssprog med en ikke-striks (\"doven\") semantik og stærke, statiske typer. Det er opkaldt efter logikeren Haskell Curry.",
+  "imdb":"Internet Movie Database, The Internet Movie Database eller forkortet IMDb, er verdens største online filmdatabase med information om stort set alt TV og film relateret.",
   "library of congress":"Library of Congress er USAs faktiske nationalbibliotek og fagbibliotek for USAs lovgivende forsamling, Kongressen. Biblioteket er beliggende i Washington, DC, umiddelbart syd for højesteretsbygningen og ret sydøst for kongresbygningen. Samlingerne omfatter mere end 30 millioner katalogiserede bøger og andet trykt materiale på over 470 sprog, mere end 58 millioner manuskripter og en mængde aviser, film, kort og lydoptagelser. Biblioteket favner vidt: Alt udgivet i USA skal i princippet være der, men man finder også f.eks. nyere norsk kriminallitteratur.",
   "mixcloud":"Mixcloud er en britisk online musik streamingtjeneste, der giver mulighed for at lytte og distributere radioprogrammer, DJ mixes og podcasts, som er delt af deres registrerede brugere. Mixcloud blev oprindeligt kun finansieret af deres grundlæggere og er fortsat udelukkende ejet af deres eget team.",
-  "openstreetmap":"OpenStreetMap (OSM) er et kollaborativt projekt, der har til formål at producere et frit redigerbart kort over verden. OSM's oprindelse og vækst har været motiveret af begrænsninger på anvendelsen eller tilgængeligheden af kort-information over store dele af verden tillige med fremkomsten af billige bærbare satellit navigationsapparater. OSM anses for at være et prominent eksempel på Volunteered geographic information (en)",
+  "openstreetmap":"OpenStreetMap (OSM) er et kollaborativt projekt, der har til formål at producere et frit redigerbart kort over verden. OSM's oprindelse og vækst har været motiveret af begrænsninger på anvendelsen eller tilgængeligheden af kort-information over store dele af verden tillige med fremkomsten af billige bærbare satellit navigationsapparater. OSM anses for at være et prominent eksempel på Volunteered geographic information",
   "piratebay":"The Pirate Bay er verdens største Bittorrent-indeks. Den blev grundlagt af Gottfrid \"anakata\" Svartholm og Fredrik \"TiAMO\" Neij i slutningen af 2003, som en del af den svenske organisation Piratbyrån, men har siden oktober 2004 været en separat organisation. Trackeren fik for alvor vind i sejlene, da den slovenske hjemmeside Suprnova.org lukkede i slutningen af 2004. Suprnova havde været et af de største piratsites i verden, og The Pirate Bay overtog nu millioner af \"hjemløse\" pirater.",
   "reddit":"Reddit er en social nyheds- og underholdningshjemmeside, hvor registrerede brugere indsender indhold i form af links eller tekst. Brugere stemmer derefter hver indgivelse \"op\" eller \"ned\" for at rangere stillingen og bestemme positionen på webstedets sider. Indholdsgallerier er organiseret af interesseområder ved navn \"subreddits\", blandt andet har Danmark sit eget subreddit.",
   "soundcloud":"SoundCloud er en lyd- og musikdelingsside, som blev oprettet i 2007. I juli 2013 havde den 40 mio. brugere og 200 mio. lyttere.",
@@ -580,7 +602,7 @@
    "currency:de",
    "ref"
   ],
-  "digg":"Digg ist ein Anbieter von Social Bookmarks, für jede Art von Nachrichten, Videos und Podcasts.",
+  "docker hub":"Docker ist eine Freie Software zur Isolierung von Anwendungen mit Hilfe von Containervirtualisierung.",
   "erowid":"Erowid ist eine Nichtregierungsorganisation, die im Oktober 1995 gegründet wurde. Die englischsprachige Website von Erowid ist eine Online-Datenbank mit Informationen zu psychoaktiven Substanzen und verwandten Themen und hat täglich im Durchschnitt über 41.000 Besucher. Erowid wird seit 1. Januar 2008 vom offiziell als Non-Profit-Organisation anerkannten „Erowid Center“ betrieben. Die Organisation hat ihren Sitz im Norden des US-Bundesstaats Kalifornien, die Server stehen in San Francisco. Erowid finanziert sich ausschließlich über Spenden. Banner oder sonstige Werbung gibt es nicht auf der Website.",
   "wikidata":"Wikidata ist eine frei bearbeitbare Wissensdatenbank, die unter anderem das Ziel hat, Wikipedia zu unterstützen. Das Projekt wurde von Wikimedia Deutschland gestartet und stellt als gemeinsame Quelle bestimmte Datentypen für Wikimedia-Projekte bereit, zum Beispiel Geburtsdaten oder sonstige allgemeingültige Daten, die in allen Artikeln der Wikimedia-Projekte verwendet werden können.",
   "duckduckgo":[
@@ -603,17 +625,18 @@
   "github":"GitHub ist ein netzbasierter Dienst zur Versionsverwaltung für Software-Entwicklungsprojekte. Namensgebend war das Versionsverwaltungssystem Git. Das Unternehmen GitHub, Inc. hat seinen Sitz in San Francisco in den USA. Seit dem 26. Dezember 2018 gehört das Unternehmen zu Microsoft.",
   "google":"Google ist eine Internet-Suchmaschine des US-amerikanischen Unternehmens Google. Übereinstimmende Statistiken zeigen bei weltweiten Suchanfragen Google als Marktführer unter den Internet-Suchmaschinen und als die meistbesuchte Website der Welt. Google bearbeitet jährlich mehr als zwei Billionen Suchanfragen.",
   "google images":[
-   "Google Bilder, die umfassendste Bildersuche im WebGoogle Bilder, die umfassendste Bildersuche im Web",
+   "Google Bilder, die umfassendste Bildersuche im Web",
    "https://images.google.com"
   ],
   "google news":"Google News ist eine Nachrichtensuchmaschine und automatisch erstellte Nachrichten-Website des US-amerikanischen Unternehmens Google LLC.",
   "google scholar":"Google Scholar ist eine Suchmaschine des Unternehmens Google LLC und dient der allgemeinen Literaturrecherche wissenschaftlicher Dokumente. Dazu zählen sowohl kostenlose Dokumente aus dem freien Internet als auch kostenpflichtige Angebote. Zumeist werden als Treffer Volltexte oder zumindest bibliographische Nachweise angezeigt. Google Scholar analysiert und extrahiert die in den Volltexten enthaltenen Zitate und erstellt daraus eine Zitationsanalyse. Darüber hinaus können die bibliographischen Angaben dieser Zitate über den Suchdienst recherchiert werden. Im Januar 2018 wurde der Umfang von Google Scholar auf ca. 389 Millionen Dokumente geschätzt. Damit ist Google Scholar derzeit die weltweit größte akademische Suchmaschine.",
-  "google play apps":"Google Play ist ein App Store des US-amerikanischen Unternehmens Google, der Mobile Apps, Handyspiele, E-Books, Hörbücher, Filme und Fernsehserien anbietet und damals Musik und digitale Zeitschriften anbot. Google Play wurde am 28. August 2008 als Android Market angekündigt und am 22. Oktober 2008 für die Nutzung zur Verfügung gestellt.",
+  "google play apps":"Google Play ist ein App Store des US-amerikanischen Unternehmens Google, der Mobile Apps, Handyspiele, E-Books, Hörbücher, Filme und Fernsehserien anbietet. Google Play wurde am 28. August 2008 als Android Market angekündigt und am 22. Oktober 2008 für die Nutzung zur Verfügung gestellt. Früher gehörten zum Angebot auch Musik und digitale Zeitschriften.",
   "google play movies":[
    "google play apps:de",
    "ref"
   ],
   "hoogle":"Haskell ist eine rein funktionale Programmiersprache, benannt nach dem US-amerikanischen Mathematiker Haskell Brooks Curry, dessen Arbeiten zur mathematischen Logik eine Grundlage funktionaler Programmiersprachen bilden. Haskell basiert auf dem Lambda-Kalkül, weshalb auch der griechische Buchstabe Lambda als Logo verwendet wird. Die wichtigste Implementierung ist der Glasgow Haskell Compiler (GHC).",
+  "imdb":"Die Internet Movie Database ist eine Datenbank zu Filmen, Fernsehserien, Videoproduktionen und Computerspielen sowie über Personen, die daran mitgewirkt haben. Im Januar 2020 gab es Einträge zu über 7,55 Millionen Filmproduktionen und zu über 11,21 Millionen Film- und Fernsehschaffenden. Betrieben wird die Datenbank von Amazon.",
   "ina":"Das Institut national de l’audiovisuel (INA) ist ein öffentlich-rechtliches französisches Unternehmen. Das INA war das erste digitalisierte Archiv Europas. Sein Auftrag ist es, alle französischen Rundfunk- und Fernsehproduktionen zu sammeln, zu bewahren und öffentlich zugänglich zu machen, in etwa vergleichbar dem Auftrag der Bibliothèque nationale de France (BnF), geschriebene und gedruckte Dokumente aller Art zu archivieren. Die Sammlungen des INA sind über seine Webseite für die Öffentlichkeit teilweise kostenlos zugänglich, der Rest unterliegt urheberrechtlichen Beschränkungen.",
   "invidious":[
    "alternatives Frontend für YouTube",
@@ -631,7 +654,7 @@
    "ref"
   ],
   "openstreetmap":"OpenStreetMap (OSM) ist ein freies Projekt, das frei nutzbare Geodaten sammelt, strukturiert und für die Nutzung durch jedermann in einer Datenbank vorhält. Diese Daten stehen unter einer freien Lizenz, der Open Database License. Kern des Projekts ist also eine offen zugängliche Datenbank aller beigetragenen Geoinformationen.",
-  "piratebay":"The Pirate Bay ist ein web-basierter Indizierer für digitale Inhalte, bei dem Besucher Magnet-Links und .torrent-Dateien finden, herunterladen und hinzufügen können, um einen Peer-to-Peer-Dateiaustausch via BitTorrent zwischen den Nutzern aufbauen zu können.",
+  "piratebay":"The Pirate Bay ist ein web-basierter Indizierer für digitale Inhalte, bei dem Besucher Magnet-Links und früher auch .torrent-Dateien finden, herunterladen und hinzufügen können, um einen Peer-to-Peer-Dateiaustausch via BitTorrent zwischen den Nutzern aufbauen zu können.",
   "pubmed":"MEDLINE ist eine öffentlich zugängliche bibliografische Datenbank des US-amerikanischen National Center for Biotechnology Information (NCBI).",
   "qwant":"Qwant ist eine Suchmaschine, die vom gleichnamigen französischen Unternehmen entwickelt wurde und mit strengen Datenschutzbestimmungen wirbt.",
   "qwant news":[
@@ -648,9 +671,25 @@
   ],
   "reddit":"Reddit [ˈrɛdɪt] ist ein Social-News-Aggregator, eine Website, auf der registrierte Benutzer Inhalte einstellen bzw. anbieten können. Ein Inhalt kann entweder aus einem Link, einem Video, einem Bild, einer Umfrage oder einem Textbeitrag bestehen. Andere Benutzer können die Beiträge als positiv oder negativ beurteilen. Die Bewertungen beeinflussen, welche Position der Beitrag auf der jeweiligen Reddit-Seite sowie der Startseite einnimmt.",
   "soundcloud":"SoundCloud ist ein Online-Musikdienst zum Austausch und zur Distribution von Audiodateien. Er dient als Kooperations- und Werbeplattform für Musiker.",
-  "stackoverflow":"Stack Overflow (englisch für Stapelüberlauf) ist eine Internetplattform, die sich an Softwareentwickler richtet. Inspiriert wurden deren Entwickler vom gleichnamigen Softwarefehler, dem Stapelüberlauf.",
+  "stackoverflow":"Stack Exchange ist ein Netzwerk von Frage-Webseiten, die jeweils verschiedene Fachthemen abdecken. Das Prinzip dieser Webseiten ist es, dass User der Community Fragen zu einem bestimmten Problem stellen können, die dann im optimalen Fall auch zufriedenstellend beantwortet werden. Die wohl bekannteste Webseite innerhalb von Stack Exchange ist Stack Overflow.",
+  "askubuntu":[
+   "stackoverflow:de",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:de",
+   "ref"
+  ],
   "startpage":"Startpage ist eine Suchmaschine, die die eingegebenen Suchanfragen an die Google-Suchmaschine weiterleitet und dadurch anonymisiert die Suchergebnisse anzeigt. Startpage will damit den Datenschutz ihrer Nutzer gewährleisten. Startpage wird von der niederländischen Startpage B.V. betrieben, die zur Surfboard Holding B.V. gehört.",
   "unsplash":"Unsplash ist eine internationale Website für Fotos, die von ihren Urhebern der Online-Community zur kostenlosen Verwendung zur Verfügung gestellt werden.",
+  "yahoo":[
+   "Yahooist Teil der Yahoo Markenfamilie",
+   "https://search.yahoo.com/"
+  ],
+  "yahoo news":[
+   "yahoo:de",
+   "ref"
+  ],
   "youtube":"YouTube ist ein 2005 gegründetes Videoportal des US-amerikanischen Unternehmens YouTube, LLC, seit 2006 eine Tochtergesellschaft von Google LLC, mit Sitz im kalifornischen San Bruno. Die Benutzer können auf dem Portal kostenlos Videoclips ansehen, bewerten, kommentieren und selbst hochladen. 2019 erzielte YouTube einen Jahresumsatz von 15 Milliarden Dollar. Die Einnahmen werden zum Großteil durch das Abspielen von Werbespots generiert.",
   "dailymotion":"Dailymotion ist ein Videoportal des gleichnamigen französischen Unternehmens, bei dem Videos hochgeladen und öffentlich angeschaut werden können. Dailymotion wurde 2005 in Paris gegründet und gehört heute zu den weltweit führenden Videoportalen im Internet. Heute gibt es mehrere Büros in Paris, Barcelona, London, Athen, Mumbai und New York City. Es gibt elf lokalisierte Portalseiten, die eine eigene Programmplanung enthalten. Insgesamt wurde bisher in 20 Sprachen übersetzt.",
   "vimeo":"Vimeo ist ein 2004 gegründetes Videoportal des US-amerikanischen Unternehmens Vimeo LLC mit Sitz ursprünglich in White Plains im Bundesstaat New York und inzwischen am Hudson River in Manhattan. Es unterstützt seit 2007 das Streaming von Videos in HD und seit 2015 in 4K Ultra HD. Neben der kostenlosen Nutzung des Portals bietet es auch die Möglichkeit, kostenpflichtige Inhalte zu veröffentlichen.",
@@ -662,6 +701,10 @@
   "wikiversity":"Die Wikiversity ist eine Online-Plattform in Form eines Wikis zum gemeinschaftlichen Lernen, Lehren und Forschen. Sie ist ein Projekt der Wikimedia Foundation und startete am 15. August 2006. Auf Wikiversity werden freie Lernmaterialien erstellt und gesammelt. Außerdem können dort Lehrveranstaltungen durchgeführt bzw. begleitet werden (E-Learning).",
   "wikivoyage":"Wikivoyage [ˌvɪkivo̯aˈjaːʒ] ist ein von ehrenamtlichen Autoren erstellter freier Führer rund ums Reisen. Im Vordergrund von Wikivoyage steht die Bereitstellung von praktisch anwendbarem Wissen zu Reisezielen und Reisethemen. Die Bezeichnung setzt sich aus den Bestandteilen „Wiki“ und dem französischen Wort „voyage“ für Reise zusammen.",
   "wolframalpha":"Wolfram Alpha ist ein auf der Software Mathematica basierender Onlinedienst zum Auffinden und Darstellen von Informationen, der von Wolfram Research entwickelt wird.",
+  "1337x":[
+   "Verzeichnis von Torrent-Dateien und Magnet-Links",
+   "wikidata"
+  ],
   "duden":[
    "Duden | Sprache sagt alles.",
    "https://www.duden.de"
@@ -681,7 +724,7 @@
   ],
   "brave":"Brave Search ist eine Internet-Suchmaschine vom US-amerikanischen Browserhersteller Brave Software Inc. Die Suchmaschine legt dabei ähnlich wie der Webbrowser vom gleichen Unternehmen wert auf die Privatsphäre des Nutzers, so dass weder Tracking noch Werbung existiert. Im Gegensatz zu vergleichbaren Angeboten von beispielsweise DuckDuckGo setzt Brave Search dabei auf einen eigenen Index, um die Suchergebnisse auszugeben. DuckDuckGo nutzt den Index der Suchmaschine Microsoft Bing."
  },
- "el_GR":{
+ "el-GR":{
   "archive is":[
    "ψηφιακό αρχείο παγκόσμιου ιστού",
    "wikidata"
@@ -690,8 +733,12 @@
   "wikipedia":"Η Βικιπαίδεια είναι διεθνής, παγκόσμια, ψηφιακή, διαδικτυακή, ελεύθερου περιεχομένου, εγκυκλοπαίδεια, που βασίζεται σε ένα μοντέλο ανοικτό στη σύνταξη του περιεχομένου της.",
   "bing":"Το Microsoft Bing είναι μια μηχανή αναζήτησης ιστού",
   "bing images":[
-   "bing:el_GR",
+   "bing:el-GR",
    "ref"
+  ],
+  "bing news":[
+   "Ειδήσεις από διεθνείς, εθνικές και τοπικές πηγές ειδήσεων, οργανωμένες έτσι, ώστε να σας παράσχουν λεπτομερή ενημέρωση για θέματα όπως σπορ, ψυχαγωγία, επιχειρήσεις, πολιτική, καιρός και άλλα.",
+   "https://www.bing.com/news"
   ],
   "bing videos":[
    "Το Bing σάς βοηθά να μετατρέψετε την πληροφορία σε δράση, επιταχύνοντας και διευκολύνοντας τη μετάβαση από την αναζήτηση στη δράση.",
@@ -703,16 +750,16 @@
    "wikidata"
   ],
   "ddg definitions":[
-   "currency:el_GR",
+   "currency:el-GR",
    "ref"
   ],
   "wikidata":"Τα Wikidata είναι ένα ελεύθερο, συνεργατικό εγχείρημα το οποίο δημιουργήθηκε το 2012 και αποτελεί μια γνωσιακή βάση δομημένων δεδομένων όπως διαγλωσσικές αναφορές και στατιστικές πληροφορίες, στην οποία όλα τα εγχειρήματα του ιδρύματος Wikimedia, σε όλες τις γλώσσες, έχουν κεντρική πρόσβαση. Το εγχείρημα χαρακτηρίζεται ως δευτερογενής βάση δεδομένων, δεδομένου ότι παρέχεται και η δυνατότητα της αναγραφής πηγών για τα δεδομένα και είναι πολύγλωσσο, παρέχεται σε όλες τις γλώσσες που επιθυμούν οι χρήστες του. Ανήκει στο ίδρυμα Wikimedia. Τα δεδομένα προσφέρονται συνεργατικά από χρήστες, όπως και στα άλλα εγχειρήματα του ιδρύματος Wikimedia, με τη διαφορά ότι στα Wikidata τα δεδομένα παρέχονται με άδεια Creative Commons Public Domain Dedication 1.0, δηλαδή έχει γίνει Εκχώρησή τους ως Κοινό Κτήμα.",
   "duckduckgo":[
-   "currency:el_GR",
+   "currency:el-GR",
    "ref"
   ],
   "duckduckgo images":[
-   "currency:el_GR",
+   "currency:el-GR",
    "ref"
   ],
   "flickr":"Το Flickr είναι μια ιστοσελίδα, η οποία δημιουργήθηκε για να φιλοξενεί φωτογραφίες και βίντεο. Δημιουργήθηκε αρχικά από την εταιρία Ludicorp και ύστερα εξαγοράστηκε από την Yahoo!. Η υπηρεσία χρησιμοποιείται συχνά από bloggers για να ενσωματώσουν τις φωτογραφίες τους στα blogs τους. Τον Σεπτέμβριο του 2010, το Flickr έφτασε τα 5 δις. φωτογραφιών. Αρκετές από τις φωτογραφίες του Flickr κυκλοφορούν υπό την άδεια Creative Commons. Η εγγραφή στο Flickr μπορεί να είναι είτε δωρεάν είτε επί πληρωμή, η οποία παρέχει περισσότερα δικαιώματα στους χρήστες του.",
@@ -721,18 +768,23 @@
   "google":"Η Google Αναζήτηση είναι μηχανή αναζήτησης που ανήκει στην Google. Η Google Αναζήτηση είναι η πιο χρησιμοποιημένη μηχανή αναζήτησης του Παγκόσμιου Ιστού, με πάνω από τρεις δισεκατομμύρια αναζητήσεις κάθε μέρα.",
   "google images":"Να μην συγχέεται με το Google Photos.",
   "google news":[
-   "Πριν συνεχίσετε",
-   "https://news.google.com"
+   "ιστότοπος και εφαρμογή συγκέντρωσης ειδήσεων της Google",
+   "wikidata"
   ],
   "google scholar":"Η Google Scholar είναι μια ελεύθερα προσβάσιμη μηχανή αναζήτησης ιστού που εντοπίζει το πλήρες κείμενο ή τα μεταδεδομένα των ακαδημαϊκών δημοσιεύσεων που έχουν υλοποιηθεί σε μία εκτεταμένη σειρά επιστημονικών και τεχνικών εκδόσεων, σε παγκόσμια κλίμακα. Η βάση αυτή αφορά δημοσιεύσεις που έχουν γίνει αποκλειστικά με χρήση της αγγλικής γλώσσας.",
   "google play apps":"Το Google Play, παλαιότερα γνωστό ως Android Market, είναι μια ψηφιακή εφαρμογή διανομής για το Android και ένα σε κατάστημα ηλεκτρονικών, το οποίο αναπτύσσεται και συντηρείται από τη Google. Η υπηρεσία επιτρέπει στους χρήστες να περιηγηθούν και να κατεβάσουν βιβλία, ταινίες, παιχνίδια και εφαρμογές που δημοσιεύθηκαν μέσω του Google, ενώ παλαιότερα επέτρεπε και την εγκατάσταση μουσικής.",
   "google play movies":[
-   "google play apps:el_GR",
+   "google play apps:el-GR",
    "ref"
   ],
   "hoogle":"Η Haskell είναι μια πρότυπη αμιγώς συναρτησιακή γλώσσα προγραμματισμού γενικής χρήσης με μη-αυστηρή σημασιολογία και ισχυρούς τύπους. Πήρε το όνομά της από τον επιστήμονα της λογικής Haskell Curry. Στη Haskell, \"μια συνάρτηση είναι μέλος πρώτης τάξης\" της γλώσσας προγραμματισμού. Ως συναρτησιακή γλώσσα προγραμματισμού, χρησιμοποιεί σαν κύρια δομή ελέγχου τη συνάρτηση. Η γλώσσα βασίζεται στις παρατηρήσεις του Haskell Curry και των πνευματικών του απογόνων, ότι \"μια απόδειξη είναι ένα πρόγραμμα και ο μαθηματικός τύπος που αποδεικνύει είναι ο τύπος του προγράμματος\".",
+  "imdb":"Η Internet Movie Database, πιο γνωστή με την συντομογραφία IMDb, είναι διαδικτυακή βάση δεδομένων με πληροφορίες για ηθοποιούς, ταινίες, τηλεοπτικά προγράμματα, παρουσιαστές της τηλεόρασης, βιντεοπαιχνίδια και συντελεστές παραγωγής ταινιών ή προγραμμάτων.",
   "library genesis":"Η Library Genesis ή LibGen είναι μια μηχανή αναζήτησης άρθρων και βιβλίων για διάφορα θέματα, η οποία επιτρέπει την ελεύθερη πρόσβαση σε περιεχόμενο, το οποίο κατά τα άλλα απαιτεί πληρωμή ή δεν είναι ψηφιοποιημένο αλλού. Μεταξύ άλλων, παρέχει αρχεία PDF από τη διαδικτυακή πύλη ScienceDirect του Elsevier.",
   "library of congress":"Η Βιβλιοθήκη του Κογκρέσου των Ηνωμένων Πολιτειών θεωρείται η μεγαλύτερη και πλουσιότερη βιβλιοθήκη παγκοσμίως. Ιδρύθηκε το 1800 και αρχικά έδρευε στο Καπιτώλιο. Το 1814 η βιβλιοθήκη κάηκε από τους Βρετανούς. Το 1897 μεταφέρθηκε στο χώρο όπου στεγάζεται μέχρι και σήμερα, στην Ουάσινγκτον.",
+  "mixcloud":[
+   "Βρετανική υπηρεσία ροής μουσικής",
+   "wikidata"
+  ],
   "openstreetmap":"Το OpenStreetMap (OSM) είναι ένας χάρτης με ελεύθερη άδεια ο οποίος αναπτύσσεται από μια κοινότητα εθελοντών που συνεισφέρουν και διατηρούν δεδομένα σχετικά με δρόμους, μονοπάτια, καφετέριες, σιδηροδρομικούς σταθμούς, και πολλά περισσότερα, σε όλον τον κόσμο. Οι συνεισφέροντες χρησιμοποιούν αεροφωτογραφίες, συσκευές GPS, και τοπικούς χάρτες χαμηλής τεχνολογίας για να σιγουρευτούν πως το OSM είναι ακριβής και ενημερωμένο στο μικρότερο δυνατό επίπεδο. Μέχρι το 2012 είχαν συνεισφέρει στη δημιουργία του πάνω από 500.000 άνθρωποι.",
   "piratebay":"Το Pirate Bay είναι ιστοσελίδα που παρέχει αρχεία torrent και magnet links για τη διευκόλυνση της ανταλλαγής αρχείων μέσω peer-to-peer χρησιμοποιώντας το πρωτοκόλλο BitTorrent. Ιδρύθηκε στη Σουηδία το 2003. Το 2009, οι ιδρυτές της ιστοσελίδας δικάστηκαν στη Σουηδία, κατηγορούμενοι για τη διευκόλυνση της παράνομης ανταλλαγής υλικού που υπόκειται σε πνευματικά δικαιώματα. Κρίθηκαν ένοχοι και καταδικάστηκαν σε ένα χρόνο φυλάκιση με πρόστιμο ύψους 30 εκατ. SEK. Σε ορισμένες χώρες, οι ISPs έχουν διαταχθεί να εμποδίσουν την πρόσβαση στην ιστοσελίδα. Από τότε, λειτουργούν διακομιστές μεσολάβησης σε όλο τον κόσμο, παρέχοντας πρόσβαση στο The Pirate Bay.",
   "pubmed":"Η MEDLINE είναι βιβλιογραφική βάση δεδομένων επιστημών ζωής και βιοϊατρικής πληροφορίας. Περιλαμβάνει βιβλιογραφικές πληροφορίες για άρθρα επιστημονικών περιοδικών που καλύπτουν ζητήματα ιατρικής, νοσηλευτικής, φαρμακευτικής, οδοντιατρικής, κτηνιατρικής. Η MEDLINE καλύπτει επίσης ένα μεγάλο τμήμα της βιολογικής και βιοχημικής βιολογίας και θέματα όπως η μοριακή εξέλιξη.",
@@ -759,11 +811,11 @@
    "Arch Linux documentation on the web",
    "wikidata"
   ],
-  "archive is":"archive.today is an archive site which stores snapshots of web pages. It retrieves one page at a time similar to WebCite, smaller than 50MB each, but with support for JavaScript-heavy sites such as Google Maps and progressive web applications such as Twitter.",
-  "artic":"The Art Institute of Chicago in Chicago's Grant Park, founded in 1879, is one of the oldest and largest art museums in the United States. Recognized for its curatorial efforts and popularity among visitors, the museum hosts approximately 1.5 million people annually. Its collection, stewarded by 11 curatorial departments, is encyclopedic, and includes iconic works such as Georges Seurat's A Sunday on La Grande Jatte, Pablo Picasso's The Old Guitarist, Edward Hopper's Nighthawks, and Grant Wood's American Gothic. Its permanent collection of nearly 300,000 works of art is augmented by more than 30 special exhibitions mounted yearly that illuminate aspects of the collection and present cutting-edge curatorial and scientific research.",
+  "archive is":"archive.today is an archive site which stores snapshots of web pages. It retrieves one page at a time similar to WebCite, smaller than 50 MB each, but with support for JavaScript-heavy sites such as Google Maps and progressive web applications such as Twitter.",
+  "artic":"The Art Institute of Chicago in Chicago's Grant Park, founded in 1879, is one of the oldest and largest art museums in the world. Recognized for its curatorial efforts and popularity among visitors, the museum hosts approximately 1.5 million people annually. Its collection, stewarded by 11 curatorial departments, is encyclopedic, and includes iconic works such as Georges Seurat's A Sunday on La Grande Jatte, Pablo Picasso's The Old Guitarist, Edward Hopper's Nighthawks, and Grant Wood's American Gothic. Its permanent collection of nearly 300,000 works of art is augmented by more than 30 special exhibitions mounted yearly that illuminate aspects of the collection and present cutting-edge curatorial and scientific research.",
   "arxiv":"arXiv is an open-access repository of electronic preprints and postprints approved for posting after moderation, but not peer review. It consists of scientific papers in the fields of mathematics, physics, astronomy, electrical engineering, computer science, quantitative biology, statistics, mathematical finance and economics, which can be accessed online. In many fields of mathematics and physics, almost all scientific papers are self-archived on the arXiv repository before publication in a peer-reviewed journal. Some publishers also grant permission for authors to archive the peer-reviewed postprint. Begun on August 14, 1991, arXiv.org passed the half-million-article milestone on October 3, 2008, and had hit a million by the end of 2014. As of April 2021, the submission rate is about 16,000 articles per month.",
   "bandcamp":"Bandcamp is an internet music company founded in 2008 by Oddpost co-founder Ethan Diamond and programmers Shawn Grunberger, Joe Holt and Neal Tucker, with headquarters in Oakland, California, US.",
-  "wikipedia":"Wikipedia is a free content, multilingual online encyclopedia written and maintained by a community of volunteers through a model of open collaboration, using a wiki-based editing system. Individual contributors, also called editors, are known as Wikipedians. It is the largest and most-read reference work in history, and consistently one of the 15 most popular websites ranked by Alexa; as of 2021, Wikipedia was ranked the 13th most popular site. It carries no advertisements and is hosted by the Wikimedia Foundation, an American non-profit organization funded mainly through small donations.",
+  "wikipedia":"Wikipedia is a free content, multilingual online encyclopedia written and maintained by a community of volunteers through a model of open collaboration, using a wiki-based editing system. Individual contributors, also called editors, are known as Wikipedians. It is the largest and most-read reference work in history, and consistently one of the 15 most popular websites ranked by Alexa; as of 2021, Wikipedia was ranked the 13th most popular site. A visitor spends an average time on Wikipedia of 3 minutes and 45 seconds each day. It is hosted by the Wikimedia Foundation, an American non-profit organization funded mainly through small donations.",
   "bing":"Microsoft Bing is a web search engine owned and operated by Microsoft. The service has its origins in Microsoft's previous search engines: MSN Search, Windows Live Search and later Live Search. Bing provides a variety of search services, including web, video, image and map search products. It is developed using ASP.NET.",
   "bing images":[
    "bing:en",
@@ -775,7 +827,7 @@
   ],
   "bing videos":"Bing Videos is a video search service and part of Microsoft's Bing search engine. The service enables users to search and view videos across various websites. Bing Videos was officially released on September 26, 2007 as Live Search Video, and rebranded as Bing Videos on June 1, 2009.",
   "bitbucket":"Bitbucket is a Git-based source code repository hosting service owned by Atlassian. Bitbucket offers both commercial plans and free accounts with an unlimited number of private repositories.",
-  "btdigg":"BTDigg is the first Mainline DHT search engine. It participated in the BitTorrent DHT network, supporting the network and making correspondence between magnet links and a few torrent attributes which are indexed and inserted into a database. For end users, BTDigg provides a full-text database search via Web interface. The web part of its search system retrieved proper information by a user's text query. The Web search supported queries in European and Asian languages. The project name was an acronym of BitTorrent Digger. It went offline in June 2016, reportedly due to index spam. The site returned later in 2016 at a dot-com domain, went offline again and is now online.. The btdig.com site has its torrent crawler's source source listed on Github, dhtcrawler2.",
+  "btdigg":"BTDigg is the first Mainline DHT search engine. It participated in the BitTorrent DHT network, supporting the network and making correspondence between magnet links and a few torrent attributes which are indexed and inserted into a database. For end users, BTDigg provides a full-text database search via Web interface. The web part of its search system retrieved proper information by a user's text query. The Web search supported queries in European and Asian languages. The project name was an acronym of BitTorrent Digger. It went offline in June 2016, reportedly due to index spam. The site returned later in 2016 at a dot-com domain, went offline again and is now online.. The btdig.com site has its torrent crawler's source source listed on GitHub, dhtcrawler2.",
   "ccc-tv":[
    "Video Streaming Portal of the Chaos Computer Club",
    "wikidata"
@@ -784,15 +836,14 @@
    "A new Creative Commons search tool for creators seeking to discover and reuse free resources with greater ease.",
    "https://search.creativecommons.org/"
   ],
-  "crossref":"Crossref is an official Digital Object Identifier (DOI) Registration Agency of the International DOI Foundation. It is run by the Publishers International Linking Association Inc. (PILA) and was launched in early 2000 as a cooperative effort among publishers to enable persistent cross-publisher citation linking in online academic journals.",
-  "currency":"DuckDuckGo is an internet search engine that emphasizes protecting searchers' privacy and avoiding the filter bubble of personalized search results. DuckDuckGo does not show search results from content farms. It uses various API of other websites to show quick results to queries and for traditional links it uses the help of its partners and its own crawler.",
+  "crossref":"Crossref is an official digital object identifier (DOI) Registration Agency of the International DOI Foundation. It is run by the Publishers International Linking Association Inc. (PILA) and was launched in early 2000 as a cooperative effort among publishers to enable persistent cross-publisher citation linking in online academic journals.",
+  "currency":"DuckDuckGo is an internet search engine that emphasizes protecting searchers' privacy and avoiding the filter bubble of personalized search results. DuckDuckGo does not show search results from content farms. It uses various APIs of other websites to show quick results to queries and for traditional links it uses the help of its partners and its own crawler.",
   "deezer":"Deezer is a French online music streaming service. It allows users to listen to music content from record labels, including Universal Music Group, Sony Music and Warner Music Group as well as podcasts on various devices online or offline.",
-  "deviantart":"DeviantArt is an American online art community featuring artwork, videography and photography subsidiary of the Israeli company Wix.com. It was launched on August 7, 2000 by Angelo Sotira, Scott Jarkoff, Matthew Stephens, and others. Artworks are organized in a category structure, including photography, digital art, traditional art, literature, Flash, filmmaking, skins for applications, operating system customization utilities and others, along with downloadable resources such as tutorials and stock photography. Additional features include journals, polls, groups, and portfolios.",
+  "deviantart":"DeviantArt is an American online art community featuring artwork, videography and photography subsidiary of the Israeli company Wix.com. It was launched on August 7, 2000 by Angelo Sotira, Scott Jarkoff, Matthew Stephens, and others.",
   "ddg definitions":[
    "currency:en",
    "ref"
   ],
-  "digg":"Digg, stylized in lowercase as digg, is an American news aggregator with a curated front page, aiming to select stories specifically for the Internet audience such as science, trending political issues, and viral Internet issues. It was launched in its current form on July 31, 2012, with support for sharing content to other social platforms such as Twitter and Facebook.",
   "docker hub":[
    "hosting service for Docker repository",
    "wikidata"
@@ -811,19 +862,19 @@
    "Transparent metasearch engine in Swiss quality. Simultaneously queries major search engines with one click.",
    "https://www.etools.ch"
   ],
-  "etymonline":"The Online Etymology Dictionary is a free online dictionary, written and compiled by Douglas R. Harper that describes the origins of English-language words.",
+  "etymonline":"The Online Etymology Dictionary is a free online dictionary, written and compiled by Douglas R. Harper, that describes the origins of English-language words.",
   "1x":[
    "1x.com is the world's biggest curated photo gallery online. Each photo is selected by professional curators. 1x.com • In Pursuit of the Sublime",
    "https://1x.com/"
   ],
   "fdroid":"F-Droid is a software repository for Android, serving a similar function to the Google Play store. The main repository, hosted by the project, contains only free and open source apps. Applications can be browsed, downloaded and installed from the F-Droid website or client app without the need to register for an account. \"Anti-Features\" such as advertising, user tracking, or dependence on nonfree software are flagged in app descriptions.",
-  "flickr":"Flickr is an American image hosting and video hosting service, as well as an online community. It was created by Ludicorp in 2004 and is a popular way for amateur and professional photographers to host high-resolution photos. It has changed ownership several times and has been owned by SmugMug since April 20, 2018.",
+  "flickr":"Flickr is an American image hosting and video hosting service, as well as an online community, founded in Canada and headquartered in the United States. It was created by Ludicorp in 2004 and is a popular way for amateur and professional photographers to host high-resolution photos. It has changed ownership several times and has been owned by SmugMug since April 20, 2018.",
   "free software directory":"The Free Software Directory (FSD) is a project of the Free Software Foundation (FSF). It catalogs free software that runs under free operating systems—particularly GNU and Linux. The cataloged projects are often able to run in several other operating systems. The project was formerly co-run by UNESCO.",
   "frinkiac":"Frinkiac is a website for users to search for words or phrases from episodes of the American animated sitcom The Simpsons. It returns screenshots related to the search terms, from which it generates memes and animated GIFs. Created by Paul Kehrer, Sean Schulte and Allie Young, the site is named after a computer built by one of the show's recurring characters, Professor Frink. The site was critically acclaimed upon its launch, and Newsweek wrote that it \"may be the greatest feat of Internet engineering we've ever seen\". As of May 2016, screenshots from the first seventeen seasons of The Simpsons are in Frinkiac's database.",
-  "genius":"Genius is an American digital media company founded in August 2009 by Tom Lehman, Ilan Zechory, and Mahbod Moghadam. The site allows users to provide annotations and interpretation to song lyrics, news stories, sources, poetry, and documents.",
-  "gigablast":"Gigablast is a free and open-source web search engine and directory. Founded in 2000, it is an independent engine and web crawler based in New Mexico, developed and maintained by Matt Wells, a former Infoseek employee and New Mexico Tech graduate.",
+  "genius":"Genius is an American digital media company founded on August 27th, 2009, by Tom Lehman, Ilan Zechory, and Mahbod Moghadam. The site allows users to provide annotations and interpretation to song lyrics, news stories, sources, poetry, and documents.",
+  "gigablast":"Gigablast is an American free and open-source web search engine and directory. Founded in 2000, it is an independent engine and web crawler, developed and maintained by Matt Wells, a former Infoseek employee and New Mexico Tech graduate.",
   "gentoo":"Gentoo Linux is a Linux distribution built using the Portage package management system. Unlike a binary software distribution, the source code is compiled locally according to the user's preferences and is often optimized for the specific type of computer. Precompiled binaries are available for some larger packages or those with no available source code.",
-  "gitlab":"GitLab is a web-based DevOps lifecycle tool that provides a Git repository manager providing wiki, issue-tracking and continuous integration and deployment pipeline features, using an open-source license, developed by GitLab Inc. The open source software project was created by Ukrainian developers Dmitriy Zaporozhets and Valery Sizov.",
+  "gitlab":"GitLab Inc. is the open-core company that provides GitLab, the DevOps platform that combines the ability to develop, secure, and operate software in a single application. The open source software project was created by Ukrainian developer Dmitriy Zaporozhets and Dutch developer Sytse Sijbrandij.",
   "github":"GitHub, Inc. is a provider of Internet hosting for software development and version control using Git. It offers the distributed version control and source code management (SCM) functionality of Git, plus its own features. It provides access control and several collaboration features such as bug tracking, feature requests, task management, continuous integration and wikis for every project. Headquartered in California, it has been a subsidiary of Microsoft since 2018.",
   "codeberg":[
    "Codeberg is founded as a Non-Profit Organization, with the objective to give the Open-Source code that is running our world a safe and friendly home, and to ensure that free code remains free and secure forever.",
@@ -849,13 +900,15 @@
   ],
   "habrahabr":"Habr is a Russian collaborative blog about IT, Computer science and anything related to the Internet, owned by TechMedia. Habrahabr was founded in June 2006. The English section of Habr was launched in 2019.",
   "hoogle":"Haskell is a general-purpose, statically typed, purely functional programming language with type inference and lazy evaluation. Designed for teaching, research and industrial application, Haskell has pioneered a number of advanced programming language features such as type classes, which enable type-safe operator overloading. Haskell's main implementation is the Glasgow Haskell Compiler (GHC). It is named after logician Haskell Curry.",
+  "imdb":"IMDb is an online database of information related to films, television series, home videos, video games, and streaming content online – including cast, production crew and personal biographies, plot summaries, trivia, ratings, and fan and critical reviews. IMDb began as a fan-operated movie database on the Usenet group \"rec.arts.movies\" in 1990, and moved to the web in 1993. It is now owned and operated by IMDb.com, Inc., a subsidiary of Amazon.",
   "ina":"The Institut national de l'audiovisuel, is a repository of all French radio and television audiovisual archives. Additionally it provides free access to archives of countries such as Afghanistan and Cambodia. It has its headquarters in Bry-sur-Marne.",
   "invidious":[
    "alternative front end for YouTube",
    "wikidata"
   ],
   "kickass":"KickassTorrents was a website that provided a directory for torrent files and magnet links to facilitate peer-to-peer file sharing using the BitTorrent protocol. It was founded in 2008 and by November 2014, KAT became the most visited BitTorrent directory in the world, overtaking The Pirate Bay, according to the site's Alexa ranking. KAT went offline on 20 July 2016 when the domain was seized by the U.S. government. The site's proxy servers were shut down by its staff at the same time.",
-  "library genesis":"Library Genesis (Libgen) is a file-sharing based shadow library website for scholarly journal articles, academic and general-interest books, images, comics, audiobooks, and magazines. The site enables free access to content that is otherwise paywalled or not digitized elsewhere. Libgen describes itself as a \"links aggregator\" providing a searchable database of items \"collected from publicly available public Internet resources\" as well as uploaded \"from users\".",
+  "library genesis":"Library Genesis (Libgen) is a file-sharing based shadow library website for scholarly journal articles, academic and general-interest books, images, comics, audiobooks, and magazines. The site enables free access to content that is otherwise paywalled or not digitized elsewhere. Libgen describes itself as a \"links aggregator\", providing a searchable database of items \"collected from publicly available public Internet resources\" as well as files uploaded \"from users\".",
+  "z-library":"Z-Library is a shadow library project for file-sharing access to scholarly journal articles, academic texts, and general-interest books,. As of 22 October, 2021, Z-lib states that it possesses more than 8,930,000 books and 84,830,000 articles. According to the project's page for academic articles, it is \"the world's largest e-book library\", as well as \"the world's largest scientific articles store\". Z-library also describes itself as a non-profit organization sustained by donations.",
   "library of congress":"The Library of Congress (LC) is the research library that officially serves the United States Congress and is the de facto national library of the United States. It is the oldest federal cultural institution in the United States. The library is housed in three buildings on Capitol Hill in Washington, D.C.; it also maintains a conservation center in Culpeper, Virginia. The library's functions are overseen by the Librarian of Congress, and its buildings are maintained by the Architect of the Capitol. The Library of Congress is one of the largest libraries in the world. Its \"collections are universal, not limited by subject, format, or national boundary, and include research materials from all parts of the world and in more than 450 languages.\"",
   "lobste.rs":[
    "social news website focused on computer engineering",
@@ -865,7 +918,7 @@
    "AZLyrics - Song Lyrics from A to Z",
    "https://azlyrics.com"
   ],
-  "microsoft academic":"Microsoft Academic is a free public web search engine for academic publications and literature, developed by Microsoft Research. Re-launched in 2016, the tool features an entirely new data structure and search engine using semantic search technologies. It currently indexes over 260 million publications, 88 million of which are journal articles.",
+  "microsoft academic":"Microsoft Academic is a free public web search engine for academic publications and literature, developed by Microsoft Research. It profiles authors, organizations, keywords, and journals. The search engine currently indexes over 260 million publications, 88 million of which are journal articles.",
   "mixcloud":"Mixcloud is a popular British online music streaming service that allows for the listening and distribution of radio shows, DJ mixes and podcasts, which are crowdsourced by its registered users.",
   "npm":"npm is a package manager for the JavaScript programming language maintained by npm, Inc.",
   "nyaa":[
@@ -900,7 +953,7 @@
   ],
   "piratebay":"The Pirate Bay is an online index of digital content of entertainment media and software. Founded in 2003 by Swedish think tank Piratbyrån, The Pirate Bay allows visitors to search, download, and contribute magnet links and torrent files, which facilitate peer-to-peer (P2P) file sharing among users of the BitTorrent protocol.",
   "pubmed":"MEDLINE is a bibliographic database of life sciences and biomedical information. It includes bibliographic information for articles from academic journals covering medicine, nursing, pharmacy, dentistry, veterinary medicine, and health care. MEDLINE also covers much of the literature in biology and biochemistry, as well as fields such as molecular evolution.",
-  "pypi":"The Python Package Index, abbreviated as PyPI and also known as the Cheese Shop, is the official third-party software repository for Python. It is analogous to CPAN, the repository for Perl. Some package managers, including pip, use PyPI as the default source for packages and their dependencies. As of 1 September 2021, over 324,836 Python packages can be accessed through PyPI.",
+  "pypi":"The Python Package Index, abbreviated as PyPI and also known as the Cheese Shop, is the official third-party software repository for Python. It is analogous to the CPAN repository for Perl and to the CRAN repository for R. PyPI is run by the Python Software Foundation, a charity. Some package managers, including pip, use PyPI as the default source for packages and their dependencies.",
   "qwant":"Qwant is a French search engine, launched in July 2013 and operated from Paris. It is one of the few EU-based search engines and one that has its own indexing engine. It claims that it does not employ user tracking or personalize search results in order to avoid trapping users in a filter bubble. The search engine is available in 26 languages.",
   "qwant news":[
    "qwant:en",
@@ -919,8 +972,16 @@
    "A search engine of PeerTube videos, channels and playlists, developed by Framasoft",
    "https://sepiasearch.org"
   ],
-  "soundcloud":"SoundCloud is a Swedish-founded online audio distribution platform and music sharing website based in Berlin, Germany that enables its users to upload, promote, and share audio, as well as a digital signal processor enabling listeners to stream audio. Started in 2007 by Alexander Ljung and Eric Wahlforss, SoundCloud has grown to be one of the largest music streaming services in the world. SoundCloud offers both free and paid memberships on the platform, available for mobile, desktop and XBOX devices.",
-  "stackoverflow":"Stack Overflow is a question and answer website for professional and enthusiast programmers. It is the flagship site of the Stack Exchange Network, created in 2008 by Jeff Atwood and Joel Spolsky. It features questions and answers on a wide range of topics in computer programming. It was created to be a more open alternative to earlier question and answer websites such as Experts-Exchange. Stack Overflow was sold to Prosus, a Netherlands-based consumer internet conglomerate, on 2 June 2021 for $1.8 billion.",
+  "soundcloud":"SoundCloud is an online audio distribution platform and music sharing website based in Berlin, Germany that enables its users to upload, promote, and share audio, as well as a digital signal processor enabling listeners to stream audio. Started in 2007 by Alexander Ljung and Eric Wahlforss, SoundCloud has grown to be one of the largest music streaming services in the world. SoundCloud offers both free and paid memberships on the platform, available for mobile, desktop and Xbox devices.",
+  "stackoverflow":"Stack Exchange is a network of question-and-answer (Q&A) websites on topics in diverse fields, each site covering a specific topic, where questions, answers, and users are subject to a reputation award process. The reputation system allows the sites to be self-moderating. As of August 2019, the three most actively-viewed sites in the network are Stack Overflow, Super User, and Ask Ubuntu.",
+  "askubuntu":[
+   "stackoverflow:en",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:en",
+   "ref"
+  ],
   "searchcode code":[
    "searchcode is a free source code search engine. Code snippets and open source (free sofware) repositories are indexed and searchable.",
    "https://searchcode.com/"
@@ -929,23 +990,19 @@
    "French-language FLOSS directory",
    "wikidata"
   ],
-  "semantic scholar":"Semantic Scholar is an artificial-intelligence backed search engine for academic publications developed at the Allen Institute for AI and publicly released in November 2015. It uses advances in natural language processing to provide summaries for scholarly papers.",
+  "semantic scholar":"Semantic Scholar is an artificial-intelligence backed search engine for academic publications developed at the Allen Institute for AI and publicly released in November 2015. It uses advances in natural language processing to provide summaries for scholarly papers. The Semantic Scholar team is actively researching the use of artificial-intelligence in natural language processing, machine learning, Human-Computer interaction, and information retrieval.",
   "startpage":"Startpage is a Dutch search engine company that highlights privacy as its distinguishing feature. The website advertises that it allows users to obtain Google Search results while protecting users' privacy by not storing personal information or search data and removing all trackers. Startpage.com also includes an Anonymous View browsing feature that allows users the option to open search results via proxy for increased anonymity. Because the company is based in the Netherlands, it is protected by Dutch and European Union privacy laws, and thus is not subject to United States surveillance programs, like PRISM.",
   "tokyotoshokan":[
    "Tokyo Toshokan :: #tokyotosho @ irc.rizon.net :: Torrent Listing",
    "https://www.tokyotosho.info/"
   ],
-  "solidtorrents":[
-   "Solid Torrents is a torrent metadata search engine.",
-   "https://www.solidtorrents.net/"
-  ],
-  "unsplash":"Unsplash is a website dedicated to sharing stock photography under the Unsplash license. Since 2021, it has been owned by Getty Images. The website claims over 207,000 contributing photographers and generates more than 17 billion photo impressions per month on their growing library of over 2 million photos. Unsplash has been cited as one of the world's leading photography websites by Forbes, Entrepreneur Magazine, CNET, Medium and The Next Web.",
+  "unsplash":"Unsplash is a website dedicated to sharing stock photography under the Unsplash license. Since 2021, it has been owned by Getty Images. The website claims over 265,000 contributing photographers and generates more than 16 billion photo impressions per month on their growing library of over 3.2 million photos. Unsplash has been cited as one of the world's leading photography websites by Forbes, Entrepreneur Magazine, CNET, Medium and The Next Web.",
   "yahoo":[
-   "Yahoo fait désormais partie de Verizon Media",
-   "https://search.yahoo.com/"
+   "yahoo:de",
+   "ref"
   ],
   "yahoo news":"Yahoo! News is a news website that originated as an internet-based news aggregator by Yahoo!. The site was created by a Yahoo! software engineer named Brad Clawsie in August 1996. Articles originally came from news services such as the Associated Press, Reuters, Fox News, Al Jazeera, ABC News, USA Today, CNN and BBC News.",
-  "youtube":"YouTube is an American online video sharing and social media platform owned by Google. It was launched in February 2005 by Steve Chen, Chad Hurley, and Jawed Karim. It is the second most visited website, with more than one billion monthly users who collectively watch more than one billion hours of videos each day. As of May 2019, videos were being uploaded at a rate of more than 500 hours of content per minute.",
+  "youtube":"YouTube is an American online video sharing and social media platform owned by Google. It was launched on February 14, 2005 by Steve Chen, Chad Hurley, and Jawed Karim. It is the second most visited website, with more than one billion monthly users who collectively watch more than one billion hours of videos each day. As of May 2019, videos were being uploaded at a rate of more than 500 hours of content per minute.",
   "dailymotion":"Dailymotion is a French video-sharing technology platform primarily owned by Vivendi. North American launch partners included Vice Media, Bloomberg, and Hearst Digital Media. Dailymotion is available worldwide in 183 languages and 43 localised versions featuring local home pages and local content. It has more than 300 million monthly users.",
   "vimeo":"Vimeo, Inc. is an American video hosting, sharing, and services platform provider headquartered in New York City. Vimeo focuses on the delivery of high-definition video across a range of devices. Vimeo's business model is through software as a service (SaaS). They derive revenue by providing subscription plans for businesses and video content producers. Vimeo provides its subscribers with tools for video creation, editing, and broadcasting, enterprise software solutions, as well as the means for video professionals to connect with clients and other professionals. As of 2021, the site has 200 million users, with around 1.6 million subscribers to its services.",
   "wiby":[
@@ -959,7 +1016,7 @@
   "wiktionary":"Wiktionary is a multilingual, web-based project to create a free content dictionary of terms in all natural languages and in a number of artificial languages. These entries may contain definitions, images for illustrations, pronunciations, etymologies, inflections, usage examples, quotations, related terms, and translations of words into other languages, among other features. It is collaboratively edited via a wiki. Its name is a portmanteau of the words wiki and dictionary. It is available in 182 languages and in Simple English. Like its sister project Wikipedia, Wiktionary is run by the Wikimedia Foundation, and is written collaboratively by volunteers, dubbed \"Wiktionarians\". Its wiki software, MediaWiki, allows almost anyone with access to the website to create and edit entries.",
   "wikiversity":"Wikiversity is a Wikimedia Foundation project that supports learning communities, their learning materials, and resulting activities. It differs from Wikipedia in that it offers tutorials and other materials for the fostering of learning, rather than an encyclopedia; like Wikipedia, it is available in many languages.",
   "wikivoyage":"Wikivoyage is a free web-based travel guide for travel destinations and travel topics written by volunteer authors. It is a sister project of Wikipedia and supported and hosted by the same non-profit Wikimedia Foundation (WMF). Wikivoyage has been called the \"Wikipedia of travel guides\".",
-  "wolframalpha":"WolframAlpha is a computational knowledge engine or answer engine developed by WolframAlpha LLC, a subsidiary of Wolfram Research. It is an online service that answers factual queries directly by computing the answer from externally sourced \"curated data\", rather than providing a list of documents or web pages that might contain the answer, as a search engine might.",
+  "wolframalpha":"WolframAlpha is a computational knowledge engine and answer engine developed by Wolfram Research. It answers factual queries directly by computing the answer from externally sourced data.",
   "dictzone":[
    "Online dictionaries: English, Spanish, German, French, Italian, Hungarian... Select your favorite dictionary!",
    "https://dictzone.com/"
@@ -979,7 +1036,7 @@
    "WhaleSlide is a search engine that protects your privacy, raises money for good causes and is completely ad free!",
    "https://whaleslide.com/"
   ],
-  "naver":"Naver is a South Korean online platform operated by Naver Corporation. It debuted in 1999 as the first web portal in South Korea to develop and use its own search engine. It was also the world's first operator to introduce the comprehensive search feature, which compiles search results from various categories and presents them in a single page. Naver has since added a multitude of new services ranging from basic features such as e-mail and news to the world's first online Q&A platform Knowledge iN.",
+  "naver":"Naver is a South Korean online platform operated by the Naver Corporation. It debuted in 1999 as the first web portal in South Korea to develop and use its own search engine. It was also the world's first operator to introduce the comprehensive search feature, which compiles search results from various categories and presents them in a single page. Naver has since added a multitude of new services ranging from basic features such as e-mail and news to the world's first online Q&A platform Knowledge iN.",
   "rubygems":"RubyGems is a package manager for the Ruby programming language that provides a standard format for distributing Ruby programs and libraries, a tool designed to easily manage the installation of gems, and a server for distributing them. It was created by Chad Fowler, Jim Weirich, David Alan Black, Paul Brannan and Richard Kilmer during RubyConf 2004.",
   "peertube":"PeerTube is a free and open-source, decentralized, federated video platform powered by ActivityPub and WebTorrent, that uses peer-to-peer technology to reduce load on individual servers when viewing videos.",
   "mediathekviewweb":"MediathekView is a free open-source software designed to manage the online multimedia libraries of several German public broadcasters as well as an Austrian, a Swiss and a Franco-German public broadcaster. The software comes with a German user interface that lists broadcasts available online. In October 2016, the developer announced that maintenance of the project would be discontinued at the end of the year. Three weeks later, the user community had formed a team to continue the project, and the software continues to remain open-source.",
@@ -992,6 +1049,10 @@
   "brave":[
    "The Brave browser is a fast, private and secure web browser for PC, Mac and mobile. Download now to enjoy a faster ad-free browsing experience that saves data and battery life by blocking tracking software.",
    "https://brave.com/search/"
+  ],
+  "onesearch":[
+   "Search engine owned by Yahoo",
+   "wikidata"
   ]
  },
  "eo":{
@@ -1028,10 +1089,11 @@
   "free software directory":"La Katalogo de Libera Programaro estas projekto de la Fondumo por Libera Programaro. Ĝi katalogas liberajn komputilajn programojn, kiuj uzeblas de liberaj operaciumoj—precipe GNU kaj Linukso. La katalogitaj projektoj ofte ankaŭ uzeblas de iuj aliaj operaciumo. Antaŭe Unesko kundirektis la projekton.",
   "github":"GitHub estas tutmonda kompanio, kiu provizas gastigadon por evoluigo de programoj per la versitena sistemo Git. Ĝi estas filio de Microsoft, kiu akiris la kompanion en 2018 por 7,5 bilionoj da usonaj dolaroj.",
   "google images":[
-   "Google Bildoj. La plej efika bildoserĉilo en Interreto.Google Bildoj. La plej efika bildoserĉilo en Interreto.",
+   "Google Bildoj. La plej efika bildoserĉilo en Interreto.",
    "https://images.google.com"
   ],
   "hoogle":"Haskell estas komputillingvo kreita de Paul Hudak, Simon Peyton Jones, kaj Philip Wadler en 1987. Pli specife, ĝi estas himonimige tipizema, nestrikta, pure funkcia lingvo. La lingvo estas nomita por Haskell Brooks Curry, kies esploro pri matematika logiko estas la fundamento de funkciaj lingvoj. Haskell baziĝas de la lambdokalkulo.",
+  "imdb":"Interreta filma datumbazo estas datumbazo kun informoj pri filmoj, televidaj programoj, aktoroj, reĝisoroj kaj ĉio cetera, kio rilatas al la filma kreado.",
   "ina":[
    "muzeo en Francio",
    "wikidata"
@@ -1061,6 +1123,15 @@
    "ref"
   ],
   "reddit":"Reddit estas socia retejo pri aktualaĵoj kie la enskribitaj uzantoj afiŝas enhavojn, aŭ per ligilo aŭ tekste (memafiŝo). Post la afiŝado, aliaj uzantoj voĉdonas \"supren\" aŭ \"malsupren\" por rangigi la afiŝon kaj decidi ĝian pozicion sur la ĉefa kaj aliaj paĝoj de la retejo.",
+  "stackoverflow":"Stack Exchange estas reto de retejoj, kie homoj povas starigi demandojn kaj respondi al demandoj pri diversaj temoj. Stack Exchange estas subdividita en diversaj retejoj.",
+  "askubuntu":[
+   "stackoverflow:eo",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:eo",
+   "ref"
+  ],
   "youtube":"YouTube ['ju:.t(j)u:b] estas retejo, videospektejo fondita en februaro 2005 de la iamaj PayPal-kunlaborantoj Chad Hurley, Steve Chen kaj Jawed Karim. Sur tiu retejo la uzantoj povas spekti filmetojn, datumflue transportatajn al la komputilo de la spektanto, kaj alŝuti proprajn filmetojn. La 9-an de oktobro 2006 Google anoncis sian aĉeton de YouTube.",
   "vimeo":"Vimeo estas entrepreno en Novjorko, Usono, kiu ekde la jaro 2004 ofertas servon de interreta televido: Sur la retejo de la entrepreno, legebla en la angla, la uzantoj povas spekti filmetojn, datumflue transportatajn al la komputilo de la spektanto, kaj registritaj uzantoj povas alŝuti proprajn filmetojn. Laŭ la reteja regularo, rajtas alŝuti filmetojn nur personoj, kiuj ilin \"mem kreis aŭ proksime kunlaboris en la kreado\".",
   "wikibooks":"Vikilibroj estas vikia loko por publikigo de libroj sen kopirajto. Ĝi estas Projekto de Fondaĵo Vikimedio kaj ekzistas ankaŭ en Esperanto.",
@@ -1074,10 +1145,7 @@
    "ĉeĥa interreta serĉilo",
    "wikidata"
   ],
-  "peertube":[
-   "malcentralizita video-gastiganta servo",
-   "wikidata"
-  ]
+  "peertube":"PeerTube estas libera programaro, malcentra, malcentralizita, federacia retapliko, kiu uzas peer-to-peer teknologion por redukti la ŝarĝon sur individuaj serviloj dum spektado de videoj."
  },
  "es":{
   "archive is":"archive.today es un servicio que permite salvaguardar una copia de cualquier página en la Web, con todas los imágenes, estilos y fuentes.",
@@ -1100,7 +1168,6 @@
    "currency:es",
    "ref"
   ],
-  "digg":"Digg es un sitio web 2.0 principalmente sobre noticias de ciencia y tecnología. Combina marcadores sociales, blogging y sindicación con una organización sin jerarquías, con control editorial democrático, lo cual permite que se publiquen artículos sobre una gran variedad de géneros.",
   "erowid":"Erowid.org, también llamada Las Bóvedas de Erowid, es una biblioteca en línea de información sobre plantas psicoactivas y sustancias químicas y otras actividades como la meditación y el sueño lúcido. Proporciona información sobre sustancias legales e ilegales, incluidos sus efectos, tanto deseados como adversos. La información está organizada por sustancias, que van desde sustancias comunes como el alcohol, a otras tan inusuales como el Bromo-Dragonfly.",
   "wikidata":"Wikidata es una base de conocimientos editada en colaboración y alojada por la Fundación Wikimedia. Tiene el objetivo de proporcionar una fuente común de datos que puedan ser utilizados por proyectos de Wikimedia como Wikipedia, y por cualquier otra persona, bajo una licencia de dominio público. Esto es similar a la forma en que Wikimedia Commons proporciona almacenamiento para archivos multimedia y acceso a estos archivos para todos los proyectos de Wikimedia. Wikidata funciona y opera con el software Wikibase.",
   "duckduckgo":[
@@ -1122,7 +1189,7 @@
   "google":"El buscador de Google o buscador web de Google es un motor de búsqueda en la web propiedad de Alphabet Inc. Es el motor de búsqueda más utilizado en la Web y recibe cientos de millones de consultas cada día a través de sus diferentes servicios. El objetivo principal del buscador de Google es buscar texto en las páginas web, en lugar de otro tipo de datos. Fue desarrollado originalmente por Larry Page y Sergey Brin en 1997.",
   "google images":"Google Imágenes es una especialización del buscador principal para imágenes, que fue implementado en el año 2001. Contiene en su interfaz distintas herramientas de búsqueda, que sirven para filtrar los resultados de las imágenes. Estos pueden ser según su tamaño, tipo, formatos, por coloración, por color, por fecha, y por imágenes similares.",
   "google news":"Google Noticias es un agregador y buscador de noticias automatizado que rastrea de forma constante la información de los principales medios de comunicación en línea.",
-  "google videos":"Google Video fue un servicio de Google que hasta enero de 2009 permitía subir clips de video a sus servidores para que cualquier persona los pudiera buscar y ver directamente desde su navegador. Inicialmente nació como competencia de YouTube, a la que terminó comprando el 10 de octubre de 2006. Finalmente, Google Video pasó a funcionar como un mero buscador de videos en la red, pasando a ser YouTube el único servicio de estos dos que permite la subida de videos.",
+  "google videos":"Google Vídeo fue un servicio de Google que hasta enero de 2009 permitía subir clips de vídeo a sus servidores para que cualquier persona los pudiera buscar y ver directamente desde su navegador. Inicialmente nació como competencia de YouTube, a la que terminó comprando el 10 de octubre de 2006. Finalmente, Google Vídeo pasó a funcionar como un mero buscador de vídeos en la red, pasando a ser YouTube el único servicio de estos dos que permite la subida de vídeos.",
   "google scholar":"Google Académico es un motor de búsqueda de Google enfocado y especializado en la búsqueda de contenido y bibliografía científico-académica. El sitio indexa editoriales, bibliotecas, repositorios, bases de datos bibliográficas, entre otros; y entre sus resultados se pueden encontrar citas, enlaces a libros, artículos de revistas científicas, comunicaciones y congresos, informes científico-técnicos, tesis, tesinas y archivos depositados en repositorios.",
   "google play apps":"Google Play es una plataforma de distribución digital de aplicaciones móviles para los dispositivos con sistema operativo Android, así como una tienda en línea desarrollada y operada por Google. Esta plataforma permite a los usuarios navegar y descargar aplicaciones, juegos, música, libros, revistas y películas. También se pueden adquirir dispositivos móviles como ordenadores Chromebook, teléfonos inteligentes Nexus y Pixel, Google Chromecast, entre otros. También cuenta con versiones para Wear OS y Leanback.",
   "google play movies":[
@@ -1130,10 +1197,11 @@
    "ref"
   ],
   "hoogle":"Haskell es un lenguaje de programación estandarizado multi-propósito, funcionalmente puro, con evaluación no estricta y memorizada, y fuerte tipificación estática. Su nombre se debe al lógico estadounidense Haskell Curry, debido a su aportación al cálculo lambda, el cual tiene gran influencia en el lenguaje. En Haskell, \"una función es un ciudadano de primera clase\" del lenguaje de programación. Como lenguaje de programación funcional, el constructor de controles primario es la función. El lenguaje tiene sus orígenes en las observaciones de Haskell Curry y sus descendientes intelectuales.",
+  "imdb":"Internet Movie Database es una base de datos en línea que en un principio almacena información relacionada con películas, y con el tiempo se transforma en la base de datos más grande del mundo donde se encuentran Programas de televisión, eventos en vivo y difundidos en televisión o en la web, entrega de premios y especiales. Se encuentra el personal de equipo de producción, actores, series y programas de televisión, videojuegos, actores de doblaje y personajes ficticios que aparecen en los medios de entretenimiento visual. Recibe más de 100 millones de usuarios únicos al mes y cuenta con una versión móvil. IMDb fue inaugurada el 17 de octubre de 1990, y en 1998 fue adquirida por Amazon.com.",
   "ina":"El Instituto nacional del audiovisual (INA) es una dependencia pública francesa dedicada a archivar las producciones audiovisuales, de producir, de editar, de ceder contenidos audiovisuales y multimedia a destino de todos los públicos, profesionales o particulares, para todas las pantallas. El INA también es un centro de formación y de investigación que pretende desarrollar y transmitir los saberes de los medios de comunicación audiovisuales.",
   "kickass":"KickassTorrents es un sitio web que proporciona un directorio de archivos torrent y enlaces magnéticos para facilitar el intercambio de archivos peer-to-peer mediante el protocolo BitTorrent. Fue fundada en 2008 y fue puesto fuera de línea el 20 de julio de 2016, cuando el dominio fue capturado por el gobierno de Estados Unidos. Los servidores proxy del sitio fueron cerrados por su personal, al mismo tiempo.",
   "library genesis":"Library Genesis o LibGen es un motor de búsqueda que permite el libre acceso a artículos científicos y libros. Posee contenido libre en formatos PDF, EPUB, MOBI, DJVU, etc., accesible en portales de numerosas editoriales académicas, como Oxford UP, Cambridge UP, Elsevier ScienceDirect, Springer, etc.",
-  "library of congress":"La Biblioteca del Congreso de Estados Unidos, situada en Washington D. C. y distribuida en tres edificios, es una de las mayores bibliotecas del mundo, con más de 158 millones de documentos. La colección de la Biblioteca del Congreso incluye más de 36,8 millones de libros en 470 idiomas, más de 68 millones de manuscritos y la colección más grande de libros raros y valiosos, incluyendo una de las únicas cuatro copias en perfecto estado de la Biblia de Gutenberg, y el borrador de la Declaración de Independencia. Además, guarda más de un millón de publicaciones del gobierno de Estados Unidos, un millón de números de periódicos de diferentes partes del mundo, de los últimos tres siglos, 500.000 rollos de microfilm, 6000 títulos de cómics, la colección más grande de documentos legales, películas, cerca de 5 millones de mapas, partituras, 2,7 millones de grabaciones sonoras, canciones y más de 13,7 millones de grabados y copias fotográficas. El documento más antiguo es una tablilla de piedra del año 2040 a. C. También alberga obras de arte, dibujos arquitectónicos, y valiosos instrumentos como el Stradivarius Betts y el Stradivarius Cassavetti.",
+  "library of congress":"La Biblioteca del Congreso de los Estados Unidos, situada en Washington D. C. y distribuida en tres edificios, es una de las mayores bibliotecas del mundo, con más de 158 millones de documentos. La colección de la Biblioteca del Congreso incluye más de 36,8 millones de libros en 470 idiomas, más de 68 millones de manuscritos y la colección más grande de libros raros y valiosos, incluyendo una de las únicas cuatro copias en perfecto estado de la Biblia de Gutenberg, y el borrador de la Declaración de Independencia. Además, guarda más de un millón de publicaciones del gobierno de Estados Unidos, un millón de números de periódicos de diferentes partes del mundo, de los últimos tres siglos, 500 000 rollos de microfilm, 6000 títulos de cómics, la colección más grande de documentos legales, películas, cerca de 5 millones de mapas, partituras, 2,7 millones de grabaciones sonoras, canciones y más de 13,7 millones de grabados y copias fotográficas. El documento más antiguo es una tablilla de piedra del año 2040 a. C. También alberga obras de arte, dibujos arquitectónicos, y valiosos instrumentos como el Stradivarius Betts y el Stradivarius Cassavetti.",
   "microsoft academic":"Microsoft Académico es un motor de búsqueda web público y libre para literatura y publicaciones científicas, desarrollado por Microsoft Research.",
   "mixcloud":"Mixcloud es un servicio británico de transmisión de música en línea que permite escuchar y distribuir programas de radio, mezclas de DJ y podcasts, que son financiados por sus usuarios registrados.",
   "npm":"npm es el sistema de gestión de paquetes por defecto para Node.js, un entorno de ejecución para JavaScript, bajo Artistic License 2.0.",
@@ -1156,7 +1224,15 @@
   ],
   "reddit":"Reddit es un sitio web de marcadores sociales y agregador de noticias donde los usuarios pueden añadir textos, imágenes, videos o enlaces. Los usuarios pueden votar a favor o en contra del contenido, haciendo que aparezcan en las publicaciones destacadas. Se trata de un mapa de discusión, como parte de un DDS global distribuido. Su público es mayoritariamente anglosajón y la mayoría de la actividad se realiza en inglés. Reddit fue software libre desde el 19 de junio de 2009 hasta septiembre de 2017, cuando la compañía archivó y cerró el acceso a sus repositorios en Github, que incluían todo el código escrito para Reddit excepto las partes anti-spam.",
   "soundcloud":"SoundCloud es una plataforma de distribución de audio en línea en la que sus usuarios pueden colaborar, promocionar y distribuir sus proyectos musicales.",
-  "stackoverflow":"Stack Overflow es un sitio de preguntas y respuestas para programadores profesionales y aficionados. Es el sitio emblemático de la red Stack Exchange, creado en 2008 por Jeff Atwood y Joel Spolsky. Contiene preguntas y respuestas sobre una amplia gama de temas de programación. Se creó para ser una alternativa más abierta a sitios previos de preguntas y respuestas como Experts-Exchange. El nombre del sitio web fue elegido por votación en abril de 2008 por los lectores de Coding Horror, el popular blog de programación de Atwood.",
+  "stackoverflow":"Stack Exchange es una red de webs de preguntas y respuestas sobre distintos temas, donde las preguntas, respuestas y los usuarios están sujetos a un sistema de reputación y recompensas. Dicho sistema permite que los sitios se automoderen.",
+  "askubuntu":[
+   "stackoverflow:es",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:es",
+   "ref"
+  ],
   "semantic scholar":"Semantic Scholar es un motor de búsqueda respaldado por un sistema de inteligencia artificial dedicado a trabajar con publicaciones académicas. Desarrollado en el Allen Institute for Artificial Intelligence, se lanzó al público en noviembre de 2015. Utiliza avances recientes en el procesamiento del lenguaje natural para proporcionar resúmenes de artículos académicos.",
   "startpage":"Startpage es un metabuscador holandés, que destaca la privacidad como su característica distintiva. El sitio web anuncia que permite a los usuarios obtener resultados del Buscador de Google protegiendo la privacidad de los usuarios al no almacenar información personal ni datos de búsqueda y eliminar todos los rastreadores. Startpage.com también incluye una función de navegación anónima que permite a los usuarios la opción de abrir los resultados de búsqueda a través de un proxy para aumentar el anonimato. Dado que la empresa tiene su sede en los Países Bajos, está protegida por las leyes de privacidad neerlandesa y de la Unión Europea, por lo que no está sujeta a los programas de vigilancia de Estados Unidos, como PRISM.",
   "unsplash":"Unsplash es el sitio web internacional en el que están colocadas las fotografías de stock con licencia Unsplash. Desde 2021 es propiedad de Getty Images. El sitio web cuenta con más de 207,000 fotógrafos colaboradores y genera más de 17 mil millones de impresiones fotográficas por mes en su creciente biblioteca de más de 2 millones de fotos. Unsplash es uno de los sitios web principales de fotografía.",
@@ -1167,7 +1243,7 @@
   "wikinews":"Wikinoticias es una fuente de noticias de contenido libre y un proyecto de la Fundación Wikimedia. El sitio funciona a través del periodismo colaborativo. El cofundador de Wikipedia, Jimmy Wales, ha distinguido a Wikinews de Wikipedia al decir \"en Wikinews, cada historia debe escribirse como una noticia en lugar de un artículo de enciclopedia\". La política de punto de vista neutral adoptada en Wikinoticias la distingue de otros esfuerzos de periodismo ciudadano como Indymedia y OhmyNews. A diferencia de la mayoría de los proyectos de la Fundación Wikimedia, Wikinews permite el trabajo original en forma de informes y entrevistas originales.",
   "wikiquote":"Wikiquote es una colección de citas célebres de personajes famosos, libros y proverbios. Se realiza de forma colaborativa a través de Internet, bajo la licencia libre GFDL, y basándose en tecnología wiki. Se basa en una idea de Daniel Alston, implementada por Brion Vibber.",
   "wikisource":"Wikisource es un proyecto hermano de Wikipedia cuyo objetivo es crear una biblioteca de textos originales, libres y que hayan sido publicados con una licencia GFDL, Creative Commons o que sean de dominio público; junto con su traducción en distintas lenguas. Este sitio forma parte de la fundación Wikimedia. Forman parte de Wikisource distintos libros publicados, así como documentos históricos, ensayos, etc. Su página de inicio presenta una clasificación general por países, géneros y épocas, entre otras opciones.",
-  "wiktionary":"El Wikcionario es un proyecto de diccionario libre de la Fundación Wikimedia, que contiene definiciones, traducciones, etimologías, sinónimos y pronunciaciones de palabras en múltiples idiomas.",
+  "wiktionary":"Wikcionario es un proyecto de diccionario libre de la Fundación Wikimedia, que contiene definiciones, traducciones, etimologías, sinónimos y pronunciaciones de palabras en múltiples idiomas.",
   "wikiversity":"Wikiversidad es un proyecto hermano de Wikipedia cuyo objetivo es construir una plataforma educativa virtual libre y gratuita, con filosofía wiki y que forme parte de la Fundación Wikimedia. En este proyecto se elaboran materiales y recursos didácticos, y se forman grupos de estudio, a diversos niveles educativos. Los materiales creados tienen una licencia Creative Commons de tipo \"Atribución-Compartir Igual\" para que sean libremente redistribuibles.",
   "wikivoyage":"Wikiviajes es una guía turística libre en Internet basada en la tecnología wiki. Fue fundada en septiembre del año 2006 por autores alemanes de Wikitravel inconformes con las políticas comerciales de los dueños de dicho sitio. Se ha convertido en el wiki con el tema viajes más popular en Alemania, y fue lanzada en inglés, neerlandés, francés, italiano, ruso y sueco.",
   "wolframalpha":"Wolfram|Alpha es un buscador de respuestas desarrollado por la compañía Wolfram Research. Es un servicio en línea que responde a las preguntas directamente, mediante el procesamiento de la respuesta extraída de una base de datos estructurados, en lugar de proporcionar una lista de los documentos o páginas web que podrían contener la respuesta, tal y como lo hace Google. Fue anunciado en marzo de 2009 por el físico británico Stephen Wolfram y está en funcionamiento desde el 15 de mayo de 2009.",
@@ -1199,7 +1275,7 @@
   "flickr":"Flickr on Yahoo! veebikeskkond, mis on loodud eelkõige fotode ja videote talletamiseks, haldamiseks ja jagamiseks. Ludicorp asutas Flickri 2004. aastal ning 2005. aastal omandas selle Yahoo. Lisaks sellele, et tegemist on populaarse veebiteenusega, milles iga kasutaja saab \"oma\" veebilehtedel jagada ja talletada enda tehtud fotosid, kasutavad Flickrit ka fototöötlejad ja blogijad, kes kasutavad fotosid blogides ja sotsiaalmeedias.",
   "github":"GitHub on Ameerika firma, mis pakub veebimajutusteenust tarkvaraarenduseks, kasutades Giti tarkvara. GitHub on Microsofti tütarfirma alates aastast 2018, mil Microsoft ostis GitHubi 7,5 miljardi dollari eest. GitHub põhineb Giti hajutatud versioonihaldusel ja lähtekoodihaldusel, kuid lisab neile veel võimalusi, näiteks võimalust kontrollida, kes pääseb koodile juurde, koodi veakontrolli, tarkvara funktsioonide taotlust ning igale projektile oma vikit. GitHub on kirjutatud Rubys ning baseerub Ruby on Railsi raamistikul.",
   "google images":[
-   "Google'i pildid. Kõige täiuslikum pildiotsing internetis.Google'i pildid. Kõige täiuslikum pildiotsing internetis.",
+   "Google'i pildid. Kõige täiuslikum pildiotsing internetis.",
    "https://images.google.com"
   ],
   "google scholar":"Google Scholar on Google'i hallatav tasuta interneti otsingumootor teadustekstide otsimiseks.",
@@ -1212,6 +1288,7 @@
    "ref"
   ],
   "hoogle":"Haskell on standardiseeritud üldotstarbeline puhtalt funktsionaalne programmeerimiskeel. Oma nime on keel saanud loogiku Haskell Curry järgi.",
+  "imdb":"The Internet Movie Database ehk IMDb on rahvusvaheline filmikunstiteemaline andmebaas.",
   "library of congress":"Ameerika Ühendriikide Kongressi raamatukogu on maailma suurim raamatukogu. See Washingtonis asuv raamatukogu asutati 1800. aastal. Raamatukogus on üle 130 miljoni trükise: 29 miljonit erinevat raamatut 460 keeles. Raamaturiiuleid on ühtekokku 850 kilomeetrit.",
   "npm":"npm on JavaScripti programmeerimiskeele jaoks loodud paketihaldur. See on JavaScripti käituskeskkonna Node.js standardne paketihaldur.",
   "openstreetmap":"OpenStreetMap on avatud lähtekoodiga projekt, mille raames luuakse vabalt kasutatavaid geograafilisi andmeid, näiteks tänavakaarte.",
@@ -1228,7 +1305,7 @@
  },
  "eu":{
   "artic":"Chicagoko Arte Institutua, ingelesez: Art Institute of Chicago, AEBetako Chicago hirian dagoen arte-museo bat da. Munduko arte-museo garrantzitsuenetako bat da, eta ziurrenik AEBetako hiru arte-museo nabarmenetako bat, New Yorkeko Metropoliar Museoa eta Bostongo Arte Ederren Museoarekin batera.",
-  "wikipedia":"Wikipedia eduki askeko entziklopedia bat da, lankidetzaz editatua, eleanitza, Interneten argitaratua, Wikimedia Fundazioa irabazi asmorik gabeko erakundeak sustengatua. Wikipedia mundu osoko boluntarioek idazten dute. Internetera konektatutako edonork parte har dezake Wikipediako artikuluetan, aldatu lotura sakatuz. 2015ko azaroaren bostean, 291 hizkuntzatako edizioak zituen, eta horietatik 275 zeuden aktibo. Proiektuaren xedea da ahalik eta hizkuntza gehienetan idatzitako entziklopedia sortu eta hedatzea. Guztira 37 milioi artikulu ditu, horietatik 378.663 euskaraz eta bost milioitik gora ingelesez.",
+  "wikipedia":"Wikipedia eduki askeko entziklopedia bat da, lankidetzaz editatua, eleanitza, Interneten argitaratua, Wikimedia Fundazioa irabazi asmorik gabeko erakundeak sustengatua. Wikipedia mundu osoko boluntarioek idazten dute. Internetera konektatutako edonork parte har dezake Wikipediako artikuluetan, aldatu lotura sakatuz. 2015ko azaroaren bostean, 291 hizkuntzatako edizioak zituen, eta horietatik 275 zeuden aktibo. Proiektuaren xedea da ahalik eta hizkuntza gehienetan idatzitako entziklopedia sortu eta hedatzea. Guztira 37 milioi artikulu ditu, horietatik 382.733 euskaraz eta bost milioitik gora ingelesez.",
   "bing":[
    "Microsoft enpresak garatutako bilaketa motorra",
    "wikidata"
@@ -1268,7 +1345,7 @@
   "github":"GitHub Inc. bertsio kontrolerako web-ostatu zerbitzua da, Git erabiltzen duena. Gehienbat iturburu koderako erabiltzen da. Git-en bertsio-kontrol banatu eta iturburu-kode kudeatzaile funtzionalitate guztiak eskaintzeaz gain bere ezaugarri propioak gehitzen ditu. Sarbide-kontrola eta proiektu bakoitzaren elkarlanerako hainbat aukera hornitzen ditu, esaterako: errore-jarraipena, ezaugarri-eskaera, zeregin-kudeaketa eta wikia. Gaur egunean milioika erabiltzaile ditu, eta milioika garapen-proiektu ere.",
   "google":"Googleren bilaketa motorra, normalean Google soilik, Alphabet Inc.-en webguneko bilatzailea da, egunero bere zerbitzuen bidez ehunka milioi kontsulta jasotzen dituena eta webean gehien erabiltzen den bilaketa motorra dena. Googleren bilatzailearen helburu nagusia webguneetan, beste mota bateko datuak bilatu beharrean, testua bilatzea da. 1997an Larry Pagek, Sergey Brinek eta Scott Hassanek garatu zuten.",
   "google images":[
-   "Google Irudiak. Internet-eko irudi bilatzaile onena.Google Irudiak. Internet-eko irudi bilatzaile onena.",
+   "Google Irudiak. Internet-eko irudi bilatzaile onena.",
    "https://images.google.com"
   ],
   "google news":"Google News albiste batzaile eta gehitzailea da.",
@@ -1279,6 +1356,7 @@
    "ref"
   ],
   "hoogle":"Haskell normalizatuta dagoen programazio lengoaia funtzionala da, semantika ulerkorra eta idazketa zorrotza duena. Haskell Curry logikariaren omenez du izena. Kaleratutako azken estandarra Haskell 2010 da, eta 2016ko maiatzetik, hurrengo bertsioa garatzen dabiltza, Haskell 2020 izena hartuko duena.",
+  "imdb":"Internet Movie Database Interneten eskuragarri dagoen datu base bat da, filmei, telebista saioei eta bideojokoei buruzko informazioa biltzen duena. Hor ageri dira, besteak beste, halako lanen zuzendariak, produktoreak, aktoreak eta fikzio pertsonaiak. IMDb 1990eko urriaren 17an inauguratu zuten, eta 1998an Amazon.com konpainiak erosi zuen.",
   "library of congress":"Ameriketako Estatu Batuetako Kongresuaren Liburutegia edota Kongresuaren Liburutegia Estatu Batuetako hiriburua den Washington Hirian kokatzen den liburutegi bat da.",
   "openstreetmap":"OpenStreetMap proiektu bat da, elkarlanean oinarritua, eta mapa libre eta editagarriak egiteko erabiltzen da. Mapa horiek egiten dira informazio geografikoa erabilita, eta harrapatuta daude GPS ibiltari, ortoargazki eta beste informazio iturri batzuen bidez. Kartografia hori guztia, bai irudi sortuak eta baita bere datu basean bildutako datu bektorialak ere, banatzen da Open Database lizentziapean.",
   "piratebay":"The Pirate Bay edo TPB webgune bat da, ustez munduko BitTorrent zerbitzaririk handiena. Bertan, aukera dago mota guztietako multimedia materiala bilatzeko .torrent artxiboetan. Copyright aurkako Piratbyrån erakundeak sortu zuen Suedian 2004. urtearen hasieran.",
@@ -1306,14 +1384,14 @@
   "wikivoyage":"Wikibidaiak edo Wikivoyage egile boluntarioen lanarekin osatutako bidai gida doan eta librea da. Izena erabiltzen duen Mediawiki teknologiatik dator.",
   "peertube":"PeerTube software librea erabilita, interneten bidez bideo digitalak partekatzeko aukera ematen duen plataforma deszentralizatua, federatua da. Peer-to-peer teknologia erabiltzen du zerbitzari pertsonalen erabilera murrizteko. GNU AGPL lizentziarekin argitaratuta dago."
  },
- "fa_IR":{
+ "fa-IR":{
   "archive is":"archive.is یک وبگاه بایگانی است که عکس‌های صفحات وب را ذخیره می‌کند. این وبگاه مشابه WebCite یک صفحه را در یک زمان بازیابی می‌کند، که هر صفحه حجمی کمتر از ۵۰ مگابایت داشته باشد اما با این تفاوت که محتویات صفحات طراحی وب ۲٫۰ را نیز شامل می‌شود.",
   "artic":"موسسه هنر شیکاگو در سال ۱۸۷۹ میلادی تأسیس شد. این مرکز از معتبرترین موزه‌های هنری در ایالات متحده آمریکا محسوب می‌شود.",
   "arxiv":"وب‌گاه آرکایو یک بایگانی برای نسخهٔ پیش‌چاپ نوشتارهای علمی در زمینه‌های فیزیک، ریاضیات، دانش رایانه، زیست‌شناسی کمّی، مدیریت مالی کمّی، و آمار است که می‌توان به آن دسترسی برخط داشت.",
   "wikipedia":"ویکی‌پدیا یک دانشنامه برخط چندزبانه مبتنی بر وب با محتوای آزاد و همکاری باز است که با همکاری افراد داوطلب نوشته می‌شود و هر کسی که به اینترنت و وب دسترسی داشته باشد می‌تواند مقالات آن را ببیند و ویرایش کند. نام ویکی‌پدیا واژه‌ای ترکیبی است که از واژه‌های ویکی و اِنسایکلوپدیا (Encyclopedia) گرفته شده‌است. هدف ویکی‌پدیا آفرینش و انتشار جهانی یک دانشنامه با محتوای آزاد به تمامی زبان‌های زندهٔ دنیا است.",
   "bing":"بینگ(به انگلیسی: Bing) یک موتور جستجوی وب متعلق به شرکت مایکروسافت است که پیشتر با نام‌های لایو سرچ، ویندوز لایو سرچ و ام. اس. ان سرچ شناخته می‌شد. استیو بالمر در ۲۸ مه ر گرفت. شرکت مایکروسافت این امکان را داده تا کاربرانی که در سیستم عامل ویندوز از مرورگر internet expoler یا microsoft edge استفاده میکنند به صورت مستقیم وارد موتور جستجو بینگ شوند.",
   "bing images":[
-   "bing:fa_IR",
+   "bing:fa-IR",
    "ref"
   ],
   "bing news":[
@@ -1327,36 +1405,36 @@
   ],
   "deezer":"دیزر رسانه جاری موسیقی و پادکست مبتنی بر اینترنت است. این سرویس در اوت ۲۰۰۷ در پاریس فرانسه پایه‌گذاری شد. تا تاریخ ۳ آوریل ۲۰۱۸، ۱۴ میلیون کاربر ماهانه فعال و ۶ میلیون مشترک پولی برای دیزر گزارش شده‌است.",
   "ddg definitions":[
-   "currency:fa_IR",
+   "currency:fa-IR",
    "ref"
   ],
-  "digg":"دیگ یک وبگاه پیونددهی جمعی است که درابتدا بیشتر بر اخبار فناوری و دانش متمرکز بود ولی اخیراً قسمت‌های متنوع دیگری به خود اضافه کرده‌است از پزشکی گرفته تا خبرهای سرگرم‌کننده و سیاست.",
   "erowid":"ایرویید که همچنین با نام مرکز ایرویید نیز شناخته می‌شود، سازمانی آموزشی و غیرانتفاعی است که تمرکز بر ارائه اطلاعات و آموزش پیرامون موادمخدر و روان‌گردان و همچنین روش‌های تغییر آگاهی مثل مدیتیشن و رویابینی دارد.",
   "wikidata":[
    "پایگاه دادهٔ آزاد و قابل ویرایش توسط همگان",
    "wikidata"
   ],
   "duckduckgo":[
-   "currency:fa_IR",
+   "currency:fa-IR",
    "ref"
   ],
   "duckduckgo images":[
-   "currency:fa_IR",
+   "currency:fa-IR",
    "ref"
   ],
   "fdroid":"اف-دروید مخزن نرم‌افزاری برای برنامه‌های اندروید است، مشابه گوگل پلی کار می‌کند ولی فقط شامل نرم‌افزارهای آزاد و متن‌باز است. برنامه‌های اف-دروید می‌توانند از طریق وب‌گاه اف-دروید یا از برنامهٔ کلاینت اف-دروید نصب شوند.",
   "flickr":"فلیکر یکی از بزرگ‌ترین سایت‌های اشتراک‌گذاری تصویر و ویدئو، خدمات وب و جوامع آنلاین است که توسط شرکت ludicorp در سال ۲۰۰۴ ایجاد شد و در سال ۲۰۰۵ توسط یاهو خریداری شد.",
   "genius":"جینیس به معنی نابغه، یک پایگاه دانش آنلاین است. این سایت به کاربر اجازه می‌دهد تا ترانه‌ها، داستان‌های جدید، اشعار، اسناد و دیگر متن‌ها را تفسیر کند. این سایت در ۲۰۰۹، با نام رپ جینیس با تمرکز روی موسیقی رپ راه اندازی شد. در ۲۰۱۴ سبک‌های دیگری مثل پاپ، آر اند بی و نوشتجات ادبی را نیز پوشش داد. همان سال یک برنامه آیفون برای سایت منتشر شد. برای انعکاس بهتر اهداف جدید سایت، دوباره در ژوئیه ۲۰۱۴ با نام جینیس راه اندازی شد. همچنین نسخه اندروید برنامه در اوت ۲۰۱۵ منتشر شد.",
-  "google":"جستجوگر گوگل یا گوگل یک موتور جستجوی وب است که توسط گوگل توسعه داده شده‌است. گوگل از راه این وبگاه روزانه صدها میلیون دلار درآمد به‌دست می‌آورد. این وبگاه در سال ۱۹۹۷ بنیاد نهاده شد. دامنهٔ اصلی این سایت در ماه مهٔ ۲۰۰۸ ۱۳۵ میلیون بار بازدید شده‌است. این موتور جستجو بیشترین بازدیدکننده در بین کاربران را دارد. موتور گوگل روزانه چندصدمیلیون بار به طرق مختلف استفاده می‌شود. مهم‌ترین هدف گوگل، یافتن متن موردنظر در میان صفحات وب است. اما انواع دیگر اطلاعات به وسیلهٔ قسمت‌های دیگر آن مثل جستجوی تصاویر گوگل، نیز مورد جستجو قرار می‌گیرند. جستجوگر گوگل توسط لَری پیج و سرگئی برین در سال ۱۹۹۷ ساخته شد. این جستجوگر به‌جز جستجوی واژگان، ۲۲ حالت جستجوی دیگر نیز دارد؛ مانند جستجوی مترادف‌ها، پیش‌بینی هوا، محدوده‌های زمانی ، قیمت سهام، اطلاعات زلزله، زمان نمایش فیلم‌ها، اطلاعات فرودگاه و… همچنین مختص اعداد، امکانات ویژه‌ای وجود دارد؛ مانند بازه (۷۰...۸۰)، دماها، واحدهای پول و تبدیل اینها به هم، عبارات محاسباتی و…",
+  "google":"جستجوگر گوگل یا گوگل یک موتور جستجوی وب است که توسط گوگل توسعه داده شده‌است. گوگل از راه این وبگاه روزانه صدها میلیون دلار درآمد به‌دست می‌آورد.\"Marketplace. American Public Media. Retrieved December 9, 2017\". این وبگاه در سال ۱۹۹۷ بنیاد نهاده شد. دامنهٔ اصلی این سایت در ماه مهٔ ۲۰۰۸ ۱۳۵ میلیون بار بازدید شده‌است. این موتور جستجو بیشترین بازدیدکننده در بین کاربران را دارد. موتور گوگل روزانه چندصدمیلیون بار به طرق مختلف استفاده می‌شود. مهم‌ترین هدف گوگل، یافتن متن موردنظر در میان صفحات وب است. اما انواع دیگر اطلاعات به وسیلهٔ قسمت‌های دیگر آن مثل جستجوی تصاویر گوگل، نیز مورد جستجو قرار می‌گیرند. جستجوگر گوگل توسط لَری پیج و سرگئی برین در سال ۱۹۹۷ ساخته شد. این جستجوگر به‌جز جستجوی واژگان، ۲۲ حالت جستجوی دیگر نیز دارد؛ مانند جستجوی مترادف‌ها، پیش‌بینی هوا، محدوده‌های زمانی ، قیمت سهام، اطلاعات زلزله، زمان نمایش فیلم‌ها، اطلاعات فرودگاه و… همچنین مختص اعداد، امکانات ویژه‌ای وجود دارد؛ مانند بازه (۷۰...۸۰)، دماها، واحدهای پول و تبدیل اینها به هم، عبارات محاسباتی و…",
   "google images":"جستجوی نگاره‌ها گوگل یکی از خدمات جستجوی ساخته‌شده توسط شرک گوگل است که امکان جستجوی محتوای نگاره را در وب جهان‌گستر برای کاربران فراهم می‌کند. این طرح در ژوئیه ۲۰۰۱ معرفی شد. کلیدواژه‌هایی که برای جستجوی نگاره‌ها مورد استفاده قرار می‌گیرد از نام پرونده، پیوند داده‌شده به نگاره، و نوشته‌های اطراف نگاره گرفته می‌شوند. در هنگام جستجو برای یک نگاره، نمونه‌های کوچکی از نگاره‌ها یافت‌شده نمایش داده می‌شوند. پس از کلیک بر روی نمایهٔ کوچک، نگاره در چارچوبی در بالای صفحه و وب‌گاهی که نگاره در آن پیدا شده بود، پایین صفحه نشان داده می‌شود تا کاربر به‌آسانی دریابد که نگاره از کجا آمده‌است.",
   "google news":"گوگل نیوز به معنای اخبار گوگل، یک وب‌گاه جمع‌آوری‌کنندهٔ خوراک‌خوان توسط گوگل است. این وب‌گاه در سپتامبر ۲۰۰۲ تأسیس‌شد و ۲۸ زبان زندهٔ جهان را پشتیبانی می‌کند. اما زبان فارسی در این ۲۸ زبان قرارندارد.",
   "google videos":"گوگل ویدئو یک سرویس برای بارگذاری و به اشتراک گذاشتن ویدئو بود. این سرویس امکان فروش ویدئوها را هم فراهم می‌کرد. این سرویس در ۲۵ ژانویه ۲۰۰۵ ایجاد شد و در اواخر سال ۲۰۰۹ به فعالیت خود پایان داد. علت این کار هم‌پوشانی سرویس با یوتیوب و صرفه‌جویی در فضای سرورها بود.",
   "google scholar":"گوگل اسکالر (به انگلیسی: Google Scholar) جستجوگری از شرکت گوگل است که امکان جستجوی واژه‌های کلیدی در مقاله‌ها، رساله‌های علمی و گزارش‌های فنی را فراهم می‌کند.",
   "google play apps":"گوگل پلی یک سرویس پخش دیجیتال محتوای چندرسانه‌ای از شرکت گوگل است که شامل یک فروشگاه آنلاین برای موسیقی، فیلم، کتاب و اپلیکیشن‌ها و بازی‌های اندروید و یک مدیا پلیر ابری می‌باشد. این خدمات از طریق وب، اپلیکیشن موبایل Play Store در آندوید و گوگل تی‌وی در دسترس می‌باشد. خریداری محتوا برای تمام پلتفرم‌ها/دستگاه‌ها قابل دسترس است. گوگل پلی در ماه مارس ۲۰۱۲ معرفی شد، زمانی که گوگل، خدمات دو برند سابق اندروید مارکت و گوگل موزیک را ادغام کرد و برند جدید گوگل پلی را معرفی کرد.",
   "google play movies":[
-   "google play apps:fa_IR",
+   "google play apps:fa-IR",
    "ref"
   ],
+  "imdb":"بانک اطلاعات اینترنتی فیلم‌ها یا پایگاه داده‌های اینترنتی فیلم‌ها یک پایگاه داده آنلاین است که دربرگیرندهٔ اطلاعات بازیگران، فیلم‌ها، بازی‌های ویدئویی، سریال‌ها و تولیدات سینمایی و تلویزیونی می‌باشد. آی‌ام‌دی‌بی کارش را به عنوان یک وبگاه سینمایی با عنوان rec.arts.movie بر روی یوزنت آغاز کرد و در سال ۱۹۹۳ به شبکهٔ جهانی اینترنت منتقل شد.",
   "library genesis":"لیبجن یک موتور جستجو برای یافتن کتاب و مقالات علمی است که به کاربر اجازه دسترسی به محتوای پولی منتشر شده توسط ناشران و ژورنال‌های مختلف را می‌دهد. این موتور جستجو، امکان دسترسی به فایل پی.دی. اف پورتال ساینس دیرکت را برای کاربران خود فراهم می‌سازد. در سال ۲۰۱۵، مؤسسه الزویر، علیه این پایگاه اینترنتی به دادگاهی در ایالات متحده شکایت و آن را به دسترسی غیرمجاز به مقالات و کتاب‌های خود محکوم کرد. از آنجا که لایبجن در روسیه و نیز شهر آمستردام (هلند) ثبت شده‌است، بررسی وضعیت دقیق حقوقی آن کار دشواری است. همچنین مشخص نیست که آیا متهمان حاضرند در دادگاه ایالات متحده حضور یابند یا خیر. هم‌اکنون برخی آی.اس. پی‌ها در بریتانیا، دسترسی به این پایگاه را محدود کرده‌اند. در اکتبر سال ۲۰۱۵، دادگاهی در منطقهٔ نیویورک، دستور تعلیق دامنهٔ این پایگاه (libgen.org) را داد، اما این تارنما همچنان از طریق دامنه‌های جایگزین در دسترس کاربران قرار دارد. لینک جدیدی که این وبگاه از آن استفاده می‌کند (gen.lib.rus.ec) می‌باشد.",
   "library of congress":"کتابخانهٔ ملی کنگرهٔ آمریکا کتابخانهٔ ملی دوفاکتوی ایالات متحده آمریکا، بازوی تحقیقاتی کنگره ایالات متحده، قدیمی‌ترین انستیتوی فرهنگی دولت فدرال آمریکا و بزرگ‌ترین کتابخانهٔ جهان است که در پایتخت ایالات متحدهٔ آمریکا، شهر واشینگتن دی‌سی، محله کپیتال هیل قرار دارد.",
   "openstreetmap":[
@@ -1367,7 +1445,15 @@
   "pubmed":"مِدلاین یکی از معروفترین پایگاه داده‌های آزاد (دیتابیس) در جهان است که حاوی اطلاعات بیبلیوگرافی پژوهشی برای تمام رشته‌های علوم پزشکی و زیست‌شناسی است.",
   "reddit":"ردیت یک وبسایت جمع‌آوری اخبار اجتماعی آمریکایی، رتبه‌بندی محتوای وب، وب سایت بحث و دارای تالار گفتگو است. اعضای عضو شده مطالب مورد نظر خود را مانند پیوندها، پست‌های متنی و تصاویر به سایت ارسال می‌کنند و سپس، توسط اعضای دیگر رأی داده می‌شود. پست‌ها در تابلوهای ایجاد شده توسط کاربر به نام ساب‌ردیت سازماندهی می‌شوند، که موضوع‌های مختلفی از جمله اخبار، علم، فیلم، بازی‌های ویدئویی، موسیقی، کتاب، تناسب اندام، غذا و اشتراک تصویر را در بر می‌گیرد.",
   "soundcloud":"ساوندکلاود یک سکوی توزیع صدا به صورت برخط است که در برلین آلمان پایه‌گذاری شد. این وبگاه امکان بارگذاری، اشتراک‌گذاری و ترویج فایل‌های صوتی که توسط کاربرانش ساخته می‌شود را فراهم می‌آورد. پروژهٔ ساوندکلاود در ابتدا در استکهلم سوئد شروع شد اما در اوت ۲۰۰۷ توسط دو سوئدی با نام‌های Alex Ljung و Eric Wahlforss در آلمان بنیانگذاری شد. در ژوئیهٔ ۲۰۱۳ این وبگاه ۴۰ میلیون کاربر ثبت‌شده و ۲۰۰ میلیون شنونده داشته‌است.",
-  "stackoverflow":"استک اورفلو وب‌گاه پرسش و پاسخی در بازه گسترده‌ای از مباحث برنامه‌نویسی رایانه است که در سال ۲۰۰۸ توسط جف اتوود و جویل اسپولسکی ایجاد شد.طبق آمار الکسا این وبگاه ۴۰ امین وبگاه پربازدید در ایران است. طبق آمار الکسا پس از ایالات متحده آمریکا ، هند ، چین ، ژاپن و ایران ، پنجمین کشور بازدید کننده از این وبگاه هستند. این وبگاه با انجام پیمایش‌های سالیانه اطلاعات تشریحی از مهارت‌های مورد نیاز بازار کار و مقایسه استعدادهای برنامه‌نویسی کشورها عرضه می‌کند.",
+  "stackoverflow":"استک اکسچنج در فارسی شبکه‌ای از وب سایت‌های سؤال و جواب در موضوعاتی با زمینه‌های مختلف است که هر سایت در زمینه یک موضوع خاص است و پرسش‌ها، پاسخ‌ها، پرسش گران و پاسخ دهندگان مشمول فرایند اعطای اعتبار هستند. سایت‌های مختلفی با اهدافی شبیه استک اکسچنج به وجود آمده‌اند. مانند سایت ولفرام آلفا، کورا و …",
+  "askubuntu":[
+   "stackoverflow:fa-IR",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:fa-IR",
+   "ref"
+  ],
   "semantic scholar":"سمانتیک اسکالر یا دانشنامهٔ معنایی پروژه‌ای است که توسط مؤسسه هوش مصنوعی آلن راه‌اندازی شد و در نوامبر ۲۰۱۵ در دسترس عموم واقع شد. این پروژه در واقع یک موتور جستجوی مقالات علمی و دانشگاهی مبتنی بر هوش مصنوعی است. در این پروژه از ترکیبی از یادگیری ماشینی، پردازش زبان‌های طبیعی و دید ماشینی است که لایه‌ای از تحلیل معنایی را به روش سنتی تحلیل استنادی اضافه می‌کند و می‌تواند نوشته‌ها، حوزه‌های تخصصی و شکل‌ها را از مقالات استخراج کند.. در مقایسه با گوگل اسکالر و پاب‌مد، سمانتیک اسکالر به‌گونه‌ای طراحی شده‌است که مهمترین و تأثیرگذاریترین مقالات را شناسایی کرده و ارتباط میان آنها را مشخص کند.",
   "unsplash":"آنسپلش یک وبگاه برای به اشتراک گذاری عکس‌های بدون حق تکثیر است. این وب سایت ادعا می‌کند بیش از ۷۰۰۰۰ عکاس دارد و کتابخانه عکس آنها بیش از ۵۰۹٬۰۰۰ عکس دارد. آنسپلش به عنوان یکی از وب سایت‌های برتر عکاسی در جهان توسط فوربز و سی‌نت شناخته شده‌است.",
   "yahoo news":"یاهو! نیوز یک سرویس اینترنتی گردآورندهٔ خبری ارائه‌شده توسط شرکت یاهو! است. مقاله‌های خبری در یاهو! نیوز عمدتاً از خبرگزاری‌های آسوشیتد پرس، رویترز، خبرگزاری فرانسه، فاکس نیوز، کریستین ساینس مانیتور، رادیوی عمومی ملی، یواس‌ای تودی، سی‌ان‌ان، سی‌بی‌سی، ۷ نیوز و بی‌بی‌سی است.",
@@ -1419,7 +1505,6 @@
    "currency:fi",
    "ref"
   ],
-  "digg":"Digg on Kevin Rosen perustama sosiaalinen verkkosivusto, jolla sen käyttäjät jakavat uutisia ja muuta sisältöä.",
   "erowid":"Erowid on järjestö, jonka keskeisin osa on psykoaktiivisista kasveista ja kemikaaleista sekä muista muuntuneita tajunnantiloja koskevista aiheista tietoa tarjoava verkkosivusto Erowid.org. Erowidin ovat luoneet salanimillä Fire ja Earth Erowid esiintyvät henkilöt. Nykyään sivustoa ylläpitävän rekisteröityneen järjestön The Erowid Centerin hallituksen jäsenten nimet löytyvät sekä järjestön omilta kotisivuilta että GuideStar-järjestöpalvelun sivuilta. Sivusto sisältää tietoa niin laillisista kuin laittomistakin aineista ja kertoo sekä niiden toivotuista että haitallisista vaikutuksista.",
   "wikidata":"Wikidata on Wikimedia Foundationin omistama yhteisesti muokattava Wikipediaa tukeva tietokanta. Saksan Wikimedia-yhdistyksen aloittaman hankkeen tarkoitus on toimia keskitettynä paikkana erilaisille tiedoille, esimerkiksi henkilöiden syntymäajoille. Palvelu avattiin virallisesti 30. lokakuuta 2012. Se on ensimmäinen Wikimedian uusi hanke vuoden 2006 jälkeen.",
   "duckduckgo":[
@@ -1436,7 +1521,7 @@
   "github":"GitHub on vuonna 2008 avattu verkkosivusto, joka tarjoaa paikan Git-versionhallintaa käyttäville ohjelmakehitysprojekteille. Git itsessään on komentoriviohjelma, jolle GitHub tarjoaa graafisen käyttöliittymän. Gitin lisäksi GitHub tarjoaa projekteille toimintoja kuten bugienseurannan, kehitystoiveet, tehtävien hallinnan ja wikin.",
   "google":"Google on yhdysvaltalaisen Google-yhtiön omistama, maailman suosituin hakukone. Hakuja sillä tehdään joka päivä yli kolme miljardia kertaa.",
   "google images":[
-   "Google-kuvat. Internetin kattavin kuvahaku.Google-kuvat. Internetin kattavin kuvahaku.",
+   "Google-kuvat. Internetin kattavin kuvahaku.",
    "https://images.google.com"
   ],
   "google news":"Google News on Googlen vuonna 2002 avaama sivusto, joka kerää uutisia eri uutissivustoilta. Sivuston betavaihe päättyi vuonna 2006.",
@@ -1448,6 +1533,7 @@
    "ref"
   ],
   "hoogle":"Haskell on yleiskäyttöinen, puhtaasti funktionaalinen ohjelmointikieli, jolla on laiskan suorituksen semantiikka ja vahva staattinen tyypitys ja jota alettiin kehittää vuonna 1987. Se on nimetty loogikko Haskell Curryn mukaan. Kielen viimeisin standardiversio on Haskell 2010, joka korvasi aiemman standardin Haskell 98:n. Lähes kaikki kielen toteutukset tukevat standardien lisäksi omia laajennoksiaan. Haskellin tunnetuin toteutus on GHC.",
+  "imdb":"The Internet Movie Database on Internetin laajin elokuvatietokanta, joka sisältää tietoa elokuvista, televisiosarjoista, animaatioista, lyhytelokuvista ja videopeleistä.",
   "ina":"Institut national de l'audiovisuel (Ina) on Ranskan kulttuuriministeriön alainen valtion virasto, jonka tehtävänä on radio- ja televisio-ohjelmien arkistointi ja tutkimus. Ina arkistoi myös ranskankielisiä verkkosivuja. Virasto aloitti toimintansa vuonna 1975. Sen pääkonttori sijaitsee Pariisin esikaupunkialueella Bry-sur-Marnessa. Vuoden 2019 loppuun mennessä Ina oli arkistoinut yli 18 miljoonaa tuntia audiovisuaalisia ohjelmia.",
   "kickass":"KickassTorrents on BitTorrent-seurantapalvelin. Kickass Torrentsista on noussut maailman suosituin torrent-sivusto sen jälkeen, kun The Pirate Bay -sivusto joutui toistuvasti vaihtamaan verkko-osoitettaan.",
   "library of congress":"Kongressin kirjasto on Yhdysvaltain tosiasiallinen kansalliskirjasto. Se sijaitsee kolmessa rakennuksessa Washingtonissa ja on hyllymetreiltään ja kirjamäärältään maailman suurin kirjasto.",
@@ -1455,7 +1541,18 @@
   "piratebay":"The Pirate Bay (TPB) on maailman suurin BitTorrent magnet-linkkien indeksi. Sen perusti ruotsalainen tekijänoikeuksia vastustava järjestö Piratbyrån vuoden 2003 lopussa, mutta se on lokakuun 2004 jälkeen toiminut itsenäisenä organisaationa. Pirate Bayn sisältö koostuu suurimmaksi osaksi laittomista kopioista tekijänoikeuksien alaista materiaalia, kuten elokuvia, musiikkia ja pelejä. Pirate Bayn taustalla toimivat ylläpitäjät Gottfrid Svartholm, Carl Lundström, Fredrik Neij sekä Peter Sunde, pitävät tätä omien sanojensa mukaan harrastuksena.",
   "reddit":"Reddit on sosiaalinen verkkosivusto, jossa käyttäjät voivat jakaa linkkejä kiinnostaviin verkkosivustoihin.",
   "soundcloud":"SoundCloud on ruotsalainen musiikin sekä muiden äänitiedostojen levitykseen ja suoratoistoon keskittyvä internet-palvelu, joka mahdollistaa pääasiassa muusikoista koostuvalle käyttäjäkunnalleen musiikkitiedostojen lataamisen palvelimille, suoranauhoituksen sekä promootion. Ammattilais- ja harrastelijamuusikot käyttävät palvelua niin valmiiden kappaleiden, raakaversioiden, demojen, podcastien kuin DJ-miksausten jakamiseen. Tuoreet, uransa alkuvaiheessa tai koko kansalle tuntemattomat, muusikot käyttävät palvelua pääasiallisena jakelumedianaan.",
-  "stackoverflow":"Stack Overflow on vuonna 2008 avattu verkkosivusto, jonka pääaiheena on ohjelmointi, ohjelmistoarkkitehtuuri, tietoturva ja muihin niihin liittyvien ongelmien ratkaiseminen ja niistä keskusteleminen. Sivustolle kuka tahansa voi lähettää ohjelmointiin liittyviä kysymyksiä ja siihen liittyvää ohjelmakoodia. Kysymysten laajuus vaihtelee aloittelijan ongelmista aina vaativimpiin kokonaisuuksiin. Sivustolla painotetaan omaa ongelmanratkaisukykyä, tiedon etsintää ja ymmärrystä ohjelmoinnista ja itse ongelmasta, ennen kuin lähetetty kysymys katsotaan aiheelliseksi.",
+  "stackoverflow":[
+   "kysymys ja vastaus -sivustojen verkosto",
+   "wikidata"
+  ],
+  "askubuntu":[
+   "stackoverflow:fi",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:fi",
+   "ref"
+  ],
   "startpage":"Startpage on anonyymi hakukone. Sen alkuperäinen nimi on Ixquick. Nimi muutettiin, koska nimi Ixquick oli liian vaikea muistaa. Nykyään hakukone toimii sekä osoitteessa startpage.com että osoitteessa ixquick.com.",
   "youtube":"YouTube on Googlen omistama Internetissä toimiva videopalvelu. Käyttäjät voivat lisätä sivustolle omia videoitaan, sekä katsoa ja kommentoida muiden käyttäjien videoita. Sivuston perusti 14. helmikuuta 2005 kolme PayPalin työntekijää: Chad Hurley, Steve Chen ja Jawed Karim. YouTuben pääkonttori sijaitsee San Brunossa, Kaliforniassa ja sen toimitusjohtajana on toiminut Susan Wojcicki helmikuusta 2014 lähtien.",
   "dailymotion":"Dailymotion on ranskalaislähtöinen Internetin videolevityssivusto. Sivusto perustettiin 15. maaliskuuta 2005, kuukausi Internetin suosituimman videolevityssivuston YouTuben perustamisen jälkeen.",
@@ -1477,9 +1574,9 @@
    "https://www.bing.com/news"
   ],
   "wikidata":"Ang Wikidata ay isang internet na wiki na pagkalagay ng datos sa mga wikang pag-aari ng Pundayson ng Wikimedia.",
-  "google":"Ang Google Search, karaniwang tinutukoy bilang Google Web Search o Google lamang, ay isang web search engine na pagmamay-ari ng Google Inc. Ito ang pinakamadalas gamiting search engine o panghanap sa World Wide Web, na mayroong higit sa tatlong bilyong mga paghahanap bawat araw.",
+  "google":"Ang Google Search, karaniwang tinutukoy bilang Google Web Search o Google lamang, ay isang web search engine na pagmamay-ari ng Google LLC Ito ang pinakamadalas gamiting search engine o panghanap sa World Wide Web, na mayroong higit sa tatlong bilyong mga paghahanap bawat araw.",
   "google images":[
-   "Google Images. Ang pinakamalawak na paghahanap ng imahe sa web.Google Images. Ang pinakamalawak na paghahanap ng imahe sa web.",
+   "Google Images. Ang pinakamalawak na paghahanap ng imahe sa web.",
    "https://images.google.com"
   ],
   "google news":[
@@ -1498,6 +1595,7 @@
    "google play apps:fil",
    "ref"
   ],
+  "imdb":"Ang Internet Movie Database (IMDb) at IMDB, ay isang online database ng impormasyon tungkol sa mga artista, pelikula, palatuntunan sa telebisyon at video games. Ang websayt ng IMDb ay nagsimula noong Setyembre 1993. Naging pagmamay-ari ito ng \"Amazon.com\" mula 1998.",
   "youtube":"Ang YouTube ay isang website na nagbabahagi ng mga bidyo at nagbibigay-daan para sa mga tagagagamit o user nito na mag-upload, makita, at ibahagi ang mga bidyo clip. Ang mga bidyo na ito ay maaaring husgahan; ang dami ng husga at ng mga nakanood ay parehong nakalathala. Maaari ring mag-iwan ng komento ang mga manonood sa karamihan ng video.",
   "vimeo":"Ang Vimeo ay isang Amerikan portal na websayt na bidyo punong abala at namamahagi ang himpilan nito ay matatagpuan sa Lungsod ng Bagong York, Bagong York noong Nobyembre 2004 na inilathala nina Zach Klein, Jake Lodwick katuwang si Anjali Sud (Indian-American), ang (CEO) ng Vimeo.",
   "wikibooks":"Ang Wikibooks ay isang base ng wiki sa Wikimedia project na pag-aari ng Wikimedia Foundation, para sa lumikha ng malayang nilalaman na textbooks o aklat na pwedeng sa lahat na pagbabago.",
@@ -1513,7 +1611,7 @@
   "artic":"L'Art Institute of Chicago est un musée situé à Chicago aux États-Unis. Deuxième plus grand musée d'art du pays après le Metropolitan Museum of Art de New York, il abrite l'une des plus importantes collections d'art des États-Unis. Ouvert au public depuis 1879, le musée fut établi initialement à l'angle sud-ouest de State Street et de Monroe Street. Lors de l'Exposition universelle de 1893, la ville construisit un nouveau bâtiment pour abriter les collections de l'Art Institute. Depuis 1893, le musée se trouve dans le Grant Park, au 111 South Michigan Avenue, dans le centre-ville de Chicago.",
   "arxiv":"arXiv est une archive ouverte de prépublications électroniques d'articles scientifiques dans les domaines de la physique, des mathématiques, de l'informatique, de la biologie quantitative, de la finance quantitative, de la statistique, de l'ingénierie électrique et des systèmes, et de l'économie, et qui est accessible gratuitement par Internet.",
   "bandcamp":"Bandcamp est un magasin de musique en ligne qui s'adresse principalement aux artistes indépendants.",
-  "wikipedia":"Wikipédia est une encyclopédie universelle et multilingue créée par Jimmy Wales et Larry Sanger le 15 janvier 2001. Il s'agit d'une œuvre libre, c'est-à-dire que chacun est libre de la rediffuser. Gérée en wiki dans le site web wikipedia.org grâce au logiciel MediaWiki, elle permet à tous les internautes d'écrire et de modifier des articles. Elle est devenue en quelques années l'encyclopédie la plus fournie et la plus consultée au monde.",
+  "wikipedia":"Wikipédia est une encyclopédie universelle et multilingue créée par Jimmy Wales et Larry Sanger le 15 janvier 2001. Il s'agit d'une œuvre libre, c'est-à-dire que chacun est libre de la rediffuser. Gérée en wiki dans le site web wikipedia.org grâce au logiciel MediaWiki, elle permet à tous les internautes d'écrire et de modifier des articles, ce qui lui vaut d'être qualilfiée d'encyclopédie participative. Elle est devenue en quelques années l'encyclopédie la plus fournie et la plus consultée au monde.",
   "bing":"Microsoft Bing, ou simplement Bing, est un moteur de recherche élaboré par la société Microsoft. Il a été rendu public le 3 juin 2009.",
   "bing images":[
    "bing:fr",
@@ -1536,7 +1634,6 @@
    "currency:fr",
    "ref"
   ],
-  "digg":"Digg est un site web agrégateur d'information de divers médias, se spécialisant dans les nouvelles destinées au lectorat d'Internet telles que la science, les tendances politiques et les phénomènes Internet viraux. Il a été lancé sous sa forme actuelle le 31 juillet 2012, avec un soutien pour le partage de contenu vers d'autres plateformes sociales telles que Twitter et Facebook.",
   "erowid":"Erowid, aussi appelé Erowid Center, est une organisation américaine à but non lucratif qui a pour but de fournir des informations sur les psychotropes naturels ou synthétiques, qu'ils soient légaux ou non, mais aussi sur les méthodes et pratiques censées permettre l'accès aux états modifiés de conscience comme la méditation ou le rêve lucide.",
   "wikidata":"Wikidata est une base de connaissances libre éditée de manière collaborative et hébergée par la Wikimedia Foundation. Son contenu étant placé sous licence CC0, elle permet de centraliser les données utilisées par différents projets Wikimedia. Cette base est destinée à fournir une source commune de données objectives, telles que les dates de naissance ou bien le PIB des pays, qui pourront être utilisées dans tous les articles des différentes versions linguistiques de Wikipédia, une mise à jour de Wikidata pouvant être alors répercutée automatiquement sur l'ensemble des Wikipédias en différentes langues.",
   "duckduckgo":[
@@ -1567,6 +1664,7 @@
   ],
   "gpodder":"gPodder est un logiciel libre spécialisé, permettant la lecture d'un ensemble de flux de podcasts audio et vidéo.",
   "hoogle":"Haskell est un langage de programmation fonctionnel fondé sur le lambda-calcul et la logique combinatoire. Son nom vient du mathématicien et logicien Haskell Curry. Il a été créé en 1990 par un comité de chercheurs en théorie des langages intéressés par les langages fonctionnels et l'évaluation paresseuse. Le dernier standard est Haskell 2010 : c'est une version minimale et portable du langage conçue à des fins pédagogiques et pratiques, dans un souci d'interopérabilité entre les implémentations du langage et comme base de futures extensions. Le langage continue d'évoluer en 2020, principalement avec GHC, constituant ainsi un standard de facto comprenant de nombreuses extensions.",
+  "imdb":"L’Internet Movie Database, abrégé en IMDb, est une base de données en ligne sur le cinéma mondial, sur la télévision, et plus secondairement les jeux vidéo. IMDb restitue un grand nombre d’informations concernant les films, les acteurs, les réalisateurs, les scénaristes et toutes personnes et entreprises intervenant dans l’élaboration d’un film, d’un téléfilm, d’une série télévisée ou d’un jeu vidéo. L’accès aux informations publiques est gratuit. Un service payant, IMDbPro, donne accès aux informations supplémentaires susceptibles d’intéresser les professionnels. Créé le 17 octobre 1990 par l'Anglais Col Needham, c’est un site visité, en 2010, par plus de 57 millions d’usagers uniques chaque mois, ce qui le plaçait au 39e rang des sites les plus visités au monde. Il appartient depuis 1998 à Amazon.",
   "ina":"L'Institut national de l'audiovisuel (INA) est un établissement public à caractère industriel et commercial français ayant pour mission principale d'archiver les productions audiovisuelles, de produire, d'éditer, de publier, de commercialiser et distribuer des contenus audiovisuels et multimédias à destination de tous les publics, professionnels, entreprises ou particuliers, pour tous les écrans ou plateformes de diffusion, y compris audio. L'INA comprend également un centre de formation et de recherche visant à développer et transmettre les savoirs et expertises dans les domaines de l'audiovisuel, des médias et du numérique.",
   "kickass":"KickassTorrents est un annuaire web de fichiers torrent et de liens magnet destiné à faciliter le partage de fichiers. Le site a été fondé en 2008 et a été mis hors ligne le 20 juillet 2016, lorsque le domaine a été saisi par le gouvernement des États-Unis. Les sites proxy ont été fermés par les membres de son équipe le même jour. Le 16 décembre 2016, KickassTorrents est de retour en ligne sur une nouvelle adresse: KATcr.co créée par l'équipe originale.",
   "library genesis":"Library Genesis ou LibGen est un moteur de recherche d'articles et de livres scientifiques qui facilite l'accès aux contenus soumis à un péage. Il diffuse notamment les fichiers PDF du portail Web ScienceDirect d'Elsevier.",
@@ -1578,7 +1676,7 @@
   "piratebay":"The Pirate Bay est un site web créé en 2003 en Suède, indexant des liens Magnets de fichiers numériques, permettant le partage de fichiers en pair à pair à l’aide du protocole de communication BitTorrent. Le site se finance par les dons et la publicité, il a été créé dans l’esprit d’une « culture libre ».",
   "pubmed":"MEDLINE est une base de données bibliographiques regroupant la littérature relative aux sciences biologiques et biomédicales. La base est gérée et mise à jour par la Bibliothèque américaine de médecine (NLM).",
   "pypi":"PyPI est le dépôt tiers officiel du langage de programmation Python. Son objectif est de doter la communauté des développeurs Python d'un catalogue complet recensant tous les paquets Python libres. Il est analogue au dépôt CPAN pour Perl.",
-  "qwant":"Qwant est un moteur de recherche français. Mis en ligne le 16 février 2013 en version bêta, puis en version définitive le 4 juillet 2013, il annonce depuis son lancement ne pas tracer ses utilisateurs, ni vendre leurs données personnelles, afin de garantir leur vie privée, et se veut neutre dans l'affichage des résultats.",
+  "qwant":"Qwant est un moteur de recherche français. Mis en ligne le 16 février 2013 en version bêta, puis en version définitive le 4 juillet 2013, il annonce depuis son lancement ne pas tracer ses utilisateurs, ni vendre leurs données personnelles, afin de garantir leur vie privée, et se veut neutre dans l'affichage des résultats. Dans les faits, des données sont cependant partagées avec Microsoft.",
   "qwant news":[
    "qwant:fr",
    "ref"
@@ -1593,7 +1691,15 @@
   ],
   "reddit":"Reddit est un site web communautaire américain d’actualités sociales fonctionnant via le partage de signets permettant aux utilisateurs de soumettre leurs liens et de voter pour les liens proposés par les autres utilisateurs. Ainsi, les liens les plus appréciés du moment se trouvent affichés en page d’accueil. Fondé en 2005, Reddit contenait alors surtout du contenu sur la programmation et la science. Il ne cesse depuis de se diversifier et de s’ouvrir à du contenu plus grand public. Ayant connu une explosion de croissance en 2010, en partie due à une baisse de popularité de son concurrent Digg, en 2020, il se place comme le 20e site web le plus populaire au monde et le 6e aux États-Unis selon Alexa Internet.",
   "soundcloud":"SoundCloud est une plate-forme de distribution audio en ligne sur laquelle les utilisateurs peuvent collaborer ainsi que promouvoir et distribuer leurs projets musicaux. En juin 2013, le site compte 40 millions d'inscrits et 200 millions de visiteurs uniques par mois.",
-  "stackoverflow":"Stack Overflow est un site web proposant des questions et réponses sur un large choix de thèmes concernant la programmation informatique. Il fait partie du réseau de sites Stack Exchange.",
+  "stackoverflow":"Stack Exchange est un réseau de sites anglophones de questions et réponses à édition collaborative, chacun traitant d'un thème particulier. Deux exemples sont les sites Stack Overflow, dont le thème est la programmation informatique, et Ask Ubuntu (en), qui offre des réponses aux problèmes rencontrés sur le système d'exploitation Ubuntu.",
+  "askubuntu":[
+   "stackoverflow:fr",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:fr",
+   "ref"
+  ],
   "framalibre":[
    "annuaire de logiciels libres francophone",
    "wikidata"
@@ -1601,10 +1707,6 @@
   "semantic scholar":"Semantic Scholar est un projet développé à l'Institut Allen pour l'intelligence artificielle. Publié en novembre 2015, il est conçu pour être un moteur de recherche d'articles de revues scientifiques sur l'IA.",
   "startpage":"Startpage est un métamoteur de recherche sur le Web. Sa spécificité est censément le respect de la vie privée de l'utilisateur et affirme ne conserver aucune trace numérique des recherches effectuées, pas même l'adresse IP. Il était précédemment connu sous le nom d'Ixquick, Startpage étant alors une variante du site principal. Les deux services fusionnent en 2016.",
   "unsplash":"Unsplash est un site web dédié au partage de photos sous licence libre. Il est basé à Montréal, la capitale économique du Québec.",
-  "yahoo":[
-   "yahoo:en",
-   "ref"
-  ],
   "yahoo news":"Yahoo! Actualités est un service en ligne gratuit de Yahoo! qui présente des articles d'information en provenance de nombreuses sources et, notamment, d'agences de presse.",
   "youtube":"YouTube est un site web d’hébergement de vidéos et un média social sur lequel les utilisateurs peuvent envoyer, regarder, commenter, évaluer et partager des vidéos en streaming. Il a été créé en février 2005 par Steve Chen, Chad Hurley et Jawed Karim, trois anciens employés de PayPal, et racheté par Google en octobre 2006 pour 1,65 milliard de dollars. Le service est situé à San Bruno, en Californie.",
   "yggtorrent":[
@@ -1618,7 +1720,7 @@
   "wikiquote":"Wikiquote est un projet multilingue et collaboratif de recueil de citations en ligne. Soutenu et hébergé par Wikimedia Foundation, son contenu est librement distribuable selon les termes de la licence Creative Commons CC-BY-SA. Fondé sur une idée de Daniel Alston et mis en œuvre par Brion Vibber, Wikiquote a pour but d'établir une base de données de référence en matière de citations. Le nom du projet accole le nom de la technologie utilisée (« wiki ») et le terme « quote », qui signifie « citation » en anglais.",
   "wikisource":"Wikisource est un projet multilingue de bibliothèque numérique, soutenu par la Wikimedia Foundation, libre d'accès, sans publicité, librement distribuable, édifiée par des bénévoles qui s'appuient sur la technologie wiki. Le projet a été lancé le 24 novembre 2003 et fut tout d'abord nommé « Projet Sourceberg », avant d'être officiellement appelé « Wikisource » le 26 décembre 2003. Le projet existe en de nombreuses langues, dont 70 sont dotées de leur propre sous-domaine Internet.",
   "wiktionary":"Le Wiktionnaire est un projet lexicographique de la Wikimedia Foundation, dont l’objectif est de définir tous les mots dans toutes les langues. Il existe plus de 150 langues de rédaction. Le terme « Wiktionnaire » désigne la version en français de ce projet, Wiktionary étant le nom officiel en anglais. Il est fondé sur un système de wiki et son contenu est librement réutilisable.",
-  "wikiversity":"Wikiversité est un projet de ressources éducatives libres, collaboratif, multilingue et gratuit soutenu par Wikimedia Foundation et lancé le 15 août 2006. Ce projet a pour but d'élaborer des projets éducatifs ou scientifiques au travers le partage de contenus pédagogiques et la mise à disposition d'un espace propice à la rédaction de travaux de recherche. L'apprentissage est facilité grâce à des liens hypertextes pointant vers les autres projets soutenus par Wikimedia Foundation.",
+  "wikiversity":"Wikiversité est un wiki multilingue de ressources éducatives libres appartenant à la Wikimedia Foundation. Ce projet permet d'apprendre, d'enseigner et de faire de la recherche scientifique au moins grâce à un espace de contenus pédagogiques et à un laboratoire virtuel de recherche. Chaque ressource peut être publiée par un individu ou par un groupe, soit de sa propre initiative, soit dans le cadre d'un projet plus large d'apprentissage.",
   "wikivoyage":"Wikivoyage est un guide touristique sur le Web, rédigé de manière participative par des auteurs bénévoles, et dont le contenu est sous licence libre. Le projet a été fondé en septembre 2006 par l'association allemande suprarégionale Wikivoyage e.V. par la création d'un fork de Wikitravel.",
   "wolframalpha":"Wolfram|Alpha est un outil de calcul en langage naturel développé par la société internationale Wolfram Research. Il s'agit d'un service internet qui répond directement à la saisie de questions factuelles en anglais par le calcul de la réponse à partir d'une base de données, au lieu de procurer une liste de documents ou de pages web pouvant contenir la réponse. Son lancement a été annoncé en mars 2009 par le physicien et mathématicien britannique Stephen Wolfram et il a été lancé le 16 mai 2009 à 3 h du matin.",
   "seznam":"Seznam est un portail web et un moteur de recherche tchèque. Il a été lancé en 1996. En novembre 2020, c'est le troisième site le plus visité en République tchèque.",
@@ -1628,7 +1730,11 @@
    "https://rubygems.org/"
   ],
   "peertube":"PeerTube est un logiciel libre d'hébergement de vidéo décentralisé permettant la diffusion en pair à pair, et un média social sur lequel les utilisateurs peuvent envoyer, regarder, commenter, évaluer et partager des vidéos en streaming. Il a été créé en 2015 et est développé depuis 2017 par Framasoft. Il fonctionne sur le principe d'une fédération d'instances hébergées par des entités autonomes. Son objectif est de fournir une alternative aux plateformes centralisées telles que YouTube, Vimeo et plus récemment Twitch avec l'ajout du support de la diffusion en direct.",
-  "wikimini":"Wikimini est une encyclopédie destinée aux enfants, accessible librement sur Internet. Elle a la particularité d'être écrite par des enfants et des adolescents. Son contenu s'adresse à de jeunes lecteurs de 8 à 13 ans environ et sa publication est faite sous les termes d'une licence libre, ce qui en facilite la diffusion et la réutilisation."
+  "wikimini":"Wikimini est une encyclopédie destinée aux enfants, accessible librement sur Internet. Elle a la particularité d'être écrite par des enfants et des adolescents. Son contenu s'adresse à de jeunes lecteurs de 8 à 13 ans environ et sa publication est faite sous les termes d'une licence libre, ce qui en facilite la diffusion et la réutilisation.",
+  "onesearch":[
+   "Moteur de recherche de la société Yahoo",
+   "wikidata"
+  ]
  },
  "gl":{
   "artic":"O Art Institute of Chicago é un museo e escola de arte situado en Grant Park, ao redor da costa do lago Michigan en Chicago. É un dos museos de arte máis importantes do mundo.",
@@ -1651,7 +1757,7 @@
    "wikidata"
   ],
   "google images":[
-   "Google Imaxes. A busca máis completa de imaxes na rede.Google Imaxes. A busca máis completa de imaxes na rede.",
+   "Google Imaxes. A busca máis completa de imaxes na rede.",
    "https://images.google.com"
   ],
   "google news":[
@@ -1664,11 +1770,20 @@
    "ref"
   ],
   "hoogle":"Haskell é unha linguaxe de programación puramente funcional de propósito xeral. O seu nome provén do lóxico Haskell Curry.",
+  "imdb":"A Internet Movie Database (IMDb) é unha base de datos en liña con información sobre directores, produtores, actores, películas, programas de televisión, videoxogos e case todo o relacionado coa industria fílmica privada e independente. Propiedade de Amazon desde 1998, IMDb celebrou o seu décimo quinto aniversario o 17 de outubro de 2005.",
   "library of congress":"A Biblioteca do Congreso é unha biblioteca de investigación que serve oficialmente ó Congreso dos Estados Unidos de América, pero que é de facto a biblioteca nacional dos Estados Unidos.",
   "openstreetmap":"OpenStreetMap é un proxecto aberto e colaborativo para crear mapas libres, gratuítos e editables. As trazas dos mapas créanse empregando información obtida de dispositivos GPS ou empregando fotografías aéreas ou de satélites e outras fontes como bases de datos da administración. Dende 2016 OSM emprega en España cartografía PNOA para mapeado e edición.",
   "stackoverflow":[
-   "sitio web con preguntas e respostas acerca de programación de ordenadores",
+   "rede de sitios web de preguntas e respostas",
    "wikidata"
+  ],
+  "askubuntu":[
+   "stackoverflow:gl",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:gl",
+   "ref"
   ],
   "youtube":"YouTube é un espazo web que lles permite aos usuarios publicar, ver e compartir vídeos. Fundouse en febreiro de 2002 por tres antigos empregados de PayPal: Chad Hurley, Steve Chen e Jawed Karim. YouTube é un nome composto de you e tube, que quere dicir algo así como ti es a televisión.",
   "dailymotion":"Dailymotion é un servidor de vídeos en Internet, con sede en París, Francia. O seu dominio foi rexistrado un mes despois que o de YouTube.",
@@ -1705,7 +1820,6 @@
    "currency:he",
    "ref"
   ],
-  "digg":"Digg.com הוא אתר חדשות בנושאים שונים מבוסס תוכן גולשים. האתר לא מייצר תוכן, וגולשים לא מעלים תכנים לאתר אלא רק קישורים לתכנים חיצוניים.",
   "wikidata":"ויקינתונים הוא מסד נתונים חופשי, שיתופי ורב-לשוני, השייך לקרן ויקימדיה. ויקינתונים משמש כמאגר נתונים מרכזי לכל המיזמים של קרן ויקימדיה, וניתן לעשות בנתונים שבו שימוש חופשי ברישיון נחלת הכלל.",
   "duckduckgo":[
    "currency:he",
@@ -1733,13 +1847,13 @@
    "ref"
   ],
   "hoogle":"Haskell (הסקל) היא שפת תכנות פונקציונלית טהורה, ובעלת טיפוסיות חזקה. היא אחת משפות התכנות הפונקציונליות הפופולריות ביותר, והשפה הפונקציונלית העצלה בה מרבית המחקר בתחום מדעי המחשב מתבצע[דרוש מקור]. השפה קרויה על שם הלוגיקן הסקל קורי.",
+  "imdb":"Internet Movie Database הוא אתר אינטרנט המכיל בסיס נתונים מקוון של מידע על סרטים, שחקני קולנוע, תוכניות טלוויזיה, צוות הפקה ומשחקי וידאו. האתר נמצא בבעלות חברת אמזון.",
   "library genesis":"ספריית ג'נסיס הוא אתר לשיתוף קבצים עבור מאמרים בכתבי עת, ספרים אקדמיים, תמונות, קומיקס ומגזינים. האתר מאפשר גישה חופשית לתכנים שאחרת הם בתשלום או שלא עברו דיגיטציה. האתר מגדיר את עצמו כמצבור קישורים המספק גישה לחיפוש פריטים שנאספו ממשאבי אינטרנט ציבוריים זמינים לציבור וכאלה שהועלו על ידי המשתמשים.",
   "library of congress":"ספריית הקונגרס היא ספריית המחקר של הקונגרס של ארצות הברית, אשר משמשת בפועל כספרייה הלאומית של ארצות הברית, ואחת מהספריות החשובות והגדולות ביותר בעולם. רק הספרייה הבריטית גדולה ממנה.",
   "openstreetmap":"OpenStreetMap הוא מיזם שיתופי ליצירת מפה חופשית של כדור הארץ. המפה נוצרת בעזרת נתונים ממכשירי GPS ניידים, תצלומי אוויר ומקורות חופשיים אחרים. גם קובצי התמונה של המפה וגם המידע הווקטורי, זמינים להורדה ולשימוש לפי רישיון \"קריאטיב קומונס - שיתוף ברישיון זהה 2.0\". משתמשים רשומים יכולים להעלות רשימות מסלולי GPS, וכן לערוך את המידע הווקטורי בעזרת כלי העריכה של המיזם. ההשראה ל-OpenStreetMap הייתה אתרי אינטרנט כגון ויקיפדיה - לצד המפה מוצגת באופן בולט לשונית \"ערוך\", ונשמרת היסטוריה מלאה של הגרסאות השונות.",
   "piratebay":"The Pirate Bay הוא אתר אינטרנט המתנגד לזכויות יוצרים הפועל משוודיה ומציג את עצמו כ-\"טראקר הטורנטים הגדול בעולם\", בנוסף האתר משמש גם כמנוע חיפוש לקובצי ביטורנט. האתר ממוקם במקום ה-78 בדירוג של חברת אלקסה ברשימת האתרים המבוקרים ביותר בעולם.",
   "reddit":"Reddit הוא אתר מדיה חברתית מסוג מערכת לוח מודעות מקוונת אשר משתמשים הרשומים אליו יכולים לשתף תכנים, כגון טקסטים או קישורים בכל נושא אפשרי וללא הגבלה והפרסומים הזוכים לדירוג גבוה יותר מופיעים בראשו, בתצוגה מתחלפת שמשאירה מקום לפוסטים חדשים שטרם זכו למידת פרסום משמעותית.",
   "soundcloud":"SoundCloud היא פלטפורמה מקוונת להפצת אודיו. לאתר ישנו גם בלוג, ערוצי שידור וקבוצות. החברה הוקמה בשנת 2007 ואתר האינטרנט שלה הוקם ב-7 באוקטובר 2008. מנהלי החברה הם אלכסנדר ליונג ואריק וואלפורס. באתר מועלים שירים, הרצאות, פודקאסטים, ושידורים חיים.",
-  "stackoverflow":"Stack Overflow הוא אתר אינטרנט פרטי פופולרי שנוצר ב-2008, העוסק בתחום שאלות ותשובות בתחומי המיחשוב ופיתוח תוכנה וחומרה. הוא אתר הדגל של רשת Stack Exchange והוא אחד האתרים הפופולריים בעולם. מייסדי האתר הם יואל ספולסקי וג'ף אטווד. ג'ף אטווד ציין חולשות של אתר Experts Exchange כמניע ליצירת Stack Overflow.",
   "youtube":"יוּטְיוּבּ היא חברה אמריקאית המפעילה אתר אינטרנט לאחסון ושיתוף סרטוני וידאו באותו שם. החברה נוסדה בפברואר 2005, על ידי שלושה עובדים לשעבר של חברת PayPal: צַ'אד הַארלי, סטיב צֶ'ן וגַ'אווֶד קַארִים. בנובמבר 2006, רכשה גוגל את החברה תמורת 1.65 מיליארד דולר; מאז, פועלת יוטיוב כאחת מחברות הבת של גוגל.",
   "vimeo":"Vimeo הוא אתר אינטרנט לשיתוף וידאו, ומשתמשיו יכולים להעלות, לשתף ולצפות בתכנים בו. שרתי האתר נמצאים בארצות הברית.",
   "wikibooks":"ויקיספר הוא מיזם רב-לשוני של קרן ויקימדיה ליצירת ספרי לימוד ומדריכים חופשיים, שיתופיים ומהימנים שכל אחד יכול לתרום ליצירתם ופיתוחם. ויקיספר העברי החל דרכו ב-30 ביולי 2004 ומאז מתווספים אליו ערכים שונים על ידי הגולשים.",
@@ -1750,7 +1864,7 @@
   "wikiversity":"ויקיברסיטה הוא מיזם של קרן ויקימדיה, הנועד להיות מקור לחומרים ופעילויות ללימוד. נכון לאפריל 2021 ויקיברסיטה קיימת בשבע-עשרה שפות, שביניהן: אנגלית, צרפתית, גרמנית, ספרדית, יפנית, רוסית, יוונית, ערבית, קוריאנית ואיטלקית.",
   "wikivoyage":"ויקימסע הוא מיזם רב-לשוני של קרן ויקימדיה ליצירת מדריך טיולים חופשי, שיתופי ומהימן שכל אחד יכול לתרום ליצירתו ופיתוחו.",
   "wolframalpha":"וולפרַם אַלפַא הוא מנוע חיפוש חישובי, שפותח על ידי מעבדות וולפרם והושק במאי 2009. ייחודו הוא בביצוע שאילתות בשפה טבעית, בשילוב עם חישובים והחזיית מידע (ויזואליזציה) נרחבת.",
-  "rumble":"ראמבל היא פלטפורמת וידאו מקוונת מקוונת קנדית, שנוסדה בשנת 2013. האתר הוקם על ידי כריס פבלובסקי, יזם טכנולוגי קנדי. האתר פופולרי בקרב יוצרי תוכן שמרניים."
+  "rumble":"ראמבל היא פלטפורמת וידאו מקוונת קנדית, שנוסדה בשנת 2013. האתר הוקם על ידי כריס פבלובסקי, יזם טכנולוגי קנדי. האתר פופולרי בקרב יוצרי תוכן שמרניים."
  },
  "hr":{
   "wikipedia":"Wikipedija višejezična je, na Webu zasnovana enciklopedija slobodnog sadržaja. Ona postoji kao wiki, što podrazumijeva da se piše u suradnji s brojnim volonterima, te većinu članaka može uređivati svatko s pristupom Internetu i odgovarajućim web preglednikom. Projekt je započet 15. siječnja 2001. kao dodatak stručno pisanoj Nupediji. Wikipedijom danas rukovodi neprofitna organizacija zaklada Wikimedija, koja ima više od 15 milijuna članaka na mnogo jezika. Od početka joj raste popularnost, djelujući pozitivno na stvaranje drugih projekata od općeg interesa. Od urednika se traži da održavaju određenu razinu \"neutralnosti\" pri sažimanju istaknutih motrišta, bez određivanja objektivnosti istine.",
@@ -1785,7 +1899,7 @@
   "flickr":"Flickr je online servis za pohranu slike i video sadržaja, kao i online društvena platforma. Uz to što je vrlo popularan kod internetskih korisnika za dijeljenje osobnih fotografija, često ga za pohranu slika koriste i blogeri.",
   "google":"Google je internetska tražilica u vlasništvu tvrtke Google LLC te je najkorištenija tražilica na internetu. Osnovala su je dva studenta, Larry Page i Sergey Brin 1997. godine. Googleova misija je, kako kažu, organizirati informacije svijeta te ih učiniti korisnima.",
   "google images":[
-   "Google Slike. Najpotpunije pretraživanja slika na webu.Google Slike. Najpotpunije pretraživanja slika na webu.",
+   "Google Slike. Najpotpunije pretraživanja slika na webu.",
    "https://images.google.com"
   ],
   "google news":[
@@ -1799,12 +1913,13 @@
    "ref"
   ],
   "hoogle":"Haskell je standardizirani čisti funkcijski programski jezik sa nestriktnom semantikom, imenovan po logičaru Haskellu Curryu. Jedan je od najpopularnijih funkcijskih programskih jezika, i predstavlja lijeni programski jezik nad kojim se izvršava ponajviše istraživanja.",
+  "imdb":"Internet Movie Database (IMDb) nalazi se na adresi www.imdb.com, a radi se o najvećoj bazi podataka o filmu na internetu koja sadrži mnoštvo podataka o filmovima, filmskim glumcima, redateljima, scenaristima, producentima, ali i o televizijskim voditeljima, serijama i emisijama.",
   "kickass":"Kickass Hydra",
   "library of congress":"Kongresna knjižnica de facto je nacionalna knjižnica Sjedinjenih Američkih Država. Nalazi se u Washingtonu, D. C.. Osnovana je 1800. godine kao knjižnica Kongresa Sjedinjenih Američkih Država, kojemu i sada služi kao dokumentacijsko i informacijsko središte. Najveća je knjižnica u svijetu.",
   "openstreetmap":"OpenStreetMap (OSM) je projekt virtualne zajednice s ciǉem stvaraǌa slobodne, svima dostupne karte koju svatko može sam i dorađivati.",
   "piratebay":"The Pirate Bay trenutno je najveći svjetski BitTorrent tracker. Osnovala ga je švedska organizacija Piratbyrån u studenom 2003. godine, ali već u listopadu 2004. godine nastupa kao odvojena organizacija. Trenutno ga vode Gottfrid Svartholm, Fredrik Neij i Peter Sunde. Kako su u mnogim zemljama BitTorrent trackeri na kojima se za slobodno skidanje može pronaći glazba i računalni programi koji su zaštićeni autorskim pravima ilegalni, u Švedskoj se takvi BitTorrent trackeri ne smatraju ilegalnim. Upravo je iz tog razloga The Pirate Bay često na udarima organizacija za zaštitu autorskih prava.",
   "reddit":"Reddit je američka internetska stranica odnosno internetski servis koji funkcionira kao križanac foruma i Useneta. Prema podacima iz ožujka 2021., Reddit je devetnaesta najposjećenija stranica na svijetu.",
-  "youtube":"YouTube je popularna mrežna usluga za razmjenu videozapisa na kojoj korisnici mogu postavljati, pregledavati i ocjenjivati videozapise. Za postavljanje sadržaja potrebna je registracija, dok za pregledavanje nije, osim sadržaja koji nije primjeren za osobe mlađe od 18 godina. Prema pravilima korištenja, korisnici mogu postavljati vlastite originalne uratke i uratke za koje imaju dopuštenje vlasnika autorskih prava, a zabranjeno je postavljanje pornografskog sadržaja, nasilja, sadržaja koji podržava kriminalne radnje, sadržaja s ciljem sramoćenja, klevete i reklama. YouTube zadržava pravo na korištenje, preinaku i brisanje postavljenoga materijala.",
+  "youtube":"YouTube je popularna mrežna usluga za razmjenu videozapisa na kojoj korisnici mogu postavljati, pregledavati, komentirati i ocjenjivati videozapise. Za postavljanje sadržaja potrebna je registracija, dok za pregledavanje nije, osim sadržaja koji nije primjeren za osobe mlađe od 18 godina. Prema pravilima korištenja, korisnici mogu postavljati vlastite originalne uratke i uratke za koje imaju dopuštenje vlasnika autorskih prava, a zabranjeno je postavljanje pornografskog sadržaja, nasilja, sadržaja koji podržava kriminalne radnje, sadržaja s ciljem sramoćenja, klevete i reklama. YouTube zadržava pravo na korištenje, preinaku i brisanje postavljenoga materijala.",
   "wikibooks":"Wikiknjige su Wikipedijin sestrinski projekt koji djeluje s ciljem stvaranja besplatnih udžbenika, zbirke knjiga iz raznih područja, slobodnog pristupa, korištenja i objavljivanja koje svako može uređivati. Wikiknjige su idealno mjesto gdje se sav postavljeni tekst, uz dogovor i radi točnosti, može ispraviti, obnoviti i nadograditi na zadovoljstvo svih zainteresiranih.",
   "wikiquote":"Wikicitat je Wikipedijina podružnica. Temelji se na MediaWiki programskoj podršci. Dio je obitelji na wikiju objedinjenih u zakladi Wikimedija.",
   "wikisource":"Wikizvor je Wikipedijin sestrinski projekt koji djeluje s ciljem stvaranja zbirke besplatnih originalnih tekstova, ali i prijevoda tih tekstova na različite jezike. Wikizvor prikuplja i u digitalnom formatu pohranjuje prethodno objavljene tekstove, između ostalog romane, nefikcijska djela, pisma, govore, zakone i povijesne dokumente. Svi prikupljeni tekstovi ili su slobodni za objavljivanje ili su objavljeni pod GNU-FDL dozvolom.",
@@ -1853,7 +1968,7 @@
   "github":"A GitHub, Inc. egy egyesült államokbeli nemzetközi vállalat, amely a Git segítségével szoftverfejlesztési verziókövetés-szolgáltatást nyújt. 2018-ban a Microsoft leányvállalata lett 7,5 milliárd dollárért. Saját funkcióin felül a Git elosztott verziókövetését és forráskódkezelését (SCM) teszi elérhetővé. Hozzáférés-kezelést és számos együttműködési funkciót nyújt, mint például bugkövetés, szolgáltatáslekérés, feladatkezelés, valamint wikiket minden projekthez.",
   "google":"A Google internetes keresőrendszer, amely egyúttal térképként, pénzváltóként, számológépként, naptárként, helyesírás-ellenőrzőként és szótárként is használható.",
   "google images":[
-   "Google Képek. Az internet legátfogóbb képkereső szolgáltatása.Google Képek. Az internet legátfogóbb képkereső szolgáltatása.",
+   "Google Képek. Az internet legátfogóbb képkereső szolgáltatása.",
    "https://images.google.com"
   ],
   "google news":"A Google Hírek egy speciális hírösszefoglaló szolgáltatás, amelyet a Google fejlesztett ki. A Google Hírek alkalmazásként is elérhető Androidon, iOS-en és webalkalmazás formájában is.",
@@ -1864,13 +1979,13 @@
    "ref"
   ],
   "hoogle":"A Haskell tisztán funkcionális, lusta kiértékelésű, polimorf típusokat és magasabb rendű függvényeket tartalmazó programozási nyelv. A nyelv ezzel meglehetősen különbözik a ma általában használatos nyelvektől. A nyelv Haskell Brooks Curry amerikai matematikusról kapta a nevét, aki a matematikai logikában kifejtett munkássága révén hozzájárult a funkcionális nyelvek elméleti alapjainak fejlődéséhez. A Haskell nyelv alapja a lambda-kalkulus.",
+  "imdb":"Az Internet Movie Database (IMDb), melynek tulajdonosa az Amazon.com, egy online információs adatbázis filmszínészekről, filmekről, filmsorozatokról, egyéb televíziós műsorokról, reklámokról és videójátékokról. A regisztrált felhasználók értékelhetik a filmeket és szerkeszthetik az adatlapokat, a változtatásokat az IMDb személyzete tartja nyílván. Az IMDb a legismertebb és legnagyobb méretű filmes internetes adatbázis.",
   "library of congress":"A Kongresszusi Könyvtár az Amerikai Egyesült Államok nemzeti könyvtára, mely Washingtonban található négy épületben. Ez a világ legnagyobb könyvtára mind fizikai méretei, mind tárolt könyveinek, dokumentumainak száma szerint.",
   "mixcloud":"A Mixcloud egy freemium zenemegosztó streamingszolgáltató weboldal, ami rádióműsorok, zenei mixek és podcastok megosztását teszi lehetővé. Az oldal crowdsourcing alapján működik, a regisztrált felhasználók által feltöltött munkák biztosítják a tartalmat. A felhasználók korlátlanul tölthetnek fel az oldalra, de a feltöltött munkákat letölteni nem lehet, csak streamelni. A Mixcloud alkalmazása megjelent Androidra és iOS-re.",
   "openstreetmap":"Az OpenStreetMap (OSM) csoportmunkán alapuló térképfejlesztés, melynek célja egy szabadon szerkeszthető és felhasználható térkép készítése az egész világról.",
   "piratebay":"A svéd The Pirate Bay (TPB) a világ egyik legnagyobb torrentoldala. Az Alexa Internet statisztikái szerint a TPB látogatottság alapján a 89. helyen áll. A portál nem tartalmaz illegális tartalmakat, csak a fájlcserét segítő információt (metaadatokat).",
   "reddit":"A Reddit egy közösségi weboldal, amelyen a felhasználók megoszthatják híreiket, képeiket és cikkeiket az ún. \"subredditeken\" (alredditeken). Kizárólag a regisztrált felhasználók adhatnak hozzá tartalmat, illetve értékelhetik a már meglévőket a \"fel\" és \"le\" nyilak segítségével. Több nyelven, köztük magyarul is elérhető.",
   "soundcloud":"A SoundCloud egy svéd alapítású, németországi székhelyű platform, ingyenes és fizetős zenei streaming szolgáltatásként, közösségi oldalként és online zeneáruházként működik. Eredetileg azért jött létre, hogy a zenészek számára kollaboratív tartalomszerkesztést biztosítson, azáltal, hogy megoszthatják felvételeiket és ezt értékelhetik, később azonban a hangsúly inkább a kész dalok közzétételére és véleményezésére helyeződött át, ezáltal az oldal egyfajta, jobbára amatőr és félprofi audio-művészeti közösségi oldallá fejlődött. Az ingyenes változat összességében korlátozott időtartamú audio felvétel feltöltését engedi - a hangmintáktól és hangszertesztektől komplett dalokon át egészen a több órás élő és bootleg felvételekig. A SoundCloud néhány hónap alatt a Myspace egyik legnagyobb riválisa lett. 2014 decemberi adatok szerint a platform 175 millió egyedi látogatót vonz és az alkotók percenként 12 órányi hangfelvételt töltenek fel rá.",
-  "stackoverflow":"A Stack Overflow egy széles körű, programozással kapcsolatos kérdéseket és válaszokat tartalmazó weblap.",
   "youtube":"A YouTube nyilvános videómegosztó webhely, ahol a felhasználók videókat tölthetnek fel és nézhetnek meg. A YouTube székhelye a kaliforniai San Brunóban található. A Time magazin a 2006-os év találmányának választotta a honlapot.",
   "dailymotion":"A Dailymotion egy francia videómegosztó weboldal, ami a francia Vivendi médiakonglomerátum leányvállalata. A székhelyük Párizsban található, de 2005-ös alapítása óta nyílt irodája Londonban, San Franciscóban, Szingapúrban és Abidjanban is. Az oldal 2017-re elérte a 300 millió havi egyedi látogatót.",
   "vimeo":"A Vimeo egy 2004-ben, az Egyesült Államokban létrehozott videómegosztó webhely.",
@@ -1887,7 +2002,7 @@
   "wikipedia":"Wikipedia [wikipeˈdia] es un projecto de Wikimedia sin scopo lucrative fundate le 15 de januario 2001 pro crear un encyclopedia in numerose linguas in le Internet per redaction collaborative utilisante un si appelate principio wiki. Secundo le demanda e le distribution public, Wikipedia es ora un del medias de massa.",
   "wikidata":"Wikidata es un base de cognoscentia modificate in collaboration e implementate per le Fundation Wikimedia. Illo es concipite pro fornir un fonte commun de typos de datos secur que pote esser usate per projectos Wikimedia como Wikipedia. Isto es simile al maniera que Wikimedia Commons forni un immagazinage central pro files multimedial pro accesso ab omne projectos Wikimedia. Wikidata es actionate per le software Wikibase.",
   "google images":[
-   "Google Imagines. Le recerca de imagines le plus comprehensive del web.Google Imagines. Le recerca de imagines le plus comprehensive del web.",
+   "Google Imagines. Le recerca de imagines le plus comprehensive del web.",
    "https://images.google.com"
   ],
   "youtube":"YouTube es un sito web, loco pro observar videos fundate in februario 2005 del cooperatores temporal del PayPal Chad Hurley, Steve Chen e Jawed Karim. Super iste sito web le usatores pote spectar parve filmes, como currente de datos transportate al computator del audiente, e supercargar proprie parve filmes. Le 9 de octobre 2006 Google annunciava su emption de YouTube.",
@@ -1921,7 +2036,6 @@
    "currency:it",
    "ref"
   ],
-  "digg":"Digg è un sito web di social bookmarking. Le notizie ed i collegamenti sono proposti dagli utenti, e sono poi promossi in prima pagina in base ad un sistema di graduatoria non gerarchico e basato sulla valutazione degli altri utenti della comunità. Digg è nato nel 2004 ed è stato fondato da Kevin Rose. Nel luglio 2012 la Betaworks, start-up di New York che ha sviluppato l'applicazione per iPhone/iPad News.me, ha acquistato Digg rilanciando, ad agosto dello stesso anno, la rinnovata versione del servizio.",
   "wikidata":"Wikidata è una base di conoscenza online collaborativa, sostenuta e ospitata dalla Wikimedia Foundation, con lo scopo di fornire un archivio comune di supporto agli altri progetti di Wikimedia, consultabile e modificabile sia da utenti umani che da bot.",
   "duckduckgo":[
    "currency:it",
@@ -1950,6 +2064,7 @@
    "ref"
   ],
   "hoogle":"Haskell è un linguaggio di programmazione puramente funzionale general-purpose creato da un apposito comitato alla fine degli anni ottanta principalmente per analizzare le caratteristiche dei linguaggi. È stato chiamato così in onore del matematico e logico statunitense Haskell Curry.",
+  "imdb":"Internet Movie Database, comunemente indicato con l'acronimo IMDb, è un sito web di proprietà di Amazon.com che gestisce informazioni su film, attori, registi, personale di produzione, programmi televisivi, e anche videogiochi. Una versione a pagamento denominata IMDb Pro è disponibile per tutti coloro che pubblicizzano i propri lavori.",
   "ina":"L'Institut national de l'audiovisuel (INA), è un ente pubblico commerciale francese, incaricato di archiviare tutte le trasmissioni radiofoniche e audiovisive del paese, come fa la Bibliothèque nationale de France con i documenti scritti.",
   "invidious":[
    "frontend libero per YouTube",
@@ -1957,7 +2072,7 @@
   ],
   "kickass":"KickassTorrents è stato un sito web, fondato nel 2008, che ospitava file torrent e magnet link per facilitare il file sharing peer-to-peer con il protocollo BitTorrent. All'agosto 2015, secondo Alexa, KAT è l'indice di file torrent più visitato al mondo e si stima riceva ogni mese più di 319 milioni di accessi. Il 20 luglio 2016 il sito è stato sequestrato dal governo degli Stati Uniti, successivamente chiuso e l'autore del sito è stato arrestato.",
   "library genesis":"Library Genesis o LibGen è un motore di ricerca di articoli e libri su vari argomenti, che consente l'accesso gratuito a contenuti normalmente a pagamento o non digitalizzati altrove. Tra gli altri, veicola contenuti in formato PDF dal portale web di Elsevier di ScienceDirect.",
-  "library of congress":"La Biblioteca del Congresso, nota con gli acronimi LOC o Loc, è de facto la biblioteca nazionale degli Stati Uniti d'America. Grazie agli oltre 158 milioni di documenti in essa custoditi è la più grande biblioteca al mondo.",
+  "library of congress":"La Biblioteca del Congresso, nota con gli acronimi LOC o Loc, è di fatto la biblioteca nazionale degli Stati Uniti d'America. Grazie agli oltre 158 milioni di documenti in essa custoditi è la più grande biblioteca al mondo.",
   "microsoft academic":"Microsoft Academic è un motore di ricerca web, pubblico e gratuito, sviluppato da Microsoft Research per le ricerche nell'ambito delle pubblicazioni e della letteratura accademica. Dal 2016 sostituisce Microsoft Academic Search, dismesso quattro anni prima. Il rilancio del servizio presenta un nuovo modello dei dati e un nuovo motore di ricerca semantica.",
   "mixcloud":"Mixcloud è un servizio musicale di streaming via internet che permette l'ascolto e la distribuzione di spettacoli radiofonici, mix di disc jockey e podcast, che sono caricati dai suoi utenti registrati.",
   "npm":"npm è un gestore di pacchetti per il linguaggio di programmazione JavaScript. È il gestore di pacchetti predefinito per l'ambiente di runtime JavaScript Node.js. Consiste in un client da linea di comando, chiamato anch'esso npm, e un database online di pacchetti pubblici e privati, chiamato npm registry.",
@@ -1979,7 +2094,18 @@
   ],
   "reddit":"Reddit, reso graficamente come reddit, è un sito Internet di social news, intrattenimento, e forum, dove gli utenti registrati possono pubblicare contenuti sotto forma di post testuali o di collegamenti ipertestuali (link). Gli utenti, inoltre, possono attribuire una valutazione, \"su\" o \"giù\", ai contenuti pubblicati: tali valutazioni determinano, poi, posizione e visibilità dei vari contenuti sulle pagine del sito. I contenuti del sito sono organizzati in aree di interesse chiamate subreddit.",
   "soundcloud":"SoundCloud è un servizio musicale svedese e sito web di music sharing che permette ai musicisti di collaborare, promuovere e distribuire la loro musica.",
-  "stackoverflow":"Stack Overflow è un sito web che fa parte della rete Stack Exchange in cui si possono porre domande riguardo a vasti argomenti di programmazione.",
+  "stackoverflow":[
+   "circuito di siti Q&A",
+   "wikidata"
+  ],
+  "askubuntu":[
+   "stackoverflow:it",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:it",
+   "ref"
+  ],
   "startpage":"Ixquick è stato un metamotore di ricerca con basi operative a New York e nei Paesi Bassi confluito nel 2018 nel progetto Startpage.com. Ixquick è stato fondato nel 1998 da David Bodnick ed aveva sede a New York. Due anni dopo, nel 2000, la proprietà è passata alla società olandese Surfboard Holding BV.",
   "unsplash":"Unsplash è un sito web dedicato alla condivisione di fotografie con licenza Unsplash.",
   "yahoo news":"Yahoo! News è un aggregatore di notizie basato su internet di Yahoo!. Gli articoli originariamente provenivano da servizi di notizie come Associated Press, Reuters, Fox News, Al Jazeera, ABC News, USA Today, CNN.com, BBC News, ecc.",
@@ -2001,6 +2127,7 @@
   "naver":"Naver è una piattaforma online sudcoreana gestita da Naver Corporation. Ha debuttato nel 1999 come il primo portale web in Corea del Sud a sviluppare e utilizzare il proprio motore di ricerca. È stato anche il primo operatore al mondo a introdurre la funzione di ricerca completa, che raccoglie i risultati della ricerca da varie categorie e li presenta in un'unica pagina. Da allora Naver ha aggiunto una moltitudine di nuovi servizi che vanno dalle funzionalità di base come casella e-mail e sito di notizie alla prima piattaforma di domande e risposte online al mondo Knowledge iN.",
   "rubygems":"RubyGems è un gestore di pacchetti per il linguaggio di programmazione Ruby che fornisce un formato standard, per distribuire i programmi e le librerie scritti in Ruby, chiamato gems (dall'inglese: gemme) è inoltre uno strumento progettato per facilitare la gestione dell'installazione delle \"gemme\" e per la loro distribuzione.",
   "peertube":"PeerTube è un software libero decentralizzato e federato che utilizza la tecnologia di rete paritaria (P2P) per ridurre il carico sui singoli server. È rilasciato sotto licenza GNU Affero General Public License. Il progetto è nato nel 2015 da un singolo programmatore. Lo sviluppo di PeerTube fu successivamente supportato da un'organizzazione non a scopo di lucro francese, la Framasoft.",
+  "rumble":"Rumble è una piattaforma di video online canadese con sede a Toronto. Fondata nel 2013 da Chris Pavlovski, un imprenditore canadese.",
   "wikimini":[
    "enciclopedia online per ragazzi",
    "wikidata"
@@ -2015,7 +2142,7 @@
   "artic":"シカゴ美術館 は、アメリカ合衆国イリノイ州シカゴ市内にある美術館である。ニューヨークのメトロポリタン美術館、ボストン市にあるボストン美術館とともにアメリカの三大美術館の1つに数えられる。館名は日本語では「シカゴ美術研究所」、「シカゴ・アート・インスティテュート」などと表記される場合もある。",
   "arxiv":"arXiv（アーカイヴ、archiveと同じ発音）は、物理学、数学、計算機科学、数量生物学、数量ファイナンス、統計学、電子工学・システム科学、経済学の、プレプリントを含む様々な論文が保存・公開されているウェブサイトである。論文のアップロード（投稿）、ダウンロード（閲覧）ともに無料で、論文はPDF形式である。1991年にスタートして、プレプリント・サーバーの先駆けとなったウェブサイトである。大文字の X をギリシャ文字のカイ（Χ）にかけて archive と読ませている。",
   "wikipedia":"ウィキペディア は、世界中のボランティアの共同作業によって執筆されるフリーの多言語インターネット百科事典である。収録されている全ての内容がオープンコンテントで商業広告が存在しないことを特徴とし、主に寄付に依って活動している非営利団体「ウィキメディア財団」が所有・運営している。「ウィキペディア（Wikipedia）」という名前は、ウェブブラウザ上でウェブページを編集することができる「ウィキ（Wiki）」というシステムを使用した「百科事典」 であることに由来する造語である。設立者の1人であるラリー・サンガーにより命名された。",
-  "bing":"Microsoft Bing（マイクロソフト・ビング）は、Microsoftが提供する検索エンジンである。「意思決定を支援する検索エンジン」というコンセプトを掲げ、他の検索エンジンとの差別化を図っている。",
+  "bing":"Microsoft Bing（マイクロソフト・ビング）は、Microsoftが提供するポータルサイトである。「意思決定を支援する検索エンジン」というコンセプトを掲げ、他の検索エンジンとの差別化を図っている。",
   "bing images":[
    "bing:ja",
    "ref"
@@ -2050,16 +2177,17 @@
   "free software directory":"Free Software Directoryとは、フリーソフトウェア財団 のプロジェクトである。フリーなオペレーティングシステム、とりわけGNUオペレーティングシステム とLinuxで稼動するフリーソフトウェアを一覧化するプロジェクトである。",
   "gitlab":"GitLab(ギットラブ)とはGitLab Inc.が開発したウェブ型のGitリポジトリマネージャーでオープンソースソフトウェアライセンスのウィキと問題追跡システムが使われている。",
   "github":"GitHub（ギットハブ）は、ソフトウェア開発のプラットフォームであり、ソースコードをホスティングする。コードのバージョン管理システムにはGitを使用する。Ruby on RailsおよびErlangで記述されており、アメリカのカリフォルニア州サンフランシスコ市に拠点を置くGitHub社によって保守されている。主な開発者はクリス・ワンストラス、P.J.ハイエット、トム・プレストン・ワーナーである。",
-  "google":"Google 検索 またはGoogle ウェブ検索 はGoogleが提供する検索エンジンで、World Wide Web上で最も多く使われている検索エンジンである。Googleは様々なサービスを通して毎日数億件の検索クエリを受け付けている。Google 画像検索などとは異なり、Google検索はウェブページ内のテキストデータを探し出すことを主な目的としている。1997年、ラリー・ペイジとセルゲイ・ブリンが開発したのが始まりである。",
+  "google":"Google 検索 またはGoogle ウェブ検索 はGoogleが提供する検索エンジンで、World Wide Web上で最も多く使われている検索エンジンである。 https://www.google.com/?hl=ja Googleは様々なサービスを通して毎日数億件の検索クエリを受け付けている。Google 画像検索などとは異なり、Google検索はウェブページ内のテキストデータを探し出すことを主な目的としている。1997年、ラリー・ペイジとセルゲイ・ブリンが開発したのが始まりである。",
   "google images":"Google 画像検索 は、Webにある画像を検索するためにGoogleが提供している検索サービスである。2001年にサービスが開始された。切っ掛けはジェニファー・ロペスが着用した緑のヴェルサーチドレスの写真が見たいという需要に通常のGoogle検索では応え切れなかったことによる。2011年に逆画像検索が追加された。",
   "google news":"Google ニュース は、Googleが提供するニュースアグリゲーター。Googleのページランクに関連して、Googleの主任研究者である Krishna Bharat が2001年に開発したストーリーランクをベースとして始まった。人間はアグリゲーションのアルゴリズムを調節するだけで、掲載する記事の選択は全て自動的に行われる。2006年1月、Google News ベータ版が登場した。",
   "google videos":"Google ビデオ は、Googleの動画検索エンジンである。かつては無料の動画共有サイトであり、YouTubeのように選択した動画をリモートのウェブページに埋め込むためのHTMLコードを提供し、帯域幅が狭くストレージ容量も少ないウェブサイトで動画を豊富に利用できるものだった。",
   "google scholar":"Google Scholar（グーグル・スカラー）は、ウェブ検索サイトのGoogleの提供する検索サービスの一つ。主に学術用途での検索を対象としており、論文、学術誌、出版物の全文やメタデータにアクセスできる。Googleはそのデータベースのサイズを公開していないが、第三者機関の調査によれば、2014年5月時点、約1.6億の文章が含まれると推定される。",
-  "google play apps":"Google Play は、Googleによって提供される、主にAndroid端末及びChromebook(2016/4以降)向けデジタルコンテンツ（アプリケーション・映画・音楽・書籍など）の配信サービス。2012年3月6日に「Android Market」を「Google Play」に改名し、「Google eBookstore」「Google Play Music」といったサービスも統合して誕生した。",
+  "google play apps":"Google Play は、Googleによって提供される、主にAndroid端末及びChromebook（2016年4月以降）向けデジタルコンテンツ（アプリケーション・映画・音楽・書籍など）の配信サービス。2012年3月6日に「Android Market」を「Google Play」に改名し、「Google eBookstore」「Google Play Music」といったサービスも統合して誕生した。",
   "google play movies":[
    "google play apps:ja",
    "ref"
   ],
+  "imdb":"IMDb は、映画、テレビ番組、ホームビデオ、ビデオゲーム、オンラインのストリーミングコンテンツに関連する情報を集めたオンラインデータベースで、キャスト、制作スタッフ、個人の経歴、プロットの概要、トリビア、評価、ファンや批評家のレビューなどが含まれている。追加のファン機能であるメッセージボードは、2017年2月に廃止された。元々はファンが運営していたウェブサイトだったが、現在はAmazonの子会社であるIMDb.com, Inc.がデータベースを所有・運営している。",
   "ina":"フランス国立視聴覚研究所 は、フランスの全ラジオ・テレビの視聴覚アーカイヴの宝庫である。ラジオフランスが主催し、放送局本部の建物内にある。内部にフランス音楽研究グループ を有する。",
   "library genesis":"Library GenesisまたはLibGenは、様々なトピックスに関する論文や書籍のためのサーチエンジンであり、 有料で配布されていたり、どこにおいてもデジタル化されていなかったりするコンテンツを無料でアクセス可能にしている。 特に、エルゼビアのScienceDirectウェブポータルで配布されているPDFファイルを収録している。",
   "library of congress":"アメリカ議会図書館 は、アメリカ合衆国の事実上の国立図書館。",
@@ -2068,9 +2196,17 @@
   "piratebay":"パイレート・ベイ は、デジタルコンテンツのトレントファイルを検索できるインデックスサイトである。2003年に、スウェーデンの反著作権団体Piratbyrånによって設立された。利用者はマグネットリンクおよびトレントファイルの検索、ダウンロード、掲載が可能である。マグネットリンクとトレントファイルは、BitTorrentプロトコルを用いたP2Pファイル共有に使用される。",
   "pubmed":"MEDLINE（メドライン）またはMEDLARS Online は、医学を中心とする生命科学の文献情報を収集したオンラインデータベースである。1964年に米国国立医学図書館 が作成したコンピューター化医学文献データベース「MEDLARS」は、1971年10月27日にオンライン検索サービスが開始され、1997年にはPubMedの名でインターネットに無料公開された後、改良が重ねられて成長を続け、2007年現在、月に7000万回程度のアクセスがある世界で最もよく使用される生物医学系データベースである。",
   "pypi":"Python Package Index は、プログラミング言語Pythonの、サードパーティーソフトウェアリポジトリである。すべてのオープンソースなPythonパッケージの包括的なカタログととらえることができる。 Pipなどのパッケージマネージャは、パッケージやその依存パッケージをPyPIからダウンロードしてインストールする機能を持つ。",
-  "reddit":"Reddit（レディット）はアメリカ合衆国の掲示板型ソーシャルニュースサイト。主に英語圏のユーザーを対象とする。ニュース記事、画像のリンクやテキストを投稿し、コメントをつけることが可能。カリフォルニア州サンフランシスコに拠点を置くReddit, Inc.が運営する。2021年1月時点の月間利用者数は4億3000万人。",
-  "soundcloud":"SoundCloud（サウンドクラウド）は、ドイツのベルリンに拠点を置くSoundCloud Limitedが運営する音声ファイル共有サービス。",
-  "stackoverflow":"Stack Overflow（スタックオーバーフロー）はStack Exchange Networkの一つで、コンピュータや情報技術、特にプログラミング技術に関するナレッジコミュニティである。サービスはJeff Atwoodとジョエル・スポルスキによって2008年に開始された。Stack Overflowという名称は、2008年4月、Atwoodが運営するブログの読者による投票で決定された。",
+  "reddit":"Reddit（レディット）はアメリカ合衆国の掲示板型ソーシャルニュースサイト。主に英語圏のユーザーを対象とする。ニュース記事、画像のリンクやテキストを投稿し、コメントをつけることが可能。カリフォルニア州サンフランシスコに拠点を置くReddit, Inc.が運営する。2021年1月時点の月間利用者数は4億3000万人。欧米ではTwitterユーザー数並び利用時間を超える。",
+  "soundcloud":"SoundCloud（サウンドクラウド）は、ドイツのベルリンに拠点を置くSoundCloud Limitedが運営する音声ファイル共有サービス。 音雲(おとくも)とも呼ばれる。",
+  "stackoverflow":"Stack Exchange（スタック・エクスチェンジ）は、様々な分野のトピックについて質疑応答 (Q&A) 形式で議論できるウェブサイト群である。ウェブサイトごとに定められた分野において、質問・回答・ユーザーが評価システムの対象となる。評価システムは議論を円滑に進める役割を持つ。このウェブサイトの原型はプログラミング関連のQ&AサイトStack Overflowにある。2017年4月地点で、人気サイトトップ3はStack Overflow、Super User、Ask Ubuntuである。ユーザーの投稿はクリエイティブコモンズ表示・継承3.0(2018/05/02以降は4.0)でライセンスされる。",
+  "askubuntu":[
+   "stackoverflow:ja",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:ja",
+   "ref"
+  ],
   "startpage":"Startpage とはニューヨークとオランダを拠点にしているメタ検索エンジンで、1998年にデビッド・ボドニックが設立し2000年にオランダのサーフボード・ホールディングBVが買収した。2015年2月2日にIxquickと姉妹プロジェクトのStartpage.comは（28日平均で）1日直接クエリ数が5,700万に達したとしている。",
   "yahoo news":[
    "Yahoo! JAPANのサービスの一つ",
@@ -2084,7 +2220,7 @@
   "vimeo":"Vimeo は、クリエイター向け動画共有サイト。「video」（ビデオ）と「me」（私）の意味と、「movie」（映画）という言葉のアナグラムである。",
   "wikisource":"ウィキソース (Wikisource) は、ウィキメディア財団が運営するウィキを利用した自由に利用できるテキストを集めた電子図書館である。ウィキソースはプロジェクトの名前でもあり、またプロジェクトのインスタンス（実体）である個々のサイト（主に各言語版）もウィキソースと呼ばれ、複数のウィキソースが集まって大きなウィキソースプロジェクトを形成している。ウィキソースの目的はあらゆる形態のフリーテキストを、多数の言語および翻訳においても提供することである。元々は有用または重要な歴史的文書を保存するアーカイブとして着想され、今では幅広いコンテンツを扱うライブラリとなっている。",
   "wiktionary":"ウィクショナリー (Wiktionary) は、コピーレフトなライセンス・オープンコンテントの辞書兼シソーラス（類語辞典）を作成し、配布することを目的としたウィキメディア財団によるプロジェクトである。GNU Free Documentation License (GFDL) およびクリエイティブ・コモンズ 表示 - 継承 3.0 非移植 のデュアルライセンスで公開される。2002年12月12日に活動を開始した。",
-  "wolframalpha":"Wolfram Alpha（WolframAlphaともWolfram|Alphaとも表記される）はウルフラム・リサーチが開発した質問応答システム。事実についての質問に対して、構造化されたデータを使って計算し、直接答えを返すオンラインサービスである。他の検索エンジンのように、答えを含んでいる可能性のあるドキュメントやウェブページのリストを返すわけではない。このサービスは2009年3月に英国人科学者スティーブン・ウルフラムが発表し、同年5月15日に公開された。また、2018年6月18日には日本語版のWolfram Alphaも公開された。現時点では日本語に対応しているのは数学関連のクエリのみであるが、「5個のボールの並べ方は何通りあるか」「ニュートン法を使ってx cos x = 0を解く」などの質問に対して日本語で答えることができる。",
+  "wolframalpha":"Wolfram Alpha（WolframAlphaともWolfram|Alphaとも表記される）はウルフラム・リサーチが開発した質問応答システム。事実についての質問に対して、構造化されたデータを使って計算し、直接答えを返すオンラインサービスである。他の検索エンジンのように、答えを含んでいる可能性のあるドキュメントやウェブページのリストを返すわけではない。このサービスは2009年3月に英国人科学者スティーブン・ウルフラムが発表し、同年5月15日に公開された。また、2018年6月18日には日本語版のWolfram Alphaも公開された。現時点では日本語に対応しているのは数学関連のクエリのみであるが、「5個のボールの並べ方は何通りあるか」「ニュートン法を使ってxcos x=0 を解く」などの質問に対して日本語で答えることができる。",
   "naver":"ネイバー は、ネイバー株式会社が運営する、大韓民国（韓国）の最大手ポータルサイトである。",
   "rubygems":"RubyGemsは、Ruby言語用のパッケージ管理システムであり、Rubyのプログラムと ライブラリの配布用標準フォーマットを提供している。gemを容易に管理でき、gemを配布するサーバの機能も持つ。Rubyバージョン1.9以降では標準ライブラリの一部となっている。"
  },
@@ -2107,7 +2243,7 @@
   "flickr":"„Flickr“ – socialinis tinklas, priklausantis „SmugMug“ bendrovei.",
   "google":"Google Search (Google) – internetinės paieškos sistema plėtojama „Google“ bendrovės. Plačiausiai naudojamas paieškos variklis internete, užimantis daugiau nei 90 % rinkos dalį. Įvykdo daugiau nei 5 mlrd. užklausų per dieną. „Google“ paieškos sistemoje ieškoma interneto puslapių, naujienų, nuotraukų, vaizdo įrašų („YouTube“) bei kitų išteklių. „Google“ siūlo ir papildomų paslaugų.",
   "google images":[
-   "„Google“ vaizdai. Išsamiausia žiniatinklio vaizdų paieška.„Google“ vaizdai. Išsamiausia žiniatinklio vaizdų paieška.",
+   "„Google“ vaizdai. Išsamiausia žiniatinklio vaizdų paieška.",
    "https://images.google.com"
   ],
   "google news":[
@@ -2121,6 +2257,7 @@
    "google play apps:lt",
    "ref"
   ],
+  "imdb":"The Internet Movie Database – nuolat atnaujinama interneto duomenų bazė apie aktorius, filmus, televizijos laidas, video žaidimus ir panašius dalykus. Svetainę valdo IMDb.com, Inc.",
   "library genesis":"„Library Genesis“ arba „LibGen“ – rinkmenų dalinimosi svetainė, kurioje talpinami moksliniai straipsniai, moksliniai veikalai ir kitos knygos.",
   "library of congress":"Kongreso biblioteka - (neoficiali) nacionalinė biblioteka JAV. Užima daug pastatų Washington D. C.. Viena reikšmingiausių pasaulio bibliotekų.",
   "openstreetmap":"OpenStreetMap – atviras projektas, kurio dalyviai naudodamiesi projekte kaupiamais GPS imtuvų duomenimis bei kita atvira informacija, pvz., Mapillary, ortofoto, ar palydovinėmis nuotraukomis, kuria laisvai prieinamą viso pasaulio kelių bei gatvių žemėlapį.",
@@ -2137,9 +2274,25 @@
   "wikiversity":"Vikiversitetas – Vikimedijos fondo projektas, pagrįstas MediaWiki technologija; vikisvetainė.",
   "wikivoyage":"Vikikelionės – internetinis projektas, kuriamas vikitechnologija bei pagrįstas MediaWiki programine įranga. Vikikelionės nuo 2013 m. sausio 15 d. yra oficialus Vikimedijos projektas."
  },
- "nb_NO":{
+ "nb-NO":{
+  "bing":[
+   "Bing lar deg gjøre om informasjon til handling slik at du raskere kan bli ferdig med å søke og komme i gang med gjøremålene.",
+   "https://www.bing.com"
+  ],
+  "bing images":[
+   "bing:nb-NO",
+   "ref"
+  ],
+  "bing news":[
+   "Nyheter fra internasjonale, nasjonale og lokale nyhetskilder, organisert slik at de gir deg dypdegående nyhetsdekning av sport, underholdning, forretningsliv, politikk, vær og mye mer.",
+   "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "bing:nb-NO",
+   "ref"
+  ],
   "google images":[
-   "Google Foto. Det mest omfattende bildesøket på Internett.Google Foto. Det mest omfattende bildesøket på Internett.",
+   "Google Foto. Det mest omfattende bildesøket på Internett.",
    "https://images.google.com"
   ],
   "google news":[
@@ -2155,8 +2308,12 @@
    "https://play.google.com/"
   ],
   "google play movies":[
-   "google play apps:nb_NO",
+   "google play apps:nb-NO",
    "ref"
+  ],
+  "openstreetmap":[
+   "OpenStreetMap is the free wiki world map.",
+   "https://www.openstreetmap.org/"
   ],
   "youtube":[
    "Med YouTube kan du se populære videoer, kose deg med favorittmusikken din og laste opp ditt eget innhold – og dele det med familie, venner og resten av verden.",
@@ -2165,31 +2322,31 @@
  },
  "nl":{
   "archive is":[
-   "archive is:nl_BE",
+   "archive is:nl-BE",
    "ref"
   ],
   "artic":[
-   "artic:nl_BE",
+   "artic:nl-BE",
    "ref"
   ],
   "arxiv":[
-   "arxiv:nl_BE",
+   "arxiv:nl-BE",
    "ref"
   ],
   "bandcamp":[
-   "bandcamp:nl_BE",
+   "bandcamp:nl-BE",
    "ref"
   ],
   "wikipedia":[
-   "wikipedia:nl_BE",
+   "wikipedia:nl-BE",
    "ref"
   ],
   "bing":[
-   "bing:nl_BE",
+   "bing:nl-BE",
    "ref"
   ],
   "bing images":[
-   "bing:nl_BE",
+   "bing:nl-BE",
    "ref"
   ],
   "bing news":[
@@ -2201,135 +2358,135 @@
    "https://www.bing.com/videos"
   ],
   "bitbucket":[
-   "bitbucket:nl_BE",
+   "bitbucket:nl-BE",
    "ref"
   ],
   "crossref":[
-   "crossref:nl_BE",
+   "crossref:nl-BE",
    "ref"
   ],
   "currency":[
-   "currency:nl_BE",
+   "currency:nl-BE",
    "ref"
   ],
   "deezer":[
-   "deezer:nl_BE",
+   "deezer:nl-BE",
    "ref"
   ],
   "deviantart":[
-   "deviantart:nl_BE",
+   "deviantart:nl-BE",
    "ref"
   ],
   "ddg definitions":[
-   "currency:nl_BE",
-   "ref"
-  ],
-  "digg":[
-   "digg:nl_BE",
+   "currency:nl-BE",
    "ref"
   ],
   "wikidata":[
-   "wikidata:nl_BE",
+   "wikidata:nl-BE",
    "ref"
   ],
   "duckduckgo":[
-   "currency:nl_BE",
+   "currency:nl-BE",
    "ref"
   ],
   "duckduckgo images":[
-   "currency:nl_BE",
+   "currency:nl-BE",
    "ref"
   ],
   "flickr":[
-   "flickr:nl_BE",
+   "flickr:nl-BE",
    "ref"
   ],
   "free software directory":[
-   "free software directory:nl_BE",
+   "free software directory:nl-BE",
    "ref"
   ],
   "genius":[
-   "genius:nl_BE",
+   "genius:nl-BE",
    "ref"
   ],
   "gitlab":[
-   "gitlab:nl_BE",
+   "gitlab:nl-BE",
    "ref"
   ],
   "github":[
-   "github:nl_BE",
+   "github:nl-BE",
    "ref"
   ],
   "google":[
-   "google:nl_BE",
+   "google:nl-BE",
    "ref"
   ],
   "google images":[
-   "google images:nl_BE",
+   "google images:nl-BE",
    "ref"
   ],
   "google news":[
-   "google news:nl_BE",
+   "google news:nl-BE",
    "ref"
   ],
   "google videos":[
-   "google videos:nl_BE",
+   "google videos:nl-BE",
    "ref"
   ],
   "google scholar":[
-   "google scholar:nl_BE",
+   "google scholar:nl-BE",
    "ref"
   ],
   "google play apps":[
-   "google play apps:nl_BE",
+   "google play apps:nl-BE",
    "ref"
   ],
   "google play movies":[
-   "google play apps:nl_BE",
+   "google play apps:nl-BE",
    "ref"
   ],
   "hoogle":[
-   "hoogle:nl_BE",
+   "hoogle:nl-BE",
+   "ref"
+  ],
+  "imdb":[
+   "imdb:nl-BE",
    "ref"
   ],
   "kickass":[
-   "kickass:nl_BE",
+   "kickass:nl-BE",
    "ref"
   ],
   "library genesis":[
-   "library genesis:nl_BE",
+   "library genesis:nl-BE",
    "ref"
   ],
   "library of congress":[
-   "library of congress:nl_BE",
+   "library of congress:nl-BE",
    "ref"
   ],
   "mixcloud":[
-   "mixcloud:nl_BE",
+   "mixcloud:nl-BE",
    "ref"
   ],
   "npm":[
-   "npm:nl_BE",
+   "npm:nl-BE",
    "ref"
   ],
   "openairedatasets":[
-   "openairedatasets:nl_BE",
+   "openairedatasets:nl-BE",
    "ref"
   ],
   "openairepublications":[
-   "openairedatasets:nl_BE",
+   "openairedatasets:nl-BE",
    "ref"
   ],
   "openstreetmap":[
-   "openstreetmap:nl_BE",
+   "openstreetmap:nl-BE",
    "ref"
   ],
   "piratebay":[
-   "piratebay:nl_BE",
+   "piratebay:nl-BE",
    "ref"
   ],
   "qwant":[
-   "Qwant is een zoekmachine die uw privacy respecteert, ontdekken en delen via een sociale benadering vergemakelijkt",
+   "Qwant is een zoekmachine die uw privacy respecteert en neutraliteit en onpartijdigheid garandeert.",
    "https://www.qwant.com/"
   ],
   "qwant news":[
@@ -2345,67 +2502,75 @@
    "ref"
   ],
   "reddit":[
-   "reddit:nl_BE",
+   "reddit:nl-BE",
    "ref"
   ],
   "soundcloud":[
-   "soundcloud:nl_BE",
+   "soundcloud:nl-BE",
    "ref"
   ],
   "stackoverflow":[
-   "stackoverflow:nl_BE",
+   "stackoverflow:nl-BE",
+   "ref"
+  ],
+  "askubuntu":[
+   "stackoverflow:nl-BE",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:nl-BE",
    "ref"
   ],
   "startpage":[
-   "startpage:nl_BE",
+   "startpage:nl-BE",
    "ref"
   ],
   "youtube":[
-   "youtube:nl_BE",
+   "youtube:nl-BE",
    "ref"
   ],
   "dailymotion":[
-   "dailymotion:nl_BE",
+   "dailymotion:nl-BE",
    "ref"
   ],
   "vimeo":[
-   "vimeo:nl_BE",
+   "vimeo:nl-BE",
    "ref"
   ],
   "wikibooks":[
-   "wikibooks:nl_BE",
+   "wikibooks:nl-BE",
    "ref"
   ],
   "wikinews":[
-   "wikinews:nl_BE",
+   "wikinews:nl-BE",
    "ref"
   ],
   "wikiquote":[
-   "wikiquote:nl_BE",
+   "wikiquote:nl-BE",
    "ref"
   ],
   "wikisource":[
-   "wikisource:nl_BE",
+   "wikisource:nl-BE",
    "ref"
   ],
   "wiktionary":[
-   "wiktionary:nl_BE",
+   "wiktionary:nl-BE",
    "ref"
   ],
   "wikiversity":[
-   "wikiversity:nl_BE",
+   "wikiversity:nl-BE",
    "ref"
   ],
   "wikivoyage":[
-   "wikivoyage:nl_BE",
+   "wikivoyage:nl-BE",
    "ref"
   ],
   "wolframalpha":[
-   "wolframalpha:nl_BE",
+   "wolframalpha:nl-BE",
    "ref"
   ],
   "seznam":[
-   "seznam:nl_BE",
+   "seznam:nl-BE",
    "ref"
   ],
   "rubygems":[
@@ -2441,7 +2606,6 @@
    "currency:pl",
    "ref"
   ],
-  "digg":"Digg – serwis internetowy tworzony przez swoich użytkowników, a zajmujący się gromadzeniem i ocenianiem linków do potencjalnie interesujących treści w internecie. Serwis Digg bywa przedstawiany jako sztandarowy przykład serwisu z nurtu Web 2.0.",
   "erowid":"Erowid – założona w październiku 1995 organizacja, zajmująca się prowadzeniem anglojęzycznego internetowego serwisu informacyjnego na tematy dotyczące roślin i substancji psychoaktywnych Erowid.org. Serwis zawiera jedną z najobszerniejszych dostępnych baz danych na ten temat, codziennie notując średnio 55 tys. odwiedzin.",
   "wikidata":"Wikidane – projekt internetowy mający na celu stworzenie wolnej, otwartej, wielojęzycznej bazy różnorodnych danych. Głównym zastosowaniem tej bazy danych jest używanie jej w projektach Wikimedia Foundation, przede wszystkim w Wikipedii.",
   "duckduckgo":[
@@ -2459,7 +2623,7 @@
   "genius":"Genius – amerykańskie przedsiębiorstwo zajmujące się mediami cyfrowymi, założone w sierpniu 2009 roku przez Toma Lehmana, Ilana Zechory’ego i Mahboda Moghadama. Witryna umożliwia użytkownikom dostarczanie adnotacji i interpretacji tekstów piosenek, wiadomości o muzykach i informacji dotyczących utworów. Pierwotnie funkcjonowała pod nazwą Rap Genius.",
   "gentoo":"Genkernel – narzędzie służące do zbudowania jądra systemowego używającego standardowej konfiguracji lub jej modyfikacji.",
   "gitlab":"GitLab – hostingowy serwis internetowy przeznaczony dla projektów programistycznych oparty o system kontroli wersji Git oraz otwartoźródłowe oprogramowanie, stworzone przez Dmitrija Zaporozhets, których obecnie właścicielem jest GitLab Inc. Serwis umożliwia bezpłatne wykorzystanie usługi lub zainstalowanie samodzielnie zarządzanego oprogramowania wraz z opcjonalnymi, płatnymi planami. Usługa jest jedną z najpopularniejszych tego typu na rynku, z której korzystają takie firmy, jak IBM, Sony, NASA, Oracle, GNOME Foundation, NVIDIA, czy SpaceX.",
-  "github":"GitHub – hostingowy serwis internetowy przeznaczony dla projektów programistycznych wykorzystujących system kontroli wersji Git. Stworzony został przy wykorzystaniu frameworka Ruby on Rails i języka Erlang. Serwis działa od kwietnia 2008 roku. GitHub udostępnia darmowy hosting programów open source i prywatnych repozytoriów. W czerwcu 2018 ogłoszono, iż serwis zostanie przejęty przez przedsiębiorstwo Microsoft za kwotę 7,5 miliarda dolarów.",
+  "github":"GitHub – hostingowy serwis internetowy przeznaczony do projektów programistycznych wykorzystujących system kontroli wersji Git. Stworzony został przy wykorzystaniu frameworka Ruby on Rails i języka Erlang. Serwis działa od kwietnia 2008 roku. GitHub udostępnia darmowy hosting programów open source i prywatnych repozytoriów. W czerwcu 2018 ogłoszono, iż serwis zostanie przejęty przez przedsiębiorstwo Microsoft za kwotę 7,5 miliarda dolarów.",
   "google":"Wyszukiwarka Google – wyszukiwarka internetowa stworzona przez amerykańską spółkę Google LLC. Jej celem jest skatalogowanie wszystkich możliwych informacji i udostępnienie ich za pomocą Internetu.",
   "google images":"Grafika Google, ang. Google Images – wyszukiwarka internetowa grafiki została uruchomiona w lipcu 2001 roku pod angielską nazwą Google Image Search. Od 9 listopada 2002 dostępna jest w polskiej wersji językowej. Za jej pomocą użytkownicy mogą przeszukiwać pliki graficzne znajdujące się na stronach internetowych. Specjalna wersja Googlebota odnajduje zdjęcia i obrazy, kategoryzuje je pod specyficzne słowa i wysyła miniaturki zdjęć na serwery Google. Stamtąd są one wyświetlane jako wyniki wyszukiwania, razem z linkami do pełnych wersji znalezionych zdjęć i stron internetowych, na których zostały znalezione. W przypisywaniu zdjęciom słów kluczowych pomaga usługa Google Image Labeler – gra polegająca na jak najszybszym otagowaniu wyświetlanych zdjęć.",
   "google news":"Wiadomości Google, ang. Google News – internetowy agregator wiadomości z serwisów informacyjnych. Został uruchomiony w wersji beta we wrześniu 2002, z której wyszedł 23 stycznia 2006.",
@@ -2471,11 +2635,12 @@
    "ref"
   ],
   "hoogle":"Haskell – czysto funkcyjny język programowania nazwany na cześć Haskella Curry'ego.",
+  "imdb":"IMDb – największa na świecie internetowa baza danych na temat filmów i ludzi z nimi związanych. Zawiera informacje o aktorach, reżyserach, scenarzystach, producentach, montażystach, operatorach, muzykach itd. Informacje nie ograniczają się do kinematografii amerykańskiej.",
   "library of congress":"Biblioteka Kongresu – biblioteka, która powstała w 1800 roku w Waszyngtonie. W 2019 roku posiadała w swoich zbiorach ponad 170 mln woluminów w ponad 470 językach. Zbiór książek i dokumentów związanych z Polską należy do jednych z największych nie tylko w USA, ale również na świecie. Pełni funkcję biblioteki narodowej. Zapewnia publiczny dostęp do zbiorów, chociaż jej głównym zadaniem jest służba Kongresowi. We wrześniu 2019 Biblioteka Kongresu zatrudniała 3210 stałych pracowników.",
   "mixcloud":"MixCloud – społeczność internetowa dla artystów tworzących i dystrybuujących audycje radiowe, mikstejpy i podkasty.",
   "npm":"npm – domyślny manager pakietów dla środowiska Node.js, może być także używany do zarządzania warstwą front-end aplikacji WWW. NPM to także repozytorium pakietów oraz nazwa firmy która nim zarządza. Istnieją także inne managery pakietów, które korzystają z repozytorium npm, np. Yarn.",
   "openstreetmap":"OpenStreetMap (OSM) – projekt społeczności internetowej mający na celu stworzenie darmowej, swobodnie dostępnej mapy całej kuli ziemskiej. Jest ona edytowalna przez zarejestrowanych użytkowników. Stworzenie i rozwój OSM było motywowane ograniczeniami w dostępności i wykorzystywaniu map oraz pojawieniem się niedrogich przenośnych urządzeń do nawigacji satelitarnej.",
-  "piratebay":"The Pirate Bay (TPB) – strona internetowa będąca wyszukiwarką plików w sieci peer-to-peer, korzystającą z protokołu BitTorrenta oraz magnet link. Strona została założona w 2003 roku przez Gottfrida Svartholma, Fredrika Neij i Petera Sunde'a. TPB nie hostuje żadnych plików – również tych, których rozpowszechnianie może naruszać prawo autorskie, a udostępnia jedynie odnośniki do danych zasobów, w postaci Magnet linków.",
+  "piratebay":"The Pirate Bay (TPB) – strona internetowa, będąca wyszukiwarką plików w sieci peer-to-peer korzystająca z protokołu BitTorrenta oraz magnet link. Strona została założona w 2003 roku przez Gottfrida Svartholma, Fredrika Neij i Petera Sunde'a. TPB nie hostuje żadnych plików – również tych, których rozpowszechnianie może naruszać prawo autorskie, a udostępnia jedynie odnośniki do danych zasobów, w postaci Magnet linków.",
   "qwant":"Qwant – francuska wyszukiwarka internetowa z siedzibą w Paryżu, utworzona w lipcu 2013 roku. Wyszukiwarka skupia się na prywatności swoich użytkowników, a tym samym nie stosuje śledzenia oraz personalizacji wyników osób z niej korzystających, aby uniknąć tak zwanej bańki filtrującej.",
   "qwant news":[
    "qwant:pl",
@@ -2491,8 +2656,17 @@
   ],
   "reddit":"Reddit – serwis internetowy przedstawiający linki do różnorodnych informacji, które ukazały się w Internecie. Serwis jest głównie anglojęzyczny, chociaż jego interfejs został przetłumaczony na wiele języków.",
   "soundcloud":"SoundCloud – społeczność internetowa dla artystów tworzących muzykę uruchomiona w 2007 roku. Portal ma na celu możliwość prezentacji własnych utworów przez artystów oraz umożliwia dyskusję na ich temat. Ponadto użytkownicy mogą szukać utworów według gatunków muzycznych, dzięki czemu mogą znaleźć interesującą ich muzykę.",
-  "stackoverflow":"Stack Overflow – serwis społecznościowy, na którym programiści mogą zadawać pytania dotyczące szeroko pojętego wytwarzania oprogramowania. Serwis został stworzony przez Jeffa Atwooda oraz Joela Spolsky'ego w 2008 roku jako bardziej wiarygodna alternatywa dla serwisu Experts Exchange. Nazwę wybrali czytelnicy Coding Horror w ramach demokratycznego głosowania. Jest on częścią Stack Exchange Network.",
+  "stackoverflow":"Stack Exchange Network – sieć darmowych w użytkowaniu stron internetowych, na których zadawać można pytania i odpowiadać w wielu różnych dziedzinach. Każda strona poświęcona jest konkretnemu tematowi, a pytania i odpowiedzi użytkowników są przedmiotem przyznawania reputacji. Strony internetowe są wzorowane na StackOverflow, forum dla programistów, który był pierwszą stroną w sieci. System reputacji jest zaprojektowany tak, by każda strona internetowa posiadała własną moderację.",
+  "askubuntu":[
+   "stackoverflow:pl",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:pl",
+   "ref"
+  ],
   "startpage":"Startpage to holenderska wyszukiwarka internetowa, nastawiona na prywatność. Strona umożliwia uzyskiwanie wyników wyszukiwania Google, jednocześnie chroniąc prywatność użytkowników, nie przechowując danych osobowych ani danych wyszukiwania i usuwając wszystkie skrypty śledzące. Startpage.com posiada również funkcję \"Anonymous View\", która umożliwia użytkownikom otwieranie wyników wyszukiwania za pośrednictwem serwera proxy w celu zwiększenia anonimowości. Ponieważ firma ma siedzibę w Holandii, jest chroniona przez holenderskie i unijne przepisy dotyczące prywatności, a zatem nie podlega programom nadzoru prowadzonym przez Stany Zjednoczone, takim jak PRISM.",
+  "unsplash":"Unsplash – społecznościowa platforma internetowa przeznaczona do udostępniania fotografii.",
   "youtube":"YouTube – serwis internetowy założony w lutym 2005 roku, który umożliwia bezpłatne umieszczanie, nadawanie na żywo, ocenianie i komentowanie filmów. Prezesem od 2014 roku jest Susan Wojcicki.",
   "dailymotion":"Dailymotion – serwis internetowy umożliwiający prezentację filmów, wideoklipów lub własnych mini produkcji w internecie, reklamujący się hasłem Regarder, publier, partager, założony w Paryżu we Francji, jako odpowiedź na serwis YouTube. Domena dailymotion.com została zarejestrowana miesiąc po YouTube. Dailymotion jest dostępny w 18 różnych językach i 35 zlokalizowanych wersjach.",
   "vimeo":"Vimeo – serwis internetowy umożliwiający oglądanie i udostępnianie plików filmowych przez użytkowników. Strona została założona w listopadzie 2004 przez Zacha Kleina oraz Jakoba Lodwicka, który również wymyślił nazwę, która stanowi grę słów opartą na wyrazach video i me, jako odniesienie do faktu udostępniania plików stworzonych wyłącznie przez użytkowników. Serwis został kupiony przez InterActiveCorp w sierpniu 2006 roku.",
@@ -2538,7 +2712,6 @@
    "currency:pt",
    "ref"
   ],
-  "digg":"Digg é um site norte-americano que reúne links para notícias, podcasts e videos enviados pelos próprios usuários e avaliados por eles. Combina social bookmarks, blog e feed. É muito popular de forma que as notícias mais aclamadas pela comunidade chegam a alcançar mais de 1000 votos (diggs). Faz parte da rede de sites pertencentes a Web 2.0.",
   "erowid":"Erowid, também chamado de Erowid Center, é uma organização educacional sem fins lucrativos que fornece informações sobre plantas e produtos químicos psicoativos. Também fornece informações sobre atividades e tecnologias que podem produzir estados alterados de consciência, como meditação, sonhos lúcidos, estimulação magnética, estimulação magnética transcraniana e neuroestimulação.",
   "wikidata":"O Wikidata é um projeto que visa fornecer uma base de dados editada colaborativamente para oferecer suporte para projetos tais como a Wikipédia. O Wikidata foi lançado em 30 de outubro de 2012. O projeto foi iniciado pela Wikimedia Deutschland e pretender fornecer uma origem comum de certos tipos de dados, como por exemplo, datas de nascimento, uma classe de dados validados, que possa ser utilizada pelos projetos da Wikimedia operando de forma similar ao funcionamento do Wikimedia Commons para imagens e outros tipos de mídia. Este foi o primeiro novo projeto da Wikimedia Foundation desde 2006.",
   "duckduckgo":[
@@ -2549,17 +2722,14 @@
    "currency:pt",
    "ref"
   ],
-  "fdroid":[
-   "F-Droid é um catálogo instalável de softwares de código livre e aberto (FOSS) para a plataforma Android. O aplicativo facilita a busca e a instalação, além ficar de olho nas atualizações no seu dispositivo.",
-   "https://f-droid.org/"
-  ],
+  "fdroid":"F-Droid é um loja de software para Android, tem uma função similar à da Google Play. O repositório principal, hospedado pelo projeto, contém apenas aplicativos gratuitos e de código aberto. Os aplicativos podem ser navegados, baixados e instalados a partir do site ou do F-Droid sem a necessidade de registro. As \"anti-features\" tais como publicidade, rastreamento de usuários ou dependência de software não livre são sinalizados nas descrições dos aplicativos.",
   "flickr":"O Flickr é um site da web de hospedagem e partilha de imagens como fotografias, desenhos e ilustrações, além de permitir novas maneiras de organizar as fotos e vídeos. Caracterizado como rede social, o site permite aos usuários criar álbuns para armazenar suas fotografias e contatar-se com usuários de diferentes locais do mundo. No início de 2005 o site foi adquirido pela Yahoo! Inc.",
-  "genius":"Genius é uma empresa estadunidense de mídia digital originalmente fundada em agosto de 2009 por Tom Lehman, Ilan Zechory e Mahbod Moghadam, o site permite que os usuários forneçam anotações e interpretações de letras de músicas, explicações de notícias, fontes, poesia e documentos.",
+  "genius":"Genius é uma empresa estadunidense de mídia digital originalmente fundada em agosto de 2009 por Tom Lehman, Ilan Zechory e Mahbod Moghadam. O site permite que os usuários forneçam anotações e interpretações de letras de músicas, explicações de notícias, fontes, poesia e documentos.",
   "gigablast":"Gigablast é um pequeno e independente motor de busca localizado em Novo México, Estados Unidos. Foi fundado em 2000 por Matt Wells, funcionário da Infoseek. Seu código-fonte foi lançado sobre licença Apache em 2013. Foi comprado pela empresa Yippy Inc. no mesmo ano.",
   "gentoo":"Genkernel é uma ferramenta para construir o módulo central do Gentoo Linux. O Genkernel compila o núcleo com todos os drivers disponíveis compilados como módulos, copiando-os para a memória RAM sendo depois copiada para o núcleo no momendo da inicialização do sistema, fornecendo detecção automática de hardware. Esta ferramenta permite utilizadores com menos experiência configurar o núcleo Linux.",
   "gitlab":"O GitLab é um gerenciador de repositório de software baseado em git, com suporte a Wiki, gerenciamento de tarefas e CI/CD. GitLab é similar ao GitHub, mas o GitLab permite que os desenvolvedores armazenem o código em seus próprios servidores, ao invés de servidores de terceiros. Ele é software livre, distribuído pela Licença MIT. Está disponível como um pacote Omnibus, assim como um instalador simplificado provido pela Bitnami e pela Digital Ocean.",
   "github":"GitHub é uma plataforma de hospedagem de código-fonte e arquivos com controle de versão usando o Git. Ele permite que programadores, utilitários ou qualquer usuário cadastrado na plataforma contribuam em projetos privados e/ou Open Source de qualquer lugar do mundo. GitHub é amplamente utilizado por programadores para divulgação de seus trabalhos ou para que outros programadores contribuam com o projeto, além de promover fácil comunicação através de recursos que relatam problemas ou mesclam repositórios remotos.",
-  "google":"O Google Busca é um serviço da empresa Google onde é possível fazer pesquisas na internet sobre qualquer tipo de assunto ou conteúdo. É atualmente o serviço de busca mais usado e também o primeiro serviço lançado pela Google Inc.",
+  "google":"O Google Busca é um serviço da empresa Google onde é possível fazer pesquisas na internet sobre qualquer tipo de assunto ou conteúdo. É atualmente o serviço de busca mais usado e também o primeiro serviço lançado pela Google LLC.",
   "google images":"O Google Imagens é um serviço de pesquisa de propriedade do Google que permite aos usuários pesquisar por conteúdo de imagem na World Wide Web. Foi introduzido em 12 de julho de 2001 devido a uma demanda por fotos do vestido verde Versace de Jennifer Lopez que a pesquisa regular do Google não conseguiu lidar. Em 2011, foi adicionada a funcionalidade de pesquisa reversa de imagens.",
   "google news":"Google Notícias é um agregador de notícias e aplicativo desenvolvido pela Google. Ele apresenta um fluxo contínuo e personalizável de artigos organizados a partir de milhares de editores e revistas. O Google Notícias está disponível no Android, no iOS e na Web.",
   "google videos":"O Google Videos foi uma página web de vídeos que permitia encontrar quaisquer vídeos alojados, não somente no Google Video, mas também no YouTube e outros websites de vídeos, até de concorrentes, como o Yahoo! Vídeos.",
@@ -2570,9 +2740,11 @@
    "ref"
   ],
   "hoogle":"Haskell é uma linguagem de programação puramente funcional, de propósito geral, nomeada em homenagem ao lógico Haskell Curry. Como uma linguagem funcional, a estrutura de controle primária é a função; a linguagem é baseada nas observações de Haskell Curry e seus descendentes intelectuais. Seu último padrão semi-oficial é o Haskell 98, destinado a especificar uma versão mínima e portável da linguagem para o ensino e como base para futuras extensões.",
+  "imdb":"IMDb, também conhecida como Internet Movie Database, é uma base de dados online de informação sobre cinema TV, música e games, hoje pertencente à Amazon.",
   "ina":"Institut national de l'audiovisuel (Ina) é uma instituição pública francesa, de caráter industrial e comercial, encarregada principalmente do arquivamento de produções audiovisuais. Também é responsável pela produção, edição, cessão de conteúdos audiovisuais e multimídia destinados a todos os públicos, profissionais ou particulares. O Ina é também um centro de formação e pesquisa que visa desenvolver e transmitir conhecimento nas áreas ligadas à produção audiovisual. É associado à Federação Internacional da Indústria Fonográfica - IFPI.Notas e referências",
   "kickass":"O KickassTorrents é um site fundado em 2008 que fornece arquivos de torrent e links magnéticos para facilitar a partilha de ficheiros peer-to-peer usando o protocolo BitTorrent. Em novembro de 2014, o KAT tornou-se o site torrent mais visitado no mundo, ultrapassando o The Pirate Bay, segundo o ranking Alexa.",
   "library genesis":"Library Genesis ou LibGen é um motor de busca de artigos científicos e livros que permite o acesso livre a conteúdos que só seriam acessíveis através de pagamentos e, também, a conteúdos que não são facilmente encontrados em formato digital. Entre outros, esse site carrega conteúdos dos portais de informação da Elsevier e ScienceDirect. LibGen é um site de biblioteca de compartilhamento de arquivos não apenas para artigos de periódicos acadêmicos, mas também para livros de interesse geral, imagens, quadrinhos, audiolivros e revistas.",
+  "z-library":"Z-Library é uma shadow-library e um projeto de compartilhamento de arquivos para artigos de jornais acadêmicos, livros acadêmicos e livros de interesse geral. A Z-Library diz que o projeto fornece acesso a mais de 6.754.720 livros e 80.759.561 artigos. A Z-Library também afirma ser \"A maior biblioteca de e-books do mundo\" na página do projeto para livros digitais, bem como \"A maior loja de artigos científicos do mundo\" na página equivalente do projeto para artigos acadêmicos (booksc.org).",
   "library of congress":"A Biblioteca do Congresso é a biblioteca de pesquisa do Congresso dos Estados Unidos, sendo de facto a biblioteca nacional dos Estados Unidos e a instituição cultural mais antiga daquele país.",
   "microsoft academic":"O Microsoft Academic é um mecanismo de pesquisa público gratuito para publicações e literatura acadêmica, desenvolvido pela Microsoft Research. Relançada em 2016, a ferramenta apresenta uma estrutura de dados e mecanismo de pesquisa totalmente novos usando tecnologias de pesquisa semântica. Atualmente indexa mais de 220 milhões de publicações, 88 milhões das quais são artigos de periódicos. A API de conhecimento acadêmico oferece recuperação de informações do banco de dados subjacente usando terminais REST para fins de pesquisa avançada.",
   "npm":"npm é um gerenciador de pacotes para o Node.JS",
@@ -2597,9 +2769,8 @@
    "qwant:pt",
    "ref"
   ],
-  "reddit":"O Reddit é uma agregador social de notícias ou um social bookmarks. O Reddit é dividido em várias comunidades chamadas de \"subreddits\". São nesses subreddits que reside o conteúdo do site. Há subreddits sobre política americana ou internacional, notícias, religião, ciência, filmes, livros, jogos eletrônicos, entre outros tópicos. Os usuários podem divulgar conteúdo da Internet como links, postagens, imagens e vídeos, e os usuários votam de forma positiva ou negativa nos conteúdos divulgados. Caso o conteúdo enviado para a comunidade receba muitos votos positivos, esse conteúdo fica no topo da página inicial do subreddit, podendo chegar na página inicial do próprio Reddit.",
+  "reddit":"O Reddit é uma agregador social de notícias ou um social bookmarks. O Reddit é dividido em várias comunidades chamadas de \"subreddits\". São nesses subreddits que reside o conteúdo do site. Há subreddits sobre política americana ou internacional, notícias, religião, ciência, filmes, livros, jogos eletrônicos, entre outros diferentes tópicos. Os usuários podem divulgar conteúdo da Internet como links, postagens, imagens e vídeos, e os usuários votam de forma positiva ou negativa nos conteúdos divulgados. Caso o conteúdo enviado para a comunidade receba muitos votos positivos, esse conteúdo fica no topo da página inicial do subreddit, podendo chegar na página inicial do próprio Reddit.",
   "soundcloud":"SoundCloud é uma plataforma online de publicação de áudio utilizada por profissionais de música sediada em Berlim, Alemanha, fundada por Alexander Ljung e Eric Wahlforss em Agosto de 2007. Nela os músicos podem colaborar, compartilhar, promover e distribuir suas composições.",
-  "stackoverflow":"Stack Overflow é um site de perguntas e respostas para profissionais e entusiastas na área de programação de computadores.",
   "semantic scholar":"Semantic Scholar é um mecanismo de busca de publicações acadêmicas por inteligência artificial desenvolvido pelo Allen Institute for Artificial Intelligence e lançado publicamente em novembro de 2015. Ele usa avanços recentes no processamento de linguagem natural para fornecer resumos de artigos acadêmicos.Referências",
   "startpage":"Startpage.com é um motor de busca baseado em Nova York e na Holanda. Fundado por David Bodnick em 1998, Startpage.com pertence a uma empresa holandesa, Surfboard Holding BV, que adquiriu a mesma no ano 2000.",
   "youtube":"YouTube é uma plataforma de compartilhamento de vídeos com sede em San Bruno, Califórnia. O serviço foi criado por três ex-funcionários do PayPal - Chad Hurley, Steve Chen e Jawed Karim - em fevereiro de 2005. A Google comprou o site em novembro de 2006 por US$ 1,65 bilhão; desde então o YouTube funciona como uma das subsidiárias da Google.",
@@ -2619,7 +2790,7 @@
   "peertube":"PeerTube é uma plataforma de vídeo livre, descentralizada e federada operada por ActivityPub e WebTorrent que usa tecnologia peer-to-peer para reduzir o estresse em servidores individuais ao assistir vídeos.",
   "rumble":"Rumble é uma plataforma de compartilhamento de vídeo canadense com sede em Toronto. O serviço foi fundado em 2013 por Chris Pavlovski, um empresário de tecnologia do Canadá. A contagem mensal de usuários do Rumble experimentou um rápido crescimento desde julho de 2020, houve um salto de 1,6 milhões de usuários mensais para 31,9 milhões no final do primeiro trimestre de 2021."
  },
- "pt_BR":{
+ "pt-BR":{
   "archive is":[
    "archive is:pt",
    "ref"
@@ -2680,10 +2851,6 @@
    "currency:pt",
    "ref"
   ],
-  "digg":[
-   "digg:pt",
-   "ref"
-  ],
   "erowid":[
    "erowid:pt",
    "ref"
@@ -2698,6 +2865,10 @@
   ],
   "duckduckgo images":[
    "currency:pt",
+   "ref"
+  ],
+  "fdroid":[
+   "fdroid:pt",
    "ref"
   ],
   "flickr":[
@@ -2756,6 +2927,10 @@
    "hoogle:pt",
    "ref"
   ],
+  "imdb":[
+   "imdb:pt",
+   "ref"
+  ],
   "ina":[
    "ina:pt",
    "ref"
@@ -2766,6 +2941,10 @@
   ],
   "library genesis":[
    "library genesis:pt",
+   "ref"
+  ],
+  "z-library":[
+   "z-library:pt",
    "ref"
   ],
   "library of congress":[
@@ -2818,10 +2997,6 @@
   ],
   "soundcloud":[
    "soundcloud:pt",
-   "ref"
-  ],
-  "stackoverflow":[
-   "stackoverflow:pt",
    "ref"
   ],
   "semantic scholar":[
@@ -2945,15 +3120,15 @@
    "ref"
   ],
   "hoogle":"Haskell este un limbaj de programare funcțională. Poartă numele lui Curry Haskell.",
+  "imdb":"Internet Movie Database (IMDb) este o bază de date pe internet, cu informații despre filme, cineaști și jocuri video, cu pagini detaliate și structurate despre fiecare.",
   "kickass":"KickassTorrents a fost un website de indexare a fișierelor torrent (BitTorrent) și magnet. A fost fondat în 2008, iar din noiembrie 2014 era cel mai vizitat website de indexare a fișierelor torrent din lume, conform Alexa.",
-  "library of congress":"Biblioteca Congresului Statelor Unite ale Americii, conform originalului, The Library of Congress of the United States of America, cunoscută sub forma prescurtată adesea folosită de The Library of Congress, sau doar Library of Congress, este biblioteca publică cea mai mare și importantă a Uniunii, fiind de fapt biblioteca națională a Statelor Unite ale Americii.",
+  "library of congress":"Biblioteca Congresului Statelor Unite ale Americii este biblioteca publică cea mai mare și importantă, fiind de fapt biblioteca națională a Statelor Unite ale Americii.",
   "openstreetmap":"OpenStreetMap este un proiect colectiv, în regim open source, ce are ca scop construirea unei baze de date geografice globale cum ar fi atlasele rutiere, folosind atât date introduse manual având ca fundal imagini spațiale, cât și date colectate de pe dispozitive GPS.",
   "piratebay":"The Pirate Bay este un website suedez de indexare a fișierelor torrent (BitTorrent) și magnet. Site-ul a fost creat în 2003 de către Gottfrid Svartholm, Fredrik Neij și Peter Sunde. Site-ul Pirate Bay apare în acte ca fiind în Seychelles și este o țintă a autorităților americane din 2011. Biroul de Comerț al Statelor Unite l-a desemnat ca fiind printre site-urile cele mai populare pentru descărcatul ilegal al fișierelor. Deoarece site-ul nu folosește serverele sale pentru a stoca filme și muzică piratată, Pirate Bay a supraviețuit la numeroase încercări de a fi oprit. Site-ul folosește o aplicație externă pentru ca utilizatorii să încarce și să descarce filme, fiind o procedură mai complicată la încărcare.",
   "reddit":"Reddit este un site web de divertisment, rețea de socializare și agregator de știri, unde membrii înregistrați ai comunității pot plasa conținut, cum ar fi postări textuale sau legături directe. Utilizatorii înregistrați pot vota postările. Postările sunt organizate după domeniul de interes, în așa-numitele subreddit-uri. Subreddit-urile au tematici diverse, cum ar fi știri, jocuri, filme, muzică, cărți, fitness, alimente și partajarea imaginilor. Trimiterile cu mai multe voturi în sus apar în partea de sus a subreditului lor și, dacă primesc suficiente voturi, în cele din urmă apar pe prima pagină a site-ului. În ciuda unor reguli stricte care interzic hărțuirea, administratorii Reddit-ului cheltuiesc resurse considerabile pentru moderarea site-ului.",
   "soundcloud":"SoundCloud este o platformă de distribuire audio online unde utilizatorii pot colabora, promova și distribui proiecte muzicale originale. În luna iulie a anului 2013, pe acest site erau înregistrați circa 40 de milioane de utilizatori 200 de milioane de ascultători. Sediul central se află în Berlin, Germania.",
-  "stackoverflow":"Stack Overflow este un site web de întrebări și răspunsuri din domeniul programării. Site-ul a fost creat în 2008 de către Jeff Atwood și Joel Spolsky, și face parte din rețeaua Stack Exchange Network,. Numele site-ului a fost ales prin vot în aprilie 2008 de către cititorii Coding Horror, un popular blog de programare a lui Atwood.",
   "youtube":"YouTube este un Site Web unde utilizatorii pot încărca și viziona materiale audio-video. YouTube a fost creat în februarie 2005 de Chad Hurley, Steve Chen și Jawed Karim. Serviciul cu sediul în San Bruno, California, folosește tehnologia Adobe Flash Player pentru a expune o gamă largă de clipuri video create chiar de utilizatori, incluzând și fragmente din programe de televiziune sau din filme. YouTube face parte din fenomenul recent numit Web 2.0.",
-  "dailymotion":"Dailymotion este un site web unde utilizatorii pot încărca și vizualiza videoclipuri. Site-ul a fost înființat în 2005 de către doi francezi, Benjamin Bejbaum și Olivier Poitrey. Principalul concurent al saitului este YouTube. În anul 2010, site-ul al avut o cifră de afaceri de 18 milioane de euro comparativ cu cele 300 de milioane de euro înregistrate de YouTube.",
+  "dailymotion":"Dailymotion este un site web unde utilizatorii pot încărca și vizualiza videoclipuri. Site-ul a fost înființat în 2005 de către doi francezi, Benjamin Bejbaum și Olivier Poitrey. Principalul concurent al site-ului este YouTube. În anul 2010, site-ul al avut o cifră de afaceri de 18 milioane de euro comparativ cu cele 300 de milioane de euro înregistrate de YouTube.",
   "vimeo":"Vimeo este un site web ce oferă servicii de video hosting, unde utilizatorii pot încărca, distribui și viziona clipuri video. El a fost fondat de Jake Lodwick și Zach Klein în noiembrie 2004. Ei au părăsit compania în 2007 și 2008 respectiv. Denumirea Vimeo a fost creată de Lodwick și este un joc de cuvinte între video, inserând cuvântul \"me\", ca referință la faptul că site-ul e dedicat clipurilor video realizate de utilizatori, denumirea de asemenea este o anagramă cuvântului \"movie\" (română:film).",
   "wikibooks":"Wikibooks, denumit și Wikimedia Free Textbook Project sau Wikimedia-Textbooks, este un wiki destinat creării de manuale cu conținut liber. Este un proiect al Fundației Wikimedia.",
   "wikinews":"Wikiștiri este o sursă liberă de știri. Ediția în limba română a fost lansată în 19 ianuarie 2005 și de atunci sunt aproape 1000 de articole scrise.",
@@ -2965,7 +3140,7 @@
   "wolframalpha":"Wolfram Alpha este un motor de căutare computațional dezvoltat de Wolfram Research. Acest serviciu online oferă răspunsuri la întrebări factuale și nu o listă de link-uri așa cum oferă motoarele de căutare obișnuite."
  },
  "ru":{
-  "archive is":"archive.today — некоммерческая организация, которой принадлежит одноимённый сайт, сохраняющий интернет-страницы в режиме онлайн. Дата-центр расположен в Нор-Па-де-Кале. Сайт позиционирует себя как временная капсула, в которой хранится содержимое всемирной паутины, что отражено на логотипе archive.is. В отличие от WebCite, archive.is умеет сохранять не только статичные веб-страницы с коротким URL, но и генерируемые Веб 2.0-проектами страницы, к которым относятся, например, карты Google. Кроме того, для сохранения запрашиваемой страницы в archive.is не требуется регистрация. По запросу правообладателей archive.is может удалять архивные страницы, нарушающие исключительные права.",
+  "archive is":"archive.today — бесплатный сервис по архивированию веб-страниц, запущенный в 2012 году одноимённой некоммерческой организацией. Archive.today сохраняет содержание страниц, включая изображения, однако не поддерживает динамический контент. В отличие от портала Wayback Machine (WB) archive.today архивирует страницы по запросу пользователей и не использует поисковых роботов.",
   "artic":"Чикагский институт искусств — художественный музей и высшее учебное заведение в Чикаго, штат Иллинойс. Основные учебные специализации — архитектура и изобразительное искусство.",
   "arxiv":"arXiv.org — бесплатный электронный архив научных статей и препринтов по физике, математике, астрономии, информатике, биологии, электротехнике, статистике, финансовой математике и экономике. Перед публикацией статьи не рецензируются, однако проходят первичную проверку модераторов.",
   "bandcamp":"Bandcamp — американская частная компания, основанная в 2007 году Этаном Даймондом и Шоном Грёнбергером, бывшими сооснователями сервиса Oddpost, вместе с программистами Джо Холтом и Нилом Такером.",
@@ -2992,7 +3167,6 @@
    "currency:ru",
    "ref"
   ],
-  "digg":"Digg — новостной социальный сайт, контент которого создаётся и оценивается пользователями. Его популярность привела к созданию большого числа социальных сайтов с подобной моделью.",
   "erowid":"Erowid — некоммерческая общеобразовательная организация, зарегистрированная в Калифорнии, США, расположенная в Северной Калифорнии, собирающая и предоставляющая информацию о растениях и химических веществах, воздействующих на психику человека, а также действиях, способных вызвать изменённые состояния сознания, такие как медитации и осознанные сновидения. Деятельность организации является воплощением на практике посредством интернета стратегии «снижения вреда».",
   "wikidata":"«Викида́нные» — совместно редактируемая база знаний, созданная Фондом Викимедиа. Используется для обеспечения централизованного хранения данных, которые могут содержаться в статьях Википедии — например, интервики-ссылок, значков статусных статей и списков или статистической информации: дат рождения, численности населения и т. п. Содержимое Викиданных распространяется по лицензии Creative Commons CC0.",
   "duckduckgo":[
@@ -3003,10 +3177,10 @@
    "currency:ru",
    "ref"
   ],
-  "fdroid":"F-Droid — каталог приложений для операционной системы Android. Главный репозиторий проекта содержит только свободное программное обеспечение. Поддерживается также работа со сторонними репозиториями, которые можно добавить путём указания их URL. Приложения могут быть просмотрены и установлены таким же образом, как в Google Play: через веб-сайт или из самого приложения F-Droid, но без необходимости регистрации учётной записи. Публикуются только бесплатные версии приложений. Реклама в приложениях, за редкими исключениями отсутствует.",
+  "fdroid":"F-Droid — каталог приложений для операционной системы Android. Главный репозиторий проекта содержит только свободное программное обеспечение. Поддерживается также работа со сторонними репозиториями, которые можно добавить путём указания их URL. Приложения могут быть просмотрены и установлены таким же образом, как в Google Play: через веб-сайт или из самого приложения F-Droid, но без необходимости регистрации учётной записи. Публикуются только бесплатные версии приложений. Реклама в приложениях, за редкими исключениями, отсутствует.",
   "flickr":"Flickr — фотохостинг, предназначенный для хранения и дальнейшего использования пользователем цифровых фотографий и видеороликов. Является одним из первых сервисов Web 2.0. Один из самых популярных сайтов для размещения фотографий. По состоянию на 4 августа 2011 года сервис имел в своей базе более 6 млрд изображений, загруженных его пользователями. Также, по данным за август 2011 года, на сервисе было зарегистрировано 51 миллион человек, а общая посещаемость составляла 80 миллионов уникальных пользователей.",
   "free software directory":"Free Software Directory — каталог свободного программного обеспечения Free Software Foundation (FSF) и ЮНЕСКО.",
-  "genius":"Genius — американский сайт, основанный в августе 2009 года Томом Леман, Иланом Зекан и Махбодом Могадам, позволяющий пользователям предоставлять аннотации и интерпретации текстов песен, новости, источники, стихи, документы.",
+  "genius":"Genius — американский сайт, основанный в августе 2009 года Томом Леман, Иланом Зекан и Махбодом Могадам , позволяющий пользователям предоставлять аннотации и интерпретации текстов песен, новости, источники, стихи, документы.",
   "gitlab":"GitLab — веб-инструмент жизненного цикла DevOps с открытым исходным кодом, представляющий систему управления репозиториями кода для Git с собственной вики, системой отслеживания ошибок, CI/CD пайплайном и другими функциями.",
   "github":"GitHub — крупнейший веб-сервис для хостинга IT-проектов и их совместной разработки.",
   "google":"Google — одна из самых крупных в мире поисковых систем интернета, принадлежащая корпорации Google Inc.",
@@ -3026,12 +3200,14 @@
   ],
   "habrahabr":"Хабр — русскоязычный веб-сайт в формате системы тематических коллективных блогов с элементами новостного сайта, созданный для публикации новостей, аналитических статей, мыслей, связанных с информационными технологиями, бизнесом и интернетом. Основан Денисом Крючковым в июне 2006 года.",
   "hoogle":"Haskell — стандартизированный чистый функциональный язык программирования общего назначения. Является одним из самых распространённых языков программирования с поддержкой отложенных вычислений. Система типов — полная, сильная, статическая, с автоматическим выводом типов, основанная на системе типов Хиндли — Милнера. Поскольку язык функциональный, то основная управляющая структура — это функция.",
+  "imdb":"Internet Movie Database — крупнейшая в мире база данных и веб-сайт о кинематографе. В базе собрана информация о более чем 6,5 млн кинофильмов, телесериалов и отдельных их серий, а также о 10,4 млн персоналий, связанных с кино, — актёрах, режиссёрах, сценаристах и др.",
   "ina":[
    "Общественная организация, отвечающая за сохранение, популяризацию и трансляцию аудиовизуального наследия Франции",
    "wikidata"
   ],
   "kickass":"KickassTorrents — веб-сайт, поисковик .torrent-файлов и magnet-ссылок. Основан в 2008 году. По состоянию на июль 2016 года сайт занимал 68 место по посещаемости в мире согласно глобальному рейтингу Alexa. Один из серверов ресурса размещен в США.",
   "library genesis":"Library Genesis — веб-сайт, поисковая система и онлайн-хранилище, предоставляющее бесплатный доступ к пиратским коллекциям и защищённым авторским правом произведениям, в основном научной тематики. LibGen также называют «теневой библиотекой». Портал был создан в 2008 году, предположительно, группой российских учёных. До 2011 года коллекция LibGen росла в основном благодаря копированию других российских интернет-архивов и интеграции около полумиллиона англоязычных работ интернет-библиотеки Library.nu, закрытой в 2012 году. Начиная с 2013 года коллекция LibGen пополняется за счет интеграции созданных издателями электронных текстовых репозиториев. До 2013 года большая часть коллекции была представлена на русском и английском языках, позднее начали добавлять работы и на немецком, итальянском, испанском и французском.",
+  "z-library":"Z-library — теневая библиотека научной, технической и научно-популярной литературы, предположительно одна из крупнейших. Согласно данным, предоставленным сайтом, на февраль 2021 года коллекция портала состояла из более чем 6,5 млн книг и более 80 млн статей. Только за июнь 2020 года сайт посетили 2,84 млн человек, из которых 14,76 % составили пользователи из США.",
   "library of congress":"Библиотека Конгресса — исследовательская библиотека, которая официально обслуживает Конгресс США и является де-факто национальной библиотекой США. Это старейшее федеральное учреждение культуры в Соединённых Штатах. Библиотека расположена в трёх зданиях в районе Капитолийского холма в Вашингтоне, округ Колумбия; она также поддерживает Национальный центр аудиовизуальной консервации в Калпепер (Виргиния). Функции библиотеки контролирует библиотекарь Конгресса, а её здания обслуживает архитектор Капитолия. Библиотека Конгресса претендует на звание самой большой библиотеки в мире. Её «коллекции универсальны, не ограничены предметом, форматом или национальной границей и включают исследовательские материалы со всех частей света и на более чем 450 языках».",
   "microsoft academic":"Microsoft Academic — открытая общедоступная поисковая система для научных публикаций и литературы, разработанная Microsoft Research.",
   "mixcloud":"Mixcloud — британская онлайн-платформа для распространения звуковой информации. Платформа позволяет размещать радиошоу, диджейские миксы и подкасты.",
@@ -3055,7 +3231,15 @@
   ],
   "reddit":"Reddit — сайт, сочетающий черты социальной сети и форума, на котором зарегистрированные пользователи могут размещать ссылки на какую-либо понравившуюся информацию в интернете и обсуждать её. Как и многие другие подобные сайты, Reddit поддерживает систему голосования за понравившиеся сообщения — наиболее популярные из них оказываются на заглавной странице сайта. Один из наиболее популярных сайтов в мире — 19-е место по посещаемости по данным Alexa Internet и SimilarWeb.",
   "soundcloud":"SoundCloud — онлайн-платформа и сайт для распространения оцифрованной звуковой информации обладающая функциями социальной сети, а также одноимённая компания.",
-  "stackoverflow":"Stack Overflow — система вопросов и ответов о программировании, разработанная Джоэлем Спольски и Джеффом Этвудом в 2008 году. Является частью Stack Exchange Network. Как и в других системах подобного рода, Stack Overflow предоставляет возможность оценивать вопросы и ответы, что поднимает или понижает репутацию зарегистрированных пользователей. Проект создан на C# с использованием ASP.NET 4 и ASP.NET MVC.",
+  "stackoverflow":"Stack Exchange — сеть веб-сайтов для работы с вопросами и ответами в различных областях. Первый сайт сети, Stack Overflow, был запущен Джоэлем Спольски и Джеффом Этвудом в 2008 году, а в 2010 году ими были открыты ещё несколько разделов и была организована сеть Stack Exchange. К осени 2012 года сеть выросла до 90 разделов, с 2 миллионами пользователей, 5 миллионами вопросов и 7 миллионами ответов",
+  "askubuntu":[
+   "stackoverflow:ru",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:ru",
+   "ref"
+  ],
   "semantic scholar":"Semantic Scholar (англ. Semantic Scholar — это поисковая интернет-платформа, разработанная в Институте искусственного интеллекта Аллена. Проект был запущен в 2015 году. Поиск научных публикаций производится с поддержкой искусственного интеллекта для статей в научных журналах. Поисковый сервис комбинирует машинное обучение, обработку естественного языка и машинного зрения, чтобы добавить слой семантического анализа к традиционным методам анализа цитирования. Semantic Scholar выделяет наиболее важные статьи, а также связи между ними.",
   "startpage":"Ixquick — метапоисковая система, основанная Дэвидом Бодникином в 1998 году в Нью-Йорке и в Нидерландах. С 2000 года принадлежит нидерландской компании Surfboard Holding BV.",
   "youtube":"YouTube — видеохостинг, предоставляющий пользователям услуги хранения, доставки и показа видео. YouTube стал популярнейшим видеохостингом и вторым сайтом в мире по количеству посетителей.",
@@ -3078,7 +3262,7 @@
  "sk":{
   "arxiv":"arXiv je elektronický archív preprintov vedeckých prác z oblasti matematiky, fyziky, informatiky a biológie, ktorý je volne dostupný na internete. V niektorých oblastiach matematiky a fyziky sú takmer všetky práce umiestnené na arXive.[chýba zdroj] V roku 2012 do tohto archívu pribudlo každý mesiac približne sedem tisíc nových prác.",
   "bandcamp":"Bandcamp je internetová hudobná spoločnosť s hlavným sídlom v Oaklande v štáte Kalifornia, ktorá slúži ako obchod aj propagačná platforma určená hlavne pre nezávislých hudobných umelcov. Umelec, ktorý chce predávať svoju hudbu prostredníctvom spoločnosti Bandcamp, má vlastnú mikrostránku, na ktorú zverejňuje albumy alebo jednotlivé piesne. Všetky skladby je možné počúvať zadarmo a umelec sa rozhodne, či ich stiahnutie je platené alebo nie. Stránka si účtuje 15% z ceny zakúpenej hudby a 10%, ak zárobky z daného albumu presiahnu 5 000 dolárov. Táto webová stránka tiež umožňuje predaj fyzických médií na základe predbežného oznámenia správcom. Stránka podporuje formáty ako .mp3, .flac, .acc, .ogg a .m4a.",
-  "wikipedia":"Wikipédia je internetová encyklopédia s otvoreným obsahom, ktorú možno slobodne upravovať a čítať. Je sponzorovaná neziskovou organizáciou Wikimedia Foundation. Má 287 nezávislých jazykových vydaní vrátane slovenského a najrozsiahlejšieho anglického. Wikipédia obsahuje popri článkoch encyklopedického typu aj články podobajúce sa almanachu, atlasu či stránky aktuálnych udalostí. Wikipédia je jedným z najpopulárnejších zdrojov informácií na webe s približne 13 miliardami zobrazení mesačne.",
+  "wikipedia":"Wikipédia je internetová encyklopédia s otvoreným obsahom, ktorú možno slobodne upravovať a čítať. Je sponzorovaná neziskovou organizáciou Wikimedia Foundation. Má 312 nezávislých jazykových vydaní vrátane slovenského a najrozsiahlejšieho anglického. Wikipédia obsahuje popri článkoch encyklopedického typu aj články podobajúce sa almanachu, atlasu či stránky aktuálnych udalostí. Wikipédia je jedným z najpopulárnejších zdrojov informácií na webe s približne 13 miliardami zobrazení mesačne.",
   "bing":"Bing je aktuálny vyhľadávač od Microsoft. Predstavil ho generálny riaditeľ spoločnosti Steve Ballmer 28. mája 2009 na konferencii All Things Digital v San Diegu, Bing je náhradou za Live Search. Plne funkčný bol 3. júna 2009, s ukážkovou verziou vydanou 1. júna 2009. V auguste 2009, Bing získal 9,3 percentný podiel trhu internetových vyhľadávačov v Spojených Štátoch. Avšak, v septembri spoločnosť StatCounter uviedla, že podiel Bingu na americkom vyhľadávacom trhu v septembri klesol o jeden precentuálny bod na 8.51%. Comscore však tvrdili opak, tvrdiac že rast Bingu sa v septembri 2009 ustálil, získal 0,1 percenta z celkového trhu vyhľadávačov v USA a jeho podiel na trhu predstavuje 9,4 percenta.",
   "bing images":[
    "bing:sk",
@@ -3108,6 +3292,7 @@
    "ref"
   ],
   "hoogle":"Haskell je štandardizovaný funkcionálny programovací jazyk s voľnou sémantikou pomenovaný po logikovi Haskellovi Currym. Bol vytvorený v 90. rokoch 20. storočia. Posledným polooficiálnym štandardom je Haskell 98, ktorý definuje minimálnu a portabilnú verziu jazyka využiteľnú na výuku alebo ako základ ďalších rozšírení. Jazyk sa rýchlo vyvíja, predovšetkým vďaka svojim implementáciám Hugs a GHC, ktoré predstavujú súčasný de facto štandard.",
+  "imdb":"Internet Movie Database, skr. IMDb je na internete dostupná databáza informácií o filmových hviezdach, filmoch, televíznych reláciach, reklamách a videohrách. Vlastní ju firma Amazon.com.",
   "invidious":[
    "alternatívny frontend pre YouTube",
    "wikidata"
@@ -3115,6 +3300,7 @@
   "library of congress":"Kongresová knižnica je de facto národnou knižnicou Spojených štátov amerických a vedeckovýskumným telesom Kongresu Spojených štátov. Situovaná je vo Washingtone D.C. v troch budovách. Je jednou z najdôležitejších a najväčších knižníc na svete. Jej zbierka zahrňuje viac ako 30 miliónov katalogizovaných kníh a iných tlačených materiálov v 470 jazykoch, viac ako 58 miliónov rukopisov, najvzácnejšiu knižnú kolekciu v Severnej Amerike vrátane Guttenbergovej Biblie, vyše milióna publikácií americkej vlády, milión výtlačkov svetových novín za posledné tri storočia, 33 000 novinových zväzkov, 500 000 mikrofilmových pásov, vyše 6 000 komiksových titulov atď. Riaditeľom knižnice je knihovník Kongresu.",
   "openstreetmap":"OpenStreetMap je otvorený projekt, ktorého cieľom je tvorba voľných geografických dát, ako sú napríklad cestné mapy. Používa predovšetkým dáta z prijímačov GPS, ktoré sú následne kontrolované a editované. Je založený na kolektívnej spolupráci a na koncepcii Open source.",
   "piratebay":"The Pirate Bay je webová stránka, ktorá patrí medzi najväčšie databázy torrentov na internete. Stránka je na 88. mieste najnavštevovanejších stránok na svete. Po skonfiškovaní serverov, ktoré sa 31. mája 2006 lokalizovali vo Švédsku, si TPB získala pozornosť švédskych a medzinárodných médií.",
+  "reddit":"Reddit je webová stránka, ktorá kombinuje funkcie sociálnej siete a fóra, kde môžu registrovaní používatelia uverejňovať odkazy na akékoľvek informácie, ktoré sa im na internete páčia, a diskutovať o nich. Rovnako ako mnoho iných podobných webových stránok, aj Reddit udržiava systém hlasovania za príspevky, ktoré sa vám páčia – tie najpopulárnejšie končia na domovskej stránke webu. Reddit je jedna z najpopulárnejších webových stránok na svete – ide o 19. najnavštevovanejšiu stránku podľa Alexa Internet. Stránka má aplikáciu pre mobilné zariadenia na báze iOS a Android.",
   "soundcloud":"SoundCloud je internetová stránka pre online distribúciu hudby. Je často využívaná menej známymi interpretmi na zdieľanie ich tvorby. V súčasnej dobe sa k nemu však na úkor MySpace obracajú aj známi interpreti. Napríklad Sonic Youth využila odkazy na SoundCloud z Twitteru na streamovanie ich posledného albumu. Moby tu zverejňuje svoje najnovšie single. A keď sa Beck rozhodol skončiť so svojimi zastaranými webovými stránkami a chcel jednoduché stránky založené na vysoko kvalitnom obsahu, tiež prešiel k SoundCloud.",
   "youtube":"YouTube je internetová databáza videí, väčšinou krátkych. YouTube založil Chad Hurley v roku 2005 a v novembri 2006 ho kúpil Google. V súčasnosti ide o najväčší svetový systém na zdieľanie video súborov na internete.",
   "vimeo":"Vimeo je webový projekt určený pre zdieľanie audiovizuálnej tvorby. Nachádzajú sa na ňom prevažne autorské a umelecké diela. Vimeo je primárne určené filmovým nadšencom a experimentátorom, ktorí sa môžu zaregistrovať a zdieľať názory a postrehy s ostatnými. Charakter Vimea je úplne odlišný od charakteru YouTube, Vimeo je zamerané na umeleckú komunitu, kde YouTube smeruje k záujmom masovej spoločnosti.",
@@ -3156,7 +3342,7 @@
   "github":"GitHub je spletni gostiteljski servis za repozitorije v Git. Ponuja distribuirano upravljanje z izvorno kodo (SCM) z Git ter nekatere dodatne storitve. V nasprotju z Git-om, ki je ukazno orodje, ponuja GitHub spletni grafični vmesnik. Zagotavlja tudi kontrolo dostopa in številne storitve za kolaborativni razvoj, npr. sledenje napakam, zahteve za lastnosti, upravljanje z nalogami in wiki za vsak projekt.",
   "google":"Iskanje Google ali pa preprosto Google je spletni iskalnik, ki ga je razvilo podjetje Google. Je najbolj uporabljen iskalnik na svetovnem spletu, ki poskrbi za več kot tri milijarde iskanj vsak dan. Od Februarja 2016 je najbolj uporabljen iskalnik v ZDA s 64.0% tržnim deležem.",
   "google images":[
-   "Google Slike. Najobsežnejše iskanje slik v spletu.Google Slike. Najobsežnejše iskanje slik v spletu.",
+   "Google Slike. Najobsežnejše iskanje slik v spletu.",
    "https://images.google.com"
   ],
   "google news":[
@@ -3173,6 +3359,7 @@
    "ref"
   ],
   "hoogle":"Haskell je popolnoma funkcijski programski jezik s polimorfičnimi tipi, ki omogoča izjemno elegantno implementacijo matematičnih struktur, predvsem neskončnih. Imenuje se po ameriškem matematiku in logiku Haskellu Brooksu Curryju.",
+  "imdb":"Internet Movie Database (IMDb) je spletna podatkovna baza o filmih in televizijskih programih ter fimskih igralcih. Spletišče je od leta 1998 v lasti Amazona, deluje pa od leta 1990. Decembra 2006 je IMDb imel podatke o 889.844 filmih in 2.283.287 ljudeh iz filmskega sveta.",
   "library of congress":"Kongresna knjižnica je študijska knjižnica s sedežem v Washingtonu, ZDA, ki uradno deluje v podporo Kongresa Združenih držav Amerike, a je odprta tudi za javnost in velja za de facto nacionalno knjižnico ZDA. Poleg tega ima vloge centra bibliografskih informacij, ameriške agencije za avtorske pravice in nacionalne knjižnice za slepe in invalidne.",
   "microsoft academic":"Microsoft Academic je brezplačen javni spletni iskalnik za akademske publikacije in literaturo, ki ga je razvil Microsoft Research. Orodje, ki je bilo ponovno zagnano leta 2016, vsebuje povsem novo strukturo podatkov in iskalnik z uporabo semantičnih iskalnih tehnologij. Trenutno indeksira več kot 220 milijonov publikacij, od tega je 88 milijonov člankov.",
   "openstreetmap":"OpenStreetMap (OSM) je projekt, kjer uporabniki sami ustvarjajo prosto dostopen zemljevid sveta. Zemljevidi so narejeni na podlagi podatkov, zbranih s prenosnimi GPS sprejemniki in drugimi prosto dostopnimi viri.",
@@ -3192,7 +3379,7 @@
  "sr":{
   "artic":"Институт уметности у Чикагу у чикашком Грант Парку, основан 1879. године, један је од најстаријих и највећих уметничких музеја у Сједињеним Државама. Музеј је популаран и посећује га 1,5 милиона људи годишње. Његова колекција, којом управља 11 кустоских одсека, енциклопедијска је, а укључује култна дела попут Недељно поподне на острву Ла Гранд Жат Жоржа Сера, Старог гитаристе Пабла Пикаса, Ноћне сове Едварда Хопера и Америчке готике Гранта Вуда. Његова стална колекција од скоро 300.000 уметничких дела увећана је са више од 30 посебних изложби постављених годишње које осветљавају аспекте колекције и представљају врхунска кустоска и научна истраживања.",
   "arxiv":"je arhiv za elektronske preprinte naučnih članaka u oblastima matematike, fizike, astronomije, računarstva, kvantitativne biologije, statistike, i kvantitativnih finansija koji su dostupni onlajn. U mnogim poljima matematike i fizike, skoro svi naučni članci su samoarhivirani u. je imao više od pola miliona članaka 3. oktobra 2008. Arhiva preprinta je bila 20 godina stara avgusta 2011. Do 2012. brzina rasta je dostigla nivo od 6000 članaka mesečno.",
-  "wikipedia":"Википедија јест енциклопедијски пројекат слободног садржаја на интернету који развијају добровољци помоћу софтвера Медијавики. Чланке на Википедији може мењати свако с приступом интернету, што је и слоган овог веб-сајта.",
+  "wikipedia":"Википедија јесте енциклопедијски пројекат слободног садржаја на интернету који развијају добровољци помоћу софтвера Медијавики. Чланке на Википедији може мењати свако с приступом интернету, што је и слоган овог веб-сајта.",
   "bing":"Bing je -ov internet pretraživač. Predstavljen je 28. maja 2009. godine na konferenciji u San Diegu. Od 3. juna bio je potpuno dostupan na internetu.",
   "bing images":[
    "bing:sr",
@@ -3203,7 +3390,7 @@
    "https://www.bing.com/news"
   ],
   "deezer":"francuski je onlajn muzički striming servis. Omogućava korisnicima da slušaju muzički sadržaj od većine svetskih izdavačkih kuća, uključujući i — na raznim uređajima, onlajn i oflajn. Sadrži i mnogo otpremljenih pesama starih/istorijskih izvođača. Nastao je u Parizu (Francuska), a ima preko 53 miliona licenciranih numera (2019) u svojoj biblioteci, s preko 30.000 radijskih kanala, 14 miliona mesečno aktivnih korisnika i 6 miliona plaćenih pratilaca. Servis je dosputan za veb, i.",
-  "deviantart":"Art website",
+  "deviantart":"DeviantArt je onlajn zajednica za umetnička dela, videografiju i fotografiju. Sajt je 7. avgusta 2000. pokrenuo Angelo Sotira, Scott Jarkoff, Matthev Stephens i drugi. Radovi su organizovani u strukturu kategorije, uključujući fotografiju, digitalnu umetnost, tradicionalnu umetnost, književnost, Fleš, snimanje filmova, skinove za aplikacije, uslužne programe za prilagođavanje operativnog sistema i druge, zajedno sa resursima za preuzimanje kao što su tutorijali i fotografije. Dodatne funkcije uključuju \"časopise\", \"ankete\", \"grupe\" i \"portfolije\".",
   "wikidata":"Википодаци је база знања коју колаборативно уређују корисници и коју одржава Фондација Викимедија. Сврха јој је да буде заједнички извор одређених врста података, које користе други Викимедијини пројекти као што је Википедија. У том смислу је слична Викимедијиној остави где се складиште медијске датотеке којима се приступа са других Викимедијиних пројекта.",
   "flickr":"je veb-sajt koji služi kao servis za skladištenje slika i videa onlajn zajednice. Kako je u pitanju popularan veb-sajt među korisnicima koji postavljaju lične fotografije, servis je dosta korišćen među blogerima kao ostava za fotografije.",
   "gitlab":"GitLab је веб-алатка животног циклуса DevOps с отвореним изворним кодом. Алатка пружа менаџер спремишта за Git који нуди функције викија, функцију праћења проблема и канал за непрекидну интеграцију. Софтвер је развила компанија GitLab Inc., а првобитно су га направили Украјинци Дмитриј Запорожец и Валериј Сизов.",
@@ -3215,13 +3402,13 @@
    "ref"
   ],
   "hoogle":"Haskel je standardizovan, funkcionalni, strogo tipiziran programski jezik opšte namjene, sa nestriktnom semantikom. Ime je dobio po logičaru koji se zove. Posljednji standard Haskela je 2010, međutim, postoji grupa koja radi na sljedećoj verziji 2020.",
-  "library of congress":"Конгресна библиотека национална је библиотека Сједињених Држава и „истраживачка рука” Конгреса Сједињених Држава. Једна је од највећих библиотека у свету. Њена збирка укључује преко 29 милиона каталогизованих књига и других штампаних материја на преко 470 језика; више од 58 милиона рукописа; највећу збирку ретких књига у Северној Америци, преко 1 милион издања Владе САД, милион издања светских новина од уназад три стотине година, 33.000 увезаних томова новина, 500.000 ролни микрофилма, преко 6.000 стрипова; и највећу светску колекцију правних материјала, филмова, 4,8 милиона мапа, нотних записа и 2,7 милиона звучних записа. Библиотеком руководи Конгресни библиотекар.",
+  "imdb":"IMDb амерички је веб-сајт који поседује базу података о свим познатијим филмским и телевизијским личностима, филмовима, телевизијским емисијама, серијама, рекламама и видео-играма, премда је најпопуларнији због базе података о филмовима. Интернет гигант Амазон је априла 1998. године купио, а 2002. године му је проширена функционалност тако што је додат, чије се коришћење наплаћује.",
+  "library of congress":"Конгресна библиотека национална је библиотека Сједињених Држава и „истраживачка рука” Конгреса Сједињених Држава. Једна је од највећих библиотека у свету. Њена збирка укључује преко 29 милиона каталогизованих књига и других штампаних материја на преко 470 језика; више од 58 милиона рукописа; највећу збирку ретких књига у Северној Америци, преко 1 милион издања Владе САД, милион издања светских новина од уназад три стотине година, 33.000 увезаних томова новина, 500.000 ролни микрофилма, преко 6.000 стрипова; и највећу светску колекцију правних материјала, филмова, 4,8 милиона мапа, нотних записа и 2,7 милиона звучних записа. Библиотеком руководи конгресни библиотекар.",
   "npm":"npm је менаџер пакета за ЈаваСкрипт програмски језик. Он је такође подразумевани менаџер пакета за ЈаваСкрипт радно окружење Node.js. Састоји се од конзоле, која се још назива npm и онлајн базе података јавних и плаћених приватних пакета, који се називају npm регистри. Овим регистрима се приступа преко клијентске конзоле, док се доступни пакети могу претраживати на npm вебсајту. Менаџером пакета и регистрима управља компанија npm",
   "openstreetmap":"Опен стрит мап (ОСМ) је заједнички пројекат да се створи слободна мапа света која је свима доступна и свако је може уређивати.",
   "piratebay":"najveći je svetski bittorent pretraživač. Osnovala ga je švedska antiautorska organizacija Piratbiron 2003. godine, ali već 2004. godine nastupaju kao odvojena organizacija. Istom trenutno rukovode Gotfrid Svartholm, Fredrik Nej i Peter Šunde. tragači na kojima mogu da se pronađu sadržaji poput muzike, kompjuterskih programa i sličnog su zaštićeni autorskim pravima pa su, s obzirom na to, ilegalni. Međutim, u Švedskoj se takvi tragači ne smatraju ilegalnim. Odatle je često na udarima organizacija za zaštitu autorskih prava.",
   "reddit":"Редит је веб сајт у виду форума заснован на принципу постављања, коментарисања и оцењивања веб садржаја. Корисници могу бити регистровани, али није неопходно за претраживање веб сајта. Корисници на сајт постављају садржај у виду текста, линкова и фотографија које потом оцењују други корисници. Садржај је подељен у сабредите, који обично покривају неку одређену тему као што су новости, наука, технологија, видео-игре, књиге, филмови, музика, храна, фотографије, као и разноврсан садржај који интернет нуди.",
   "soundcloud":"SoundCloud онлајн је веб-сајт платформа за аудио-дистрибуцију и дељење музике са седиштем у Берлину. Корисници имају могућност да отпреме, уреде и поделе аудио снимке.",
-  "stackoverflow":"Stack Overflow је веб-сајт са питањима и одговорима за професионалне програмере и ентузијасте. То је приватни веб-сајт, водећа страница мреже Stack Exchange, коју су 2008. створили Јеф Етвуд и Џол Сполски. Садржи питања и одговоре на широк спектар тема везаних за програмирање. Створена је као отворенија алтернатива ранијим сајтовима за питања и одговоре као што је Experts-Exchange. Назив за веб-сајт гласањем су изабрали читаоци Етвудовог популарног блога Coding Horror априла 2008. године.",
   "yahoo news":"је интернет новинарски агрегатор које је покренула компанија Јаху. Вести на овом сајту подељене су у категорије политика, бизнис, здравље, путовања, време, нове слике и друге.",
   "youtube":"Јутјуб или Јутуб амерички је веб-сајт за дијељење и размјену видео-датотека.",
   "dailymotion":[
@@ -3269,7 +3456,6 @@
    "currency:sv",
    "ref"
   ],
-  "digg":"Digg är en engelskspråkig, användargenererad webbplats som startades i experimentell form av Kevin Rose, Owen Byrne, Ron Gorodetzky och Jay Adelson 2004. Webbplatsen är en internetbaserad community som huvudsakligen förmedlar nyheter och artiklar med tyngden på teknik.",
   "erowid":"Erowid, även kallat Erowid Center är en ideell organisation som arbetar för drogupplysning och skademinimering genom att tillhandahålla information om hur psykoaktiva substanser används i världen. Organisationen driver webbplatsen Erowid.org som primär fokus, men bidrar också med forskningsdata till andra hälso- och utbildningsorganisationer. Erowid finansieras av donationer.",
   "wikidata":"Wikidata är ett projekt initierat av Wikimedia Tyskland, som startade en wiki den 30 oktober 2012 för gemensam flerspråkig lagring av data. Projektet drivs sedan 2013 av Wikimedia Foundation. Målet var i ett första skede att möjliggöra synkronisering av olika språkversioner av Wikipedia vad gäller språklänkar, och senare även uppgifter i faktarutor, länklistor, tabeller, diagram och sifferuppgifter i den löpande texten, tillsammans med källhänvisningar. Wikidata är lämplig för sifferuppgifter och andra kvantitativ data som inte är löpande text, exempelvis geografiska positioner, folkmängd, sportresultat, och hur olika objekt (Wikidataartiklar) är relaterade till varandra. Ett syfte med wikidata är att underlätta arbetet med att underhålla flera språkversioner av Wikimedias olika projekt. Wikidata lagrar data gemensamt på motsvarande sätt som Wikimedia Commons lagrar multimediala filer gemensamt. Mycket av datat i wikidata har hämtats av bottar från Wikipedias faktarutor på olika språk, men också från andra källor, exempelvis ontologier som beskriver vilka begrepp som är instanser och underklasser av varandra. Wikidatas innehåll redigeras dessutom manuellt, på liknande vis som Wikipedias innehåll.",
   "duckduckgo":[
@@ -3298,11 +3484,12 @@
   ],
   "gpodder":"gPodder är ett datorprogram för bland annat GNU/Linux, Windows och Mac OS och fungerar som en hanterare för poddradiokanaler. Programmet är GNU GPL-licensierat och är således fri programvara. Programmets senaste stabila utgåva är version 2.9 och utgavs i oktober 2010. gPodder är skrivet i Python, och utvecklas av the gPodder Team, som leds av Thomas Perl.",
   "hoogle":"Haskell är ett funktionellt programspråk. Utvecklingen av språket, som fick sitt namn efter den amerikanska logikern Haskell Curry, startades 1987 av en internationell kommitté. Femton år senare, år 2003, publicerade de sedan en stabil definition av språket. Haskell bygger till stor del, som många andra funktionella programspråk, på lambdauttryck och rekursion, men har också ett starkt typsystem och flera andra relativt ovanliga egenskaper som exempelvis lat evaluering. Språket är också konstruerat för att vara så kompakt och så likt matematik som möjligt, och lånar därför symboler ur både logiken och matematiken.",
+  "imdb":"Internet Movie Database är den äldsta och största filmdatabasen på internet. Dess tyngdpunkt ligger på engelskspråkiga filmer, men innehåller även information om icke-engelska filmer, lågbudget- och TV-filmer, TV-serier, datorspel samt i viss utsträckning TV-program. Enligt IMDB besöks webbplatsen av över 100 miljoner personer per månad och databasen innehåller över 3,5 miljoner filmer, TV-serier och program. Sedan 1998 ägs IMDB av Amazon.com.",
   "ina":[
    "museum i Frankrike",
    "wikidata"
   ],
-  "library genesis":"Library Genesis eller LibGen är en sökmotor för vetenskapliga artiklar och böcker, som ger fri tillgång till annars betalt innehåll. Bland annat innehåller den PDF-filer från en webbportal vid namn ScienceDirect, vilket ägs av bokförlaget Elsevier. I augusti 2019 innehöll databasen mer än 76 miljoner vetenskapliga artiklar, 2,3 miljoner facklitterära böcker, 2,1 miljoner skönlitterära böcker och 2 miljoner filer av tecknare serier.",
+  "library genesis":"Library Genesis eller LibGen är en sökmotor för vetenskapliga artiklar och böcker, som ger fri tillgång till annars betalt innehåll. Bland annat innehåller den PDF-filer från en webbportal vid namn ScienceDirect, vilket ägs av bokförlaget Elsevier. I augusti 2019 innehöll databasen mer än 76 miljoner vetenskapliga artiklar, 2,3 miljoner facklitterära böcker, 2,1 miljoner skönlitterära böcker och 2 miljoner filer av tecknade serier.",
   "library of congress":[
    "de facto nationalbibliotek för Amerikas förenta stater.",
    "wikidata"
@@ -3310,7 +3497,7 @@
   "openstreetmap":"Open Street Map, internt sammanskrivet som OpenStreetMap, är ett ideellt projekt för framtagning av geografisk information. Datan kan sedan användas för att skapa vägkartor, kartor för geocaching, kartor över sevärdheter i en viss ort eller andra ändamål, både ideellt och kommersiellt.",
   "piratebay":"The Pirate Bay, TPB, är en svensk trackersökmotor som grundades i Sverige 2003, vilken i dagsläget har över 5 miljoner användare och indexerar över 10 miljoner torrent-filer. \"Trackern\" är en av världens största och en pionjär inom nätbaserad kopiering och spridning av digitalt material. The Pirate Bays logotyp föreställer ett piratskepp vars ena segel innehåller en variant av Jolly Roger (\"Sjörövarflaggan\"), i vilken dödskallen ersatts av ett kassettband. Symbolen kassettband och korsade ben användes under 1980-talet av musikindustrin i kampanjen Home Taping is Killing Music, och en variant används även av Piratbyrån. I december 2014 släcktes hemsidan ner efter en razzia av svenska polisen. Den 31 januari 2015 återkom sajten med en fågel Fenix som logga istället för ett piratskepp.",
   "pubmed":"Medline är en databas för vetenskapliga artiklar inom det medicinska fältet, som drivs av United States National Library of Medicine. Databasen omfattar bibliografiuppgifter med mer än 24 miljoner referenser som publicerats i över 5 200 vetenskapliga tidskrifter på numer omkring 40 språk; tidigare upp till omkring 60 språk. Från 1950-talet och framåt ingår ofta citeringar och sammanfattningar för forskningsartiklar inom det biomedicinska fältet, medan tidigare artiklar anges ofta enbart med uppgift om rubrik och författare.",
-  "reddit":"Reddit är en social nyhetssida på internet. Användare kan förutom att läsa innehållet också posta egna länkar till innehåll på nätet eller posta \"self\"-poster som innehåller användarskapad text. Andra användare kan sen antingen rösta \"upp\" eller \"ner\" de postade länkarna, och de mest framgångsrika länkarna når då framsidan. Användare kan också kommentera länkar som postats och svara på andra kommentarer, vilket skapar ett community. Reddit-användare kan också skapa sina egna inriktade sektioner som kallas subreddits. Ett exempel på en sådan är den svenska (r/sweden), där man kan posta länkar och kommentera.",
+  "reddit":"Reddit är en webbplats med nyheter och diskussionsforum. Användare kan förutom att läsa innehållet också posta egna länkar till innehåll på nätet eller posta \"self\"-poster som innehåller användarskapad text. Andra användare kan sen antingen rösta \"upp\" eller \"ner\" de postade länkarna, och de mest framgångsrika länkarna når då framsidan. Användare kan också kommentera länkar som postats och svara på andra kommentarer, vilket skapar ett community. Reddit-användare kan också skapa sina egna inriktade sektioner som kallas subreddits. Ett exempel på en sådan är den svenska (r/sweden), där man kan posta länkar och kommentera.",
   "soundcloud":"Soundcloud är en onlineplattform för distribution av ljud, främst musik via datormoln.",
   "youtube":"Youtube är en videogemenskap, det vill säga en webbplats med videoklipp som laddas upp av dess användare, med tillhörande diskussioner och sociala medier-funktioner. Webbplatsen öppnades den 14 februari 2005.",
   "dailymotion":"Dailymotion är en fransk videogemenskap, det vill säga en webbplats med videoklipp som laddas upp av dess användare, med tillhörande diskussioner och sociala medier-funktioner. Webbplatsen öppnades i mars 2005. Sedan våren 2014 har Dailymotion stöd för Chromecast.",
@@ -3330,7 +3517,7 @@
  },
  "ta":{
   "artic":"ஆர்ட் இன்ஸ்டியூட் ஆப் சிகாகோ என்பது ஐக்கிய அமெரிக்காவின் சிகாகோ நகரில் அமைந்துள்ள கலைக்களஞ்சிய அருங்காட்சியகம் ஆகும். இவ்வருங்காட்சியகம் மிகப்பிரம்மாண்டமான மூன்று கட்டடங்களில் இயங்குகிறது. இம்மூன்று கட்டடங்களும் முதல் தளத்துடன் இணைக்கப்பட்டுள்ளன.",
-  "wikipedia":"விக்கிப்பீடியா என்பது, வணிக நோக்கற்ற விக்கிமீடியா நிறுவனத்தின் உதவியுடன் நடத்தப்படும், கூட்டாகத் தொகுக்கப்படும், பன்மொழி, கட்டற்ற இணையக் கலைக்களஞ்சியமாகும். தமிழ் விக்கிப்பீடியாவின் 1,00,000க்கும் மேற்பட்ட கட்டுரைகளுடன் சேர்த்து இதன் மொத்தக் கட்டுரைகளான 24 மில்லியன் கட்டுரைகளும் உலகெங்கிலுமுள்ள தன்னார்வலர்களால் கூட்டாக எழுதப்படுகின்றன. பெரும்பாலும் இதன் எல்லாக் கட்டுரைகளும், இதனைப் பயன்படுத்தும் எவராலும், தொகுக்கப்படக் கூடுவன. மேலும் இது கிட்டத்தட்ட 100,000 முனைப்பான பங்களிப்பாளர்களையும் கொண்டுள்ளது. செப்டம்பர் 2021 வரையில், விக்கிப்பீடியா 285 மொழிகளில் செயற்படுகிறது. இது இணையத்தளத்தில் இயங்கும் உசாத்துணைப் பகுதிகளிலேயே மிகவும் பெரியதும், அதிகப் புகழ்பெற்றதுமாகும். மேலும், இது அலெக்சா இணையத்தளத்தில் காணப்படும் இணையத்தளங்களின் தரவரிசையில் ஆறாவது இடத்தில் உள்ளதோடு, உலகளவில் அண்ணளவாக 365 மில்லியன் வாசகர்களையும் கொண்டுள்ளது.",
+  "wikipedia":"விக்கிப்பீடியா என்பது, வணிக நோக்கற்ற விக்கிமீடியா நிறுவனத்தின் உதவியுடன் நடத்தப்படும், கூட்டாகத் தொகுக்கப்படும், பன்மொழி, கட்டற்ற இணையக் கலைக்களஞ்சியமாகும். தமிழ் விக்கிப்பீடியாவின் 1,00,000க்கும் மேற்பட்ட கட்டுரைகளுடன் சேர்த்து இதன் மொத்தக் கட்டுரைகளான 24 மில்லியன் கட்டுரைகளும் உலகெங்கிலுமுள்ள தன்னார்வலர்களால் கூட்டாக எழுதப்படுகின்றன. பெரும்பாலும் இதன் எல்லாக் கட்டுரைகளும், இதனைப் பயன்படுத்தும் எவராலும், தொகுக்கப்படக் கூடுவன. மேலும் இது கிட்டத்தட்ட 100,000 முனைப்பான பங்களிப்பாளர்களையும் கொண்டுள்ளது. நவம்பர் 2021 வரையில், விக்கிப்பீடியா 285 மொழிகளில் செயற்படுகிறது. இது இணையத்தளத்தில் இயங்கும் உசாத்துணைப் பகுதிகளிலேயே மிகவும் பெரியதும், அதிகப் புகழ்பெற்றதுமாகும். மேலும், இது அலெக்சா இணையத்தளத்தில் காணப்படும் இணையத்தளங்களின் தரவரிசையில் ஆறாவது இடத்தில் உள்ளதோடு, உலகளவில் அண்ணளவாக 365 மில்லியன் வாசகர்களையும் கொண்டுள்ளது.",
   "bing":"பிங் (Bing) என்பது மைக்ரோசாப்ட் நிறுவத்திற்குச் சொந்தமான வலைத் தேடல் பொறி ஆகும். இத்தேடல் பொறியானது முன்னர் லைவ் சேர்ச், வின்டோசு லைவ் சேர்ச், எம்எஸ்என் சேர்ச் ஆகிய பெயர்களைக் கொண்டு அமைந்திருந்தது. இத்தேடல் பொறி மைக்ரோசாப்ட் நிறுவனத்தினால் முடிவெடுக்கும் பொறியாக விளம்பரப்படுத்தப்பட்டது. 2009 ஆம் ஆண்டு மே மாதம் 28 ஆம் திகதியன்று சான் டியேகோ நகரில் இடம்பெற்ற ஆல் திங்ஸ் டிஜிட்டல் (All Things Digital) மாநாட்டின் போது மைக்ரோசாப்ட் நிறுவனத்தின் முன்னாள் தலைமை நிர்வாக அதிகாரி இசுட்டீவ் பால்மரால் இத்தேடல் பொறி அறிமுகப்படுத்தப்பட்டு சூன் 1 இல் வெளியிடப்படும் எனவும் அறிவிக்கப்பட்டது.. 2009 ஆம் ஆண்டு சூன், 29 ஆம் திகதியன்று யாகூ! தேடல் பொறியினை பிங் தேடல் பொறி நிர்வகிக்கும் என அறிவிக்கப்பட்டது.",
   "bing images":[
    "bing:ta",
@@ -3358,7 +3545,7 @@
   "github":"கிட்ஹப் இன்க் ஒரு இணைய வழி கிட் திருத்தக் கட்டுப்பாடு ஆகும். இது பெரும்பாலும் கணினி நிரல்களுக்காகப் பயன்படுகிறது. இது நிரல் திருத்தக்கட்டுப்பாடும், நிரல் மேலான்மையயும், இன்னும் பிற சேவைகளையும் அளிக்கிறது. இது பயனர் நுழைவுக் கட்டுப்பாடு, பிழை கண்காணிப்பு, திட்ட மேலான்மை, புதிய வேண்டுகோள், மற்றும் திட்டத்திற்கான விக்கி சேவையையும் வழங்குகின்றது.",
   "google":"கூகிள் தேடல் கூகிள் நிறுவனத்தின் உலகின் மிகப் பெரும் தேடற்பொறியாகும். கூகிள் தேடுபொறி இணையத்தில் உள்ள அனைத்து பக்கங்களில் பயனர்களின் தேடலுக்கு ஒத்த உள்ளடக்கத்தை உள்ளவையாக கருதப்படும் பக்கங்களை பட்டியலிடுகின்றது. கூகிள் தேடுபொறி பல்வேறு சேவைகள் மூலமாக பல நூறு மில்லியன் தேடல்களை மேற்கொள்கின்றது. சமீபத்தில் வெளியான கூகிள் தேடுபொறி பற்றிய வீடியோ விளம்பரம் ஒன்று பிரபலங்களை கண்கலங்க வைத்துள்ளது.",
   "google images":[
-   "Google Images. வலையில் கிடைக்கக்கூடிய மிக விரிவான படத் தேடல்.Google Images. வலையில் கிடைக்கக்கூடிய மிக விரிவான படத் தேடல்.",
+   "Google Images. வலையில் கிடைக்கக்கூடிய மிக விரிவான படத் தேடல்.",
    "https://images.google.com"
   ],
   "google news":"கூகிள் செய்திகள், கூகிள் நிறுவனத்தால் வழங்கப்படும் இலவச செய்தி திரட்டி ஆகும். ஒரு தானியங்கி திரட்டல் வழிமுறை மூலம் ஆயிரக்கணக்கான பிரசுரங்களின் சமீபத்திய செய்திகளை இது தேர்ந்தெடுக்கிறது.",
@@ -3369,13 +3556,13 @@
    "google play apps:ta",
    "ref"
   ],
+  "imdb":"ஐ. எம். டி. பி (IMDb) இவ்விணையத்தளம் ஆனது உலக திரைப்படங்களினைப் பற்றிய அனைத்துத் தகவல்களையும் வழங்கும் தளமாக விளங்குகின்றது. மேலும் இவ்விணையத்தளத்தினை இலவசமாகப் பயனர் பகுதியை ஏற்படுத்திக் கொள்ள வாய்ப்புகளும் உண்டு. உலகளவில் திரைப்படங்களிற்காகப் பார்க்கப்படும் தளங்களில் இத்தளம் முதலிடத்தில் இருப்பது குறிப்பிடத்தக்கது. மிகப் பெரிய பட விநியோக நிறுவனங்களான பாராமவுண்ட், யுனிவெர்சல், ஃபாக்ஸ் பிக்சர்ஸ், வார்னர் ப்ரதர்ஸ், கொலம்பியா பிக்சர்ஸ் போன்றவை தங்களது படங்களைப் பற்றி அவர்களே தகவல்களை இந்த தரவுத் தளத்தில் உள்ளீடு செய்வார்கள்.",
   "library of congress":"காங்கிரசு நூலகம் என்பது அமெரிக்கக் காங்கிரசின் நூலகத்தைக் குறிக்கிறது. நடைமுறையில் ஐக்கிய அமெரிக்காவின் தேசிய நூலகமாகச் செயற்படும் இது, அமெரிக்கக் காங்கிரசின் ஆய்வுப் பிரிவாகவும் தொழிற்படுகிறது. வாசிங்டன் டி. சி. இல் அமைந்துள்ள இந் நூலகம் பரப்பளவிலும், நூல்களின் எண்ணிக்கையிலும் உலகிலேயே மிகவும் பெரியது ஆகும். 2007 ஆம் ஆண்டின் கணக்கின் படி இந்நூலகத்தில் 32,332,832 நூல்களும், மொத்தமாக 138,313,427 உருப்படிகளும் உள்ளன",
   "microsoft academic":"மைக்ரோசாப்ட் அகாடமிக் என்பது மைக்ரோசாப்ட் ஆய்வு உருவாக்கிய கல்வி வெளியீடுகள் மற்றும் இலக்கியங்களுக்கான இலவச பொது வலை தேடுபொறி ஆகும். முன்பிருந்த இந்த 2016ஆம் ஆண்டில் மீண்டும் தொடங்கப்பட்டது. இதில் கருவி சொற்பொருள் தேடல் முதலியவற்றில் புதிய தொழில்நுட்பங்களைப் பயன்படுத்தி முற்றிலும் புதிய தரவு அமைப்பாகவும் தேடுபொறியுடன் கூடியது. இதில் தற்போது 220 மில்லியனுக்கும் அதிகமான வெளியீடுகளைக் கொண்டுள்ளது. இவற்றில் 88 மில்லியன் ஆய்விதழில் வெளியான கட்டுரைகள் உள்ளன. மேம்பட்ட அறிவு நோக்கங்களுக்காக ரெஸ்ட் (REST) இறுதி புள்ளிகளைப் பயன்படுத்தி அடிப்படை தரவுத்தளத்திலிருந்து தகவல்களை மீட்டெடுப்பதைக் கல்வி அறிவு ஏபிஐ (API) வழங்குகிறது.",
   "openstreetmap":[
    "அனைவரும் தொகுக்கக்கூடிய கட்டற்ற உலக வரைபடம்",
    "wikidata"
   ],
-  "stackoverflow":"இசுடாக் ஓவர்ஃபுலோ என்பது நிரலாக்கம் தொடர்பான கேள்வி பதில் வழங்கும் ஆங்கில வலைத்தளம். இத் தளத்தில் பயனர்கள் நிரலாக்கம் தொடர்பான கேள்விகளைக் கேட்கலாம், கேட்கப்பட்ட கேள்விகளுக்கு பதில் வழங்கலாம். இச்சேவை இலவசமாக வழங்கப்படுகிறது. எனினும் இது ஒரு கட்டற்ற மென்பொருள் இல்லை. பயனர்கள் பதிவு செய்யாமலே கேள்விகளைக் கேட்கலாம், எனினும் பதிவு செய்யம் பயனர்கள் கூடிய அணுகூலங்களை தளத்தில் பெறுகின்றார்கள். பயனர்கள் எவ்வாறு செயற்படுகிறார்கள் என்பதைப் பொறுத்து அவர்களின் செல்வாக்கு அத்தளத்தில் கூடும்.",
   "yahoo news":"யாஹூ! செய்திகள் யாஹூ! இன் செய்திச் சேவையாகும். இதன் ஆங்கிலச் செய்திகள் CNN, USA Today போன்றவற்றில் இருந்து வருவதாகும். தமிழ்ச் செய்திகள் பெரும்பாலும் வெப்தூனியாவில் இருந்து வருவதாகும்.",
   "youtube":"யூடியூப் அல்லது வலையொளி (YouTube) என்பது ஒரு அமெரிக்க நாட்டு நிகழ்நிலை காணொளி பகிர்வு மற்றும் சமூக ஊடக தளமாகும், இது சாட் ஹர்லி, ஸ்டீவ் சென் மற்றும் ஜவேத் கரீம் ஆகியோரால் பிப்ரவரி 2005 இல் தொடங்கப்பட்டது. உலகம் முழுவதும் வலையொளி பயனர்கள் ஒவ்வொரு நாளும் ஒரு பில்லியன் மணிநேர காணொளிகளைப் பார்க்கிறார்கள். யூடியூபர்கள் என பிரபலமாக குறிப்பிடப்படும் யூடியூப் உள்ளடக்க படைப்பாளர்கள் நிமிடத்திற்கு 100 மணி நேர உள்ளடக்கத்தை பதிவேற்றுகிறார்கள்.",
   "vimeo":"விமியோ (Vimeo) என்பது நிகழ்படங்களைப் பகிர்ந்து கொள்ளவும், பதிவேற்றவும், பதிவிறக்கவும், பார்ப்பதற்கும் துணைபுரியும் ஓர் இணையதளம் ஆகும். இது 2004ஆம் ஆண்டு சாக் லோடுவிக், சாக் கிளின் ஆகியோரால் தொடங்கப்பட்டது. இந்த நிறுவனமே 2007ஆம் ஆண்டு முதன்முதலாக உயர்தர நிகழ்படங்களைப் பகிர்ந்து கொள்வதற்கான வசதியை பொதுமக்களுக்கு ஏற்படுத்திக் கொடுத்தது. நல்ல இலக்கு நோக்கி செயற்படும் சிந்தனையாளர்களால், இந்த இணையம் அதிகம் பயன்படுத்தப்படுகிறது. இந்த இணையதளத்தில் பயனில்லா நிகழ்படங்கள் மிகவும் குறைவு. இந்த இணையதளத்தில் காணும் நிகழ்படங்களைக் கட்டணமின்றி பதிவிறக்கமும் செய்து கொள்ளலாம். இருப்பினும், கட்டணம் செலுத்தி, மேலதிக வசதிகளைப்பெற முடியும். இதில் 7கோடி பேர் உறுப்பினர்களாக உள்ளனர். குறும்படங்களையும், திரைப்படங்களையும் விற்பனை செய்வதில் இத்தளம் கவனம் செலுத்துகிறது. இருப்பினும் கட்டற்ற மென்பொருட்களை பயன்படுத்துதல் குறித்த வழிகாட்டுதல்கள் படங்கள் நிறைய உள்ளன.",
@@ -3404,8 +3591,9 @@
    "ref"
   ],
   "wikidata":"వికీడేటా అనేది వికీమీడియా ఫౌండేషన్ అందచేస్తున్న సహకారంతో సవరించగల జ్ఞాన భాండారము. ఇది ఒక సాధారణ స్వేచ్ఛా డేటా మూలం. దీనిని వికీపీడియా లాంటి వికీమీడియా ప్రాజెక్టులలో వాడతారు, ఇది ప్రజోపయోగ పరిధి షరతులతో అందుబాటులో ఉంది. మీడియా ఫైళ్ళకు నిల్వ ప్రాజెక్టు వికీమీడియా కామన్స్లాగా, ఇది అన్ని వికీమీడియా ప్రాజెక్టుల కోసం జ్ఞాన భాండాగారం. వికీడేటా సాఫ్ట్‌వేర్ ను వికీబేస్(Wikibase) గా వ్యవహరిస్తారు.",
+  "google":"గూగుల్ శోధన,ఇది గూగుల్ అందించిన సెర్చ్ ఇంజిన్.2021లో రోజుకు 2 ట్రిలియన్ల కంటే ఎక్కువ అంతర్జాల శోధనలు దీని ద్వారా జరుగుతాయి,ఇది ప్రపంచ శోధన ఇంజిన్ మార్కెట్లో 92% వాటాను కలిగి ఉంది. ఇది ప్రపంచంలో అత్యధికంగా సందర్శించే వెబ్ సైట్ కూడా. ఇందులో వెతికిన విషయానికి గూగుల్ ద్వారా తిరిగి ఇవ్వబడ్డ శోధన ఫలితాల క్రమం, పాక్షికంగా,\"పేజ్ ర్యాంక్\"అని పిలువబడే ప్రాధాన్యతా ర్యాంక్ వ్యవస్థపై ఆధారపడి ఉంటుంది, అంతర్జాలంలో బహిరంగంగా అందుబాటులో ఉన్న పత్రాలలో వచనం (టెక్స్ట్) మాత్రమే కాక అనేక ప్రత్యేక సేవలు అందిస్తుంది. వీటిలో పర్యాయపదాలు, వాతావరణ అంచనాలు, సమయ మండలాలు, స్టాక్ కోట్స్, మ్యాప్ లు, భూకంప డేటా, మూవీ షోటైమ్స్, విమానాశ్రయాలు, గృహ జాబితాలు, మరియు క్రీడా ఫలితాలు ఉన్నాయి. దీనిని మొదట 1997లో లారీ పేజ్, సెర్జీ బ్రిన్,మరియు స్కాట్ హసన్అభివృద్ధి చేశారు. దీనిపేరు అసలు ప్రణాళికాబద్ధమైన పేరు గూగోల్ googol తప్పుగా వ్రాయడం నుండి తీసుకోబడింది. 1999 మధ్యనాటికి, గూగుల్ $25 మిలియన్ రౌండ్ వెంచర్ క్యాపిటల్ ఫండింగ్ అందుకున్నప్పుడు, ఇది రోజుకు 500,000 శోధనలను ప్రాసెస్ చేస్తోంది",
   "google images":[
-   "Google Images. వెబ్లో విస్తృతమైన చిత్ర శోధన.Google Images. వెబ్లో విస్తృతమైన చిత్ర శోధన.",
+   "Google Images. వెబ్లో విస్తృతమైన చిత్ర శోధన.",
    "https://images.google.com"
   ],
   "google news":[
@@ -3417,7 +3605,12 @@
    "google play apps:te",
    "ref"
   ],
+  "imdb":"ఇంటర్నెట్ మూవీ డేటాబేసు వీడియోలకి సంబంధించిన ఒక వెబ్ సైటు. ఇది సినిమాలు, TV షోలు, నటులు, సాంకేతిక నిపుణుల వివరాలతో కూడిన అతి పెద్ద ఆన్ లైన్ సమాచార నిధి (డేటాబేసు). ఇది ప్రస్తుతం Amazon.com సంస్థ ఆధ్వర్వంలో నడుస్తుంది. ఇది అందుబాటులో ఉన్న ఏకైక భాష ఆంగ్లం.",
   "library of congress":"ప్రపంచంలోని అతి పెద్ద గ్రంథాలయం యునైటెడ్ స్టేట్స్ లైబ్రరీ ఆఫ్ కాంగ్రెస్, వాషింగ్టన్, డి.సి. లోని కాపిటల్ హిల్ పైన స్థాపించారు. ఇది 1800వ సంవత్సరం ఏప్రిల్ 24న స్థాపితమైంది.",
+  "openstreetmap":[
+   "openstreetmap:nb-NO",
+   "ref"
+  ],
   "youtube":"యూట్యూబు అనేది అంతర్జాలంలో వీడియోలను ఇతరులతో పంచుకోవడాని వీలుకల్పించే ఒక అంతర్జాతీయ సేవ. దీని ప్రధాన కార్యాలయం అమెరికాలోని, కాలిఫోర్నియా రాష్ట్రం, శాన్ బ్రూనో అనే నగరంలో ఉంది.",
   "wikibooks":"వికీబుక్స్ స్వేచ్ఛానకలుహక్కులతో సమష్టిగా తయారు చేయగల పుస్తకాల జాల స్థలి. ఇది 2004 ఆగస్టు 13న ప్రారంభమైంది. వికీ ప్రాజెక్టులన్నిటిలోఅతితక్కువ వ్యాసపేజీలు ఉన్నాయి. దీనిలో ఉబుంటు వాడుకరి మార్గదర్శిని పూర్తికాబడిన పుస్తకం. దీనిలో ఉబుంటుతో తెలుగులో టైపు చేయడం దగ్గరనుండి, ఉత్తరములు వ్రాయుట, ప్రదర్శన పత్రములు చేయుట, వివిధ రకాల ధ్వని, దృశ్య శ్రవణ మాధ్యమములను నడుపుట, వాడబడే విహరిణులు లాంటివన్నీ ఎలా చేయవచ్చో వివరించటమైనది. ఇంకా వంట పుస్తకం ప్రారంభించబడింది. వికీసోర్స్ లో ఉండవలసిన కొన్ని వ్యాసాలు పొరపాటున వికీబుక్స్ లో సృష్టించబడినవి. ఈ ప్రాజెక్టు ప్రధాన ఉద్దేశం పాఠ్యపుస్తకాలు సమష్టిగా వృద్ధిచేయటం. ఏప్రిల్ 2010 అలెక్సా లెక్కల ప్రకారం ప్రపంచంలోని జాలస్థలులన్నిటిలో 2,462వ స్థానములోఉన్నది.",
   "wikiquote":"వికీకోట్ అనగా వికీవ్యాఖ్య .వికీమీడియా ఫౌండేషను ఆధ్వర్యములో మీడియావికీ సాఫ్టువేరుతో నడిచే వికీ ఆధారిత ప్రాజెక్టు కుటుంబములో ఒక ప్రాజెక్టు. డేనియల్ ఆల్స్టన్ యొక్క ఆలోచనను బ్రయన్ విబ్బర్ కార్యాచరణలో పెట్టగా రూపొందిన ఈ ప్రాజెక్టు యొక్క లక్ష్యం సమిష్టి సమన్వయ కృషితో వివిధ ప్రముఖ వ్యక్తులు, పుస్తకాలు, సామెతలనుండి సేకరించిన వ్యాఖ్యల యొక్క విస్తృత వనరును తయారుచేసి వాటికి సంబంధించిన వివరాలు పొందుపరచడం. అనేక అన్లైన్ వ్యాఖ్యల సేకరణలు ఉన్నప్పటికీ సందర్శకులను సేకరణ ప్రక్రియలో పాలుపంచుకొనే అవకాశము ఇస్తున్న అతికొద్ది వాటిల్లో వికీవ్యాఖ్య ఒకటిగా విశిష్ఠత సంపాదించుకొన్నది.",
@@ -3439,15 +3632,14 @@
   "bing videos":"Bing Videos Microsoft'un Bing arama motorunun bir parçası ve video arama hizmetidir. Hizmet, kullanıcılara çeşitli web sitelerindeki videoları aramasına ve görüntülemesine olanak tanır. Bing Videos resmi olarak 26 Eylül 2007'de Live Search Video olarak yayınlandı ve 1 Haziran 2009'da Bing Videos olarak yeniden markalandı.",
   "bitbucket":"Bitbucket, Git sürüm kontrol sistemi kullanan projeler için bir ağ depolama servisi olup Django kullanılarak Python programlama dili ile yazılmıştır.",
   "currency":"DuckDuckGo kişisel gizliliğe önem veren açık kaynaklı bir web arama motoru ve mobil web tarayıcısıdır. Kullanıcıların IP adreslerini ve kişiler bilgilerini kaydetmemektedir. Arama motoru Gabriel Weinberg tarafından ABD'de kurulmuştur. DuckDuckGo Perl dilinde programlanmıştır ve FreeBSD üzerinde çalışmaktadır.",
-  "deezer":"Deezer web tabanlı bir müzik yayını servisidir. Kullanıcıların çevrim içi veya çevrim dışı olarak çeşitli cihazlarda müzik dinlemelerini sağlar. Paris, Fransa'da oluşturulmuştur. Deezer 56 milyondan fazla lisanslı müzik parçası, 30.000'den fazla radyo kanalı ve 12 milyon aylık aktif kullanıcıya sahiptir.",
+  "deezer":"Deezer web tabanlı bir müzik yayını servisidir. Kullanıcıların çevrimiçi veya çevrimdışı olarak çeşitli cihazlarda müzik dinlemelerini sağlar. Paris, Fransa'da oluşturulmuştur. Deezer 56 milyondan fazla lisanslı müzik parçası, 30.000'den fazla radyo kanalı ve 12 milyon aylık aktif kullanıcıya sahiptir.",
   "deviantart":"deviantART, İnternet ortamında bulunan sanat ortamı ve sanatçı topluluğudur. Kısaca dA olarak yazılır. 6 Ağustos 2000'de Scott Jarkoff ve Matthew Stephens tarafından kurulmuştur. DeviantART'ın şimdiki CEO'su Angelo Sotira'dır.",
   "ddg definitions":[
    "currency:tr",
    "ref"
   ],
-  "digg":"Digg haber paylaşım ve okuma platformu. Digg, genellikle politika, bilim ve diğer Internet trendlerinin paylaşıldığı, oylandığı ve yorumlandığı bir platform olarak ön plana çıkmaktadır. Kasım 2004'te kurulan Digg, 31 Temmuz 2012 tarihinde format değişikliğine giderek haberlerin Facebook, Twitter gibi sosyal medya platformlarında paylaşıldığı bir ortam haline gelmiştir.",
   "erowid":"Erowid ya da diğer adıyla Erowid Center, psikoaktif bitkiler ve kimyasalların yanı sıra, meditasyon, lüsid rüya, transkraniyal manyetik stimülasyon ve elektrosötikal gibi farklılaşmış bilinç halleri üreten faaliyetler ve teknolojiler hakkında bilgi sağlayan kâr amacı gütmeyen bir eğitim kuruluşudur.",
-  "wikidata":"Vikiveri veya İngilizce özgün adıyla Wikidata, Vikipedi gibi Vikimedya projelerini desteklemek üzere iş birliği içinde düzenlenebilir veritabanı sağlamak amacıyla başlatılmış bir projedir. Vikiveri projesi, 30 Ekim 2012 tarihinde Vikimedya Almanya tarafından Wikimedia Commons ve benzeri sistemlerde ortak belirli veri türlerini, örneğin doğum tarihleri ve geçerli diğer sınıfları bir araya toplamak üzere başlatılmıştır. Proje Wikimedia Vakfının 2006 yılından bu yana başlattığı ilk yeni proje olmuştur.",
+  "wikidata":"Vikiveri veya İngilizce özgün adıyla Wikidata, Vikipedi gibi Vikimedya projelerini desteklemek üzere iş birliği içinde düzenlenebilir veritabanı sağlamak amacıyla başlatılmış bir projedir. Vikiveri projesi, 29 Ekim 2012 tarihinde Vikimedya Almanya tarafından Wikimedia Commons ve benzeri sistemlerde ortak belirli veri türlerini, örneğin doğum tarihleri ve geçerli diğer sınıfları bir araya toplamak üzere başlatılmıştır. Proje Wikimedia Vakfının 2006 yılından bu yana başlattığı ilk yeni proje olmuştur.",
   "duckduckgo":[
    "currency:tr",
    "ref"
@@ -3476,6 +3668,7 @@
    "ref"
   ],
   "hoogle":"Haskell, isim babası matematikçi Haskell Curry olan arı işlevsel programlama dilidir. Haskell'i birçok programlama dilinden ayıran özellikleri tembel değerlendirme, monadlar ve tür sınıflarıdır. Haskell, Miranda dilinin semantikleri üzerine kuruludur. Akademide yoğun olarak kullanılmasıyla birlikte endüstride de kullanılmaktadır.",
+  "imdb":"IMDb ; filmler, diziler, televizyon programları, video oyunları ve internet içerikleri hakkında bilgiler barındıran çevrimiçi bir veri tabanıdır. Yapımlarla ilgili oyuncu kadrosu, yapım ekibi, biyografiler, özetler, ilginç bilgiler, puanlar ve eleştiriler gibi bilgileri içerir. İlk kurulduğunda sinemaseverler tarafından yönetilen IMDb, günümüzde Amazon'un alt kuruluşu IMDb.com, Inc. tarafından yönetilmektedir.",
   "kickass":"KickassTorrents bir dizin için torrent dosyaları ve magnet bağlantıları kullanarak kullanıcıdan kullanıcıya dosya paylaşımı yöntemini sunan ve BitTorrent protokolünü kullanan bir web sitesi idi. Site 2008'de kuruldu ve 20 Temmuz 2016'da Amerika Birleşik Devletleri Hükümeti tarafından alan adına el konularak kullanıma kapatıldı. Sitenin proxy sunucuları da çalışanlar tarafından yayından kaldırıldı.",
   "library genesis":"Library Genesis (Libgen) bilimsel dergi makaleleri, akademik ve genel ilgi kitapları, resimler, çizgi romanlar ve dergiler için bir dosya paylaşım web sitesidir. Kısmen, site başka türlü ödeme duvarı olan veya başka bir yerde dijitalleştirilmeyen içeriğe ücretsiz erişim sağlar. Libgen kendisini \"kamuya açık internet kaynaklarından toplanan\" ve kullanıcılar tarafından yüklenen araştırılabilir makale, kitap ve resim veri tabanı sağlayan bir \"link toplayıcı\" olarak tanımlamaktadır.",
   "library of congress":"Amerika Birleşik Devletleri Kongre Kütüphanesi ABD'nin ulusal kütüphanesidir. Dünyanın en büyük ve en önemli kütüphanelerinden olan kongre kütüphanesi Washington'da bulunmaktadır. Ayrıca ABD’de yer alan en eski federal kültür yapısıdır.",
@@ -3499,7 +3692,15 @@
   ],
   "reddit":"Reddit, Conde Nast Digital şirketine ait bir sosyal haber, tartışma sitesidir. Siteye kayıtlı kullanıcılar bağlantı, metin, fotoğraf, anket ve video içerebilen gönderiler paylaşabilir, diğer kullanıcılar da bu gönderileri oylayarak gönderinin sayfada üste çıkmasını veya alta inmesini sağlayabilirler. Reddit'te gönderiler kullanıcılar tarafından oluşturulmuş; spor, oyun, müzik, yemek, fotoğrafçılık, haber gibi farklı konuları ele alan, \"subreddit\" denilen alt gruplarda paylaşılır. Bir subreddit'te paylaşılmış gönderi yeteri kadar oy alırsa bu gönderi Reddit'in ana sayfasına çıkar. Siteye kayıtlı her kullanıcı kendi subreddit'ini oluşturabilir.",
   "soundcloud":"SoundCloud, İsveç'te kurulan ve Berlin'den yönetilen çevrimiçi ses dağıtım platformu ve müzik paylaşım sitesi. Kullanıcıların ses dosyalarını yükleyip tanıtmasına ve paylaşmasına, dinleyicilerin bu dosyaları web üzerinden dinlemesine olanak sağlar. 2007'de Alexander Ljung ve Eric Wahlforss tarafından kurulan SoundCloud zaman içinde dünyanın en büyük müzik akış servislerinden biri oldu. Ücretsiz ve ücretli üyelik seçenekleri bulunmakta, bilgisayar ve mobil cihazlarda kullanılabilmektedir.",
-  "stackoverflow":"Stack Overflow, bilgisayar programcılığı ile ilgili kullanıcı odaklı soru cevap sitesi. Stack Exchange siteleri içinde yer alan Stack Overflow, 2008 yılında Jeff Atwood ve Joel Spolsky tarafından kuruldu.",
+  "stackoverflow":"Stack Exchange, çeşitli konularda soru-cevap sitelerini bir araya getiren site ağı. Stack Exchange, aralarında Matematik, İstatistik, Din, Astronomi, Bilgisayar programcılığı gibi belirli konularda özelleşmiş 130'un üzerinde soru-cevap sitelerini barındırmaktadır.",
+  "askubuntu":[
+   "stackoverflow:tr",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:tr",
+   "ref"
+  ],
   "startpage":"Startpage, Hollanda merkezli, gizlilik odaklı bir arama motoru şirketidir. Web sitesi, kullanıcıların verilerinin depolanmadan ve izleyiciler tarafından takip edilmeden Google Arama sonuçlarına erişmesine olanak sağlar. Startpage.com ayrıca, kullanıcıların daha fazla anonimlik için proxy aracılığıyla arama sonuçlarını açmasına olanak tanıyan bir Anonim Görünüm tarama özelliği içerir. Şirketin merkezi Hollanda'da olduğundan, Hollanda ve Avrupa Birliği gizlilik yasaları tarafından korunmaktadır ve bu nedenle PRISM gibi Amerika Birleşik Devletleri gözetim programlarına tabi değildir.",
   "youtube":"YouTube, video barındırma web sitesi. Merkezi Amerika Birleşik Devletleri'ndeki San Bruno, Kaliforniya şehrindedir. 15 Şubat 2005'te 3 eski PayPal çalışanı tarafından kurulmuştur. Kasım 2006'da Google tarafından 1,65 milyar dolara satın alınmıştır. Günümüzde Google'ın yan kuruluşlarından biri olarak faaliyetine devam etmektedir. Site, kullanıcılarına video yükleme, izleme ve paylaşma imkânı sunmaktadır. Medya şirketleri ve kullanıcı üretimi videoların gösterimi için WebM, H.264 ve Adobe Flash Video teknolojilerini kullanır. Genel olarak video klipler, televizyon klipleri, müzik videoları, video bloglar, kısa özgün videolar ve eğitim videoları gibi içerikler yayınlanmaktadır.",
   "dailymotion":"Dailymotion, 2005 yılının Mart ayında, Benjamin Bejbaum ve Olivier Poitrey tarafından Fransa'nın Paris şehrinde kurulmuş olan bir video barındırma web sitesidir. Sitenin yapımına Poitrey'nin evinin oturma odasında başlamışlardır. 15 Mart 2005'te yayına girmiştir ve kısa sürede popüler bir video paylaşım sitesi olmuştur.",
@@ -3537,14 +3738,13 @@
   "bitbucket":"Bitbucket — веб-сервіс для хостингу проєктів на базі систем керування версіями: Mercurial та Git. Bitbucket надає як безкоштовні так і платні послуги. Є аналогом GitHub, однак, на відміну від GitHub, який до січня 2019 року зберігав файли безкоштовних профілів лише у відкритому доступі, Bitbucket від самого початку дозволяв безкоштовно створювати приватні репозиторії з можливістю спільної роботи з файлами до 5-ти користувачів. Bitbucket інтегрований з іншими програмними продуктами Atlassian, такими як, JIRA, Confluence, Bamboo та HipChat.",
   "btdigg":"BTDigg (укр.:БТДиґ)— це перша BitTorrent DHT пошукова система. Ця DHT пошукова система бере участь в BitTorrent DHT мережі, підтримує мережі і робить відповідності між magnet-посиланнями і кількома торент-атрибутами, які проіндексовані і вставляються в базу даних. BTDigg забезпечує повнотекстовий пошук по базі даних через веб-інтерфейс. Веб-частина пошукової системи отримує необхідну інформацію від тексту запиту користувача. Веб-пошук підтримує запити європейських і азійських мов. Назва проекту є абревіатурою від BitTorrent Digger.",
   "crossref":"Crossref — це об'єднання видавців наукових публікацій, створене з метою розробки та підтримки всесвітньої високотехнологічної інфраструктури наукових комунікацій. Головним завданням CrossRef є сприяння широкому використанню інноваційних технологій для прискорення і полегшення наукових досліджень.",
-  "currency":"DuckDuckGo — пошукова система з відкритим початковим кодом, що використовує інформацію з багатьох джерел для надання точних та різноманітних результатів та не використовує приватну інформацію про своїх користувачів.[джерело?] Пошуковик позиціює себе як альтернативу Google та іншим схожим системам вебпошуку. Заснована у вересні 2008 року Гебріелом Вайнбергом.",
+  "currency":"DuckDuckGo — пошукова система з відкритим початковим кодом, що використовує інформацію з багатьох джерел для надання точних та різноманітних результатів. Не використовує приватну інформацію про своїх користувачів.[джерело?] Пошуковик позиціює себе як альтернативу Google та іншим схожим системам вебпошуку. Заснована у вересні 2008 року Гебріелом Вайнбергом.",
   "deezer":"Deezer — вебсайт для прослуховування музики в потоковому форматі. Дозволяє користувачам слухати на різних пристроях онлайн чи офлайн записи найбільших лейблів, як Sony, EMI, Warner Music Group, Universal Music Group. Сайт створений у Франції 2007 року. В його бібліотеці станом на серпень 2018 року представлено понад 53 млн ліцензованих треків, понад 2 млн альбомів, понад 30 тис. радіоканалів, та понад 100 млн плейлистів. Також Deezer складає чарти найпопулярніших пісень як в світовому масштабі, так і за країнами, зокрема і в Україні. Його щомісячна аудиторія, станом на 2018 рік, сягає 14 млн користувачів і 6 млн абонентів. Має застосунки для мобільних пристроїв на iOS, Android, Windows Phone та розумних годинників Garmin.",
   "deviantart":"DeviantArt — соціальна мережа для митців і комерційна онлайн-галерея. Надає можливість демонструвати свої твори, продавати їх, обговорювати чужі. DeviantArt було запущено 7 серпня 2000 року і відтоді він періодично оновлюється, додаючи нові функції. Українською сайт не перекладений, проте має україномовні спільноти. Офіційний маскот сайту — робот-кішка Фелла (Fella). DeviantArt іноді скорочують до абревіатури «dA»",
   "ddg definitions":[
    "currency:uk",
    "ref"
   ],
-  "digg":"Digg — соціальний новинний веб-портал, заснований у 2004 році. Digg був першим популярним сервісом, побудованому на концепції новин, що створюються і оцінюються самими користувачами. Великою мірою завдяки Digg в інтернеті утвердилася концепція «карми».",
   "wikidata":"Wikidata — загальне централізоване сховище для різних типів даних, як-от інтервікі-посилання, метричні параметри, кількісні параметри та будь-яка статистична верифікована інформація, що може бути використана на сторінках проєктів фонду Wikimedia. Розробка проєкту розпочата на Wikimedia Deutschland. Проєкт запущений 30 жовтня 2012 року, що дало йому змогу стати першим новим проєктом Wikimedia Foundation з 2006 року.",
   "duckduckgo":[
    "currency:uk",
@@ -3556,12 +3756,12 @@
   ],
   "fdroid":"F-Droid — централізований каталог програмних застосунків для електронних пристроїв з операційною системою Android. Основною особливістю проекту є те, що основний каталог містить тільки вільне ПЗ. Каталог також позначає в описі застосунку: використання реклами, відстеження користувачів, залежність від комерційного або обмеженого у використанні ПЗ, посилання на сайти або репозитарії із сирцевим кодом самого мобільного застосунку.",
   "flickr":"Flickr — вебсайт для розміщення фотографій та відеоматеріалів, їх перегляду, обговорення, оцінки та архівування. Flickr популярний завдяки зручній та простій системі завантаження та пошуку фотографій. Дозволяє спілкуватися та створювати тематичні групи, соціальні мережі.",
-  "genius":"Genius — американський веб-сайт, заснований у серпні 2009 року Томом Леманом, Іленом Зекорі та Мебодом Магедом. Сайт дає можливість користувачам надавати анотації та інтерпретації до текстів пісень, додавати новини, джерела інформації, поезії та документи.",
+  "genius":"Genius — американський вебсайт, заснований у серпні 2009 року Томом Леманом, Іленом Зекорі та Мебодом Магедом. Сайт дає можливість користувачам надавати анотації та інтерпретації до текстів пісень, додавати новини, джерела інформації, поезії та документи.",
   "gitlab":"GitLab — сайт та система керування репозиторіями програмного коду для Git, з додаткових можливостей: власна вікі та система відстеження помилок.",
   "github":"GitHub — один з найбільших веб-сервісів для спільної розробки програмного забезпечення. Існують безкоштовні та платні тарифні плани користування сайтом. Базується на системі керування версіями Git і розроблений на Ruby on Rails і Erlang компанією GitHub, Inc.",
   "google":"Google Search або Google — найбільша пошукова система, що належить корпорації Google Inc.",
   "google images":[
-   "Зображення Google. Найповніша система пошуку зображень у мережі.Зображення Google. Найповніша система пошуку зображень у мережі.",
+   "Зображення Google. Найповніша система пошуку зображень у мережі.",
    "https://images.google.com"
   ],
   "google news":"Google Новини — це безкоштовний агрегатор новин, який підтримується та керується Google, що вибирає найактуальніші новини з тисяч публікацій.",
@@ -3572,25 +3772,35 @@
    "google play apps:uk",
    "ref"
   ],
-  "habrahabr":"Хабрахабр (Хабр) — веб-сайт, який поєднує ознаки соціальної мережі і колективного блогу, створений для публікації новин, аналітичних статей, думок, пов'язаних із інформаційними технологіями, бізнесом та Інтернетом.",
+  "habrahabr":"Хабрахабр (Хабр) — вебсайт, який поєднує ознаки соціальної мережі і колективного блогу, створений для публікації новин, аналітичних статей, думок, пов'язаних із інформаційними технологіями, бізнесом та Інтернетом.",
   "hoogle":"Haskell — стандартизована, винятково функційна мова програмування з нестрогою семантикою. Названа на честь американського математика Гаскелла Каррі, роботи якого в галузі математичної логіки є базовими для функційного програмування. Гаскель базується на лямбда численні. Найважливішими реалізаціями є компілятор Glasgow Haskell Compiler (GHC) та оснований на ньому компілятор GHCJS, що компілює Гаскель-код у скрипт мовою JavaScript. Історично важливим також є інтерпретатор Hugs, але на сьогодні він не підтримується.",
+  "imdb":"База даних фільмів в Інтернеті — найбільша база даних та вебсайт про кінематограф. База даних значною мірою заповнюється добровольцями, це чимось нагадує концепцію вікі. У базі зараз зібрана інформація про понад 7,7 млн фільмів і телесеріалів, є інформація майже про 10,4 млн акторів, режисерів та інших професіоналів кіно зі всього світу.",
   "kickass":"KickassTorrents — у минулому одна з найбільших Bittorent-толок світу що проіснувала з 2008 по липень 2016 року. Сайт трекеру працював як пошуковий індекс для .torrent файлів та magnet-посилань). Станом на липень 2016 року сайт займав 68 місце за відвідуваністю у світі згідно з глобальним рейтингом Alexa. Один з серверів ресурсу було розміщено в США.",
-  "library genesis":"Library Genesis або LibGen — веб-сайт та онлайн-сховище, що нелегально надає безкоштовний доступ до наукових статей, книг, та наукових праць захищених авторським правом. Окрім іншого, на сайті розміщено PDF-файли з сайту ScienceDirect.",
+  "library genesis":"Library Genesis або LibGen — вебсайт та онлайн-сховище, що нелегально надає безкоштовний доступ до наукових статей, книг, та наукових праць захищених авторським правом. Окрім іншого, на сайті розміщено PDF-файли з сайту ScienceDirect.",
+  "z-library":"Z-Library — онлайн-бібліотека та проект спільного використання файлів для наукових статей. Z-Library заявляє, що проект надає доступ до понад 6 754 720 книг та 80 759 561 статей на 2021 рік.",
   "library of congress":"Бібліотека Конгресу — національна бібліотека Сполучених Штатів Америки та дослідницький підрозділ Конгресу США. Є найбільшим за площею книгосховищем та однією з найважливіших бібліотек світу. Розташована у Вашингтоні, має три основні будівлі.",
   "mixcloud":"Mixcloud онлайн сервіс зі стримінгу музики, який забезпечує прослуховування і розповсюдження радіо-шоу, DJ-міксів і подкастів, які надаються його ж зареєстрованими користувачами.",
-  "npm":"npm - це менеджер пакунків для мови програмування JavaScript. Для середовища виконання Node.js це менеджер пакунків за замовчуванням. Включає в себе клієнт командного рядка, який також називається npm, а також онлайн-базу даних публічних та приватних пакунків, яка називається реєстром npm. Реєстр доступний через клієнт, а доступні пакунки можна переглядати та шукати через веб-сайт npm. Менеджер пакунків та реєстр керуються npm, Inc.",
+  "npm":"npm - це менеджер пакунків для мови програмування JavaScript. Для середовища виконання Node.js це менеджер пакунків за замовчуванням. Включає в себе клієнт командного рядка, який також називається npm, а також онлайн-базу даних публічних та приватних пакунків, яка називається реєстром npm. Реєстр доступний через клієнт, а доступні пакунки можна переглядати та шукати через вебсайт npm. Менеджер пакунків та реєстр керуються npm, Inc.",
   "openstreetmap":"OpenStreetMap — це відкритий проєкт, спрямований на збір, збереження та розповсюдження загальнодоступних геопросторових даних, створення інструментів для роботи з ними силами спільноти волонтерів.",
   "piratebay":"The Pirate Bay — це вебсайт, засновники якого позиціонують його як «найбільший у світі BitTorrent-трекер». Він також служить як пошуковий індекс для .torrent файлів. ThePirateBay.org знаходиться на 101 місці року в світовому рейтингу вебсайтів Alexa та на 258 в рейтингу від Quantcast. The Pirate Bay був започаткований шведською організацією Piratbyrån в листопаді 2003, але з початку жовтня 2004 почав існувати як окрема організація. Зараз сайт підтримується Готфрідом Свартгольмом («anakata»), Фредеріком Нейжом («TiAMO») та Петером Сунде («brokep»).",
   "pubmed":"MEDLINE — це бібліографічна база даних про біологічні науки та біомедичну інформацію. Включає бібліографічну інформацію для статей з академічних журналів, що охоплюють медицину, сестринську справу, фармацію, стоматологію, ветеринарію та охорону здоров'я. MEDLINE також охоплює значну частину літератури з біології та біохімії, а також таких галузей, як молекулярна еволюція.",
   "pypi":"PyPI — каталог програмного забезпечення, написаного на мові програмування Python. У поєднанні з системами управління бібліотечними пакетами аналогічні PEAR для PHP і CPAN для Perl. За даними лічильника на головній сторінці в липні 2014 містив дані про більш ніж 46000 пакетів, тоді як в 2010 році пакетів було всього близько 10000.",
   "reddit":"Reddit — це розважальний, новинний онлайн-сервіс, а також інтернет-ЗМІ, де зареєстровані користувачі можуть додавати свій контент, такий як текстові пости або прямі посилання й обговорювати їх (BBS). Як і багато інших подібних сайтів, Reddit підтримує систему голосування за вподобані повідомлення — найбільш популярні з них з'являються на головній сторінці сайту. Також найпопулярніші пости показуються угорі відповідних категорій. Контент організовано за допомогою осередків за інтересами, які звуться «subreddits». Тематика сабредитів досить широка: новини, ігри, кіно, музика, книги, спорт, їжа, фотографії тощо.",
   "soundcloud":"SoundCloud — стримінгова платформа та вебсайт для розповсюдження оцифрованої звукової інформації, володіє функціями соціальної мережі та однойменної організації.",
-  "stackoverflow":"Stack Overflow — популярна система питань і відповідей для професійних програмістів та ентузіастів. Це приватний вебсайт, основний у мережі Stack Exchange Network, створений Джеффом Етвудом та Джоелом Спольським у 2008.",
+  "stackoverflow":"Stack Exchange — це мережа вебсайтів для питань і відповідей з різних тем, в якій питання, відповіді і користувачі мають рейтинг. Першим і одним з найвідоміших сайтів мережі є Stack Overflow, що присвячений питанням з програмування. Система рейтингів дозволяє сайтам мережі бути самомодерованими. Питання і відповіді користувачів публікуються під вільною ліцензією Creative Commons Attribution-ShareAlike 3.0 Unported.",
+  "askubuntu":[
+   "stackoverflow:uk",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:uk",
+   "ref"
+  ],
   "startpage":"Startpage — нідерландська пошукова система, що позиціонує себе як конфіденційний засіб пошуку в інтернеті. Сайт надає результати запитів Google, захищаючи право конфіденційності користувача, відмовляючись зберігати особисті дані й дані результату пошуку. Також пошукова система має функцію анонімного перегляду, що надає результати через проксі-сервер для більшої анонімності. Особливою перевагою Startpage є базування у Нідерландах, що свідчить про захист законами ЄС конфіденційності, запобігаючи стеження з боку державних програм, як приміром PRISM.",
   "youtube":"YouTube — популярний відеохостинг, що надає послуги розміщення відеоматеріалів. Заснований 14 лютого 2005 року трьома працівниками PayPal: Чадом Герлі, Стівеном Чені та Джаведом Карімом. Є підрозділом компанії Google. Станом на серпень 2019 року YouTube є другим за відвідуваністю сайтом в Інтернеті.",
   "dailymotion":"Dailymotion — французький відеохостинг. Головний офіс компанії знаходиться у 17-му окрузі Парижа. Dailymotion є третім за відвідуваністю відео обмінником, після YouTube і Vimeo.",
   "vimeo":"Vimeo — сервіс, що надає послуги в збереженні та трансляції відеоматеріалів в мережі Інтернет за допомогою протоколу HTTPS.",
-  "wikibooks":"Вікіпідру́чник — веб-сайт для колективного написання навчальної та іншої літератури, що працює за технологією «вікі» на принципах свободи інформації: кожен може створити і змінити будь-яку сторінку будь-якого підручника, і кожен може безкоштовно читати, копіювати, видаляти і змінювати його зміст.",
+  "wikibooks":"Вікіпідру́чник — вебсайт для колективного написання навчальної та іншої літератури, що працює за технологією «вікі» на принципах свободи інформації: кожен може створити і змінити будь-яку сторінку будь-якого підручника, і кожен може безкоштовно читати, копіювати, видаляти і змінювати його зміст.",
   "wikinews":"Вікіновини — відкрите новинне інтернет-видання, яке створюється неоплачуваними дописувачами. Технологія й принципи написання новинних статей у Вікіновинах такі ж, як в інших виданнях фонду «Вікімедіа», — некомерційної організації, що підтримує Вікіновини.",
   "wikiquote":"Вікіцитати — вільне інтернет-зібрання цитат відомих осіб, висловів із книг, фільмів тощо. Сайт створений фондом «Вікімедія» із застосуванням технології «Вікі». Усі розміщені у Вікіцитатах цитати можна використовувати за умовами ліцензії GNU Free Documentation License.",
   "wikisource":"Вікіджерела — це інтернет-бібліотека безкоштовних текстових джерел у вікі, що керується Фондом Вікімедіа. Вікіджерела — це назва проєкту в цілому і назва для кожного екземпляра цього проєкту ; декілька Вікіджерел становлять загальний проєкт Вікіджерела. Метою проєкту є розміщення всіх форм вільного тексту багатьма мовами й перекладах. Спочатку задуманий як архів для зберігання корисних або важливих історичних текстів, він розширився і став бібліотекою загального змісту. Офіційний початок проєкту започатковано 24 листопада 2003 року під назвою англ. Project Sourceberg, гра слів з назвою знаменитого Проєкт «Гутенберг», де source в перекладі з англійської — джерело. Назва «Вікіджерела» була прийнята в тому ж році, а через сім місяців проєкт отримав власне доменне ім'я.",
@@ -3629,7 +3839,6 @@
    "currency:vi",
    "ref"
   ],
-  "digg":"Digg là một trang tổng hợp tin tức với trang nhất được quản lý, nhằm mục đích chọn các câu chuyện dành riêng cho khán giả Internet như khoa học, xu hướng các vấn đề chính trị và các vấn đề Internet lan truyền. Nó được ra mắt dưới dạng hiện tại vào ngày 31 tháng 7 năm 2012, với sự hỗ trợ chia sẻ nội dung lên các nền tảng xã hội khác như Twitter và Facebook.",
   "wikidata":"Wikidata được thành lập ngày 30 tháng 10 năm 2012 và là dự án mới đầu tiên của Wikimedia Foundation kể từ năm 2006.",
   "duckduckgo":[
    "currency:vi",
@@ -3652,6 +3861,7 @@
    "ref"
   ],
   "hoogle":"Haskell là ngôn ngữ lập trình thuần hàm, đặt theo tên của Haskell Curry. Vì là ngôn ngữ lập trình hàm, trong Haskell, hàm là \"cư dân hạng nhất\", với hầu hết các cấu trúc điều khiển là hàm.",
+  "imdb":"Internet Movie Database là một trang cơ sở dữ liệu trực tuyến về điện ảnh thế giới. Nó cung cấp thông tin về phim, diễn viên, đạo diễn, nhà làm phim... và tất cả những người, công ty trong lĩnh vực sản xuất phim, phim truyền hình và cả trò chơi video.",
   "library of congress":"Thư viện Quốc hội, trên thực tế là thư viện quốc gia của Hoa Kỳ, là đơn vị nghiên cứu của Quốc hội Hoa Kỳ. Với trụ sở gồm 3 tòa nhà đóng tại Washington, D.C., đây là thư viện lớn nhất theo diện tích để sách và một trong những thư viện quan trọng nhất trên thế giới. Kho tư liệu của nó bao gồm hơn 30 triệu cuốn sách được phân loại và các tài liệu in ấn khác được viết bằng 470 thứ tiếng; hơn 61 triệu bản thảo viết tay; bộ sưu tập các cuốn sách hiếm lớn nhất Bắc Mỹ, bao gồm bản sơ thảo Tuyên ngôn Độc lập Hoa Kỳ, Kinh Thánh Gutenberg ; hơn 1 triệu ấn bản các văn kiện của Chính phủ Hoa Kỳ; 1 triệu ấn bản báo chí thế giới trong suốt 3 thế kỷ qua; 33.000 bộ nhật báo đóng tập; 500.000 cuộn microfilm; hơn 6.000 tựa truyện tranh; cơ sở dữ liệu luật lớn nhất thế giới; các bộ phim; hơn 4,8 triệu bản đồ, bản nhạc; 2,7 triệu bản ghi âm; hơn 13,7 triệu hình in và chụp bao gồm các tác phẩm nghệ thuật chuyên nghiệp và nghệ thuật quần chúng, các bản vẽ kiến trúc; cây vĩ cầm cổ Betts Stradivarius; và cây viola Cassavetti Stradivarius;",
   "npm":"NPM là chương trình quản lý thư viện ngầm định trong môi trường Node.js. Nó bao gồm một trình gọi dòng lệnh từ máy khách Client với tên gọi là npm, và cơ sở dữ liệu trực tuyến chứa các gói public và private còn được gọi là npm registry. Npm registry được gọi từ npm client và trên web browser. Tất cả được quản lý trực tiếp từ NPM, inc.",
   "openstreetmap":"OpenStreetMap là một dịch vụ bản đồ thế giới trực tuyến có nội dung mở. OpenStreetMap nhằm mục đích cung cấp dữ liệu địa lý do nhiều người cùng cộng tác với nhau trên hệ thống wiki. Nó thường được gọi \"Wikipedia của bản đồ\". Dự án OpenStreetMap được sáng lập năm 2004, chủ yếu để cạnh tranh với các công ty và cơ quan chính phủ cung cấp dữ liệu địa lý theo các điều khoản sử dụng được coi là quá chặt chẽ.",
@@ -3659,6 +3869,15 @@
   "pubmed":"MEDLINE là một cơ sở dữ liệu hỗn hợp của các ngành khoa học sự sống và y sinh học. Các lĩnh vực phục vụ của MEDLINE bào gồm y học, kỹ thuật điều dưỡng, nha khoa, thú y và tổ chức y tế. Với mục đích cung cấp lượng thông tin tối đa, các ngành liên quan như sinh học và hóa sinh học đã được đưa vào cơ sở dữ liệu, thậm chí cả một số ngành không trực tiếp phục vụ y học như tiến hóa phân tử.",
   "reddit":"Reddit , hay cách điệu là reddit, là một trang web giải trí, dịch vụ giao tiếp xã hội, tin tức xã hội và tin tức trực tuyến, nơi mà cộng đồng các thành viên đã đăng ký có thể gửi lên nhiều loại nội dung, chẳng hạn như bài đăng chữ hay đường dẫn trực tiếp. Chỉ có các thành viên đăng ký sau đó mới có thể bầu chọn bằng mũi tên lên và mũi tên xuống cho những nội dung được gửi lên để sắp xếp các bài đăng và quyết định vị trí của nó trên các trang của trang web. Các mục nội dung được tổ chức theo lĩnh vực quan tâm gọi là các \"subreddit\" mà người dùng đăng ký có thể tự do tạo ra cộng đồng thảo luận của riêng mình với bất kì ngôn ngữ nào.",
   "soundcloud":"SoundCloud là trang mạng chia sẻ nhạc trực tuyến cho phép người dùng tải lên, quảng bá và chia sẻ âm thanh cũng như là DSP cho phép người nghe truyền phát âm thanh có trụ sở tại Berlin, Đức. Công ty do hai nhà sáng lập người Thụy Điển là Alexander Ljung và Eric Wahlforss khởi tạo vào năm 2007, chính thức hoạt động tháng 10 năm 2008. SoundCloud đã phát triển trở thành một trong những dịch vụ phát trực tuyến nhạc lớn nhất với hơn 175 triệu người dùng hàng tháng trên toàn thế giới.SoundCloud cung cấp cả tư cách thành viên miễn phí và trả phí trên nền tảng, có sẵn cho máy tính để bàn và thiết bị di động.",
+  "stackoverflow":"Stack Exchange là mạng lưới các trang web hỏi và trả lời (Q&A) về các chủ đề trong các lĩnh vực đa dạng, mỗi trang bao gồm một chủ đề cụ thể, nơi các câu hỏi, câu trả lời và người dùng phải tuân theo quy trình thưởng danh tiếng. Hệ thống danh tiếng cho phép các trang web tự kiểm duyệt. Kể từ tháng 8 năm 2019, ba trang web được xem tích cực nhất trong mạng là Stack Overflow, Super User và Ask Ubuntu.",
+  "askubuntu":[
+   "stackoverflow:vi",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:vi",
+   "ref"
+  ],
   "semantic scholar":"Semantic Scholar là một công cụ tìm kiếm được hỗ trợ bởi trí thông minh nhân tạo cho các ấn phẩm học thuật được phát triển tại Viện Trí tuệ Nhân tạo Allen và được phát hành công khai vào tháng 11 năm 2015. Dự án sử dụng sự kết hợp của máy học, xử lý ngôn ngữ tự nhiên và thị giác máy để thêm một lớp phân tích ngữ nghĩa vào các phương pháp phân tích trích dẫn truyền thống và trích xuất các số liệu, thực thể và địa điểm có liên quan từ các bài báo.Liu, Ying; Gayle, Albert A; Wilder-Smith, Annelies; Rocklöv, Joacim. “The reproductive number of COVID-19 is higher compared to SARS coronavirus”. Journal of Travel Medicine. 27 (2). doi:10.1093/jtm/taaa021. PMC 7074654. PMID 32052846. S2CID 211099356.",
   "youtube":"YouTube là một nền tảng chia sẻ video trực tuyến của Mỹ có trụ sở chính tại San Bruno, California. Nền tảng này được tạo ra vào tháng 2 năm 2005 bởi ba nhân viên cũ của PayPal — Chad Hurley, Steve Chen và Jawed Karim — đã được Google mua lại vào tháng 11 năm 2006 với giá 1,65 tỷ đô la Mỹ và hiện hoạt động như một trong những công ty con của Google. YouTube là trang web được truy cập nhiều thứ hai sau Google Tìm kiếm, theo xếp hạng của Alexa Internet.",
   "dailymotion":"Dailymotion là một trang web dịch vụ chia sẻ video của Pháp được sở hữu và quản lý bởi Vivendi; có trụ sở tại Quận 18, Paris, Pháp. Theo comScore, Dailymotion là trang web video lớn thứ hai thế giới, sau YouTube. Hiện Dailymotion đã có phiên bản của hơn 183 ngôn ngữ và 43 phiên bản bản địa phương khác nhau với các trang chủ và nội dung riêng trên toàn thế giới. Trang web hiện giờ đã có hơn 300 triệu người dùng hàng tháng.",
@@ -3669,114 +3888,241 @@
   "wiktionary":"Wiktionary là một trong những dự án trực thuộc Quỹ Hỗ trợ Wikimedia, cùng với Wikipedia, để biên soạn một bộ từ điển nội dung mở dùng hệ thống wiki, bao gồm nhiều ngôn ngữ. Dựa vào ý tưởng của ông Daniel Alston, nó được thành lập vào ngày 12 tháng 12 năm 2002. Vào ngày 29 tháng 3 năm 2004, hai phiên bản ngôn ngữ đầu tiên của Wiktionary được mở cửa, tiếng Pháp và tiếng Ba Lan. Sau đó, nhiều phiên bản ngôn ngữ khác được bắt đầu và đang được phát triển. Wiktionary đã ở một địa chỉ tạm đến ngày 1 tháng 5 năm 2004, khi nó được di chuyển đến địa chỉ chính của nó. Wiktionary tiếng Anh đã có hơn 896.000 mục từ và Wiktionary tiếng Việt là phiên bản ngôn ngữ lớn thứ năm có hơn 228.000 mục từ.",
   "wikiversity":"Wikiversity là một dự án của Wikimedia Foundation cung cấp các học liệu trực tuyến và các bài giảng cho mọi người với giấy phép tự do. Tuy nhiên, Wikiversity không phải là một bách khoa toàn thư như Wikipedia.",
   "wikivoyage":"Wikivoyage một dự án xây dựng cẩm nang du lịch trực tuyến có nội dung tự do. Là một dự án \"chị em\" với Wikipedia, nó trực thuộc tổ chức Wikimedia Foundation và cho phép mọi người tham gia biên tập. Dự án tách ra khỏi Wikitravel tiếng Đức ngày 10 tháng 12 năm 2006 sau khi công ty Internet Brands mua Wikitravel. Họ thành lập tổ chức Wikivoyage e.V. tại Đức để quản lý dự án. Vào giữa năm 2012, đa số thành viên Wikitravel tiếng Anh, bao gồm phần nhiều bảo quản viên, quyết định hợp nhất các cộng đồng Wikitravel và Wikivoyage vào một dự án phi lợi nhuận mới. Wikivoyage yêu cầu gia nhập vào Wikimedia Foundation và Wikimedia phê chuẩn vào tháng 10 năm 2012.",
-  "wolframalpha":"Wolfram|Alpha là một máy trả lời do Wolfram Research phát triển. Đây là một dịch vụ trực tuyến có nhiệm vụ trả lời các câu hỏi nhập vào trực tiếp bằng cách tính toán câu trả lời từ các dữ liệu có cấu trúc, chứ không chỉ cung cấp một danh sách các tài liệu hoặc trang có web có thể chứa câu trả lời như cách máy tìm kiếm thường làm. Website này được Stephen Wolfram công bố vào tháng 3 năm 2009, và được phát hành cho công chúng ngày 15 tháng 5 năm 2009.",
+  "wolframalpha":"WolframAlpha là một máy trả lời do Wolfram Research phát triển. Đây là một dịch vụ trực tuyến có nhiệm vụ trả lời các câu hỏi nhập vào trực tiếp bằng cách tính toán câu trả lời từ các dữ liệu có cấu trúc, chứ không chỉ cung cấp một danh sách các tài liệu hoặc trang có web có thể chứa câu trả lời như cách máy tìm kiếm thường làm. Website này được Stephen Wolfram công bố vào tháng 3 năm 2009, và được phát hành cho công chúng ngày 15 tháng 5 năm 2009.",
   "naver":"Naver IPA: [nəvɛ́:r] là một nền tảng trực tuyến của Hàn Quốc được điều hành bởi Naver Corporation. Được ra mắt lần đầu năm 1999, Naver vốn là cổng thông tin điện tử đầu tiên tại Hàn Quốc, sau đó được phát triển thành một công cụ tìm kiếm riêng. Đây cũng là nhà điều hành đầu tiên trên thế giới ra mắt tính năng tìm kiếm toàn diện, tính toán các kết quả tìm kiếm từ nhiều danh mục tìm kiếm khác nhau và trình bày chúng trong một trang duy nhất. Từ đó, Naver cũng đã xây dựng thêm vô số các dịch vụ từ cơ bản như e-mail, tin tức đến nền tảng trực tuyến Q&A đầu tiên trên thế giới Knowledge iN.",
   "peertube":"PeerTube là một nền tảng chia sẻ video liên hợp, tự do và nguồn mở hoạt động với hình thức tự lưu trữ (self-hosting). Nền tảng này sử dụng giao thức ActivityPub và WebTorrent, một công nghệ P2P tiết kiệm tài nguyên cho các máy chủ cá nhân."
  },
- "zh_CN":{
-  "archive is":"archive.today前称archive.is，是一个私人资助的网页存档网站，资料中心位于欧洲法国的北部-加来海峡。这个网站典藏档案馆使用Apache Hadoop与Apache Accumulo软件。它可以一次取回一个类似于WebCite的小于50MB的页面，并能收录Google地图与Twitter。",
-  "arxiv":"arXiv 是一个收集物理学、数学、计算机科学、生物学与数理经济学的论文预印本的网站，始于1991年8月14日。截至2008年10月，arXiv.org已收集超过50万篇预印本；至2014年底，藏量达到1百万篇。截至2016年10月，提交率已达每月超过10,000篇。",
+ "zh-Hans-CN":{
+  "archive is":"archive.today前称archive.is，是一個私人資助的网页存档網站，資料中心位於歐洲法國的北部-加来海峡。這個網站典藏檔案館使用Apache Hadoop與Apache Accumulo軟體。它可以一次取回一個類似於WebCite的小於50MB的頁面，並能收錄Google地圖與Twitter。",
+  "arxiv":"arXiv 是一個收集物理學、數學、計算機科學、生物學與數理經濟學的論文預印本的網站，始于1991年8月14日。截至2008年10月，arXiv.org已收集超過50萬篇預印本；至2014年底，藏量達到1百萬篇。截至2016年10月，提交率已達每月超過10,000篇。",
   "bandcamp":"Bandcamp是一家美国在线音乐公司， 由前Oddpost联合创始人Ethan Diamond与程序员Shawn Grunberger、Joe Holt和Neal Tucker于2008年创立，总部位于加利福尼亚。",
-  "wikipedia":"维基百科 是维基媒体基金会运营的一个多语言的线上百科全书，并以创建和维护作为开放式协同合作项目，特点是自由内容、自由编辑、自由版权。目前是全球网络上最大且最受大众欢迎的参考工具书，名列全球二十大最受欢迎的网站，其在搜寻引擎中排名亦较为靠前。维基百科目前由非营利组织维基媒体基金会负责营运。Wikipedia是混成词，分别取自于网站核心技术“Wiki”以及英文中百科全书之意的“encyclopedia”。截至2021年初，所有语种的维基百科条目数量达5500万。",
-  "bing":"是一款由微软公司推出的网路搜寻引擎。Bing的历史可追溯至于1998年的第三个季度发布的MSN Search，它的由Looksmart和Inktomi等提供；2006年3月8日，微软发布了Windows Live Search的公测版，并于同年9月11日让其取代了MSN Search，该引擎开始使用搜寻选项卡；次年3月，微软将其与Windows Live分开并更名Live Search，在此期间，其子服务曾经多次重组、关闭。到了2009年6月3日，微软将Live Search改造成了今天的Bing并正式发布。微软认为Bing一词简单明了、易于拼写，容易被人记住；它源自成语“有求必应”。微软声称，此款搜寻引擎将以全新的姿态面世并带来革命。Bing的内测代号为Kumo，其后才被命名为Bing。2020年10月5日，Bing更名为Microsoft Bing。",
+  "wikipedia":"維基百科 是维基媒体基金会运营的一个多语言的線上百科全書，并以创建和维护作为开放式协同合作项目，特点是自由內容、自由编辑、自由版权。目前是全球網絡上最大且最受大眾歡迎的参考工具书，名列全球二十大最受歡迎的網站，其在搜尋引擎中排名亦較為靠前。維基百科目前由非營利組織維基媒體基金會負責營運。Wikipedia是混成詞，分别取自於網站核心技術「Wiki」以及英文中百科全書之意的「encyclopedia」。截至2021年初，所有語種的維基百科條目數量達5500萬。",
+  "bing":"是一款由微软公司推出的網路搜尋引擎。Bing的历史可追溯至于1998年的第三个季度发布的MSN Search，它的由Looksmart和Inktomi等提供；2006年3月8日，微软发布了Windows Live Search的公测版，并于同年9月11日让其取代了MSN Search，该引擎开始使用搜尋選項卡；次年3月，微软将其与Windows Live分开并更名Live Search，在此期间，其子服务曾经多次重组、关闭。到了2009年6月3日，微软将Live Search改造成了今天的Bing并正式发布。微软认为一词简单明了、易于拼写，容易被人记住；它源自成语「有求必应」。微软声称，此款搜尋引擎将以全新的姿态面世並带来革命。Bing的内测代号为Kumo，其后才被命名为。2020年10月5日，Bing更名為Microsoft Bing。",
   "bing images":[
-   "bing:zh_CN",
+   "bing:zh-Hans-CN",
    "ref"
   ],
-  "deezer":"Deezer是一家法国在线音乐流媒体服务提供商。它允许用户在各种设备上在线或离线收听来自包括环球音乐集团、索尼音乐和华纳音乐集团在内的各家唱片公司的音乐。2007年，Deezer创建于法国巴黎，截至2019年1月，Deezer拥有5600万首授权曲目，拥有超过3万个电台频道，月活跃用户达1400万，付费用户为700万。该服务适用于Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",
-  "wikidata":"维基数据 是一个可协同编辑的知识库，是继2006年的维基学院之后，第一个新的维基媒体基金会项目。这一项目与维基共享资源的工作方式类似，将为其他维基计划及各语种维基百科中的信息框、列表及跨语言连结等提供统一存放的数据，该项目在2012年10月30日投入使用。维基数据藉由软件Wikibase运行。",
-  "etymonline":"在线词源词典 是免费的在线词典，由道格拉斯·哈珀 编纂和撰写，用于描述英语单词的词源。",
-  "fdroid":"F-Droid是一个Android应用程序的软件资源库（或应用商店）；其功能类似于Google Play商店，但只包含自由及开放源代码软件。应用可从F-Droid网站或直接从F-Droid客户端应用浏览及安装，F-Droid客户端应用会自动更新其应用。F-Droid不要求用户注册账号。如果应用包含广告、用户分析器，追踪器或倚赖非自由软件，会被标记存在“负功能”（antifeatures）。运行F-Droid的服务器也均使用自由及开放源代码软件，从而允许任何人创建自己的软件库。",
-  "flickr":"Flickr为一家提供图片分享的网路相簿，是Web 2.0的最佳利用例子之一。",
-  "free software directory":"自由软件目录是一个自由软件基金会（FSF）和联合国教育、科学及文化组织（ UNESCO ）的项目。自由软件目录包含自由操作系统下运行的有用自由软件。",
-  "genius":"Genius 是一家北美数字媒体公司，于2009年8月由汤姆·雷曼、伊兰·泽科里和马胡德·莫哈代姆建立。该网站允许使用者对歌曲歌词、新闻故事、诗歌和文件等提供注释和解释。",
-  "gitlab":"GitLab 是由 GitLab Inc.开发，一款基于 Git 的完全集成的软件开发平台。 另外，GitLab 且具有wiki以及在线编辑、issue跟踪功能、CI/CD 等功能。",
-  "github":"GitHub是通过Git进行版本控制的软件源代码托管服务平台，由GitHub公司 的开发者Chris Wanstrath、P. J. Hyett和汤姆·普雷斯顿·沃纳使用Ruby on Rails编写而成。",
-  "google images":"Google图片搜索是Google公司于2001年7月推出的图片搜索服务。Google Chrome及Firefox提供扩充功能搜索网络图像。",
-  "google news":"Google新闻是Google开发的一款Web新闻聚合器，由Google首席工程师克里希纳·巴拉特 创造与领导开发。",
-  "google videos":"Google影片 是由Google提供的一项视讯共享和搜索服务。与YouTube类似，“Google影片”向用户提供必要的HTML代码，允许用户将选定的视讯嵌入到其它的网站的页面中。这种方法可以使用户在网站中嵌入大量的视讯而无需考虑带宽和储存容量限制的问题。在2006年10月9日，Google收购了前竞争对手YouTube，并在2007年6月13日发表声明，“Google影片”的搜索结果将包含由网络蜘蛛在其它托管服务、YouTube和用户上传中抓取的内容。",
-  "google scholar":"Google学术搜索 是一个可以免费搜索学术文章的网络搜索引擎，由计算机专家阿努拉·阿查雅开发。2004年11月，Google第一次发布了Google学术搜索的试用版。该项索引包括了世界上绝大部分出版的学术期刊。",
-  "google play apps":"Google Play又称Play 商店，前身为Android Market。是由Google为Android作业系统所开发的流动应用程式数位发行平台，包括数位媒体商店。它作为Android作业系统的官方应用商店，允许用户浏览和下载使用Android SDK开发并透过Google发布的应用程式。 Google Play也是数位媒体商店，提供音乐，杂志，书籍，电影和电视节目。它之前提供了Google硬件装置，直到2015年3月11日推出一个单独的线上硬件零售商Google Store。",
-  "google play movies":[
-   "google play apps:zh_CN",
-   "ref"
+  "bing videos":[
+   "Bing 可協助您將資訊轉化為行動，從開始搜尋到採取行動更快、更輕鬆。",
+   "https://www.bing.com/videos"
   ],
-  "hoogle":"Haskell 是一种标准化的，通用的纯函数式编程语言，有惰性求值和强静态类型。它的命名源自美国逻辑学家哈斯凯尔·加里，他在数理逻辑方面上的工作使得函数式编程语言有了广泛的基础。在Haskell中，“函数是第一类物件”。作为一门函数程式语言，主要控制结构是函数。Haskell语言是1990年在编程语言Miranda的基础上标准化的，并且以λ演算为基础发展而来。这也是为什么Haskell语言以希腊字母“λ”（Lambda）作为自己的标志。Haskell具有“证明即程序、命题为类型”的特征。",
-  "library genesis":"创世纪图书馆 是一个影子图书馆，用户可在此一网站上分享下载学术期刊文章、学术书籍、一般书籍、杂志、漫画。此一网站为用户提供挡在付费墙背后，抑或官方没释出电子版本的资料。创世纪图书馆形容自身为“资讯整合连结”网站，为“互联网上所收集及用户上载的”资源提供可供查找的资料库。",
-  "npm":"npm 是Node.js预设的、用JavaScript编写的软件套件管理系统。",
-  "openstreetmap":"开放街图 是一个建构自由内容之网上地图协作计划，目标是创造一个内容自由且能让所有人编辑的世界地图，并且让一般的行动装置有方便的导航方案。",
-  "piratebay":"海盗湾 是一个专门储存、分类及搜寻Bittorrent种子文件及磁力连结的网站，由瑞典的民间反版权组织海盗署于2003年成立，支持35种语言。",
-  "pypi":"PyPI 是Python的正式第三方 软件包的软件存储库，它类似于CPAN（Perl的存储库）。一些软件包管理器例如pip，就是默认从PyPI下载软件包。用户通过PyPI可以下载超过235,000个Python软件包。",
-  "reddit":"Reddit（） 是一个娱乐、社交及新闻网站，注册用户可以将文字或连结在网站上发布，使它基本上成为了一个电子布告栏系统。注册用户可以对这些帖子进行投票，结果将被用来进行排名和决定它在首页或子页的位置。网站上的内容分类被称为“subreddit”。subreddit的内容包括新闻、电子游戏、电影、音乐、书籍、健身、食物和图片分享等。",
-  "stackoverflow":"Stack Overflow是一个程式设计领域的问答网站，隶属Stack Exchange Network。网站允许注册用户提出或回答问题，利用积分制度让用户自行管理。另外网站也会根据用户的贡献颁发徽章。用户建立的内容都使用知识共享协议授权。",
-  "startpage":"Startpage为一荷兰公司Startpage B.V.所推出的搜寻引擎服务，其前身为元搜寻引擎Ixquick，Startpage当时Ixquick旗下之服务，两者于2016年改为合并并改为现名。Startpage以强调对客户隐私的保护闻名。",
-  "unsplash":"Unsplash是一个免费的照片共享网站。摄影师可以将照片上传到Unsplash，照片编辑者们会对用户上传的照片进行整理。Unsplash使用了较为自由的著作权许可条款，这让Unsplash成为了互联网上最大的摄影照片供应商之一，其网站上的照片经常在文章配图中出现。截止至2020年4月，该网站拥有超过18万名摄影师，图库中储存了超过160万张照片。Unsplash被《福布斯》、《企业家杂志》、CNET和The Next Web评为全球领先的摄影网站之一。",
-  "yahoo news":"雅虎新闻 是一个美国新闻网站，最初是基于雅虎的新闻聚合服务而建立。该站点最早由雅虎软件工程师布拉德·克劳斯易 于1996年8月开发完成，而最初的文章则来自其他新闻媒体的服务，例如：美联社、路透社、福斯新闻台、半岛电视台、ABC新闻、《今日美国》、有线电视新闻网和BBC新闻。",
-  "youtube":"YouTube，源自美国影片分享网站，也是目前全球最大的影片搜寻和分享平台，让使用者上传、观看、分享及评论影片。公司于2005年2月14日注册，网站的口号为“Broadcast Yourself”，网站的标志意念来自早期电视机（阴极射线管）。此网站尚无官方中文名，中国大陆有时候将其译为优兔或优管、油管、Y站等。也简称“YT”。",
-  "dailymotion":"Dailymotion 是一家视讯分享网站，总部位于法国巴黎十七区。它的域名在YouTube之后一个月注册。Dailymotion最广为人知的特点之一就是其提供支援开放格式ogg的视讯。和同类型的其他Flash视讯分享网站相比，Dailymotion以其短片具有高清晰画质而闻名。到2008年1月，每天上传到该站的短片大约是16,000，网页浏览次数平均一天超过2600万次。2008年1月，Dailymotion的Alexa全球网站排名为38。母公司为威望迪。",
-  "wikibooks":"维基教科书 是维基媒体的一项计划，于2003年7月10日开放。 此计划收集自由的教科书，并让用户自己编辑教科书——任何人都可以进入“编辑”页面修改任何一本教科书。",
-  "wikinews":"维基新闻 是由一群志愿者、即民间记者运营的网络媒体。同时是一个自由内容的维基，属维基媒体计划项目，由维基媒体基金会负责运营。维基新闻通过协作新闻学的工作模式去运行，同时亦努力通过中性的观点报导新闻。",
-  "wikiquote":"维基语录 是维基媒体基金会下属的一个维基计划，属于维基百科的一个姊妹计划，同样使用MediaWiki软件。维基语录旨在创建一个各种语言的名人名言以及谚语等内容的自由的在线语录。",
-  "wikisource":"维基文库 是维基媒体基金会旗下维基百科的姊妹计划，目的是创建一个自由的、基于Wiki的文献仓库，包括每一个语言版本的完整原始文献，并且把这些文献翻译成多种语言。刚开始叫做“Sourceberg”，在2003年12月6日经过投票确定为现在的名称。",
-  "wiktionary":"维基词典，粤文版作维基辞典，是维基百科的姊妹工程，旨在创建基于所有语言的自由词典。该项目于2002年12月12日启动，发起人是维基人Daniel Alston。",
-  "wikiversity":"维基学院 是维基媒体基金会的一项计划。",
-  "wikivoyage":"维基导游 是基于Wiki系统，由志愿者撰写的免费互联网旅游指南。项目于2006年9月由德国的同名组织Wikivoyage e.V.发起，于2006年12月10日上线，2012年8月加入维基媒体基金会。项目内容使用知识共享-署名-相同方式共享协议授权，因此可供其他用户自由地用作商业用途。同时访客可以免费访问任何内容，并可以自由下载离线版本。对此类计划有害的商业性影响，例如来自旅游业的影响，被排斥于计划之外。",
-  "wolframalpha":"Wolfram Alpha，是由 Wolfram Research 公司推出的一款在线自动问答系统。其特色是可以直接向用户返回答案，而不是像传统搜索引擎一样提供一系列可能含有用户所需答案的相关网页。",
-  "naver":"NAVER 是Naver公司旗下韩国著名入口／搜索引擎网站，其Logo为一顶草帽，于1999年6月正式投入使用。它使用独有的搜寻引擎，并且在韩文搜寻服务中独占鳌头。除了搜寻之外也提供入口网站的许多服务，例如新闻、电子信箱、电子地图服务（含街景地图）等。在Alexa排名上是韩国国内第一大的入口网站。 据ComScore统计，Naver在2007年8月收到二十亿次搜索，占70％以上的韩国搜索查询，它是世界上排名第十五的网民最常用的搜索引擎，超过25万韩国人选择Naver作为浏览器起始页。",
-  "rubygems":"RubyGems是Ruby的一个包管理器，提供了分发Ruby程序和函式库的标准格式“gem”，旨在方便地管理gem安装的工具，以及用于分发gem的服务器。这类似于Python的pip。RubyGems大约创建于2003年11月，从Ruby 1.9版起成为Ruby标准库的一部分。",
-  "rumble":"Rumble，是加拿大影片分享网站，让使用者上载、观看、分享及评论影片，科技企业家克里斯·帕夫洛夫斯基 于2013年创立。自2020年7月以来，Rumble的月度用户数经历了快速增长，从160万月度用户增加到2021年第一季度末的3190万。"
- },
- "zh_TW":{
-  "archive is":"archive.today前稱archive.is，是一個私人資助的網頁存檔網站，資料中心位於歐洲法國的北部-加來海峽。這個網站典藏檔案館使用Apache Hadoop與Apache Accumulo軟體。它可以一次取回一個類似於WebCite的小於50MB的頁面，並能收錄Google地圖與Twitter。",
-  "arxiv":"arXiv 是一個收集物理學、數學、計算機科學、生物學與數理經濟學的論文預印本的網站，始於1991年8月14日。截至2008年10月，arXiv.org已收集超過50萬篇預印本；至2014年底，藏量達到1百萬篇。截至2016年10月，提交率已達每月超過10,000篇。",
-  "bandcamp":"Bandcamp是一家美國在線音樂公司， 由前Oddpost聯合創始人Ethan Diamond與程序員Shawn Grunberger、Joe Holt和Neal Tucker於2008年創立，總部位於加利福尼亞。",
-  "wikipedia":"維基百科 是維基媒體基金會運營的一個多語言的線上百科全書，並以創建和維護作為開放式協同合作項目，特點是自由內容、自由編輯、自由版權。目前是全球網絡上最大且最受大眾歡迎的參考工具書，名列全球二十大最受歡迎的網站，其在搜尋引擎中排名亦較為靠前。維基百科目前由非營利組織維基媒體基金會負責營運。Wikipedia是混成詞，分別取自於網站核心技術「Wiki」以及英文中百科全書之意的「encyclopedia」。截至2021年初，所有語種的維基百科條目數量達5500萬。",
-  "bing":"是一款由微軟公司推出的網路搜尋引擎。Bing的歷史可追溯至於1998年的第三個季度發布的MSN Search，它的由Looksmart和Inktomi等提供；2006年3月8日，微軟發布了Windows Live Search的公測版，並於同年9月11日讓其取代了MSN Search，該引擎開始使用搜尋選項卡；次年3月，微軟將其與Windows Live分開並更名Live Search，在此期間，其子服務曾經多次重組、關閉。到了2009年6月3日，微軟將Live Search改造成了今天的Bing並正式發布。微軟認為Bing一詞簡單明了、易於拼寫，容易被人記住；它源自成語「有求必應」。微軟聲稱，此款搜尋引擎將以全新的姿態面世並帶來革命。Bing的內測代號為Kumo，其後才被命名為Bing。2020年10月5日，Bing更名為Microsoft Bing。",
-  "bing images":[
-   "bing:zh_TW",
-   "ref"
-  ],
-  "deezer":"Deezer是一家法國在線音樂流媒體服務提供商。它允許用戶在各種設備上在線或離線收聽來自包括環球音樂集團、索尼音樂和華納音樂集團在內的各家唱片公司的音樂。2007年，Deezer創建於法國巴黎，截至2019年1月，Deezer擁有5600萬首授權曲目，擁有超過3萬個電台頻道，月活躍用戶達1400萬，付費用戶為700萬。該服務適用於Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",
-  "wikidata":"維基數據 是一個可協同編輯的知識庫，是繼2006年的維基學院之後，第一個新的維基媒體基金會項目。這一項目與維基共享資源的工作方式類似，將為其他維基計劃及各語種維基百科中的信息框、列表及跨語言連結等提供統一存放的數據，該項目在2012年10月30日投入使用。維基數據藉由軟體Wikibase運行。",
-  "etymonline":"在線詞源詞典 是免費的在線詞典，由道格拉斯·哈珀 編纂和撰寫，用於描述英語單詞的詞源。",
-  "fdroid":"F-Droid是一個Android應用程序的軟件資源庫（或應用商店）；其功能類似於Google Play商店，但只包含自由及開放源代碼軟件。應用可從F-Droid網站或直接從F-Droid客戶端應用瀏覽及安裝，F-Droid客戶端應用會自動更新其應用。F-Droid不要求用戶注冊帳號。如果應用包含廣告、用戶分析器，追蹤器或倚賴非自由軟件，會被標記存在「負功能」（antifeatures）。運行F-Droid的服務器也均使用自由及開放源代碼軟件，從而允許任何人創建自己的軟件庫。",
+  "deezer":"Deezer是一家法国在线音乐流媒体服务提供商。它允许用户在各种设备上在线或离线收听来自包括环球音乐集团、索尼音乐和华纳音乐集团在內的各家唱片公司的音乐。2007年，Deezer创建于法国巴黎，截至2019年1月，Deezer拥有5600万首授权曲目，拥有超过3万个电台频道，月活跃用户達1400万，付费用户為700万。该服务适用于Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",
+  "etymonline":"在线词源词典（英語：）是免费的在线词典，由道格拉斯·哈珀 编纂和撰写，用于描述英语单词的词源。",
+  "fdroid":"是一个Android应用程序的软件资源库（或应用商店）；其功能类似于Google Play商店，但只包含自由及开放源代码软件。应用可从F-Droid网站或直接从F-Droid客户端应用浏览及安装，F-Droid客户端应用会自动更新其应用。F-Droid不要求用户注册账号。如果应用包含广告、用户分析器，追踪器或倚赖非自由软件，会被标记存在「负功能」（antifeatures）。运行F-Droid的服务器也均使用自由及开放源代码软件，从而允许任何人创建自己的软件库。",
   "flickr":"Flickr為一家提供圖片分享的網路相簿，是Web 2.0的最佳利用例子之一。",
-  "free software directory":"自由軟件目錄是一個自由軟件基金會（FSF）和聯合國教育、科學及文化組織（ UNESCO ）的項目。自由軟件目錄包含自由操作系統下運行的有用自由軟件。",
-  "genius":"Genius 是一家北美數字媒體公司，於2009年8月由湯姆·雷曼、伊蘭·澤科里和馬胡德·莫哈代姆建立。該網站允許使用者對歌曲歌詞、新聞故事、詩歌和文件等提供注釋和解釋。",
-  "gitlab":"GitLab 是由 GitLab Inc.開發，一款基於 Git 的完全集成的軟件開發平台。 另外，GitLab 且具有wiki以及在線編輯、issue跟蹤功能、CI/CD 等功能。",
-  "github":"GitHub是通過Git進行版本控制的軟件源代碼托管服務平台，由GitHub公司 的開發者Chris Wanstrath、P. J. Hyett和湯姆·普雷斯頓·沃納使用Ruby on Rails編寫而成。",
-  "google images":"Google圖片搜索是Google公司於2001年7月推出的圖片搜索服務。Google Chrome及Firefox提供擴充功能搜索網絡圖像。",
-  "google news":"Google新聞是Google開發的一款Web新聞聚合器，由Google首席工程師克里希納·巴拉特 創造與領導開發。",
-  "google videos":"Google影片 是由Google提供的一項視訊共享和搜索服務。與YouTube類似，「Google影片」向用戶提供必要的HTML代碼，允許用戶將選定的視訊嵌入到其它的網站的頁面中。這種方法可以使用戶在網站中嵌入大量的視訊而無需考慮頻寬和儲存容量限制的問題。在2006年10月9日，Google收購了前競爭對手YouTube，並在2007年6月13日發表聲明，「Google影片」的搜索結果將包含由網絡蜘蛛在其它托管服務、YouTube和用戶上傳中抓取的內容。",
-  "google scholar":"Google學術搜索 是一個可以免費搜索學術文章的網絡搜索引擎，由計算機專家阿努拉·阿查雅開發。2004年11月，Google第一次發布了Google學術搜索的試用版。該項索引包括了世界上絕大部分出版的學術期刊。",
-  "google play apps":"Google Play又稱Play 商店，前身為Android Market。是由Google為Android作業系統所開發的流動應用程式數位發行平台，包括數位媒體商店。它作為Android作業系統的官方應用商店，允許用戶瀏覽和下載使用Android SDK開發並透過Google發布的應用程式。 Google Play也是數位媒體商店，提供音樂，雜誌，書籍，電影和電視節目。它之前提供了Google硬件裝置，直到2015年3月11日推出一個單獨的線上硬件零售商Google Store。",
+  "free software directory":"自由软件目录是一个自由软件基金会（FSF）和联合国教育、科学及文化组织（ UNESCO ）的项目。自由软件目录包含自由操作系统下运行的有用自由软件。",
+  "genius":"Genius 是一家北美数字媒体公司，於2009年8月由湯姆·雷曼、伊兰·泽科里和马胡德·莫哈代姆建立。該網站允許使用者對歌曲歌词、新闻故事、诗歌和文件等提供注釋和解释。",
+  "gitlab":"GitLab 是由 GitLab Inc.开发，一款基于 Git 的完全集成的软件开发平台。 另外，GitLab 且具有wiki以及在线编辑、issue跟踪功能、CI/CD 等功能。",
+  "github":"GitHub是通过Git进行版本控制的软件源代码托管服务平台，由公司（曾称）的开发者Chris Wanstrath、P. J. Hyett和汤姆·普雷斯顿·沃纳使用Ruby on Rails编写而成。",
+  "google images":"Google图片搜索是Google公司於2001年7月推出的图片搜索服務。Google Chrome及Firefox提供擴充功能搜索網絡圖像。",
+  "google news":"Google新闻是Google开发的一款Web新闻聚合器，由Google首席工程師克里希纳·巴拉特 創造與領導開發。",
+  "google videos":"Google影片 是由Google提供的一项視訊共享和搜索服务。与YouTube类似，「Google影片」向用户提供必要的HTML代码，允许用户将选定的視訊嵌入到其它的网站的页面中。这种方法可以使用户在网站中嵌入大量的視訊而无需考虑頻寬和儲存容量限制的问题。在2006年10月9日，Google收购了前競争对手YouTube，并在2007年6月13日发表声明，「Google影片」的搜索结果将包含由网络蜘蛛在其它托管服务、YouTube和用户上传中抓取的内容。",
+  "google scholar":[
+   "借助 Google 学术搜索，您可以轻松地大范围搜索学术文献。搜索范围囊括众多知识领域和来源：文章、论文、图书、摘要和法院判决意见书。",
+   "https://scholar.google.com"
+  ],
+  "google play apps":"又稱Play 商店，前身为Android Market。是由Google为Android作業系統所開發的流動應用程式數位發行平台，包括數位媒體商店。它作為Android作業系統的官方應用商店，允許用戶瀏覽和下載使用Android SDK開發並透過Google發布的應用程式。 Google Play也是數位媒體商店，提供音樂，雜誌，書籍，電影和電視節目。它之前提供了Google硬件裝置，直到2015年3月11日推出一個單獨的線上硬件零售商Google Store。",
   "google play movies":[
-   "google play apps:zh_TW",
+   "google play apps:zh-Hans-CN",
    "ref"
   ],
-  "hoogle":"Haskell 是一種標准化的，通用的純函數式編程語言，有惰性求值和強靜態類型。它的命名源自美國邏輯學家哈斯凱爾·加里，他在數理邏輯方面上的工作使得函數式編程語言有了廣泛的基礎。在Haskell中，「函數是第一類物件」。作為一門函數程式語言，主要控制結構是函數。Haskell語言是1990年在編程語言Miranda的基礎上標准化的，並且以λ演算為基礎發展而來。這也是為什麼Haskell語言以希臘字母「λ」（Lambda）作為自己的標志。Haskell具有「證明即程序、命題為類型」的特征。",
-  "library genesis":"創世紀圖書館 是一個影子圖書館，用戶可在此一網站上分享下載學術期刊文章、學術書籍、一般書籍、雜誌、漫畫。此一網站為用戶提供擋在付費牆背後，抑或官方沒釋出電子版本的資料。創世紀圖書館形容自身為「資訊整合連結」網站，為「互聯網上所收集及用戶上載的」資源提供可供查找的資料庫。",
+  "hoogle":"Haskell 是一种标准化的，通用的纯函數式編程語言，有惰性求值和强静态类型。它的命名源自美国逻辑学家哈斯凱爾·加里，他在数理逻辑方面上的工作使得函数式编程语言有了广泛的基础。在Haskell中，“函数是第一類物件”。作为一门函數程式語言，主要控制结构是函数。Haskell语言是1990年在编程语言Miranda的基础上标准化的，并且以λ演算为基础发展而来。这也是为什么Haskell语言以希腊字母「λ」（Lambda）作为自己的标志。Haskell具有“证明即程序、命题为类型”的特征。",
+  "imdb":"網路電影資料庫 是一个关于电影演员、电影、电视节目、电视藝人、电子游戏和電影製作小組的在线数据库。IMDb開辦於1990年10月17日，從1998年開始成為亚马逊公司旗下的网站，在2020年10月17日時，IMDb慶祝了他們30週年的紀念。",
+  "library genesis":"創世紀圖書館 是一個影子圖書館，用戶可在此一網站上分享下載学术期刊文章、学术書籍、一般書籍、雜誌、漫畫。此一網站為用戶提供擋在付費牆背後，抑或官方沒釋出電子版本的資料。創世紀圖書館形容自身為「資訊整合連結」網站，為「互聯網上所收集及用戶上載的」資源提供可供查找的資料庫。",
+  "z-library":"Z-Library 是一個影子圖書館和檔案分享計劃，用戶可在此一網站上下載期刊文章以及各種類型的書籍。根據Z-Library的說法，截至2021年5月14日，其共收錄了7,256,881本書和80,759,561篇文章。Z-Library在其電子書搜尋頁面上宣稱自己是「全球最大的數字圖書館」，並在文章搜尋頁面上稱自身是「全球最大的科學文章儲存庫」。它是創世紀圖書館計劃的一部分。",
   "npm":"npm 是Node.js預設的、用JavaScript編寫的軟體套件管理系統。",
   "openstreetmap":"開放街圖 是一個建構自由內容之網上地圖協作計劃，目標是創造一個內容自由且能讓所有人編輯的世界地圖，並且讓一般的行動裝置有方便的導航方案。",
-  "piratebay":"海盜灣 是一個專門儲存、分類及搜尋Bittorrent種子文件及磁力連結的網站，由瑞典的民間反版權組織海盜署於2003年成立，支持35種語言。",
-  "pypi":"PyPI 是Python的正式第三方 軟件包的軟件存儲庫，它類似於CPAN（Perl的存儲庫）。一些軟件包管理器例如pip，就是默認從PyPI下載軟件包。用戶通過PyPI可以下載超過235,000個Python軟件包。",
-  "reddit":"Reddit（） 是一個娛樂、社交及新聞網站，注冊用戶可以將文字或連結在網站上發布，使它基本上成為了一個電子布告欄系統。注冊用戶可以對這些帖子進行投票，結果將被用來進行排名和決定它在首頁或子頁的位置。網站上的內容分類被稱為「subreddit」。subreddit的內容包括新聞、電子遊戲、電影、音樂、書籍、健身、食物和圖片分享等。",
-  "stackoverflow":"Stack Overflow是一個程式設計領域的問答網站，隸屬Stack Exchange Network。網站允許註冊用戶提出或回答問題，利用積分制度讓用戶自行管理。另外網站也會根據用戶的貢獻頒發徽章。用戶建立的內容都使用知識共享協議授權。",
+  "piratebay":"海盜灣 是一個專門儲存、分類及搜尋Bittorrent种子文件及磁力連結的網站，由瑞典的民間反版權組織海盜署於2003年成立，支持35种语言。",
+  "pypi":"PyPI 是Python的正式第三方 軟件包的軟件存儲庫，它类似于CPAN（Perl的存储库）。一些软件包管理器例如pip，就是默認從PyPI下載软件包。用戶通过PyPI可以下載超过235,000个Python软件包。",
+  "reddit":"（） 是一个娱乐、社交及新聞网站，注册用户可以将文字或連結在網站上發布，使它基本上成為了一個電子佈告欄系統。注册用户可以对这些帖子进行投票，结果将被用来进行排名和决定它在首页或子页的位置。網站上的內容分類被稱為「subreddit」。subreddit的內容包括新聞、電子遊戲、電影、音樂、書籍、健身、食物和圖片分享等。",
+  "stackoverflow":"Stack Exchange是一系列问答网站，每一个网站包含不同领域的问题。这些网站参考Stack Overflow，一个关于程序设计的问答网站，也是Stack Exchange的第一个成员。如同Stack Overflow，这些网站使用声望奖励系统，用户对问题和答案进行投票，并影响用户声望。声望系统使这些网站可以自我控制。",
+  "askubuntu":[
+   "stackoverflow:zh-Hans-CN",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:zh-Hans-CN",
+   "ref"
+  ],
   "startpage":"Startpage為一荷蘭公司Startpage B.V.所推出的搜尋引擎服務，其前身為元搜尋引擎Ixquick，Startpage當時Ixquick旗下之服務，兩者於2016年改為合併並改為現名。Startpage以強調對客戶隱私的保護聞名。",
-  "unsplash":"Unsplash是一個免費的照片共享網站。攝影師可以將照片上傳到Unsplash，照片編輯者們會對用戶上傳的照片進行整理。Unsplash使用了較為自由的著作權許可條款，這讓Unsplash成為了互聯網上最大的攝影照片供應商之一，其網站上的照片經常在文章配圖中出現。截止至2020年4月，該網站擁有超過18萬名攝影師，圖庫中儲存了超過160萬張照片。Unsplash被《福布斯》、《企業家雜志》、CNET和The Next Web評為全球領先的攝影網站之一。",
-  "yahoo news":"雅虎新聞 是一個美國新聞網站，最初是基於雅虎的新聞聚合服務而建立。該站點最早由雅虎軟件工程師布拉德·克勞斯易 於1996年8月開發完成，而最初的文章則來自其他新聞媒體的服務，例如：美聯社、路透社、福斯新聞台、半島電視台、ABC新聞、《今日美國》、有線電視新聞網和BBC新聞。",
-  "youtube":"YouTube，源自美國影片分享網站，也是目前全球最大的影片搜尋和分享平臺，讓使用者上傳、觀看、分享及評論影片。公司於2005年2月14日註冊，網站的口號為「Broadcast Yourself」，網站的標誌意念來自早期電視機（陰極射線管）。此網站尚無官方中文名，中國大陸有時候將其譯為優兔或優管、油管、Y站等。也簡稱「YT」。",
-  "dailymotion":"Dailymotion 是一家視訊分享網站，總部位於法國巴黎十七區。它的域名在YouTube之後一個月注冊。Dailymotion最廣為人知的特點之一就是其提供支援開放格式ogg的視訊。和同類型的其他Flash視訊分享網站相比，Dailymotion以其短片具有高清晰畫質而聞名。到2008年1月，每天上傳到該站的短片大約是16,000，網頁瀏覽次數平均一天超過2600萬次。2008年1月，Dailymotion的Alexa全球網站排名為38。母公司為威望迪。",
-  "wikibooks":"維基教科書 是維基媒體的一項計劃，於2003年7月10日開放。 此計劃收集自由的教科書，並讓用戶自己編輯教科書——任何人都可以進入「編輯」頁面修改任何一本教科書。",
+  "unsplash":"Unsplash是一个免费的照片共享网站。攝影師可以将照片上传到Unsplash，照片编辑者们会对用户上传的照片进行整理。Unsplash使用了较为自由的著作權许可条款，这让Unsplash成为了互联网上最大的摄影照片供应商之一，其网站上的照片经常在文章配图中出现。截止至2020年4月，该网站拥有超过18万名摄影师，图库中储存了超过160万张照片。Unsplash被《福布斯》、《企业家杂志》、CNET和The Next Web评为全球领先的摄影网站之一。",
+  "youtube":[
+   "在 YouTube 上畅享您喜爱的视频和音乐，上传原创内容并与亲朋好友和全世界观众分享您的视频。",
+   "https://www.youtube.com/"
+  ],
+  "dailymotion":"Dailymotion 是一家視訊分享網站，總部位於法國巴黎十七區。它的域名在YouTube之後一個月注冊。Dailymotion最广为人知的特点之一就是其提供支援开放格式ogg的視訊。和同類型的其他Flash視訊分享網站相比，Dailymotion以其短片具有高清晰畫質而聞名。到2008年1月，每天上傳到該站的短片大約是16,000，網頁瀏覽次數平均一天超過2600萬次。2008年1月，Dailymotion的Alexa全球網站排名為38。母公司為威望迪。",
+  "wikibooks":"維基教科書（英語：）是維基媒體的一項計劃，於2003年7月10日開放。 此計劃收集自由的教科書，並讓用戶自己編輯教科書——任何人都可以進入“編輯”頁面修改任何一本教科書。",
   "wikinews":"維基新聞 是由一群志願者、即民間記者運營的網絡媒體。同時是一個自由內容的維基，屬維基媒體計劃項目，由維基媒體基金會負責運營。維基新聞通過協作新聞學的工作模式去運行，同時亦努力通過中性的觀點報導新聞。",
-  "wikiquote":"維基語錄 是維基媒體基金會下屬的一個維基計劃，屬於維基百科的一個姊妹計劃，同樣使用MediaWiki軟件。維基語錄旨在創建一個各種語言的名人名言以及諺語等內容的自由的在線語錄。",
-  "wikisource":"維基文庫 是維基媒體基金會旗下維基百科的姊妹計劃，目的是創建一個自由的、基於Wiki的文獻倉庫，包括每一個語言版本的完整原始文獻，並且把這些文獻翻譯成多種語言。剛開始叫做「Sourceberg」，在2003年12月6日經過投票確定為現在的名稱。",
-  "wiktionary":"維基詞典，粵文版作維基辭典，是維基百科的姊妹工程，旨在創建基於所有語言的自由詞典。該項目於2002年12月12日啟動，發起人是維基人Daniel Alston。",
-  "wikiversity":"維基學院 是維基媒體基金會的一項計劃。",
-  "wikivoyage":"維基導游 是基於Wiki系統，由志願者撰寫的免費互聯網旅游指南。項目於2006年9月由德國的同名組織Wikivoyage e.V.發起，於2006年12月10日上線，2012年8月加入維基媒體基金會。項目內容使用知識共享-署名-相同方式共享協議授權，因此可供其他用戶自由地用作商業用途。同時訪客可以免費訪問任何內容，並可以自由下載離線版本。對此類計劃有害的商業性影響，例如來自旅游業的影響，被排斥於計劃之外。",
-  "wolframalpha":"Wolfram Alpha，是由 Wolfram Research 公司推出的一款在線自動問答系統。其特色是可以直接向用戶返回答案，而不是像傳統搜索引擎一樣提供一系列可能含有用戶所需答案的相關網頁。",
-  "naver":"NAVER 是Naver公司旗下韓國著名入口／搜索引擎網站，其Logo為一頂草帽，於1999年6月正式投入使用。它使用獨有的搜尋引擎，並且在韓文搜尋服務中獨佔鰲頭。除了搜尋之外也提供入口網站的許多服務，例如新聞、電子信箱、電子地圖服務（含街景地圖）等。在Alexa排名上是韓國國內第一大的入口網站。 據ComScore統計，Naver在2007年8月收到二十億次搜索，占70％以上的韓國搜索查詢，它是世界上排名第十五的網民最常用的搜索引擎，超過25萬韓國人選擇Naver作為瀏覽器起始頁。",
-  "rubygems":"RubyGems是Ruby的一個包管理器，提供了分發Ruby程序和函式庫的標准格式「gem」，旨在方便地管理gem安裝的工具，以及用於分發gem的服務器。這類似於Python的pip。RubyGems大約創建於2003年11月，從Ruby 1.9版起成為Ruby標准庫的一部分。",
-  "rumble":"Rumble，是加拿大影片分享網站，讓使用者上載、觀看、分享及評論影片，科技企業家克里斯·帕夫洛夫斯基 於2013年創立。自2020年7月以來，Rumble的月度用戶數經歷了快速增長，從160萬月度用戶增加到2021年第一季度末的3190萬。"
+  "wiktionary":"维基词典（英語：），粵文版作維基辭典，是维基百科的姊妹工程，旨在创建基于所有语言的自由词典。该项目于2002年12月12日启动，发起人是维基人Daniel Alston。",
+  "wikivoyage":"维基导游（英語：）是基于Wiki系统，由志愿者撰写的免费互联网旅游指南。项目于2006年9月由德国的同名组织Wikivoyage e.V.发起，于2006年12月10日上线，2012年8月加入维基媒体基金会。项目内容使用知识共享-署名-相同方式共享协议授权，因此可供其他用户自由地用作商业用途。同时访客可以免费访问任何内容，并可以自由下载离线版本。对此类计划有害的商业性影响，例如来自旅游业的影响，被排斥于计划之外。",
+  "wolframalpha":"，是由 Wolfram Research 公司推出的一款在线自动问答系统。其特色是可以直接向用户返回答案，而不是像传统搜索引擎一样提供一系列可能含有用户所需答案的相关网页。",
+  "naver":"NAVER（韓語：）是Naver公司旗下韩国著名入口／搜索引擎网站，其Logo为一顶草帽，于1999年6月正式投入使用。它使用獨有的搜尋引擎，並且在韓文搜尋服務中獨佔鰲頭。除了搜尋之外也提供入口網站的許多服務，例如新聞、電子信箱、電子地圖服務（含街景地圖）等。在Alexa排名上是韓國國內第一大的入口網站。 据ComScore统计，Naver在2007年8月收到二十亿次搜索，占70％以上的韩国搜索查询，它是世界上排名第十五的网民最常用的搜索引擎，超过25万韩国人选择Naver作为浏览器起始页。",
+  "rubygems":"RubyGems是Ruby的一个包管理器，提供了分发Ruby程序和函式庫的标准格式“gem”，旨在方便地管理gem安装的工具，以及用于分发gem的服务器。这类似于Python的pip。RubyGems大约创建于2003年11月，从Ruby 1.9版起成为Ruby标准库的一部分。"
+ },
+ "zh-Hant-TW":{
+  "archive is":[
+   "archive is:zh-Hans-CN",
+   "ref"
+  ],
+  "arxiv":[
+   "arxiv:zh-Hans-CN",
+   "ref"
+  ],
+  "bandcamp":[
+   "bandcamp:zh-Hans-CN",
+   "ref"
+  ],
+  "wikipedia":[
+   "wikipedia:zh-Hans-CN",
+   "ref"
+  ],
+  "bing":[
+   "bing:zh-Hans-CN",
+   "ref"
+  ],
+  "bing images":[
+   "bing:zh-Hans-CN",
+   "ref"
+  ],
+  "deezer":[
+   "deezer:zh-Hans-CN",
+   "ref"
+  ],
+  "etymonline":[
+   "etymonline:zh-Hans-CN",
+   "ref"
+  ],
+  "fdroid":[
+   "fdroid:zh-Hans-CN",
+   "ref"
+  ],
+  "flickr":[
+   "flickr:zh-Hans-CN",
+   "ref"
+  ],
+  "free software directory":[
+   "free software directory:zh-Hans-CN",
+   "ref"
+  ],
+  "genius":[
+   "genius:zh-Hans-CN",
+   "ref"
+  ],
+  "gitlab":[
+   "gitlab:zh-Hans-CN",
+   "ref"
+  ],
+  "github":[
+   "github:zh-Hans-CN",
+   "ref"
+  ],
+  "google images":[
+   "google images:zh-Hans-CN",
+   "ref"
+  ],
+  "google news":[
+   "google news:zh-Hans-CN",
+   "ref"
+  ],
+  "google videos":[
+   "google videos:zh-Hans-CN",
+   "ref"
+  ],
+  "google play apps":[
+   "google play apps:zh-Hans-CN",
+   "ref"
+  ],
+  "google play movies":[
+   "google play apps:zh-Hans-CN",
+   "ref"
+  ],
+  "hoogle":[
+   "hoogle:zh-Hans-CN",
+   "ref"
+  ],
+  "imdb":[
+   "imdb:zh-Hans-CN",
+   "ref"
+  ],
+  "library genesis":[
+   "library genesis:zh-Hans-CN",
+   "ref"
+  ],
+  "z-library":[
+   "z-library:zh-Hans-CN",
+   "ref"
+  ],
+  "npm":[
+   "npm:zh-Hans-CN",
+   "ref"
+  ],
+  "openstreetmap":[
+   "openstreetmap:zh-Hans-CN",
+   "ref"
+  ],
+  "piratebay":[
+   "piratebay:zh-Hans-CN",
+   "ref"
+  ],
+  "pypi":[
+   "pypi:zh-Hans-CN",
+   "ref"
+  ],
+  "reddit":[
+   "reddit:zh-Hans-CN",
+   "ref"
+  ],
+  "stackoverflow":[
+   "stackoverflow:zh-Hans-CN",
+   "ref"
+  ],
+  "askubuntu":[
+   "stackoverflow:zh-Hans-CN",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:zh-Hans-CN",
+   "ref"
+  ],
+  "startpage":[
+   "startpage:zh-Hans-CN",
+   "ref"
+  ],
+  "unsplash":[
+   "unsplash:zh-Hans-CN",
+   "ref"
+  ],
+  "dailymotion":[
+   "dailymotion:zh-Hans-CN",
+   "ref"
+  ],
+  "wikibooks":[
+   "wikibooks:zh-Hans-CN",
+   "ref"
+  ],
+  "wikinews":[
+   "wikinews:zh-Hans-CN",
+   "ref"
+  ],
+  "wiktionary":[
+   "wiktionary:zh-Hans-CN",
+   "ref"
+  ],
+  "wikivoyage":[
+   "wikivoyage:zh-Hans-CN",
+   "ref"
+  ],
+  "wolframalpha":[
+   "wolframalpha:zh-Hans-CN",
+   "ref"
+  ],
+  "naver":[
+   "naver:zh-Hans-CN",
+   "ref"
+  ],
+  "rubygems":[
+   "rubygems:zh-Hans-CN",
+   "ref"
+  ]
  }
 }

--- a/searx/engines/onesearch.py
+++ b/searx/engines/onesearch.py
@@ -37,11 +37,11 @@ about = {
 categories = ['general']
 paging = True
 
-URL = 'https://www.onesearch.com/yhs/search;?p=%s&b=%d'
+URL = 'https://www.onesearch.com/yhs/search;?p=%s&b=%d&intl=%s'
 
 def request(query, params):
     starting_from = (params['pageno'] * 10) - 9
-    params['url'] = URL % (query, starting_from)
+    params['url'] = URL % (query, starting_from, params['language'][:2])
     return params
 
 def response(resp):

--- a/searx/engines/onesearch.py
+++ b/searx/engines/onesearch.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+
+"""OneSearch (Yahoo & Verizon)
+
+- https://www.onesearch.com
+
+OneSearch is literally just Bing results flanked by ads that don’t track you
+despite being from a company that makes money tracking you [1].
+
+According to the OneSearch privacy policy, search results will only be
+personalized based on location, which it will collect from IP addresses.
+OneSearch says that it will separate IP addresses from users and their search
+results [2].
+
+[1] https://lifehacker.com/is-yahoos-new-onesearch-engine-good-for-privacy-1841042875
+[2] https://www.theverge.com/2020/1/14/21065640/verizon-onesearch-privacy-tracking-yahoo-breach-hack
+"""
+
+import re
+from urllib.parse import unquote
+from lxml.html import fromstring
+from searx.utils import (
+    eval_xpath,
+    extract_text,
+)
+
+about = {
+    "website": 'https://www.onesearch.com',
+    "wikidata_id": 'Q109682354',
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+
+# engine dependent config
+categories = ['general']
+paging = True
+
+URL = 'https://www.onesearch.com/yhs/search;?p=%s&b=%d'
+
+def request(query, params):
+    starting_from = (params['pageno'] * 10) - 9
+    params['url'] = URL % (query, starting_from)
+    return params
+
+def response(resp):
+
+    results = []
+    doc = fromstring(resp.text)
+
+    titles_tags = eval_xpath(
+        doc, '//div[contains(@class, "algo")]//h3[contains(@class, "title")]')
+    contents = eval_xpath(
+        doc, '//div[contains(@class, "algo")]/div[contains(@class, "compText")]/p')
+    onesearch_urls = eval_xpath(
+        doc, '//div[contains(@class, "algo")]//h3[contains(@class, "title")]/a/@href')
+
+    for title_tag, content, onesearch_url in zip(titles_tags, contents, onesearch_urls):
+        matches = re.search(r'RU=(.*?)\/', onesearch_url)
+        results.append({
+            'title': title_tag.text_content(),
+            'content': extract_text(content),
+            'url': unquote(matches.group(1)),
+        })
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1698,6 +1698,12 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name: onesearch
+    shortcut: one
+    engine: onesearch
+    categories: general
+    disabled: true
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name: ubuntuwiki


### PR DESCRIPTION
## What does this PR do?

Add Onesearch engine / Merged from @e-foundation's onesearch-engine branch [1] and slightly modfied / see [2].

[1] https://github.com/e-foundation/searx/tree/onesearch-engine
[2] https://github.com/searx/searx/pull/3065

**pro**: engine does fast response
~**hint**: engine is enabled by default~
**hint**: is literally just **Bing** --> could be a replacement for the bing engine / that is enabled by default but has some issues

**ToDo:** :

- [ ] Engine needs some polish .. this version does not support languages
- [ ] images: https://images.onesearch.com/yhs/search;?p=paris
- [ ] videos: https://video.onesearch.com/yhs/search;?p=paris
- [ ] news news: https://images.onesearch.com/yhs/search;?p=covid

-----
OneSearch is literally just **Bing** results flanked by ads that don’t track you despite being from a company that makes money tracking you [ref(https://lifehacker.com/is-yahoos-new-onesearch-engine-good-for-privacy-1841042875)].

According to the OneSearch privacy policy, search results will only be personalized based on location, which it will collect from IP addresses. OneSearch says that it will separate IP addresses from users and their search results [ref](https://www.theverge.com/2020/1/14/21065640/verizon-onesearch-privacy-tracking-yahoo-breach-hack).

## How to test this PR locally?

    !one search term