### PR TITLE
[mod] filtron.sh - install github.com/searxng/filtron

### DIFF
--- a/docs/admin/filtron.rst
+++ b/docs/admin/filtron.rst
@@ -16,7 +16,7 @@ How to protect an instance
    :local:
    :backlinks: entry
 
-.. _filtron: https://github.com/asciimoo/filtron
+.. _filtron: https://github.com/searxng/filtron
 
 SearXNG depends on external search services.  To avoid the abuse of these services
 it is advised to limit the number of requests processed by SearXNG.
@@ -30,7 +30,7 @@ filtron & go
 ============
 
 .. _Go: https://golang.org/
-.. _filtron README: https://github.com/asciimoo/filtron/blob/master/README.md
+.. _filtron README: https://github.com/searxng/filtron/blob/master/README.md
 
 Filtron needs Go_ installed.  If Go_ is preinstalled, filtron_ is simply
 installed by ``go get`` package management (see `filtron README`_).  If you use

--- a/docs/build-templates/filtron.rst
+++ b/docs/build-templates/filtron.rst
@@ -48,6 +48,6 @@
     .. code-block:: bash
 
        $ sudo -i -u \"${SERVICE_USER}\"
-       (${SERVICE_USER}) $ go get -v -u github.com/asciimoo/filtron
+       (${SERVICE_USER}) $ go get -v -u github.com/searxng/filtron
 
 .. END install filtron

--- a/docs/utils/filtron.sh.rst
+++ b/docs/utils/filtron.sh.rst
@@ -13,8 +13,8 @@
      <installation apache>`)
 
 .. _Go: https://golang.org/
-.. _filtron: https://github.com/asciimoo/filtron
-.. _filtron README: https://github.com/asciimoo/filtron/blob/master/README.md
+.. _filtron: https://github.com/searxng/filtron
+.. _filtron README: https://github.com/searxng/filtron/blob/master/README.md
 
 To simplify installation and maintenance of a filtron instance you can use the
 script :origin:`utils/filtron.sh`.  In most cases you will install filtron_
@@ -30,7 +30,7 @@ into this user account:
 #. Create a separated user account (``filtron``).
 #. Download and install Go_ binary in user's $HOME (``~filtron``).
 #. Install filtron with the package management from Go_ (``go get -v -u
-   github.com/asciimoo/filtron``)
+   github.com/searxng/filtron``)
 #. Setup a proper rule configuration :origin:`[ref]
    <utils/templates/etc/filtron/rules.json>` (``/etc/filtron/rules.json``).
 #. Setup a systemd service unit :origin:`[ref]

--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -348,13 +348,13 @@ filtron_is_installed() {
 install_filtron() {
     rst_title "Install filtron in user's ~/go-apps" section
     echo
-    go.install github.com/asciimoo/filtron@latest "${SERVICE_USER}"
+    go.install github.com/searxng/filtron@latest "${SERVICE_USER}"
 }
 
 update_filtron() {
     rst_title "Update filtron" section
     echo
-    go.install github.com/asciimoo/filtron@latest "${SERVICE_USER}"
+    go.install github.com/searxng/filtron@latest "${SERVICE_USER}"
 }
 
 install_rules() {

--- a/utils/filtron.sh
+++ b/utils/filtron.sh
@@ -337,7 +337,8 @@ EOF
     echo "export SERVICE_HOME=$SERVICE_HOME"
 
     tee_stderr <<EOF | sudo -i -u "$SERVICE_USER"
-grep -qFs -- 'source $GO_ENV' ~/.profile || echo 'source $GO_ENV' >> ~/.profile
+touch "$GO_ENV"
+grep -qFs -- 'source "$GO_ENV"' ~/.profile || echo 'source "$GO_ENV"' >> ~/.profile
 EOF
 }
 

--- a/utils/morty.sh
+++ b/utils/morty.sh
@@ -337,7 +337,8 @@ EOF
     echo "export SERVICE_HOME=$SERVICE_HOME"
 
     tee_stderr <<EOF | sudo -i -u "$SERVICE_USER"
-grep -qFs -- 'source $GO_ENV' ~/.profile || echo 'source $GO_ENV' >> ~/.profile
+touch $GO_ENV
+grep -qFs -- 'source "$GO_ENV"' ~/.profile || echo 'source "$GO_ENV"' >> ~/.profile
 EOF
 }
 


### PR DESCRIPTION
## What does this PR do?

The filtron.sh installation script now installs from the filtron fork of the SearXNG team.

## Why is this change important?

SearXNG maintains a fork of filtron at https://github.com/searxng/filtron

## How to test this PR locally?

Install filtron [ref](https://searxng.github.io/searxng/utils/filtron.sh.html#filtron-sh):

    sudo -H ./utils/filtron.sh install all

An existing filtron installation needs to be removed before installing [ref](https://searxng.github.io/searxng/utils/filtron.sh.html#overview)

## Related issues

Related: https://github.com/searxng/searxng/issues/507#issuecomment-970254027
