### PR TITLE
[fix] make nvm.clean - don't raise error when NVM is not installed

### DIFF
--- a/utils/lib_nvm.sh
+++ b/utils/lib_nvm.sh
@@ -120,14 +120,17 @@ nvm.install() {
 
 nvm.clean() {
     if ! nvm.is_installed; then
-        info_msg "NVM is not installed"
-        return 42
+        build_msg CLEAN "[NVM] not installed"
+        return
     fi
     if ! nvm.is_local; then
-        info_msg "can't remove NVM from ${NVM_DIR}"
-        return 42
+        build_msg CLEAN "[NVM] can't remove nvm from ${NVM_DIR}"
+        return
     fi
-    rm -rf "${NVM_DIR}"
+    if [ -n "${NVM_DIR}" ]; then
+        build_msg CLEAN "[NVM] drop $(realpath --relative-to=. "${NVM_DIR}")/"
+        rm -rf "${NVM_DIR}"
+    fi
 }
 
 nvm.status(){


### PR DESCRIPTION
## What does this PR do?

[fix] make nvmclean - don't raise error when NVM is not installed

BTW: change info_msg to build_msg

Issue was::

    $ LANG=C make nvm.clean
    INFO:  NVM is not installed
    make: *** [Makefile:99: nvm.clean] Error 42

Now::

    $ LANG=C make nvm.clean
    CLEAN     [NVM] not installed

## How to test this PR locally?

    make nvm.clean

