### PR TITLE
[fix] enigne library genesis - remove 'enable_http: true'

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -801,7 +801,6 @@ engines:
 
   - name: library genesis
     engine: xpath
-    enable_http: true
     search_url: https://libgen.rs/search.php?req={query}
     url_xpath: //a[contains(@href,"bookfi.net/md5")]/@href
     title_xpath: //a[contains(@href,"book/")]/text()[1]


### PR DESCRIPTION
## What does this PR do?

[fix] enigne library genesis - remove 'enable_http: true'

## Related issues

Related: https://github.com/searxng/searxng/pull/509#issuecomment-971334755

