### PR TITLE
[fix] npm engine: don't ignore the first result

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -903,6 +903,7 @@ engines:
   - name: npm
     engine: json_engine
     paging: true
+    first_page_num: 0
     search_url: https://api.npms.io/v2/search?q={query}&size=25&from={pageno}
     results_query: results
     url_query: package/links/npm


### PR DESCRIPTION
## What does this PR do?

the "from" parameter starts at 0, in the master branch it starts at 1 which ignore the most relevant result

## Why is this change important?

bug fix

## How to test this PR locally?

* `!npm grunt` for example (or any npm package)

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
