### PR TITLE
[fix] google images: @href index 0 not found

### DIFF
--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -172,7 +172,10 @@ def response(resp):
                 thumbnail_src = ''
 
         link_node = eval_xpath_getindex(img_node, '../../../a[2]', 0)
-        url = eval_xpath_getindex(link_node, '@href', 0)
+        url = eval_xpath_getindex(link_node, '@href', 0, None)
+        if url is None:
+            logger.error("missing @href in node: %s", html.tostring(link_node))
+            continue
 
         pub_nodes = eval_xpath(link_node, './div/div')
         pub_descr = img_alt


### PR DESCRIPTION
## What does this PR do?

[fix] google images: @href index 0 not found

BTW: add an error logging with the `<a..>` tag that is missed a `href` attribute.

## Why is this change important?

Sometimes there is no href in the `<a ..>` tag of a *link_node* [1].

[1] https://github.com/searxng/searxng/issues/532

## How to test this PR locally?

It is hard to reproduce the issue that had been reported (https://github.com/searxng/searxng/issues/532#issuecomment-974773483) / I don't have a clue, may be the issue is related to .pw tld. To test use `!goi n64 controller` (from a .pw tld)

## Related issues

Closes: https://github.com/searxng/searxng/issues/532