### PR TITLE
[emacs] .dir-locals.el: use jinja2-mode to format html files

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -51,6 +51,8 @@
      (indent-tabs-mode . nil)
      (eval . (progn
 
+               (add-to-list 'auto-mode-alist '("\\.html\\'" . jinja2-mode))
+
                ;; project root folder is where the `.dir-locals.el' is located
                (setq-local prj-root
                            (locate-dominating-file  default-directory ".dir-locals.el"))


### PR DESCRIPTION
## What does this PR do?

[emacs] .dir-locals.el: use jinja2-mode to format html files

The jinja2-mode [1] can be installed from melpa [2]:

    M-x package-install / jinja2-mode

[1] https://github.com/paradoxxxzero/jinja2-mode
[2] https://melpa.org/#/jinja2-mode

## Why is this change important?

Emacs IDE / better indentation and highlighting handling of jinja2 templates.

## How to test this PR locally?

Open HTML file in emacs
