### PR TITLE
[fix] templates: remove unneeded escape \' of single quotation mark

### DIFF
--- a/searx/templates/oscar/messages/no_results.html
+++ b/searx/templates/oscar/messages/no_results.html
@@ -15,6 +15,6 @@
 {% else %}
 <div class="alert alert-info fade in" role="alert">
     <strong class="lead">{{ icon('info-sign') }} {{ _('Sorry!') }}</strong>
-    {{ _('we didn\'t find any results. Please use another query or search in more categories.') }}
+    {{ _("we didn't find any results. Please use another query or search in more categories.") }}
 </div>
 {% endif %}

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -281,8 +281,8 @@
                         {% endif %}
 
                         {% if 'query_in_title' not in locked_preferences %}
-                        {% set query_in_title_label = _('Query in the page\'s title') %}
-                        {% set query_in_title_info = _('When enabled, the result page\'s title contains your query. Your browser can record this title') %}
+                        {% set query_in_title_label = _("Query in the page's title") %}
+                        {% set query_in_title_info = _("When enabled, the result page's title contains your query. Your browser can record this title") %}
                         {{ preferences_item_header(query_in_title_info, query_in_title_label, rtl, 'query_in_title') }}
                             <select class="form-control {{ custom_select_class(rtl) }}" name="query_in_title" id="query_in_title">
                                 <option value="1" {% if query_in_title  %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
@@ -408,7 +408,7 @@
                     </thead>
                     <tbody>
                         <td></td>
-                        <th scope="colgroup" colspan="4">{{ _('This is the list of SearXNG\'s instant answering modules.') }}</th>
+                        <th scope="colgroup" colspan="4">{{ _("This is the list of SearXNG's instant answering modules.") }}</th>
                         {% for answerer in answerers %}
                         <tr>
                             <td></td>

--- a/searx/templates/simple/messages/no_results.html
+++ b/searx/templates/simple/messages/no_results.html
@@ -18,6 +18,6 @@
 {% else %}
 <div class="dialog-error" role="alert">
   <p><strong>{{ _('Sorry!') }}</strong></p>
-  <p>{{ _('we didn\'t find any results. Please use another query or search in more categories.') }}</p>
+  <p>{{ _("we didn't find any results. Please use another query or search in more categories.") }}</p>
 </div>
 {% endif %}

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -258,14 +258,14 @@
     {% endif %}
     {% if 'query_in_title' not in locked_preferences %}
     <fieldset>
-      <legend>{{ _('Query in the page\'s title') }}</legend>
+      <legend>{{ _("Query in the page's title") }}</legend>
       <p class="value">
         <select name='query_in_title'>
           <option value="1" {% if query_in_title %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
           <option value="" {% if not query_in_title %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>
         </select>
       </p>
-      <div class="description">{{ _('When enabled, the result page\'s title contains your query. Your browser can record this title.') }}</div>
+      <div class="description">{{ _("When enabled, the result page's title contains your query. Your browser can record this title") }}</div>
     </fieldset>
     {% endif %}
     {{ plugin_preferences('privacy') }}
@@ -324,7 +324,7 @@
         <th>{{ _('Examples') }}</th>
       </tr>
       <td></td>
-      <th scope="colgroup" colspan="4">{{ _('This is the list of SearXNG\'s instant answering modules.') }}</th>
+      <th scope="colgroup" colspan="4">{{ _("This is the list of SearXNG's instant answering modules.") }}</th>
       {% for answerer in answerers %}
       <tr>
         <td></td>


### PR DESCRIPTION
## What does this PR do?

[fix] templates: remove unneeded escape \' of single quotation mark

BTW: remove a leading dot in the simple theme [1].

## Why is this change important?

Strings like:

    'Query in the page\'s title'

are hard to read / remove escape sequence by using double quotation marks for strings:

    "Query in the page's title"

## Related issues

[1] https://github.com/searxng/searxng/pull/485/files/80fb77476fad4b229418c530f3ffda67f357a15a#r756112716

