### PR TITLE
[fix] searx.sh update: replace git pull by a hard reset

### DIFF
--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -402,11 +402,11 @@ install_check() {
 update_searx() {
     rst_title "Update SearXNG instance"
 
-    echo
+    rst_para "fetch from $GIT_URL and reset to origin/$GIT_BRANCH"
     tee_stderr 0.3 <<EOF | sudo -H -u "${SERVICE_USER}" -i 2>&1 |  prefix_stdout "$_service_prefix"
 cd ${SEARX_SRC}
-git checkout -B "$GIT_BRANCH"
-git pull
+git fetch origin "$GIT_BRANCH"
+git reset --hard "origin/$GIT_BRANCH"
 pip install -U pip
 pip install -U setuptools
 pip install -U wheel


### PR DESCRIPTION
## What does this PR do?

[fix] searx.sh update: replace git pull by a hard reset

## Why is this change important?

If the fetched branch has been rebased a `git pull` fails.  To get fetched branch in the working tree, a `git reset` is needed.

## How to test this PR locally?

Can only be tested on an existing instance, that has been installed by searx.sh:

    sudo -H ./utils/searx.sh update searx 

## Author's checklist

I have tested the update script on my darmarit.org instance
