### PR TITLE
[fix] google-videos engine: ignore news articles

### DIFF
--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -154,25 +154,23 @@ def response(resp):
     # parse results
     for result in eval_xpath_list(dom, '//div[contains(@class, "g ")]'):
 
-        # google *sections*
+        # ignore google *sections*
         if extract_text(eval_xpath(result, g_section_with_header)):
             logger.debug("ingoring <g-section-with-header>")
             continue
 
-        title = extract_text(eval_xpath_getindex(result, title_xpath, 0))
-        url = eval_xpath_getindex(result, './/div[@class="dXiKIc"]//a/@href', 0)
-
-        # <img id="vidthumb1" ...>
+        # ingnore articles without an image id / e.g. news articles
         img_id = eval_xpath_getindex(result, './/g-img/img/@id', 0, default=None)
         if img_id is None:
-            logger.error("no img_id for: %s" % result)
+            logger.error("no img_id found in item %s (news article?)", len(results) + 1)
             continue
 
         img_src = vidthumb_imgdata.get(img_id, None)
         if not img_src:
-            logger.error("no vidthumb imgdata for: %s" % img_id)
             img_src = thumbs_src.get(img_id, "")
 
+        title = extract_text(eval_xpath_getindex(result, title_xpath, 0))
+        url = eval_xpath_getindex(result, './/div[@class="dXiKIc"]//a/@href', 0)
         length = extract_text(eval_xpath(
             result, './/div[contains(@class, "P7xzyf")]/span/span'))
         c_node = eval_xpath_getindex(result, './/div[@class="Uroaid"]', 0)


### PR DESCRIPTION
## What does this PR do?

[fix] google-videos engine: ignore news articles

## Why is this change important?

In the video search, google also sometimes includes news.  E.g. in the DE language when you search for `!gov paris`, google adds an article from a german newspaper (FAZ), I assume these are sponsored links (not tagged advertisement?)

Those links do not have an image / this patch ignores *video links* without an image ID.

![grafik](https://user-images.githubusercontent.com/554536/143610898-869f75aa-5e2a-4516-88ec-e48ce9cf0078.png)

## How to test this PR locally?

    !gov paris

---

OT here / but while war are a google engines ..

@unixfox you pinged me about _"Another Google search parameter to set country"_ issue 3073 at searx .. I don't know if we really need this parameter / if you think there is a need for, please open an issue here at SearXNG / I don't want to spread a discussions about a SearXNG topic in other repositories / hope that is OK for you / thanks!



