### PR TITLE
[fix] route /autocompleter: escape '<' and '>' in the response

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -916,6 +916,7 @@ def autocompleter():
         suggestions = json.dumps([sug_prefix, results])
         mimetype = 'application/x-suggestions+json'
 
+    suggestions = escape(suggestions, False)
     return Response(suggestions, mimetype=mimetype)
 
 


### PR DESCRIPTION
## What does this PR do?

[fix] route /autocompleter: escape `<` and `>` in the response

## Why is this change important?

Completions should not contain markup from one of the SGML derivatives.