### PR TITLE
[fix] route /autocompleter: escape `<` and `>` in the simple theme

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -916,7 +916,8 @@ def autocompleter():
         suggestions = json.dumps([sug_prefix, results])
         mimetype = 'application/x-suggestions+json'
 
-    suggestions = escape(suggestions, False)
+    if get_current_theme_name() == 'simple':
+        suggestions = escape(suggestions, False)
     return Response(suggestions, mimetype=mimetype)
 
 


### PR DESCRIPTION
## What does this PR do?

[fix] route /autocompleter: escape `<` and `>` in the simple theme / **not in the oscar theme**

This is a follow up of 9a3253fc escaping `<` and `>` in all themes.


## Oscar theme

**before**

![image](https://user-images.githubusercontent.com/1594191/143682655-0014abe9-d963-4704-987a-44dbd493cfb5.png)

**after**

![grafik](https://user-images.githubusercontent.com/554536/143768599-bbc82298-4f6e-4c03-a324-62940c462086.png)

