### PR TITLE
[fix] query_in_title: add missing space in title

### DIFF
--- a/searx/templates/oscar/results.html
+++ b/searx/templates/oscar/results.html
@@ -16,7 +16,7 @@
 {%- endmacro %}
 {%- macro search_url() %}{{ url_for('search', _external=True) }}?q={{ q|urlencode }}{% if selected_categories %}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}{% endif %}{% if pageno > 1 %}&amp;pageno={{ pageno }}{% endif %}{% if time_range %}&amp;time_range={{ time_range }}{% endif %}{% if current_language != 'all' %}&amp;language={{ current_language }}{% endif %}{% endmacro -%}
 
-{% block title %}{% if query_in_title %}{{- q|e -}} - {% endif %}{% endblock %}
+{% block title %}{% if query_in_title %}{{- q|e }} - {% endif %}{% endblock %}
 {% block meta %}{{"    "}}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ search_url() }}&amp;format=rss">{% endblock %}
 {% block content %}
     {% include 'oscar/search.html' %}

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -7,7 +7,7 @@
         {% endfor %}
     {% endfor %}
 {%- endmacro %}
-{% block title %}{% if query_in_title %}{{- q|e -}} - {% endif %}{% endblock %}
+{% block title %}{% if query_in_title %}{{- q|e }} - {% endif %}{% endblock %}
 {% block meta %}<link rel="alternate" type="application/rss+xml" title="Searx search: {{ q|e }}" href="{{ url_for('search', _external=True) }}?q={{ q|urlencode }}&amp;categories={{ selected_categories|join(",") | replace(' ','+') }}&amp;pageno={{ pageno }}&amp;time_range={{ time_range }}&amp;language={{ current_language }}&amp;safesearch={{ safesearch }}&amp;format=rss">{% endblock %}
 {% block content %}
 <nav id="linkto_preferences"><a href="{{ url_for('preferences') }}">{{ icon_big('menu-outline') }}</a></nav>


### PR DESCRIPTION
## What does this PR do?

[fix] query_in_title: add missing space in title

Suggested-by: @unixfox https://github.com/searxng/searxng/pull/485#issuecomment-981406978

## Why is this change important?

See https://github.com/searxng/searxng/pull/485#issuecomment-981406978 ..
> ![image](https://user-images.githubusercontent.com/4016501/143835657-d5690567-a2d6-4bc7-9b55-449f76a4fe23.png)
>
> There is a space missing before the `-`

This patch adds the missing space ...

![grafik](https://user-images.githubusercontent.com/554536/143849258-f3a571e9-d8f7-4fc8-84a0-d07a37479120.png)

