### PR TITLE
[fix] simple theme: remove width  45% from language and time filters

### DIFF
--- a/searx/static/themes/simple/src/less/search.less
+++ b/searx/static/themes/simple/src/less/search.less
@@ -253,11 +253,6 @@
     margin: 0;
   }
 
-  .language,
-  .time_range {
-    width: 45%;
-  }
-
   .category {
     display: block;
     width: 100%;


### PR DESCRIPTION
## What does this PR do?

[fix] simple theme: remove width  45% from language and time filters

All three filters (`language`, `time_range` and `safesearch`) are rendered in one line.  A size of 45% for `language` and `time_range` left only 10% for the `safesearch` filter.  Solution: drop with from `language` and `time_range`.

## How to test this PR locally?

On a small device / **before**:

![grafik](https://user-images.githubusercontent.com/554536/144748587-0f8626b0-7744-4827-acfb-1e8cc6d5b3b0.png)

and **after** PR applied:

![grafik](https://user-images.githubusercontent.com/554536/144748620-d6646143-be46-412c-8142-9588835b0589.png)

## Author's checklist

See also https://github.com/searxng/searxng/pull/585