### PR TITLE
[fix] gigablast engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -558,7 +558,7 @@ engines:
   - name: gigablast
     engine: gigablast
     shortcut: gb
-    timeout: 3.0
+    timeout: 4.0
     disabled: true
     additional_tests:
       rosebud: *test_rosebud


### PR DESCRIPTION
## What does this PR do?

In the master branch the extra parameters are fetched when the app starts once for all.

In this PR, the extra params are fetched 3000 seconds after the last request.

## Why is this change important?

Currently after one hour the engine is broken.

## How to test this PR locally?

* Change the value of `extra_param_expiration_delay` to `30` seconds
* make a request to the engine `!gigablast time`
* check that the extra param are fetched
* make a second request right away
* check that the extra param are NOT fetched
* wait 30 seconds
* make a third request
* check that the extra param are fetched

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

searx issue 3078
