### PR TITLE
Upgrade httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ lxml==4.7.1
 pygments==2.11.0
 python-dateutil==2.8.2
 pyyaml==6.0
-httpx[http2]==0.19.0
+httpx[http2]==0.21.2
 Brotli==1.0.9
 uvloop==0.16.0
-httpx-socks[asyncio]==0.4.1
+httpx-socks[asyncio]==0.7.2
 langdetect==1.0.9
 setproctitle==1.2.2

--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -213,15 +213,18 @@ class Network:
         await asyncio.gather(*[close_client(client) for client in self._clients.values()], return_exceptions=False)
 
     @staticmethod
-    def get_kwargs_clients(kwargs):
+    def extract_kwargs_clients(kwargs):
         kwargs_clients = {}
         if 'verify' in kwargs:
             kwargs_clients['verify'] = kwargs.pop('verify')
         if 'max_redirects' in kwargs:
             kwargs_clients['max_redirects'] = kwargs.pop('max_redirects')
+        if 'allow_redirects' in kwargs:
+            # see https://github.com/encode/httpx/pull/1808
+            kwargs['follow_redirects'] = kwargs.pop('allow_redirects')
         return kwargs_clients
 
-    def is_valid_respones(self, response):
+    def is_valid_response(self, response):
         # pylint: disable=too-many-boolean-expressions
         if (
             (self.retry_on_http_error is True and 400 <= response.status_code <= 599)
@@ -231,33 +234,39 @@ class Network:
             return False
         return True
 
-    async def request(self, method, url, **kwargs):
+    async def call_client(self, stream, method, url, **kwargs):
         retries = self.retries
+        was_disconnected = False
+        kwargs_clients = Network.extract_kwargs_clients(kwargs)
         while retries >= 0:  # pragma: no cover
-            kwargs_clients = Network.get_kwargs_clients(kwargs)
             client = await self.get_client(**kwargs_clients)
             try:
-                response = await client.request(method, url, **kwargs)
-                if self.is_valid_respones(response) or retries <= 0:
+                if stream:
+                    response = client.stream(method, url, **kwargs)
+                else:
+                    response = await client.request(method, url, **kwargs)
+                if self.is_valid_response(response) or retries <= 0:
                     return response
+            except httpx.RemoteProtocolError as e:
+                if not was_disconnected:
+                    # the server has closed the connection:
+                    # try again without decreasing the retries variable & with a new HTTP client
+                    was_disconnected = True
+                    await client.aclose()
+                    self._logger.warning('httpx.RemoteProtocolError: the server has disconnected, retrying')
+                    continue
+                if retries <= 0:
+                    raise e
             except (httpx.RequestError, httpx.HTTPStatusError) as e:
                 if retries <= 0:
                     raise e
             retries -= 1
 
+    async def request(self, method, url, **kwargs):
+        return await self.call_client(False, method, url, **kwargs)
+
     async def stream(self, method, url, **kwargs):
-        retries = self.retries
-        while retries >= 0:  # pragma: no cover
-            kwargs_clients = Network.get_kwargs_clients(kwargs)
-            client = await self.get_client(**kwargs_clients)
-            try:
-                response = client.stream(method, url, **kwargs)
-                if self.is_valid_respones(response) or retries <= 0:
-                    return response
-            except (httpx.RequestError, httpx.HTTPStatusError) as e:
-                if retries <= 0:
-                    raise e
-            retries -= 1
+        return await self.call_client(True, method, url, **kwargs)
 
     @classmethod
     async def aclose_all(cls):

--- a/tests/unit/network/test_network.py
+++ b/tests/unit/network/test_network.py
@@ -76,13 +76,15 @@ class TestNetwork(SearxTestCase):
             'verify': True,
             'max_redirects': 5,
             'timeout': 2,
+            'allow_redirects': True,
         }
-        kwargs_client = Network.get_kwargs_clients(kwargs)
+        kwargs_client = Network.extract_kwargs_clients(kwargs)
 
         self.assertEqual(len(kwargs_client), 2)
-        self.assertEqual(len(kwargs), 1)
+        self.assertEqual(len(kwargs), 2)
 
         self.assertEqual(kwargs['timeout'], 2)
+        self.assertEqual(kwargs['follow_redirects'], True)
 
         self.assertTrue(kwargs_client['verify'])
         self.assertEqual(kwargs_client['max_redirects'], 5)


### PR DESCRIPTION
## What does this PR do?

Upgrade to httpx 0.21.2

Change in searx.network.client:
* remove `close_connections_for_url` : httpcore closes the connections now.
* keep `AsyncProxyTransportFixed` to map the exception from httpx_socks to httpx exception WITH the "request" object.
* remove `AsyncHTTPTransportFixed`: the retry mecanism has moved to searx.network.network to decrease the number of access to the private API of httpx / httpcore.

`httpx.RemoteProtocolError` happens when a server closes an HTTP/2 connection. In the master branch, `AsyncHTTPTransportFixed` closes all connections. In this PR, the `httpx.AsyncClient` is closed. It makes no difference except when different proxies are specified, for example:

```yaml
proxies:
  https://bing.com/: socks5h://127.0.0.1:1337
  all://: socks5h://127.0.0.1:1338
```

With this configuration, and with an `httpx.RemoteProtocolError` exception coming from the proxy on the port 1337:
* in the master branch: connections using the proxy on the port 1337 are closed. Connections using the proxy on the port 1338 are untouched.
* in this PR: connections using the proxy on ports 1337 and 1338 are closed.

@unixfox @tiekoetter @paulgio I don't know you use this configuration?

An alternative configuration not impacted by this PR:
```
outgoing:
	proxies:
		all://: socks://127.0.0.1:1337	

engines:
  - name: bing
    engine: bing
    shortcut: bi
	proxies:
		all://: socks://127.0.0.1:1338
```

---

~This is WIP, todo list~:
  * [x] use a released httpcore version
  * [x] check for memory leak over a week
  * [x] check for error log over a week:
     * in the master branch, there is a close connections + retry mechanism in a case of specific error.
       this a workaround to fix some of the httpcore issues
     * the latest httpcore commit seems to have fix most of them
     * the change in this commit remove the "close connections + retry"
     * an error log over a long time can confirm that httpcore has been fixed

## Why is this change important?

* Remove a bunch of hack to fix an old httpcore version
* With this change, httpx can be upgraded easily (= just change requirements.txt)

## How to test this PR locally?

A lot of changes have been made to httpx, httpcore and anyio since the last upgrade, a full check is require over a long time.

what can be done locally:
* check the error for various HTTP error (domain not found)
* check that HTTP proxy works
* check that SOCKS proxy works
* check that HTTP2 connection works
* check this scenario: 
    * make a HTTP2 request
    * wait for the server to disconnect
    * maka another HTTP2 request

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to https://github.com/searxng/searxng/issues/589
