### PR TITLE
Dockerfile: use alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 ENTRYPOINT ["/sbin/tini","--","/usr/local/searxng/dockerfiles/docker-entrypoint.sh"]
 EXPOSE 8080
 VOLUME /etc/searx


### PR DESCRIPTION
## What does this PR do?

Use Python 3.9.7-r4 (previously 3.9.5-r2)

## Why is this change important?

Up to date dependencies

## How to test this PR locally?

* `make docker`
* start the docker image

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
