### PR TITLE
[fix] engine: MediathekViewWeb (mvw) disable by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1604,6 +1604,7 @@ engines:
   - name: mediathekviewweb
     engine: mediathekviewweb
     shortcut: mvw
+    disabled: true
 
   # - name: yacy
   #   engine: yacy


### PR DESCRIPTION
## What does this PR do?

[fix] engine: MediathekViewWeb (mvw) disable by default

## Why is this change important?

The MediathekViewWeb delivers only content for the german speaking area.

