### PR TITLE
update_firefox_version.py: update user agent signature

### DIFF
--- a/searxng_extra/update/update_firefox_version.py
+++ b/searxng_extra/update/update_firefox_version.py
@@ -20,7 +20,7 @@ NORMAL_REGEX = re.compile('^[0-9]+\.[0-9](\.[0-9])?$')
 #
 useragents = {
     "versions": (),
-    "os": ('Windows NT 10.0; WOW64',
+    "os": ('Windows NT 10.0; Win64; x64',
            'X11; Linux x86_64'),
     "ua": "Mozilla/5.0 ({os}; rv:{version}) Gecko/20100101 Firefox/{version}"
 }


### PR DESCRIPTION
## What does this PR do?

For the version 95.0, the user agent from Windows is
`Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:95.0) Gecko/20100101 Firefox/95.0`
not
`Mozilla/5.0 (Windows NT 10.0; WOW64; rv:95.0) Gecko/20100101 Firefox/95.0`

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox#windows

## Why is this change important?

stealth instances, less blocking ?

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
