### PR TITLE
[fix] weblate: separate commit description from commit body

### DIFF
--- a/manage
+++ b/manage
@@ -229,7 +229,7 @@ weblate.translations.commit() {
                 -d "searx/translations"
         # git add/commit (no push)
         commit_body=$(cd "${TRANSLATIONS_WORKTREE}"; git log --pretty=format:'%h - %as - %aN <%ae>' "${existing_commit_hash}..HEAD")
-        commit_message=$(echo -e "[translations] update\n${commit_body}")
+        commit_message=$(echo -e "[translations] update from Weblate\n\n${commit_body}")
         git add searx/translations
         git commit -m "${commit_message}"
     )


### PR DESCRIPTION
## What does this PR do?

[fix] weblate: separate commit description from commit body


## Why is this change important?

It is a common convention to separate commit description from commit body by a
empty line [1].

[1] https://www.conventionalcommits.org/en/v1.0.0/#summary

