### PR TITLE
[mod] Dockerfile: use binary from pypi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk upgrade --no-cache \
     uwsgi-python3 \
     brotli \
  && pip3 install --upgrade pip wheel setuptools \
- && pip3 install --no-cache  --no-binary :all: -r requirements.txt \
+ && pip3 install --no-cache -r requirements.txt \
  && apk del build-dependencies \
  && rm -rf /root/.cache
 


### PR DESCRIPTION
## What does this PR do?

lxml doesn't raise any exception

## Why is this change important?

When a dependency change, the GitHub workflow runs for 3 hours. The limit is 6 hours.
This PR restore the usage of the wheels, and the build time should come back to about 1 hour.

## How to test this PR locally?

* `make docker`
* run the docker image

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* #482
* #483
