### PR TITLE
[doc] engine-table: sort by Disabled and Name

### DIFF
--- a/docs/admin/engines/configured_engines.rst
+++ b/docs/admin/engines/configured_engines.rst
@@ -37,7 +37,7 @@ Explanation of the :ref:`general engine configuration` shown in the table
         - Safe search
         - Time range
 
-      {% for name, mod in engines %}
+      {% for name, mod in engines | sort_engines %}
 
       * - `{{name}} <{{mod.about and mod.about.website}}>`_
         - ``!{{mod.shortcut}}``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,9 @@ jinja_contexts = {
         },
     },
 }
+jinja_filters = {
+    'sort_engines': lambda engines: sorted(engines, key=lambda engine: (engine[1].disabled, engine[0]))
+}
 
 # usage::   lorem :patch:`f373169` ipsum
 extlinks = {}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ twine==3.7.1
 Pallets-Sphinx-Themes==2.0.2
 Sphinx==4.3.1
 sphinx-issues==1.2.0
-sphinx-jinja==1.1.1
+sphinx-jinja==1.2.1
 sphinx-tabs==3.2.0
 sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14


### PR DESCRIPTION
## What does this PR do?

Sorts enabled before disabled and then by engine name.

Before:

![image](https://user-images.githubusercontent.com/73739153/146843828-5740ca5e-628a-42c7-91e7-1d9470d131e8.png)

After:

![image](https://user-images.githubusercontent.com/73739153/146843847-806729e7-a0f3-464e-b66c-a38599927c8d.png)

## Why is this change important?

Makes it easier to see which engines are enabled / disabled by default. Makes it easier to find engines by name.

## How to test this PR locally?

Run `make docs` and open `dist/docs/admin/engines/configured_engines.html` in your browser.

