### PR TITLE
[doc] introduce about.language and sort engines by it

### DIFF
--- a/docs/admin/engines/configured_engines.rst
+++ b/docs/admin/engines/configured_engines.rst
@@ -43,6 +43,9 @@ Explanation of the :ref:`general engine configuration` shown in the table
         - ``!{{mod.shortcut}}``
         - {{mod.__name__}}
         - {{(mod.disabled and "y") or ""}}
+          {%- if mod.about and  mod.about.language %}
+          ({{mod.about.language | upper}})
+          {%- endif %}
         - {{mod.timeout}}
         - {{mod.weight or 1 }}
         {% if mod.engine_type == 'online' %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,11 @@ jinja_contexts = {
     },
 }
 jinja_filters = {
-    'sort_engines': lambda engines: sorted(engines, key=lambda engine: (engine[1].disabled, engine[0]))
+    'sort_engines':
+    lambda engines: sorted(
+        engines,
+        key=lambda engine: (engine[1].disabled, engine[1].about.get('language', ''), engine[0])
+    )
 }
 
 # usage::   lorem :patch:`f373169` ipsum

--- a/searx/engines/duden.py
+++ b/searx/engines/duden.py
@@ -16,6 +16,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": 'HTML',
+    "language": 'de',
 }
 
 categories = ['general']

--- a/searx/engines/ina.py
+++ b/searx/engines/ina.py
@@ -18,6 +18,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": 'HTML',
+    "language": 'fr',
 }
 
 # engine dependent config

--- a/searx/engines/mediathekviewweb.py
+++ b/searx/engines/mediathekviewweb.py
@@ -14,6 +14,7 @@ about = {
     "use_official_api": True,
     "require_api_key": False,
     "results": 'JSON',
+    "language": "de",
 }
 
 categories = ['videos']

--- a/searx/engines/seznam.py
+++ b/searx/engines/seznam.py
@@ -22,6 +22,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "HTML",
+    "language": "cz",
 }
 
 base_url = 'https://search.seznam.cz/'

--- a/searx/engines/sjp.py
+++ b/searx/engines/sjp.py
@@ -18,6 +18,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": 'HTML',
+    "language": 'pl',
 }
 
 categories = ['general']

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -352,6 +352,9 @@ engines:
       use_official_api: false
       require_api_key: false
       results: HTML
+      # We don't set language: de here because media.ccc.de is not just
+      # for a German audience. It contains many English videos and many
+      # German videos have English subtitles.
 
   - name: ccengine
     engine: ccengine
@@ -1573,6 +1576,7 @@ engines:
       use_official_api: false
       require_api_key: false
       results: HTML
+      language: ko
 
   - name: rubygems
     shortcut: rbg
@@ -1649,6 +1653,7 @@ engines:
       use_official_api: false
       require_api_key: false
       results: HTML
+      language: de
 
   - name: słownik języka polskiego
     engine: sjp
@@ -1676,6 +1681,7 @@ engines:
       use_official_api: false
       require_api_key: false
       results: HTML
+      language: fr
 
   - name: brave
     shortcut: brave


### PR DESCRIPTION
## What does this PR do?

Introduces `about.language` for non-English engines and sorts the tables after (disabled, about.language, name).

Before:

![image](https://user-images.githubusercontent.com/73739153/146898746-f5a274f4-a90f-4b3c-a841-ff7d64d2371e.png)

After:

![image](https://user-images.githubusercontent.com/73739153/146898792-93ac3e9e-b72f-4025-b1e8-90ac0442c8b6.png)


## Why is this change important?

It helps non-English speakers find engines of their language.

## Related issues

#623