### PR TITLE
[doc] say how many engines are supported / enabled

### DIFF
--- a/docs/admin/engines/configured_engines.rst
+++ b/docs/admin/engines/configured_engines.rst
@@ -14,6 +14,8 @@ Explanation of the :ref:`general engine configuration` shown in the table
 
 .. jinja:: searx
 
+   SearXNG supports {{engines | length}} search engines (of which {{enabled_engine_count}} are enabled by default).
+
    {% for category, engines in engines.items() | groupby('1.categories.0') %}
 
    {{category}} search engines

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ jinja_contexts = {
         'version': {
             'node': os.getenv('NODE_MINIMUM_VERSION')
         },
+        'enabled_engine_count': sum(not x.disabled for x in searx.engines.engines.values()),
     },
 }
 jinja_filters = {


### PR DESCRIPTION
## What does this PR do?

Adds a paragraph about how many engines are supported / enabled by default to the documentation.

![image](https://user-images.githubusercontent.com/73739153/146926757-01cf15cc-17c5-4615-97d8-083bc45e3c03.png)


## Why is this change important?

It's neat.