### PR TITLE
[doc] engine-table: rename Engine column to Module & link

### DIFF
--- a/docs/admin/engines/configured_engines.rst
+++ b/docs/admin/engines/configured_engines.rst
@@ -43,7 +43,11 @@ Explanation of the :ref:`general engine configuration` shown in the table
 
       * - `{{name}} <{{mod.about and mod.about.website}}>`_
         - ``!{{mod.shortcut}}``
-        - :origin:`{{mod.__name__}} <searx/engines/{{mod.__name__}}.py>`
+        - {%- if 'searx.engines.' + mod.__name__ in documented_modules %}
+          :py:mod:`~searx.engines.{{mod.__name__}}`
+          {%- else %}
+          :origin:`{{mod.__name__}} <searx/engines/{{mod.__name__}}.py>`
+          {%- endif %}
         - {{(mod.disabled and "y") or ""}}
           {%- if mod.about and  mod.about.language %}
           ({{mod.about.language | upper}})

--- a/docs/admin/engines/configured_engines.rst
+++ b/docs/admin/engines/configured_engines.rst
@@ -30,7 +30,7 @@ Explanation of the :ref:`general engine configuration` shown in the table
 
       * - Name
         - Shortcut
-        - Engine
+        - Module
         - Disabled
         - Timeout
         - Weight
@@ -43,7 +43,7 @@ Explanation of the :ref:`general engine configuration` shown in the table
 
       * - `{{name}} <{{mod.about and mod.about.website}}>`_
         - ``!{{mod.shortcut}}``
-        - {{mod.__name__}}
+        - :origin:`{{mod.__name__}} <searx/engines/{{mod.__name__}}.py>`
         - {{(mod.disabled and "y") or ""}}
           {%- if mod.about and  mod.about.language %}
           ({{mod.about.language | upper}})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,25 @@ jinja_filters = {
     )
 }
 
+# Let the Jinja template in configured_engines.rst access documented_modules
+# to automatically link documentation for modules if it exists.
+def setup(app):
+    ENGINES_DOCNAME = 'admin/engines/configured_engines'
+
+    def before_read_docs(app, env, docnames):
+        assert ENGINES_DOCNAME in docnames
+        docnames.remove(ENGINES_DOCNAME)
+        docnames.append(ENGINES_DOCNAME)
+        # configured_engines must come last so that sphinx already has
+        # discovered the python module documentations
+
+    def source_read(app, docname, source):
+        if docname == ENGINES_DOCNAME:
+            jinja_contexts['searx']['documented_modules'] = app.env.domains['py'].modules
+
+    app.connect('env-before-read-docs', before_read_docs)
+    app.connect('source-read', source_read)
+
 # usage::   lorem :patch:`f373169` ipsum
 extlinks = {}
 


### PR DESCRIPTION
## What does this PR do?

Renames the "Engine" column to "Module" and adds hyperlinks to GitHub:

![image](https://user-images.githubusercontent.com/73739153/146949403-848efc41-99d8-428c-bf79-5bd67dda7b2f.png)

## Why is this change important?

Reduces potential user confusion.

## Related issues

#631
