### PR TITLE
[ci] drop Python 3.6

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version:  ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version:  ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ python-dateutil==2.8.2
 pyyaml==6.0
 httpx[http2]==0.19.0
 Brotli==1.0.9
-uvloop==0.16.0; python_version >= '3.7'
-uvloop==0.14.0; python_version < '3.7'
+uvloop==0.16.0
 httpx-socks[asyncio]==0.4.1
 langdetect==1.0.9
 setproctitle==1.2.2


### PR DESCRIPTION
## What does this PR do?

[ci] drop Python 3.6

## Why is this change important?

Python 3.6 reached EOL / https://github.com/searxng/searxng/pull/548#issuecomment-1000113683

## How to test this PR locally?

can't test it locally
