### PR TITLE
[doc] add global TOC to sidebar

### DIFF
--- a/docs/_themes/searxng/static/searxng.css
+++ b/docs/_themes/searxng/static/searxng.css
@@ -20,6 +20,10 @@ div.sidebar {
   border-radius: 3pt;
 }
 
+div.sphinxsidebar p.caption {
+  display: none;
+}
+
 p.sidebar-title, .sidebar p {
   margin: 6pt;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,13 @@ if CONTACT_URL:
     html_context["project_links"].append(ProjectLink("Contact", CONTACT_URL))
 
 html_sidebars = {
-    "**": ["project.html", "relations.html", "searchbox.html", "sourcelink.html"],
+    "**": [
+        "globaltoc.html",
+        "project.html",
+        "relations.html",
+        "searchbox.html",
+        "sourcelink.html"
+    ],
 }
 singlehtml_sidebars = {"index": ["project.html", "localtoc.html"]}
 html_logo = "../src/brand/searxng-wordmark.svg"


### PR DESCRIPTION
## What does this PR do?

[doc] add global TOC to sidebar

## Why is this change important?

see https://github.com/searxng/searxng/issues/635#issue-1086589861

## How to test this PR locally?

preview: https://return42.github.io/searxng/index.html

![grafik](https://user-images.githubusercontent.com/554536/147283445-502c1937-072e-49d0-a80c-4e6cc61f1fe7.png)
