### PR TITLE
[fix] utils/searx.sh : add libvips-dev dependency

### DIFF
--- a/utils/searx.sh
+++ b/utils/searx.sh
@@ -43,7 +43,7 @@ shellcheck"
 BUILD_PACKAGES_debian="\
 firefox graphviz imagemagick texlive-xetex librsvg2-bin
 texlive-latex-recommended texlive-extra-utils fonts-dejavu
-latexmk"
+latexmk libvips-dev"
 
 # pacman packages
 SEARX_PACKAGES_arch="\
@@ -54,7 +54,7 @@ shellcheck"
 
 BUILD_PACKAGES_arch="\
 firefox graphviz imagemagick texlive-bin extra/librsvg
-texlive-core texlive-latexextra ttf-dejavu"
+texlive-core texlive-latexextra ttf-dejavu libvips"
 
 # dnf packages
 SEARX_PACKAGES_fedora="\
@@ -67,7 +67,7 @@ BUILD_PACKAGES_fedora="\
 firefox graphviz graphviz-gd ImageMagick librsvg2-tools
 texlive-xetex-bin texlive-collection-fontsrecommended
 texlive-collection-latex dejavu-sans-fonts dejavu-serif-fonts
-dejavu-sans-mono-fonts"
+dejavu-sans-mono-fonts libvips-devel"
 
 # yum packages
 #


### PR DESCRIPTION
## What does this PR do?

The [libvips42-dev](https://packages.debian.org/bullseye/libvips-dev) package (*) is required to build the simple theme.

(*) link to Debian, but also for the different distro except CentOS: https://github.com/libvips/libvips/issues/528

## Why is this change important?

Fix CI

## How to test this PR locally?

* in a freshly new installed Debian, try `make themes` (or check the CI result since this is what is done)
 
## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
