### PR TITLE
changes about the secret_key

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1067,8 +1067,9 @@ def image_proxy():
     if not url:
         return '', 400
 
-    h = new_hmac(settings['server']['secret_key'], url.encode())
-    if h != request.args.get('h'):
+    h_url = new_hmac(settings['server']['secret_key'], url.encode())
+    h_args = request.args.get('h')
+    if len(h_url) != len(h_args) or not hmac.compare_digest(h_url, h_args):
         return '', 400
 
     maximum_size = 5 * 1024 * 1024

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -71,6 +71,7 @@ from searx.webutils import (
     get_themes,
     prettify_url,
     new_hmac,
+    is_hmac_of,
     is_flask_run_cmdline,
 )
 from searx.webadapter import (
@@ -1067,9 +1068,7 @@ def image_proxy():
     if not url:
         return '', 400
 
-    h_url = new_hmac(settings['server']['secret_key'], url.encode())
-    h_args = request.args.get('h')
-    if len(h_url) != len(h_args) or not hmac.compare_digest(h_url, h_args):
+    if not is_hmac_of(settings['server']['secret_key'], url.encode(), request.args.get('h', '')):
         return '', 400
 
     maximum_size = 5 * 1024 * 1024

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -77,14 +77,7 @@ def get_result_templates(templates_path):
 
 
 def new_hmac(secret_key, url):
-    try:
-        secret_key_bytes = bytes(secret_key, 'utf-8')
-    except TypeError as err:
-        if isinstance(secret_key, bytes):
-            secret_key_bytes = secret_key
-        else:
-            raise err
-    return hmac.new(secret_key_bytes, url, hashlib.sha256).hexdigest()
+    return hmac.new(secret_key.encode(), url, hashlib.sha256).hexdigest()
 
 
 def prettify_url(url, max_length=74):

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -80,6 +80,11 @@ def new_hmac(secret_key, url):
     return hmac.new(secret_key.encode(), url, hashlib.sha256).hexdigest()
 
 
+def is_hmac_of(secret_key, value, hmac_to_check):
+    hmac_of_value = new_hmac(secret_key, value)
+    return len(hmac_of_value) == len(hmac_to_check) and hmac.compare_digest(hmac_of_value, hmac_to_check)
+
+
 def prettify_url(url, max_length=74):
     if len(url) > max_length:
         chunk_len = int(max_length / 2 + 1)

--- a/tests/unit/test_webutils.py
+++ b/tests/unit/test_webutils.py
@@ -78,10 +78,12 @@ class TestUnicodeWriter(SearxTestCase):
 
 class TestNewHmac(SearxTestCase):
     def test_bytes(self):
-        for secret_key in ['secret', b'secret', 1]:
-            if secret_key == 1:
-                with self.assertRaises(TypeError):
-                    webutils.new_hmac(secret_key, b'http://example.com')
-                continue
-            res = webutils.new_hmac(secret_key, b'http://example.com')
-            self.assertEqual(res, '23e2baa2404012a5cc8e4a18b4aabf0dde4cb9b56f679ddc0fd6d7c24339d819')
+        data = b'http://example.com'
+        with self.assertRaises(AttributeError):
+            webutils.new_hmac(b'secret', data)
+
+        with self.assertRaises(AttributeError):
+            webutils.new_hmac(1, data)
+
+        res = webutils.new_hmac('secret', data)
+        self.assertEqual(res, '23e2baa2404012a5cc8e4a18b4aabf0dde4cb9b56f679ddc0fd6d7c24339d819')


### PR DESCRIPTION
## What does this PR do?

Two commits about the secret_key:
* the first commit uses [hmac.compare_digest](https://docs.python.org/3/library/hmac.html#hmac.compare_digest) to prevent timing attack.
* the second commit remove dead code: the secret_key is always a str, never bytes.

## Why is this change important?

* security fix
* clean code

## How to test this PR locally?

* in the master branch and on this branch, set the secret_key to something like `!!binary NGViODljMDY2YWJhNGVhNDZkNjA2NzAxZjlkMmY0`  : the server doesn't start.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
