### PR TITLE
[mod] manage: add themes.live command (rebuild on modification)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,7 @@ help:
 
 PHONY += run
 run:  install
-	$(Q) ( \
-	sleep 2 ; \
-	xdg-open http://127.0.0.1:8888/ ; \
-	) &
-	SEARXNG_DEBUG=1 ./manage pyenv.cmd python -m searx.webapp
+	$(Q)./manage webapp.run
 
 PHONY += install uninstall
 install uninstall:

--- a/docs/dev/makefile.rst
+++ b/docs/dev/makefile.rst
@@ -13,7 +13,7 @@ Makefile
 
    To install system requirements follow :ref:`buildhosts`.
 
-All relevant build tasks are implemented in :origin:`manage.sh` and for CI or
+All relevant build tasks are implemented in :origin:`manage` and for CI or
 IDE integration a small ``Makefile`` wrapper is available.  If you are not
 familiar with Makefiles, we recommend to read gnu-make_ introduction.
 
@@ -173,14 +173,19 @@ Install latest Node.js_ LTS locally (uses nvm_)::
 
 To get up a running a developer instance simply call ``make run``.  This enables
 *debug* option in :origin:`searx/settings.yml`, starts a ``./searx/webapp.py``
-instance, disables *debug* option again and opens the URL in your favorite WEB
-browser (:man:`xdg-open`)::
+instance and opens the URL in your favorite WEB browser (:man:`xdg-open`)::
 
    $ make run
-   PYENV     OK
-   SEARXNG_DEBUG=1 ./manage.sh pyenv.cmd python ./searx/webapp.py
-   ...
-   INFO:werkzeug: * Running on http://127.0.0.1:8888/ (Press CTRL+C to quit)
+
+Changes to theme's HTML templates (jinja2) are instant.  Changes to the CSS & JS
+sources of the theme need to be rebuild.  You can do that by running::
+
+  $ make themes.all
+
+Alternatively to ``themes.all`` you can run *live builds* of the theme you are
+modify::
+
+  $ LIVE_THEME=simple make run
 
 .. _make clean:
 

--- a/docs/dev/quickstart.rst
+++ b/docs/dev/quickstart.rst
@@ -40,9 +40,14 @@ JavaScript:
 
 Alternatively you can also compile selective the theme you have modified,
 e.g. the *simple* theme.
+
 .. code:: sh
 
    make themes.simple
+
+.. tip::
+
+   To get live builds while modifying CSS & JS use: ``LIVE_THEME=simple make run``
 
 If you finished your *tests* you can start to commit your changes.  To separate
 the modified source code from the build products first run:

--- a/manage
+++ b/manage
@@ -732,7 +732,6 @@ themes.oscar() {
 }
 
 themes.simple() {
-    local static="searx/static/themes/simple"
     (   set -e
         build_msg GRUNT "theme: simple"
         npm --prefix searx/static/themes/simple run build

--- a/manage
+++ b/manage
@@ -511,12 +511,15 @@ gecko.driver() {
     dump_return $?
 }
 
-node.env() {
+nodejs.ensure() {
     if ! nvm.min_node "${NODE_MINIMUM_VERSION}"; then
         info_msg "install Node.js by NVM"
         nvm.nodejs
     fi
+}
 
+node.env() {
+    nodejs.ensure
     (   set -e
 
         build_msg INSTALL "searx/static/themes/oscar/package.json"
@@ -698,6 +701,30 @@ themes.all() {
     dump_return $?
 }
 
+themes.live() {
+    local LIVE_THEME="${LIVE_THEME:-${1}}"
+    case "${LIVE_THEME}" in
+        simple|oscar)
+            theme="searx/static/themes/${LIVE_THEME}"
+            ;;
+        '')
+            die_caller 42 "missing theme argument"
+            ;;
+        *)
+            die_caller 42 "unknown theme '${LIVE_THEME}' // [simple|oscar]'"
+            ;;
+    esac
+    build_msg GRUNT "theme: $1 (live build)"
+    nodejs.ensure
+    cd "${theme}"
+    {
+        npm install
+        npm run watch
+    } 2>&1 \
+        | prefix_stdout "${_Blue}THEME ${1} ${_creset}  " \
+        | grep -E --ignore-case --color 'error[s]?[:]? |warning[s]?[:]? |'
+}
+
 themes.oscar() {
     build_msg GRUNT "theme: oscar"
     npm --prefix searx/static/themes/oscar run build
@@ -715,10 +742,7 @@ themes.simple() {
 
 themes.simple.test() {
     build_msg TEST "theme: simple"
-    if ! nvm.min_node "${NODE_MINIMUM_VERSION}"; then
-        info_msg "install Node.js by NVM"
-        nvm.nodejs
-    fi
+    nodejs.ensure
     npm --prefix searx/static/themes/simple install
     npm --prefix searx/static/themes/simple run test
     dump_return $?

--- a/manage
+++ b/manage
@@ -117,6 +117,17 @@ fi
 # needed by sphinx-docs
 export DOCS_BUILD
 
+webapp.run() {
+    SEARXNG_DEBUG=1 pyenv.cmd python -m searx.webapp &
+    sleep 3
+    if [ "${LIVE_THEME}" ]; then
+        themes.live "${LIVE_THEME}" &
+    fi
+    xdg-open http://127.0.0.1:8888/
+    wait -n
+    kill 0
+}
+
 buildenv() {
 
     # settings file from repository's working tree are used by default


### PR DESCRIPTION
## What does this PR do?

[mod] manage: add themes.live command (rebuild on modification)

## Why is this change important?

To get live builds while editing the HTML client of a theme.  The first argument of the command is the theme name:

    ./manage themes.live simple

To get live builds on `make run` use environment variable:

    LIVE_THEME=simple make run

## How to test this PR locally?

Start developer session:

    LIVE_THEME=simple make run

and edit CSS (LESS) & JS of the simple theme.

## Related issues

- https://github.com/searxng/searxng/pull/473#discussion_r745371694
- https://github.com/searxng/searxng/issues/498#issuecomment-1002286730
