### PR TITLE
[mod] switch default theme from oscar to simple

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -76,7 +76,7 @@ ui:
   # it decreases the privacy, since the browser can records the page titles.
   query_in_title: false
   # ui theme
-  default_theme: oscar
+  default_theme: simple
   # Default interface locale - leave blank to detect from browser information or
   # use codes from the 'locales' config section
   default_locale: ""

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -177,7 +177,7 @@ SCHEMA = {
     'ui': {
         'static_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'static')),
         'templates_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'templates')),
-        'default_theme': SettingsValue(str, 'oscar'),
+        'default_theme': SettingsValue(str, 'simple'),
         'default_locale': SettingsValue(str, ''),
         'theme_args': {
             'oscar_style': SettingsValue(OSCAR_STYLE, 'logicodev'),

--- a/searxng_extra/standalone_searx.py
+++ b/searxng_extra/standalone_searx.py
@@ -105,7 +105,7 @@ def get_search_query(
         "language": args.lang,
         "time_range": args.timerange,
     }
-    preferences = searx.preferences.Preferences(['oscar'], engine_categories, searx.engines.engines, [])
+    preferences = searx.preferences.Preferences(['simple'], engine_categories, searx.engines.engines, [])
     preferences.key_value_settings['safesearch'].parse(args.safesearch)
 
     search_query = searx.webadapter.get_search_query_from_webapp(preferences, form)[0]

--- a/tests/unit/settings/user_settings.yml
+++ b/tests/unit/settings/user_settings.yml
@@ -27,10 +27,10 @@ server:
 ui:
   static_path: ""
   templates_path: ""
-  default_theme: oscar
+  default_theme: simple
   default_locale: ""
   theme_args:
-    oscar_style: logicodev
+    simple_style: auto
 
 engines:
   - name: wikidata

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -119,7 +119,7 @@ class TestPreferences(SearxTestCase):
     def test_encode(self):
         from searx.preferences import Preferences
 
-        pref = Preferences(['oscar'], ['general'], {}, [])
+        pref = Preferences(['oscar', 'simple'], ['general'], {}, [])
         url_params = (
             'eJx1VMmO2zAM_Zr6YrTocujJh6JF0QEKzKAz7VVgJNohLIseUU7ivy-VcWy5yyGOTVGP73GLKJNPYjiYgGeT4NB8BS9YOSY'
             'TUdifMDYM-vmGY1d5CN0EHTYOK88W_PXNkcDBozOjnzoK0vyi4bWnHs2RU4-zvHr_-RF9a-5Cy3GARByy7X7EkKMoBeMp9CuPQ-SzYMx'

--- a/tests/unit/test_webadapter.py
+++ b/tests/unit/test_webadapter.py
@@ -30,14 +30,14 @@ class ValidateQueryCase(SearxTestCase):
         searx.search.initialize(TEST_ENGINES)
 
     def test_query_private_engine_without_token(self):
-        preferences = Preferences(['oscar'], ['general'], engines, [])
+        preferences = Preferences(['simple'], ['general'], engines, [])
         valid, unknown, invalid_token = validate_engineref_list(SEARCHQUERY, preferences)
         self.assertEqual(len(valid), 0)
         self.assertEqual(len(unknown), 0)
         self.assertEqual(len(invalid_token), 1)
 
     def test_query_private_engine_with_incorrect_token(self):
-        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
+        preferences_with_tokens = Preferences(['simple'], ['general'], engines, [])
         preferences_with_tokens.parse_dict({'tokens': 'bad-token'})
         valid, unknown, invalid_token = validate_engineref_list(SEARCHQUERY, preferences_with_tokens)
         self.assertEqual(len(valid), 0)
@@ -45,7 +45,7 @@ class ValidateQueryCase(SearxTestCase):
         self.assertEqual(len(invalid_token), 1)
 
     def test_query_private_engine_with_correct_token(self):
-        preferences_with_tokens = Preferences(['oscar'], ['general'], engines, [])
+        preferences_with_tokens = Preferences(['simple'], ['general'], engines, [])
         preferences_with_tokens.parse_dict({'tokens': 'my-token'})
         valid, unknown, invalid_token = validate_engineref_list(SEARCHQUERY, preferences_with_tokens)
         self.assertEqual(len(valid), 1)

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -73,7 +73,7 @@ class ViewsTestCase(SearxTestCase):
         def get_current_theme_name_mock(override=None):
             if override:
                 return override
-            return 'oscar'
+            return 'simple'
 
         self.setattr4test(webapp, 'get_current_theme_name', get_current_theme_name_mock)
 
@@ -83,9 +83,7 @@ class ViewsTestCase(SearxTestCase):
         result = self.app.post('/')
         self.assertEqual(result.status_code, 200)
         self.assertIn(
-            b'<div class="text-hide center-block" id="main-logo">'
-            + b'<img class="center-block img-responsive" src="/static/themes/oscar/img/searxng.svg"'
-            + b' alt="searx logo" />SearXNG</div>',
+            b'<div class="title"><h1>SearXNG</h1></div>',
             result.data,
         )
 
@@ -102,7 +100,7 @@ class ViewsTestCase(SearxTestCase):
     def test_search_empty_html(self):
         result = self.app.post('/search', data={'q': ''})
         self.assertEqual(result.status_code, 200)
-        self.assertIn(b'<span class="instance pull-left"><a href="/">SearXNG</a></span>', result.data)
+        self.assertIn(b'<div class="title"><h1>SearXNG</h1></div>', result.data)
 
     def test_search_empty_json(self):
         result = self.app.post('/search', data={'q': '', 'format': 'json'})
@@ -120,13 +118,12 @@ class ViewsTestCase(SearxTestCase):
         result = self.app.post('/search', data={'q': 'test'})
 
         self.assertIn(
-            b'<h4 class="result_header" id="result-2"><img width="32" height="32" class="favicon"'
-            + b' src="/static/themes/oscar/img/icons/youtube.png" alt="youtube" /><a href="http://second.test.xyz"'
-            + b' rel="noreferrer" aria-labelledby="result-2">Second <span class="highlight">Test</span></a></h4>',  # noqa
+            b'<span class="url_o1"><span class="url_i1">http://second.test.xyz</span></span>',
             result.data,
         )
         self.assertIn(
-            b'<p class="result-content">second <span class="highlight">test</span> content</p>', result.data  # noqa
+            b'<p class="content">\n    second <span class="highlight">test</span> ',
+            result.data,
         )
 
     def test_index_json(self):
@@ -186,9 +183,11 @@ class ViewsTestCase(SearxTestCase):
     def test_preferences(self):
         result = self.app.get('/preferences')
         self.assertEqual(result.status_code, 200)
-        self.assertIn(b'<form method="post" action="/preferences" id="search_form" autocomplete="off">', result.data)
-        self.assertIn(b'<label class="col-sm-3 col-md-2" for="categories">Default categories</label>', result.data)
-        self.assertIn(b'<label class="col-sm-3 col-md-2" for="locale">Interface language</label>', result.data)
+        self.assertIn(b'<form id="search_form" method="post" action="/preferences"', result.data)
+        self.assertIn(
+            b'<input type="checkbox" id="checkbox_general" name="category_general" checked="checked"/>', result.data
+        )
+        self.assertIn(b'<legend>Interface language</legend>', result.data)
 
     def test_browser_locale(self):
         result = self.app.get('/preferences', headers={'Accept-Language': 'zh-tw;q=0.8'})


### PR DESCRIPTION
## What does this PR do?

switch default theme from oscar to simple

## Why is this change important?

Thanks to the fabulous work from @dalf and @mrpaulblack the simple theme is now ready to become the default.  I tested the simple theme over 3 weeks in my daily usage and I can't find a reason why oscar should be longer the default.

## Open issues

- [ ] [Simple theme as the default theme](https://github.com/searxng/searxng/projects/1)
- [x] #463
- [x] #542
- [x] #368
- [x] #351
