### PR TITLE
[fix] disabling all engines in a category makes the bang search in general

### DIFF
--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -236,7 +236,7 @@ def get_search_query_from_webapp(
     external_bang = raw_text_query.external_bang
     engine_data = parse_engine_data(form)
 
-    if not is_locked('categories') and raw_text_query.enginerefs and raw_text_query.specific:
+    if not is_locked('categories') and raw_text_query.specific:
         # if engines are calculated from query,
         # set categories by using that informations
         query_engineref_list = raw_text_query.enginerefs


### PR DESCRIPTION
## What does this PR do?

With this PR, there is no result

The condition (in the master branch)
`if not is_locked('categories') and raw_text_query.enginerefs and raw_text_query.specific:`
has been replaced by (in this PR)
`if not is_locked('categories') and raw_text_query.specific:`

So even if `raw_text_query.enginerefs` is an empty list, the query is processed as a specific query (= with a bang).

## Why is this change important?

Fix an unexpected result

## How to test this PR locally?

* In the preferences, disable all the engines for an category (any category, except the general category). For example, the `files` category.
* search for `!files time`.
* check there is no result (in the master branch, the query are sent to the general category engines)

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #685
