### PR TITLE
[fix] debug console (pdb) in a session started by `make run`

### DIFF
--- a/manage
+++ b/manage
@@ -121,14 +121,18 @@ fi
 export DOCS_BUILD
 
 webapp.run() {
-    SEARXNG_DEBUG=1 pyenv.cmd python -m searx.webapp &
-    sleep 3
-    if [ "${LIVE_THEME}" ]; then
-        themes.live "${LIVE_THEME}" &
-    fi
-    xdg-open http://127.0.0.1:8888/
-    wait -n
-    kill 0
+    local parent_proc="$$"
+    (
+        if [ "${LIVE_THEME}" ]; then
+            ( themes.live "${LIVE_THEME}" )
+            kill $parent_proc
+        fi
+    )&
+    (
+        sleep 3
+        xdg-open http://127.0.0.1:8888/
+    )&
+    SEARXNG_DEBUG=1 pyenv.cmd python -m searx.webapp
 }
 
 buildenv() {


### PR DESCRIPTION
## What does this PR do?

[fix] debug console (pdb) in a session started by `make run`

This patch moves all processes to the background except the searx.webapp.

## Why is this change important?

Commit c7f27404 moves the `python -m searx.webapp` process to the background.  A background job can't open a simple python-debugger (pdb) console.

## How to test this PR locally?

Insert a break point somewhere in the webapp application::

    import pdb
    pdb.set_trace()

And start a debug session by::

    make run

and test you break point.

To test that the entire `make run` stops in the case of an error in the themes.live [1] background process try:

    make LIVE_THEME=typo-theme-name run

[1] https://github.com/searxng/searxng/pull/664#discussion_r776419585

## Related issues

- https://github.com/searxng/searxng/pull/664
