### PR TITLE
[fix] startpage engine / modified API

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -1,17 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Startpage (Web)
+
 """
- Startpage (Web)
-"""
+
+import re
 
 from urllib.parse import urlencode
-
-from lxml import html
-from dateutil import parser
-from datetime import datetime, timedelta
-import re
 from unicodedata import normalize, combining
+from datetime import datetime, timedelta
+
+from dateutil import parser
+from lxml import html
 from babel import Locale
 from babel.localedata import locale_identifiers
+
 from searx.utils import extract_text, eval_xpath, match_language
 
 # about
@@ -135,10 +138,11 @@ def response(resp):
 
 # get supported languages from their site
 def _fetch_supported_languages(resp):
-    # startpage's language selector is a mess
-    # each option has a displayed name and a value, either of which may represent the language name
-    # in the native script, the language name in English, an English transliteration of the native name,
-    # the English name of the writing script used by the language, or occasionally something else entirely.
+    # startpage's language selector is a mess each option has a displayed name
+    # and a value, either of which may represent the language name in the native
+    # script, the language name in English, an English transliteration of the
+    # native name, the English name of the writing script used by the language,
+    # or occasionally something else entirely.
 
     # this cases are so special they need to be hardcoded, a couple of them are mispellings
     language_names = {
@@ -152,7 +156,15 @@ def _fetch_supported_languages(resp):
     }
 
     # get the English name of every language known by babel
-    language_names.update({name.lower(): lang_code for lang_code, name in Locale('en')._data['languages'].items()})
+    language_names.update(
+        {
+            # fmt: off
+            name.lower(): lang_code
+            # pylint: disable=protected-access
+            for lang_code, name in Locale('en')._data['languages'].items()
+            # fmt: on
+        }
+    )
 
     # get the native name of every language known by babel
     for lang_code in filter(lambda lang_code: lang_code.find('_') == -1, locale_identifiers()):
@@ -177,8 +189,8 @@ def _fetch_supported_languages(resp):
         if isinstance(lang_code, str):
             supported_languages[lang_code] = {'alias': sp_option_value}
         elif isinstance(lang_code, list):
-            for lc in lang_code:
-                supported_languages[lc] = {'alias': sp_option_value}
+            for _lc in lang_code:
+                supported_languages[_lc] = {'alias': sp_option_value}
         else:
             print('Unknown language option in Startpage: {} ({})'.format(sp_option_value, sp_option_text))
 

--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -95,7 +95,7 @@ def get_sc_code(headers):
             # suspend startpage API --> https://github.com/searxng/searxng/pull/695
             raise SearxEngineResponseException(
                 suspended_time=7 * 24 * 3600, message="PR-695: query new sc time-stamp failed!"
-            )
+            ) from exc
 
         sc_code = href[5:]
         sc_code_ts = time()
@@ -107,10 +107,19 @@ def get_sc_code(headers):
 # do search-request
 def request(query, params):
 
+    # pylint: disable=line-too-long
+    # The format string from Startpage's FFox add-on [1]::
+    #
+    #     https://www.startpage.com/do/dsearch?query={searchTerms}&cat=web&pl=ext-ff&language=__MSG_extensionUrlLanguage__&extVersion=1.3.0
+    #
+    # [1] https://addons.mozilla.org/en-US/firefox/addon/startpage-private-search/
+
     args = {
         'query': query,
         'page': params['pageno'],
         'cat': 'web',
+        # 'pl': 'ext-ff',
+        # 'extVersion': '1.3.0',
         # 'abp': "-1",
         'sc': get_sc_code(params['headers']),
     }

--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -3,6 +3,8 @@
  Startpage (Web)
 """
 
+from urllib.parse import urlencode
+
 from lxml import html
 from dateutil import parser
 from datetime import datetime, timedelta
@@ -33,7 +35,7 @@ supported_languages_url = 'https://www.startpage.com/do/settings'
 
 # search-url
 base_url = 'https://startpage.com/'
-search_url = base_url + 'do/search'
+search_url = base_url + 'sp/search?'
 
 # specific xpath variables
 # ads xpath //div[@id="results"]/div[@id="sponsored"]//div[@class="result"]
@@ -46,14 +48,12 @@ content_xpath = './/p[@class="w-gl__description"]'
 # do search-request
 def request(query, params):
 
-    params['url'] = search_url
-    params['method'] = 'POST'
-    params['data'] = {
+    args = {
         'query': query,
         'page': params['pageno'],
         'cat': 'web',
-        'cmd': 'process_search',
-        'engine0': 'v1all',
+        # 'abp': "-1",
+        'sc': 'Mj4jZy61QETj20',
     }
 
     # set language if specified
@@ -61,9 +61,10 @@ def request(query, params):
         lang_code = match_language(params['language'], supported_languages, fallback=None)
         if lang_code:
             language_name = supported_languages[lang_code]['alias']
-            params['data']['language'] = language_name
-            params['data']['lui'] = language_name
+            args['language'] = language_name
+            args['lui'] = language_name
 
+    params['url'] = search_url + urlencode(args)
     return params
 
 

--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -16,7 +16,7 @@ from lxml import html
 from babel import Locale
 from babel.localedata import locale_identifiers
 
-from searx import network
+from searx.network import get
 from searx.utils import extract_text, eval_xpath, match_language
 from searx.exceptions import (
     SearxEngineResponseException,
@@ -84,7 +84,7 @@ def get_sc_code(headers):
     if time() > (sc_code_ts + 3000):
         logger.debug("query new sc time-stamp ...")
 
-        resp = network.get(base_url, headers=headers)
+        resp = get(base_url, headers=headers)
         raise_captcha(resp)
         dom = html.fromstring(resp.text)
 


### PR DESCRIPTION
## What does this PR do?

- [fix] startpage engine - avoid captcha
- [pylint] Startpage engine

## Why is this change important?

Startpage has introduced new anti-scraping measures that make SearXNG instances run into captchas:

1. some arguments has been removed and a new `sc` has been added.
2. search path changed from `do/search` to `sp/search`
3. POST request is no longer needed

## How to test this PR locally?

    make run

try to query `!sp foo`

## Author's checklist

## Related issues

Closes: https://github.com/searxng/searxng/issues/692
