### PR TITLE
[mod] adjust dockerfiles/uwsgi.ini

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -4,7 +4,8 @@ uid = searxng
 gid = searxng
 
 # Number of workers (usually CPU count)
-workers = 4
+workers = %k
+threads = 4
 
 # The right granted on the created socket
 chmod-socket = 666
@@ -23,8 +24,14 @@ module = searx.webapp
 pythonpath = /usr/local/searxng/
 chdir = /usr/local/searxng/searx/
 
+# automatically set processes name to something meaningful
+auto-procname = true
+
 # Disable logging for privacy
-disable-logging=True
+disable-logging = true
+
+# Set the max size of a request (request-body excluded)
+buffer-size = 8192
 
 # But keep errors for 2 days
 touch-logrotate = /run/uwsgi-logrotate


### PR DESCRIPTION
## What does this PR do?

* create %k process (%k = number of core), instead of the hard coded value 4.
* create 4 threads per process.
* increase the request buffer size.
* enable `auto-procname`: automatically set processes name to something meaningful

## Why is this change important?

More threads per process helps the embedded image proxy.
Only `uwsgi.ini` from the docker image is replaced. If this is confirm, other uwsgi.ini version have to be updated.

## How to test this PR locally?

* `make docker` (check the image name)
* start the image https://docs.searxng.org/admin/installation-docker.html#searxng-searxng
* enable the embedded image proxy
* check everything works fine

## Author's checklist

Open question (perhaps another issue): should the uwsgi log be displayed on `/dev/stdout` like many other Docker images?

## Related issues

<!--
Closes #234
-->
