### PR TITLE
[fix] remove broken ? search operator

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -302,7 +302,7 @@ engine is shown.  Most of the options have a default value or even are optional.
   search engine.
 
 ``shortcut`` :
-  Code used to execute bang requests (in this case using ``!bi`` or ``?bi``)
+  Code used to execute bang requests (in this case using ``!bi``)
 
 ``base_url`` : optional
   Part of the URL that should be stable across every request.  Can be useful to

--- a/docs/user/search_syntax.rst
+++ b/docs/user/search_syntax.rst
@@ -14,9 +14,6 @@ Prefix ``!``
 Prefix: ``:``
   to set language
 
-Prefix: ``?``
-  to add engines and categories to the currently selected categories
-
 Abbrevations of the engines and languages are also accepted.  Engine/category
 modifiers are chainable and inclusive (e.g. with :search:`!it !ddg !wp qwer
 <?q=%21it%20%21ddg%20%21wp%20qwer>` search in IT category **and** duckduckgo

--- a/searx/query.py
+++ b/searx/query.py
@@ -177,7 +177,7 @@ class ExternalBangParser(QueryPartParser):
 class BangParser(QueryPartParser):
     @staticmethod
     def check(raw_value):
-        return raw_value[0] == '!' or raw_value[0] == '?'
+        return raw_value[0] == '!'
 
     def __call__(self, raw_value):
         value = raw_value[1:].replace('-', ' ').replace('_', ' ')

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -230,13 +230,12 @@ class TestExternalBangParser(SearxTestCase):
 class TestBang(SearxTestCase):
 
     SPECIFIC_BANGS = ['!dummy_engine', '!du', '!general']
-    NOT_SPECIFIC_BANGS = ['?dummy_engine', '?du', '?general']
     THE_QUERY = 'the query'
 
     def test_bang(self):
         load_engines(TEST_ENGINES)
 
-        for bang in TestBang.SPECIFIC_BANGS + TestBang.NOT_SPECIFIC_BANGS:
+        for bang in TestBang.SPECIFIC_BANGS:
             with self.subTest(msg="Check bang", bang=bang):
                 query_text = TestBang.THE_QUERY + ' ' + bang
                 query = RawTextQuery(query_text, [])
@@ -251,13 +250,6 @@ class TestBang(SearxTestCase):
                 query_text = TestBang.THE_QUERY + ' ' + bang
                 query = RawTextQuery(query_text, [])
                 self.assertTrue(query.specific)
-
-    def test_not_specific(self):
-        for bang in TestBang.NOT_SPECIFIC_BANGS:
-            with self.subTest(msg="Check bang is not specific", bang=bang):
-                query_text = TestBang.THE_QUERY + ' ' + bang
-                query = RawTextQuery(query_text, [])
-                self.assertFalse(query.specific)
 
     def test_bang_not_found(self):
         load_engines(TEST_ENGINES)
@@ -278,5 +270,5 @@ class TestBang(SearxTestCase):
         query = RawTextQuery('the query !', [])
         self.assertEqual(query.autocomplete_list, ['!images', '!wikipedia', '!osm'])
 
-        query = RawTextQuery('the query ?', ['osm'])
-        self.assertEqual(query.autocomplete_list, ['?images', '?wikipedia'])
+        query = RawTextQuery('the query !', ['osm'])
+        self.assertEqual(query.autocomplete_list, ['!images', '!wikipedia'])


### PR DESCRIPTION
The ? search operator has been broken for some time and
currently only raises the question why it's still there.

## Context ##

The query "Paris !images" searches for "Paris" in the "images" category.

Once upon a time Searx supported "Paris ?images" to search for "Paris"
in the currently enabled categories and the "images" category.

The feature makes sense ... the ? syntax does not.
We will hopefully introduce a +!images syntax in the future.

Fixes #702.

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
