### PR TITLE
[fix] filtron.service: set -read-buffer-size 65536

### DIFF
--- a/utils/templates/lib/systemd/system/filtron.service
+++ b/utils/templates/lib/systemd/system/filtron.service
@@ -10,7 +10,7 @@ Type=simple
 User=${SERVICE_USER}
 Group=${SERVICE_GROUP}
 WorkingDirectory=${SERVICE_HOME}
-ExecStart=${SERVICE_HOME}/go-apps/bin/filtron -api '${FILTRON_API}' -listen '${FILTRON_LISTEN}' -rules '${FILTRON_RULES}' -target '${FILTRON_TARGET}'
+ExecStart=${SERVICE_HOME}/go-apps/bin/filtron -api '${FILTRON_API}' -listen '${FILTRON_LISTEN}' -rules '${FILTRON_RULES}' -target '${FILTRON_TARGET}' -read-buffer-size 65536
 
 Restart=always
 Environment=USER=${SERVICE_USER} HOME=${SERVICE_HOME}


### PR DESCRIPTION
## What does this PR do?

[fix] filtron.service: set -read-buffer-size 65536

## Why is this change important?

Increase filtron buffer size to prevent `Too big request header` errors.

See https://github.com/searxng/filtron/issues/6#issuecomment-1009367442

## How to test this PR locally?

To test a filtron installation [`sudo -H ./utils/filtron.sh install all`](https://docs.searxng.org/utils/filtron.sh.html) is needed.

I tested this installation on my public SearXNG instance.

----

@dalf do we need to fix [docker-compose.yaml `filtron: command:`](https://github.com/searxng/searxng-docker/blob/c7b3f004eb5b304a5695dccea2d7c975a6cc6c43/docker-compose.yaml#L32) also?