### PR TITLE
[mod] engine mysql_server: make port configurable

### DIFF
--- a/searx/engines/mysql_server.py
+++ b/searx/engines/mysql_server.py
@@ -11,6 +11,7 @@ import mysql.connector  # pylint: disable=import-error
 engine_type = 'offline'
 auth_plugin = 'caching_sha2_password'
 host = "127.0.0.1"
+port = 3306
 database = ""
 username = ""
 password = ""
@@ -35,6 +36,7 @@ def init(engine_settings):
         user=username,
         password=password,
         host=host,
+        port=port,
         auth_plugin=auth_plugin,
     )
 


### PR DESCRIPTION
## What does this PR do?

[mod] engine mysql_server: make port configurable

Cherry piked from https://github.com/searx/searx/commit/82ac634070

## Why is this change important?

Suggested-by: https://github.com/searx/searx/issues/3117