### PR TITLE
[hotfix] interim fix to get docker-build of CI without issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ uvloop==0.16.0
 httpx-socks[asyncio]==0.7.2
 langdetect==1.0.9
 setproctitle==1.2.2
-redis==4.1.0

--- a/searx/shared/redisdb.py
+++ b/searx/shared/redisdb.py
@@ -20,7 +20,6 @@ A redis DB connect can be tested by::
 """
 
 import logging
-import redis
 from searx import get_setting
 
 logger = logging.getLogger('searx.shared.redis')
@@ -29,6 +28,8 @@ _client = None
 
 def client():
     global _client  # pylint: disable=global-statement
+    import redis  # pylint: disable=import-error, import-outside-toplevel
+
     if _client is None:
         # not thread safe: in the worst case scenario, two or more clients are
         # initialized only one is kept, the others are garbage collected.
@@ -37,6 +38,8 @@ def client():
 
 
 def init():
+    import redis  # pylint: disable=import-error, import-outside-toplevel
+
     try:
         c = client()
         logger.info("connected redis DB --> %s", c.acl_whoami())


### PR DESCRIPTION
## What does this PR do?

[hotfix] interim fix to get docker-build of CI without issues

[ERROR: Cannot uninstall 'packaging'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.](
https://github.com/searxng/searxng/runs/4780168620?check_suite_focus=true#step:8:804)

Issue seems fixed in [2]

## Why is this change important?

There is an issue with redis v4.1.0 [1] / for the interim lets remove this
python dependency.

## Related issue

[1] https://github.com/searxng/searxng/issues/741
[2] https://github.com/redis/redis-py/pull/1854/files

