### PR TITLE
[fix] stop less grunt runner on missing files

### DIFF
--- a/searx/static/themes/simple/gruntfile.js
+++ b/searx/static/themes/simple/gruntfile.js
@@ -4,6 +4,15 @@ module.exports = function (grunt) {
 
   const eachAsync = require('each-async');
 
+  function file_exists (filepath) {
+    // filter function to exit grunt task with error if a (src) file not exists
+    if (!grunt.file.exists(filepath)) {
+      grunt.fail.fatal('Could not find: ' + filepath, 42);
+    } else {
+      return true;
+    }
+  }
+
   grunt.initConfig({
 
     _brand: '../../../../src/brand',
@@ -116,10 +125,20 @@ module.exports = function (grunt) {
           sourceMapURL: (name) => { const s = name.split('/'); return s[s.length - 1] + '.map'; },
           outputSourceFiles: true,
         },
-        files: {
-          "css/searxng.min.css": "src/less/style.less",
-          "css/searxng-rtl.min.css": "src/less/style-rtl.less"
-        }
+        files: [
+          {
+            src: ['src/less/style.less'],
+            dest: 'css/searxng.min.css',
+            nonull: true,
+            filter: file_exists,
+          },
+          {
+            src: ['src/less/style-rtl.less'],
+            dest: 'css/searxng-rtl.min.css',
+            nonull: true,
+            filter: file_exists,
+          },
+        ],
       },
     },
     image: {


### PR DESCRIPTION
## What does this PR do?

[fix] stop less grunt runner on missing files

## Why is this change important?

The less grunt runner silently ignore missing files and continue with the build[1]::

    Running "less:production" (less) task
    >> Destination css/searxng.min.css not written because no source files were found.
    >> 1 stylesheet created.
    >> 1 sourcemap created.

Add filter function that calls grunt.fail() if the scr file does not exists.

## How to test this PR locally?

register an unknown file ...

```diff
diff --git a/searx/static/themes/simple/gruntfile.js b/searx/static/themes/simple/gruntfile.js
index abb2dc44..3a515557 100644
--- a/searx/static/themes/simple/gruntfile.js
+++ b/searx/static/themes/simple/gruntfile.js
@@ -127,7 +127,7 @@ module.exports = function (grunt) {
         },
         files: [
           {
-            src: ['src/less/style.less'],
+            src: ['src/less/unknown.less'],
             dest: 'css/searxng.min.css',
             nonull: true,
             filter: file_exists,
```

and run ...

```
$ make themes.simple
GRUNT     theme: simple

> build
> grunt

Running "eslint:target" (eslint) task

Running "stylelint:src" (stylelint) task
>> Linted 13 files without errors

Running "copy:js" (copy) task
Copied 1 file

Running "copy:css" (copy) task
Copied 1 file

Running "copy:leaflet_images" (copy) task
Copied 5 files

Running "uglify:dist" (uglify) task
>> 2 sourcemaps created.
>> 2 files created 56.1 kB → 27.34 kB

Running "less:production" (less) task
Fatal error: Could not find: src/less/unknown.less
ERROR: themes.simple exit with error (42)
make: *** [Makefile:97: themes.simple] Fehler 42
```

## Related issues

[1] https://github.com/searxng/searxng/pull/750#discussion_r784357031
