### PR TITLE
[enh] add blocked_plugins setting do completly remove plugin from que…

### DIFF
--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -226,10 +226,9 @@ def plugin_module_names():
 
 
 def initialize(app):
-    # it is possible to block plugins from being registered into plugin chain
-    blocked_plugins = settings['outgoing'].get('blocked_plugins', [])
-
     for module_name, external in plugin_module_names():
-        plugin = load_and_initialize_plugin(module_name, external, (app, settings))
-        if plugin and plugin.name not in blocked_plugins:
-            plugins.register(plugin)
+        # it is possible to block plugins from being registered into plugin chain in settings.yml
+        if module_name not in settings['blocked_plugins']:
+            plugin = load_and_initialize_plugin(module_name, external, (app, settings))
+            if plugin:
+                plugins.register(plugin)

--- a/searx/plugins/__init__.py
+++ b/searx/plugins/__init__.py
@@ -226,7 +226,10 @@ def plugin_module_names():
 
 
 def initialize(app):
+    # it is possible to block plugins from being registered into plugin chain
+    blocked_plugins = settings['outgoing'].get('blocked_plugins', [])
+
     for module_name, external in plugin_module_names():
         plugin = load_and_initialize_plugin(module_name, external, (app, settings))
-        if plugin:
+        if plugin and plugin.name not in blocked_plugins:
             plugins.register(plugin)

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -157,6 +157,12 @@ outgoing:
 #   - plugin2
 #   - ...
 
+# Plugins listed here will be loaded, but will not be registered into plugins chain.
+# The engine will not use them to process queries.
+#
+#  blocked_plugins:
+#    - 'Self Informations'
+
 # Comment or un-comment plugin to activate / deactivate by default.
 #
 # enabled_plugins:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -160,8 +160,8 @@ outgoing:
 # Plugins listed here will be loaded, but will not be registered into plugins chain.
 # The engine will not use them to process queries.
 #
-#  blocked_plugins:
-#    - 'Self Informations'
+#blocked_plugins:
+#  - searx.plugins.self_info
 
 # Comment or un-comment plugin to activate / deactivate by default.
 #

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -212,6 +212,7 @@ SCHEMA = {
     },
     'plugins': SettingsValue(list, []),
     'enabled_plugins': SettingsValue((None, list), None),
+    'blocked_plugins': SettingsValue(list, []),
     'checker': {
         'off_when_debug': SettingsValue(bool, True),
     },


### PR DESCRIPTION
## What does this PR do?

There is already `enabled_plugins` and `disabled_plugins` they set the default way how plugins are used. It is not possible to block the plugin from processing queries;

This pull request adds `blocker_plugins` property to completely remove plugin from being used.
It is loading the plugin to obtain the plugin name familiar to users, but then it is not registered.

## Why is this change important?

This pull request improves security and public hosting of searx:

* 'Self Informations' may display internal IP address if server is not correctly configured
* 'Hash plugin' uses server CPU and this functionality doesn't need to be necessary wanted what the public hoster want's to provide to users
* it is possible to disable all engines until valid token is provided, but users are always able to use the instance for some functionality provided by plugins

I am running public instance of seax for a group of people. I provided them with token which makes it for me possible to keep the instance performing well by controlling the number of users with access to my small instance.

## How to test this PR locally?

Ucommend in settings.yml following:
```yaml
  blocked_plugins:
    - 'Self Informations'
```

Now ip` query should not be processed at all and the plugin will not be listed in /preferences page.