### PR TITLE
Revert "[hotfix] interim fix to get docker-build of CI without issues"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ uvloop==0.16.0
 httpx-socks[asyncio]==0.7.2
 langdetect==1.0.9
 setproctitle==1.2.2
+redis==4.1.1

--- a/searx/shared/redisdb.py
+++ b/searx/shared/redisdb.py
@@ -20,6 +20,7 @@ A redis DB connect can be tested by::
 """
 
 import logging
+import redis
 from searx import get_setting
 
 logger = logging.getLogger('searx.shared.redis')
@@ -28,8 +29,6 @@ _client = None
 
 def client():
     global _client  # pylint: disable=global-statement
-    import redis  # pylint: disable=import-error, import-outside-toplevel
-
     if _client is None:
         # not thread safe: in the worst case scenario, two or more clients are
         # initialized only one is kept, the others are garbage collected.
@@ -38,8 +37,6 @@ def client():
 
 
 def init():
-    import redis  # pylint: disable=import-error, import-outside-toplevel
-
     try:
         c = client()
         logger.info("connected redis DB --> %s", c.acl_whoami())


### PR DESCRIPTION
This reverts interim fix from commit 50c4b58db (https://github.com/searxng/searxng/pull/745) and adds requirement `redis==4.1.1`.

The interim fix was needed by Alpine images (Docker) [1] and has been fixed in
commit [2] merged with the patch series from [3].  In redis-py version 4.1.1
this pach has been released on PyPi [4].

[1] https://github.com/redis/redis-py/issues/1869
[2] https://github.com/redis/redis-py/commit/1fc1233f
[3] https://github.com/redis/redis-py/pull/1854
[4] https://github.com/redis/redis-py/issues/1880
