### PR TITLE
[fix] issues reported by and fix documentation of test.shell

### DIFF
--- a/docs/dev/makefile.rst
+++ b/docs/dev/makefile.rst
@@ -238,10 +238,10 @@ and ``test.robot``.  You can run tests selective, e.g.::
   ...
   TEST      test.sh OK
 
-.. _make test.sh:
+.. _make test.shell:
 
-``make test.sh``
-================
+``make test.shell``
+===================
 
 :ref:`sh lint` / if you have changed some bash scripting run this test before
 commit.

--- a/manage
+++ b/manage
@@ -713,7 +713,7 @@ test.robot() {
 }
 
 test.rst() {
-    build_msg TEST "[reST markup] ${RST_FILES[@]}"
+    build_msg TEST "[reST markup] ${RST_FILES[*]}"
     for rst in "${RST_FILES[@]}"; do
         pyenv.cmd rst2html.py --halt error "$rst" > /dev/null || die 42 "fix issue in $rst"
     done


### PR DESCRIPTION
## What does this PR do?

[fix] issue reported by: make test.shell

    $ make test.shell
    ./manage line 716:
    build_msg TEST "[reST markup] ${RST_FILES[@]}"
                                  ^-------------^ SC2145: Argument mixes string and array. Use 

[fix] typo 'test.sh' in the docs/dev/makefile.rst to 'test.shell'

    make test.sh --> make test.shell

