### PR TITLE
Fix Tor

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -255,7 +255,7 @@ def is_engine_active(engine: Engine):
         return False
 
     # exclude onion engines if not using tor
-    if 'onions' in engine.categories and not settings['outgoing'].get('using_tor_proxy'):
+    if 'onions' in engine.categories and not engine.using_tor_proxy:
         return False
 
     return True

--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -167,9 +167,6 @@ class Network:
         for transport in client._mounts.values():  # pylint: disable=protected-access
             if isinstance(transport, AsyncHTTPTransportNoHttp):
                 continue
-            if not getattr(transport, '_rdns', False):
-                result = False
-                break
         else:
             response = await client.get('https://check.torproject.org/api/ip')
             if not response.json()['IsTor']:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -135,7 +135,6 @@ outgoing:
   #      - http://proxy1:8080
   #      - http://proxy2:8080
   #
-  #  using_tor_proxy: true
   #
   # Extra seconds to add in order to account for the time taken by the proxy
   #
@@ -254,6 +253,7 @@ engines:
   # Requires Tor
   - name: ahmia
     engine: ahmia
+    using_tor_proxy: false
     categories: onions
     enable_http: true
     shortcut: ah
@@ -1272,6 +1272,7 @@ engines:
   # Requires Tor
   - name: torch
     engine: xpath
+    using_tor_proxy: false
     paging: true
     search_url:
       http://xmh57jrknzkhv6y3ls3ubitzfqnkrwxhopf5aygthi7d6rplyvk3noyd.onion/cgi-bin/omega/omega?P={query}&DEFAULTOP=and


### PR DESCRIPTION
## What does this PR do?

This PR allows 'using_tor_proxy' to be checked for each engine individually. This allows SearXNG to use Tor engines without routing everything over the Tor network.

## Why is this change important?

Tor engines are "broken" right now and can't be used as intended. This PR would allow using Tor engines without sacrificing speed on all other engines.

## How to test this PR locally?

- Install Tor proxy
- Add Tor proxy to the engines
Example:
```
  - name: ahmia
    engine: ahmia
    using_tor_proxy: true
    proxies:
      all://:
        - socks5h://127.0.0.1:9050
    categories: onions
    enable_http: true
    shortcut: ah
```
- `make run`
- Search `!ah test`

## Related issues

Closes #790 
