### PR TITLE
Add autocompleter from Brave 

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -36,6 +36,20 @@ def get(*args, **kwargs):
     return http_get(*args, **kwargs)
 
 
+def brave(query, lang):
+    # brave search autocompleter
+    url = 'https://search.brave.com/api/suggest?{query}'
+    resp = get(url.format(query=urlencode({'q': query})))
+
+    results = []
+
+    if resp.ok:
+        data = loads(resp.text)
+        for item in data[1]:
+            results.append(item)
+    return results
+
+
 def dbpedia(query, lang):
     # dbpedia autocompleter, no HTTPS
     autocomplete_url = 'https://lookup.dbpedia.org/api/search.asmx/KeywordSearch?'
@@ -128,6 +142,7 @@ backends = {
     'swisscows': swisscows,
     'qwant': qwant,
     'wikipedia': wikipedia,
+    'brave': brave,
 }
 
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -1,32 +1,22 @@
-'''
-searx is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""This module implements functions needed for the autocompleter.
 
-searx is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+"""
 
-You should have received a copy of the GNU Affero General Public License
-along with searx. If not, see < http://www.gnu.org/licenses/ >.
-
-(C) 2013- by Adam Tauber, <asciimoo@gmail.com>
-'''
-
-
-from lxml import etree
 from json import loads
 from urllib.parse import urlencode
 
+from lxml import etree
 from httpx import HTTPError
-
 
 from searx import settings
 from searx.data import ENGINES_LANGUAGES
 from searx.network import get as http_get
 from searx.exceptions import SearxEngineResponseException
+
+# a fetch_supported_languages() for XPath engines isn't available right now
+# _brave = ENGINES_LANGUAGES['brave'].keys()
 
 
 def get(*args, **kwargs):
@@ -36,10 +26,15 @@ def get(*args, **kwargs):
     return http_get(*args, **kwargs)
 
 
-def brave(query, lang):
+def brave(query, _lang):
     # brave search autocompleter
-    url = 'https://search.brave.com/api/suggest?{query}'
-    resp = get(url.format(query=urlencode({'q': query})))
+    url = 'https://search.brave.com/api/suggest?'
+    url += urlencode({'q': query})
+    country = 'all'
+    # if lang in _brave:
+    #    country = lang
+    kwargs = {'cookies': {'country': country}}
+    resp = get(url, **kwargs)
 
     results = []
 
@@ -50,7 +45,7 @@ def brave(query, lang):
     return results
 
 
-def dbpedia(query, lang):
+def dbpedia(query, _lang):
     # dbpedia autocompleter, no HTTPS
     autocomplete_url = 'https://lookup.dbpedia.org/api/search.asmx/KeywordSearch?'
 
@@ -65,7 +60,7 @@ def dbpedia(query, lang):
     return results
 
 
-def duckduckgo(query, lang):
+def duckduckgo(query, _lang):
     # duckduckgo autocompleter
     url = 'https://ac.duckduckgo.com/ac/?{0}&type=list'
 
@@ -99,7 +94,7 @@ def startpage(query, lang):
     return [e['text'] for e in data.get('suggestions', []) if 'text' in e]
 
 
-def swisscows(query, lang):
+def swisscows(query, _lang):
     # swisscows autocompleter
     url = 'https://swisscows.ch/api/suggest?{query}&itemsCount=5'
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -39,7 +39,7 @@ def brave(query, _lang):
     results = []
 
     if resp.ok:
-        data = loads(resp.text)
+        data = resp.json()
         for item in data[1]:
             results.append(item)
     return results


### PR DESCRIPTION
## What does this PR do?

Add autocompleter from Brave / BTW add SPDX tag to `autocomplete.py`

## Why is this change important?

one more alternative

## How to test this PR locally?

    make run

Activate brave auto completion and test completion in various languages

## Related issues

Initial commit was cherry picked from https://github.com/searx/searx/pull/3109 (and slightly modified to fit SearXNG needs)