### PR TITLE
[fix] Hoogle engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -746,22 +746,19 @@ engines:
 
   - name: hoogle
     engine: xpath
-    paging: true
     search_url: https://hoogle.haskell.org/?hoogle={query}&start={pageno}
     results_xpath: '//div[@class="result"]'
-    title_xpath: './/div[@class="ans"]//a'
-    url_xpath: './/div[@class="ans"]//a/@href'
-    content_xpath: './/div[@class="from"]'
-    page_size: 20
-    categories: [it, packages]
+    title_xpath: './div[@class="ans"]'
+    url_xpath: './div[@class="ans"]//a/@href'
+    content_xpath: './div[contains(@class, "doc")]'
+    categories: it
     shortcut: ho
     about:
       website: https://hoogle.haskell.org/
       wikidata_id: Q34010
-      official_api_documentation: https://hackage.haskell.org/api
       use_official_api: false
       require_api_key: false
-      results: JSON
+      results: HTML
 
   - name: imdb
     engine: imdb


### PR DESCRIPTION
The Hoogle engine was incorrect in a number of places.

The things this PR does:

1. In the result content: Currently it returns the list of names of links to
   modules. I changed it to display the documentation of the entry the result
   actually links to.

2. The metadata was incorrect:

   - The link to API was linking to the Hackage API. It is a completely
     different service. Hoogle does not have an API as far as I am aware.
   - The engine uses HTML instead of JSON
   - The link provided didn't link to Hoogle, but linked to the Haskell website.
   - Hoogle returns all results on one page. There is no paging.

Cherry-picked from searx PR 3146 [1] commit [2] / slightly modified to fit
SearXNG needs.

[1] https://github.com/searx/searx/pull/3146
[2] https://github.com/ilyakooo0/searx/commit/5b61eac8404cd3bcb6507bc23c8ef3d8f20cee11
