### PR TITLE
Fix Tor

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -42,6 +42,7 @@ ENGINE_DEFAULT_ARGS = {
     "safesearch": False,
     "time_range_support": False,
     "enable_http": False,
+    "using_tor_proxy": False,
     "display_error_messages": True,
     "tokens": [],
     "about": {},
@@ -230,8 +231,8 @@ def set_language_attributes(engine: Engine):
         )
 
 
-def update_attributes_for_tor(engine):
-    if settings['outgoing'].get('using_tor_proxy') and hasattr(engine, 'onion_url'):
+def update_attributes_for_tor(engine: Engine) -> bool:
+    if using_tor_proxy(engine) and hasattr(engine, 'onion_url'):
         engine.search_url = engine.onion_url + getattr(engine, 'search_path', '')
         engine.timeout += settings['outgoing'].get('extra_proxy_timeout', 0)
 
@@ -249,13 +250,18 @@ def is_missing_required_attributes(engine):
     return missing
 
 
+def using_tor_proxy(engine: Engine):
+    """Return True if the engine configuration declares to use Tor."""
+    return settings['outgoing'].get('using_tor_proxy') or getattr(engine, 'using_tor_proxy', False)
+
+
 def is_engine_active(engine: Engine):
     # check if engine is inactive
     if engine.inactive is True:
         return False
 
     # exclude onion engines if not using tor
-    if 'onions' in engine.categories and not settings['outgoing'].get('using_tor_proxy'):
+    if 'onions' in engine.categories and not using_tor_proxy(engine):
         return False
 
     return True

--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -167,13 +167,14 @@ class Network:
         for transport in client._mounts.values():  # pylint: disable=protected-access
             if isinstance(transport, AsyncHTTPTransportNoHttp):
                 continue
-            if not getattr(transport, '_rdns', False):
-                result = False
-                break
-        else:
-            response = await client.get('https://check.torproject.org/api/ip')
-            if not response.json()['IsTor']:
-                result = False
+            if getattr(transport, "_pool") and getattr(
+                transport._pool, "_rdns", False  # pylint: disable=protected-access
+            ):
+                continue
+            return False
+        response = await client.get("https://check.torproject.org/api/ip", timeout=10)
+        if not response.json()["IsTor"]:
+            result = False
         Network._TOR_CHECK_RESULT[proxies] = result
         return result
 


### PR DESCRIPTION
## What does this PR do?

This PR allows 'using_tor_proxy' to be checked for each engine individually. This allows SearXNG to use Tor engines without routing everything over the Tor network.

## Why is this change important?

Tor engines are "broken" right now and can't be used as intended. This PR would allow using Tor engines without sacrificing speed on all other engines.

## How to test this PR locally?

- Install Tor proxy
- Add Tor proxy to the engines
Example:
```
  - name: ahmia
    engine: ahmia
    using_tor_proxy: true
    proxies:
      all://:
        - socks5h://127.0.0.1:9050
    categories: onions
    enable_http: true
    shortcut: ah
```
- `make run`
- Search `!ah test`

## Related issues

Closes #790 