### PR TITLE
[mod] configuration to overwrite engine description

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1170,6 +1170,13 @@ def engine_descriptions():
         if isinstance(description, str):
             description = [description, 'wikipedia']
         result[engine] = description
+
+    # overwrite by about:description (from settings)
+    for engine_name, engine_mod in engines.items():
+        descr = getattr(engine_mod, 'about', {}).get('description', None)
+        if descr is not None:
+            result[engine_name] = [descr, "SearXNG config"]
+
     return jsonify(result)
 
 


### PR DESCRIPTION
Engine description can be configured, this is needed e.g. by custom search
engines.  Here is an example of a command engine with a description in the about
section::

```yaml
    - name: locate
      engine: command
      command: ['locate', '{{QUERY}}']
      disabled: true
      categories: files
      about:
        description: local files
        website: 'https://www.man7.org/linux/man-pages/man1/locate.1.html'
      delimiter:
          chars: ' '
          keys: ['line']
```

Closes: https://github.com/searxng/searxng/issues/788
