### PR TITLE
Move WolframAlpha away from Science category

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1455,7 +1455,7 @@ engines:
     # Or you can use the html non-stable engine, activated by default
     engine: wolframalpha_noapi
     timeout: 6.0
-    categories: science
+    categories: []
 
   - name: dictzone
     engine: dictzone


### PR DESCRIPTION
## What does this PR do?

I just noticed #634 and I loved it.
I've always thought that WolframAlpha was a little bit out of place in the Science category, which is otherwise exclusively used for scientific articles, so if you wanted to use the `!science` bang for papers you had to remember to disable Wolfram first.

For now I just left the category blank, but technically it could be part of a Calculator or Mathematics category if there were more engines of that type.

Related-ish issue: https://github.com/searx/searx/issues/2472

## How to test this PR locally?
1. Go to Preferences and then to Engines.
1. WolframAlpha should be in Other/Other section instead of Science.
1. Run a query with `!science` bang.
1. WolframAlpha shouldn't be called.