### PR TITLE
[enh] add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+We love responsible reports of (potential) security issues in SearXNG.
+
+You can contact us at security@searxng.org.
+
+Be sure to provide as much information as possible and if found
+also reproduction steps of the identified vulnerability. Also
+add the specific URL of the project as well as code you found
+the issue in to your report.


### PR DESCRIPTION
## What does this PR do?

This PR adds a security policy to the SearXNG org as well as a way for people to contact us if a vuln. is found.

## Why is this change important?

Make the SearXNG project more secure, by enabling users to contact us without disclosing a security issues found to the public.

## How to test this PR locally?

Check out the commit text. The text is going to be  displayed in the `Security` tab on github after merge.

## Author's checklist

ping @not-my-profile 

## Related issues

<!--
Closes #234
-->
