### PR TITLE
[emacs] flycheck should use the eslint checker from developer tools

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -103,6 +103,10 @@
                ;; use nodejs from the (local) NVM environment (see nvm-dir)
                (nvm-use-for-buffer)
                (setq-local js-indent-level 2)
+               ;; flycheck should use the eslint checker from developer tools
+               (setq-local flycheck-javascript-eslint-executable
+                           (expand-file-name "node_modules/.bin/eslint" prj-root))
+
                (flycheck-mode)
                ))))
 


### PR DESCRIPTION
Since commit cac03529 the eslint has been moved from the local nvm to the
developer packages (in `./node_modules`).
