### PR TITLE
[test.pyright] suppress warnings about intentional monkey patching

### DIFF
--- a/manage
+++ b/manage
@@ -696,10 +696,14 @@ test.pyright() {
     node.env.devtools
     # We run Pyright in the virtual environment because Pyright
     # executes "python" to determine the Python version.
-    pyenv.cmd npx --no-install pyright -p pyrightconfig-ci.json
+    build_msg TEST "[pyright] suppress warnings related to intentional monkey patching"
+    pyenv.cmd npx --no-install pyright -p pyrightconfig-ci.json \
+        | grep -v ".py$" \
+        | grep -v '/engines/.*.py.* - warning: "logger" is not defined'\
+        | grep -v '/engines/.*.py.* - warning: "supported_languages" is not defined' \
+        | grep -v '/engines/.*.py.* - warning: "language_aliases" is not defined'
     dump_return $?
 }
-
 
 test.black() {
     build_msg TEST "[black] \$BLACK_TARGETS"


### PR DESCRIPTION
The warnings:

- "logger" is not defined'
- "supported_languages" is not defined'
- "language_aliases" is not defined'

are very verbose and superfluous, since these messages are related to
intentional monkey patching.

[1] https://github.com/searxng/searxng/pull/783#issuecomment-1019818178

-----

I think it is enough when we remove the messages about monkey patching and leave other messages in the output:

```
Searching for source files
Found 202 source files
  searx/version.py:94:10 - warning: Import "searx.version_frozen" could not be resolved (reportMissingImports)
  searx/engines/mongodb.py:8:6 - warning: Import "pymongo" could not be resolved (reportMissingImports)
  searx/engines/mysql_server.py:9:8 - warning: Import "mysql.connector" could not be resolved (reportMissingImports)
  searx/engines/postgresql.py:9:8 - warning: Import "psycopg2" could not be resolved from source (reportMissingModuleSource)
  searx/engines/xpath.py:179:28 - warning: "categories" is not defined (reportUndefinedVariable)
  searx/search/__init__.py:184:82 - warning: "flask" is not defined (reportUndefinedVariable)
  searx/shared/__init__.py:8:12 - warning: Import "uwsgi" could not be resolved (reportMissingImports)
  searx/shared/shared_uwsgi.py:4:8 - warning: Import "uwsgi" could not be resolved (reportMissingImports)
0 errors, 86 warnings, 0 informations 

```