### PR TITLE
[mod] improve setup of invidious engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -777,11 +777,16 @@ engines:
 
   - name: invidious
     engine: invidious
+    # Instanes will be selected randomly, see https://api.invidious.io/ for
+    # instances that are stable (good uptime) and close to you.
     base_url:
-      - https://invidious.tube/
       - https://invidious.snopyta.org/
+      - https://vid.puffyan.us/
+      - https://invidious.kavin.rocks/
+      - https://invidio.xamh.de/
+      - https://inv.riverside.rocks/
     shortcut: iv
-    timeout: 5.0
+    timeout: 3.0
     disabled: true
 
   - name: kickass


### PR DESCRIPTION
- My experience is, that a timeout of 5 sec is not need, I got fast response
  less than a second.

- https://invidious.tube/ redirects to http://ww25.invidious.tube/
  - in SearXNG defaults the http protocol is unsafe and raise an error
  - https://ww25.invidious.tube has SSL_ERROR_UNSAFE_NEGOTIATION

Related-to: https://github.com/searxng/searxng/issues/821
