### PR TITLE
[fix] simple theme: don't crash when the checker is enabled

### DIFF
--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -1,3 +1,5 @@
+{% from 'simple/icons.html' import icon_small %}
+
 <!-- Draw favicon -->
 {% macro draw_favicon(favicon) -%}
     <img width="14" height="14" class="favicon" src="{{ url_for('static', filename='themes/simple/img/icons/' + favicon + '.png') }}" alt="{{ favicon }}">


### PR DESCRIPTION
## What does this PR do?

The macro "checkbox" in macros.html uses the macro "icon_small"
from icons.html

The commit imports icon_small in macros.html to fix the issue.
It works because the macros in macros.html are imported with the Jinja2 context.

See https://jinja.palletsprojects.com/en/3.0.x/templates/#import-visibility

## Why is this change important?

Fix `/preferences` when the checker is enabled

## How to test this PR locally?

* `kill -USR1 <pid>`
* wait for the checker to finish the tests
* go to `/preferences` using the Simple theme.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

close #819