### PR TITLE
Introduce Next-Gen Engines

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -63,6 +63,8 @@ disable=bad-whitespace,
         duplicate-code,
         missing-function-docstring,
         consider-using-f-string,
+        no-else-return,
+        arguments-renamed,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/docs/admin/engines/configured_engines.rst
+++ b/docs/admin/engines/configured_engines.rst
@@ -48,12 +48,14 @@ Explanation of the :ref:`general engine configuration` shown in the table
 
       {% for mod in engines %}
 
+      {% set mod_name = mod['__name__'] or mod.__module__ %}
+
       * - `{{mod.name}} <{{mod.about and mod.about.website}}>`_
         - ``!{{mod.shortcut}}``
-        - {%- if 'searx.engines.' + mod.__name__ in documented_modules %}
-          :py:mod:`~searx.engines.{{mod.__name__}}`
+        - {%- if 'searx.engines.' + mod_name in documented_modules %}
+          :py:mod:`~searx.engines.{{mod_name}}`
           {%- else %}
-          :origin:`{{mod.__name__}} <searx/engines/{{mod.__name__}}.py>`
+          :origin:`{{mod_name}} <searx/engines/{{mod_name}}.py>`
           {%- endif %}
         - {{(mod.disabled and "y") or ""}}
           {%- if mod.about and  mod.about.language %}

--- a/manage
+++ b/manage
@@ -697,7 +697,7 @@ test.pyright() {
     # We run Pyright in the virtual environment because Pyright
     # executes "python" to determine the Python version.
     build_msg TEST "[pyright] suppress warnings related to intentional monkey patching"
-    pyenv.cmd npx --no-install pyright -p pyrightconfig-ci.json \
+    pyenv.cmd npx --no-install pyright -p pyrightconfig-ci.json "$@" \
         | grep -v ".py$" \
         | grep -v '/engines/.*.py.* - warning: "logger" is not defined'\
         | grep -v '/engines/.*.py.* - warning: "supported_languages" is not defined' \

--- a/searx/engine.py
+++ b/searx/engine.py
@@ -1,0 +1,100 @@
+# pyright: strict
+from logging import Logger
+from typing import Iterable, List, NamedTuple, Optional, Dict, Union
+from typing_extensions import Literal, TypedDict, NotRequired
+from dataclasses import dataclass
+
+from httpx import Response
+
+
+class Engine:
+    categories: Optional[List[str]]
+    paging = False
+    time_range_support = False
+    supported_languages: List[str]
+    language_aliases: Dict[str, str]
+    about: 'About'
+
+    def __init__(self, logger: Logger) -> None:
+        self.logger = logger
+
+
+class About(TypedDict, total=False):
+    website: str
+    wikidata_id: Optional[str]
+    official_api_documentation: Optional[str]
+    use_official_api: bool
+    require_api_key: bool
+    results: Literal["HTML", "JSON"]
+    language: NotRequired[str]
+
+
+class OnlineEngine(Engine):
+    def request(self, query: str, ctx: 'QueryContext') -> 'OnlineRequest':
+        raise NotImplementedError()
+
+    def response(self, response: Response) -> List['Result']:
+        raise NotImplementedError()
+
+
+class QueryContext(NamedTuple):
+    category: str
+    """current category"""
+    safesearch: Literal[0, 1, 2]
+    """desired content safety (normal, moderate, strict)"""
+    time_range: Optional[Literal['day', 'week', 'month', 'year']]
+    """current time range (if any)"""
+    pageno: int
+    """current page number"""
+    language: str
+    """specific language code like ``en_US``, or ``all`` if unspecified"""
+
+
+@dataclass
+class OnlineRequest:
+    url: str
+    """requested URL"""
+    method: Literal['GET', 'POST'] = 'GET'
+    """HTTP request method"""
+    headers: Optional[Dict[str, str]] = None
+    """HTTP headers"""
+    data: Optional[Dict[str, str]] = None
+    """data to be sent as the HTTP body"""
+    cookies: Optional[Dict[str, str]] = None
+    """HTTP cookies"""
+    verify: bool = True
+    """Assert that the TLS certificate is valid"""
+    allow_redirects: bool = True
+    """follow redirects"""
+    max_redirects: Optional[int] = None
+    """maximum redirects, hard limit"""
+    soft_max_redirects: Optional[int] = None
+    """maximum redirects, soft limit. Record an error but don't stop the engine"""
+    raise_for_httperror: bool = True
+    """raise an exception if the HTTP code of response is >= 300"""
+
+    def set_header(self, name: str, value: str):
+        if self.headers is None:
+            self.headers = {}
+        self.headers[name] = value
+
+
+Result = Union['StandardResult', 'InfoBox']
+
+
+@dataclass
+class StandardResult:
+    url: str
+    title: str
+    content: str = ''
+
+
+@dataclass
+class InfoBox(StandardResult):
+    img_src: Optional[str] = None
+    links: Iterable['Link'] = ()
+
+
+class Link(TypedDict):
+    title: str
+    url: str

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -51,7 +51,7 @@ ENGINE_DEFAULT_ARGS = {
 OTHER_CATEGORY = 'other'
 
 
-class Engine:  # pylint: disable=too-few-public-methods
+class ConfiguredEngine:  # pylint: disable=too-few-public-methods
     """This class is currently never initialized and only used for type hinting."""
 
     name: str
@@ -72,7 +72,7 @@ class Engine:  # pylint: disable=too-few-public-methods
 # Defaults for the namespace of an engine module, see :py:func:`load_engine`
 
 categories = {'general': []}
-engines: Dict[str, Engine] = {}
+engines: Dict[str, ConfiguredEngine] = {}
 engine_shortcuts = {}
 """Simple map of registered *shortcuts* to name of the engine (or ``None``).
 
@@ -83,7 +83,7 @@ engine_shortcuts = {}
 """
 
 
-def load_engine(engine_data: dict) -> Optional[Engine]:
+def load_engine(engine_data: dict) -> Optional[ConfiguredEngine]:
     """Load engine from ``engine_data``.
 
     :param dict engine_data:  Attributes from YAML ``settings:engines/<engine>``
@@ -159,7 +159,7 @@ def set_loggers(engine, engine_name):
             module.logger = logger.getChild(module_engine_name)
 
 
-def update_engine_attributes(engine: Engine, engine_data):
+def update_engine_attributes(engine: ConfiguredEngine, engine_data):
     # set engine attributes from engine_data
     for param_name, param_value in engine_data.items():
         if param_name == 'categories':
@@ -177,7 +177,7 @@ def update_engine_attributes(engine: Engine, engine_data):
             setattr(engine, arg_name, copy.deepcopy(arg_value))
 
 
-def set_language_attributes(engine: Engine):
+def set_language_attributes(engine: ConfiguredEngine):
     # assign supported languages from json file
     if engine.name in ENGINES_LANGUAGES:
         engine.supported_languages = ENGINES_LANGUAGES[engine.name]
@@ -231,7 +231,7 @@ def set_language_attributes(engine: Engine):
         )
 
 
-def update_attributes_for_tor(engine: Engine) -> bool:
+def update_attributes_for_tor(engine: ConfiguredEngine) -> bool:
     if using_tor_proxy(engine) and hasattr(engine, 'onion_url'):
         engine.search_url = engine.onion_url + getattr(engine, 'search_path', '')
         engine.timeout += settings['outgoing'].get('extra_proxy_timeout', 0)
@@ -250,12 +250,12 @@ def is_missing_required_attributes(engine):
     return missing
 
 
-def using_tor_proxy(engine: Engine):
+def using_tor_proxy(engine: ConfiguredEngine):
     """Return True if the engine configuration declares to use Tor."""
     return settings['outgoing'].get('using_tor_proxy') or getattr(engine, 'using_tor_proxy', False)
 
 
-def is_engine_active(engine: Engine):
+def is_engine_active(engine: ConfiguredEngine):
     # check if engine is inactive
     if engine.inactive is True:
         return False
@@ -267,7 +267,7 @@ def is_engine_active(engine: Engine):
     return True
 
 
-def register_engine(engine: Engine):
+def register_engine(engine: ConfiguredEngine):
     if engine.name in engines:
         logger.error('Engine config error: ambigious name: {0}'.format(engine.name))
         sys.exit(1)

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -23,6 +23,7 @@ from searx.utils import load_module, gen_useragent, find_language_aliases
 from searx.engine import Engine
 
 _NEXTGEN_ENGINES = {
+    'wikipedia': 'WikipediaEngine',
 }
 """maps module names to class names for engines that are implemented using the new class-based approach"""
 

--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -25,74 +25,74 @@ supported_languages_url = 'https://meta.wikimedia.org/wiki/List_of_Wikipedias'
 language_variants = {"zh": ("zh-cn", "zh-hk", "zh-mo", "zh-my", "zh-sg", "zh-tw")}
 
 
-# set language in base_url
-def url_lang(lang):
-    lang_pre = lang.split('-')[0]
-    if lang_pre == 'all' or lang_pre not in supported_languages and lang_pre not in language_aliases:
-        return 'en'
-    return match_language(lang, supported_languages, language_aliases).split('-')[0]
+    # set language in base_url
+    def url_lang(lang):
+        lang_pre = lang.split('-')[0]
+        if lang_pre == 'all' or lang_pre not in supported_languages and lang_pre not in language_aliases:
+            return 'en'
+        return match_language(lang, supported_languages, language_aliases).split('-')[0]
 
 
-# do search-request
-def request(query, params):
-    if query.islower():
-        query = query.title()
+    # do search-request
+    def request(query, params):
+        if query.islower():
+            query = query.title()
 
-    language = url_lang(params['language'])
-    params['url'] = search_url.format(title=quote(query), language=language)
+        language = url_lang(params['language'])
+        params['url'] = search_url.format(title=quote(query), language=language)
 
-    if params['language'].lower() in language_variants.get(language, []):
-        params['headers']['Accept-Language'] = params['language'].lower()
+        if params['language'].lower() in language_variants.get(language, []):
+            params['headers']['Accept-Language'] = params['language'].lower()
 
-    params['headers']['User-Agent'] = searx_useragent()
-    params['raise_for_httperror'] = False
-    params['soft_max_redirects'] = 2
+        params['headers']['User-Agent'] = searx_useragent()
+        params['raise_for_httperror'] = False
+        params['soft_max_redirects'] = 2
 
-    return params
+        return params
 
 
-# get response from search-request
-def response(resp):
-    if resp.status_code == 404:
-        return []
+    # get response from search-request
+    def response(resp):
+        if resp.status_code == 404:
+            return []
 
-    if resp.status_code == 400:
-        try:
-            api_result = loads(resp.text)
-        except:
-            pass
-        else:
-            if (
-                api_result['type'] == 'https://mediawiki.org/wiki/HyperSwitch/errors/bad_request'
-                and api_result['detail'] == 'title-invalid-characters'
-            ):
-                return []
+        if resp.status_code == 400:
+            try:
+                api_result = loads(resp.text)
+            except:
+                pass
+            else:
+                if (
+                    api_result['type'] == 'https://mediawiki.org/wiki/HyperSwitch/errors/bad_request'
+                    and api_result['detail'] == 'title-invalid-characters'
+                ):
+                    return []
 
-    raise_for_httperror(resp)
+        raise_for_httperror(resp)
 
-    results = []
-    api_result = loads(resp.text)
+        results = []
+        api_result = loads(resp.text)
 
-    # skip disambiguation pages
-    if api_result.get('type') != 'standard':
-        return []
+        # skip disambiguation pages
+        if api_result.get('type') != 'standard':
+            return []
 
-    title = api_result['title']
-    wikipedia_link = api_result['content_urls']['desktop']['page']
+        title = api_result['title']
+        wikipedia_link = api_result['content_urls']['desktop']['page']
 
-    results.append({'url': wikipedia_link, 'title': title})
+        results.append({'url': wikipedia_link, 'title': title})
 
-    results.append(
-        {
-            'infobox': title,
-            'id': wikipedia_link,
-            'content': api_result.get('extract', ''),
-            'img_src': api_result.get('thumbnail', {}).get('source'),
-            'urls': [{'title': 'Wikipedia', 'url': wikipedia_link}],
-        }
-    )
+        results.append(
+            {
+                'infobox': title,
+                'id': wikipedia_link,
+                'content': api_result.get('extract', ''),
+                'img_src': api_result.get('thumbnail', {}).get('source'),
+                'urls': [{'title': 'Wikipedia', 'url': wikipedia_link}],
+            }
+        )
 
-    return results
+        return results
 
 
 # get supported languages from their site

--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -13,7 +13,7 @@ from typing import Iterable, Dict, List
 import flask
 
 from searx import settings, autocomplete
-from searx.engines import Engine
+from searx.engines import ConfiguredEngine
 from searx.plugins import Plugin
 from searx.locales import LOCALE_NAMES
 from searx.webutils import VALID_LANGUAGE_CODE
@@ -257,7 +257,7 @@ class BooleanChoices:
 class EnginesSetting(BooleanChoices):
     """Engine settings"""
 
-    def __init__(self, default_value, engines: Iterable[Engine]):
+    def __init__(self, default_value, engines: Iterable[ConfiguredEngine]):
         choices = {}
         for engine in engines:
             for category in engine.categories:
@@ -292,7 +292,9 @@ class PluginsSetting(BooleanChoices):
 class Preferences:
     """Validates and saves preferences to cookies"""
 
-    def __init__(self, themes: List[str], categories: List[str], engines: Dict[str, Engine], plugins: Iterable[Plugin]):
+    def __init__(
+        self, themes: List[str], categories: List[str], engines: Dict[str, ConfiguredEngine], plugins: Iterable[Plugin]
+    ):
         super().__init__()
 
         self.key_value_settings: Dict[str, Setting] = {

--- a/searx/results.py
+++ b/searx/results.py
@@ -6,6 +6,7 @@ from typing import List, NamedTuple, Set
 from urllib.parse import urlparse, unquote
 
 from searx import logger
+from searx.engine import InfoBox, StandardResult
 from searx.engines import engines
 from searx.metrics import histogram_observe, counter_add, count_error
 
@@ -195,6 +196,17 @@ class ResultContainer:
         standard_result_count = 0
         error_msgs = set()
         for result in list(results):
+            if isinstance(result, InfoBox):
+                result = {
+                    'infobox': result.title,
+                    'id': result.url,
+                    'content': result.content,
+                    'img_src': result.img_src,
+                    'urls': result.links,
+                }
+            elif isinstance(result, StandardResult):
+                result = result.__dict__
+
             result['engine'] = engine_name
             if 'suggestion' in result and self.on_result(result):
                 self.suggestions.add(result['suggestion'])

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -12,7 +12,7 @@ from io import StringIO
 from codecs import getincrementalencoder
 
 from searx import logger, settings
-from searx.engines import Engine, OTHER_CATEGORY
+from searx.engines import ConfiguredEngine, OTHER_CATEGORY
 
 
 VALID_LANGUAGE_CODE = re.compile(r'^[a-z]{2,3}(-[a-zA-Z]{2})?$')
@@ -142,7 +142,7 @@ def is_flask_run_cmdline():
 DEFAULT_GROUP_NAME = 'others'
 
 
-def group_engines_in_tab(engines: Iterable[Engine]) -> List[Tuple[str, Iterable[Engine]]]:
+def group_engines_in_tab(engines: Iterable[ConfiguredEngine]) -> List[Tuple[str, Iterable[ConfiguredEngine]]]:
     """Groups an Iterable of engines by their first non tab category"""
 
     def get_group(eng):


### PR DESCRIPTION
This commit introduces a new class-based API to implement online engines.
The new API is designed so that it is backwards compatible with our current module-based engine API.

The Wikipedia engine is converted to the new API as a proof of concept.

For details please refer to the commits.

Planned followups:

* convert more engines to see if the API is flexible enough or needs to be changed
* introduce `Engine` subclasses for online_dictionary & online_currency
* add more docstrings for classes & fields
* document the new API in the developer documentation