### PR TITLE
Fix setup.py help folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             '../requirements.txt',
             '../requirements-dev.txt',
             'data/*',
+            'help/*',
             'plugins/*/*',
             'static/*.*',
             'static/*/*.*',


### PR DESCRIPTION
## What does this PR do?

This PR fixes the PR https://github.com/searxng/searxng/pull/758!

```
janv. 29 13:05:31 arch-server uwsgi[4180414]: Traceback (most recent call last):
janv. 29 13:05:31 arch-server uwsgi[4180414]:   File "/usr/lib/python3.10/site-packages/searx/webapp.py", line 1370, in <module>
janv. 29 13:05:31 arch-server uwsgi[4180414]:     user_help.render(app)
janv. 29 13:05:31 arch-server uwsgi[4180414]:   File "/usr/lib/python3.10/site-packages/searx/user_help.py", line 40, in render
janv. 29 13:05:31 arch-server uwsgi[4180414]:     for filename in pkg_resources.resource_listdir(__name__, 'help'):
janv. 29 13:05:31 arch-server uwsgi[4180414]:   File "/usr/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1153, in resource_listdir
janv. 29 13:05:31 arch-server uwsgi[4180414]:     return get_provider(package_or_requirement).resource_listdir(
janv. 29 13:05:31 arch-server uwsgi[4180414]:   File "/usr/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1431, in resource_listdir
janv. 29 13:05:31 arch-server uwsgi[4180414]:     return self._listdir(self._fn(self.module_path, resource_name))
janv. 29 13:05:31 arch-server uwsgi[4180414]:   File "/usr/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1610, in _listdir
janv. 29 13:05:31 arch-server uwsgi[4180414]:     return os.listdir(path)
janv. 29 13:05:31 arch-server uwsgi[4180414]: FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/python3.10/site-packages/searx/help'
janv. 29 13:05:31 arch-server uwsgi[4180414]: unable to load app 0 (mountpoint='') (callable not found or import error)
janv. 29 13:05:31 arch-server uwsgi[4180414]: *** no app loaded. going in full dynamic mode ***
```
