### PR TITLE
[fix] Broken links (to example.org) in official documentation

### DIFF
--- a/docs/user/search_syntax.rst
+++ b/docs/user/search_syntax.rst
@@ -9,31 +9,24 @@ SearXNG allows you to modify the default categories, engines and search language
 via the search query.
 
 Prefix ``!``
-  to set Category/engine
+  to set category/engine
 
 Prefix: ``:``
   to set language
 
 Abbrevations of the engines and languages are also accepted.  Engine/category
-modifiers are chainable and inclusive (e.g. with :search:`!it !ddg !wp qwer
-<?q=%21it%20%21ddg%20%21wp%20qwer>` search in IT category **and** duckduckgo
-**and** wikipedia for ``qwer``).
+modifiers are chainable and inclusive. E.g. with ``!it !ddg !wp qwer`` search in
+IT category **and** duckduckgo **and** wikipedia for ``qwer``.
 
-See the :search:`/preferences page <preferences>` for the list of engines,
-categories and languages.
+See the ``/preferences page`` for the list of engines, categories and languages.
 
 Examples
 ========
 
-Search in wikipedia for ``qwer``:
+- Image search: ``!images Sagrada``
+- Custom language in wikipedia: ``!wp :hu hackerspace``
+- Search in wikipedia for ``qwer``:
 
-- :search:`!wp qwer <?q=%21wp%20qwer>` or
-- :search:`!wikipedia qwer :search:<?q=%21wikipedia%20qwer>`
+  - ``!wp qwer`` or
+  - ``!wikipedia qwer``
 
-Image search:
-
-- :search:`!images Cthulhu <?q=%21images%20Cthulhu>`
-
-Custom language in wikipedia:
-
-- :search:`:hu !wp hackerspace <?q=%3Ahu%20%21wp%20hackerspace>`


### PR DESCRIPTION
Closes: https://github.com/searxng/searxng/issues/659
