### PR TITLE
preferences: Set autocomplete=off for form

### DIFF
--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -94,7 +94,7 @@
 <div>
 
     <h1>{{ _('Preferences') }}</h1>
-    <form method="post" action="{{ url_for('preferences') }}" id="search_form">
+    <form method="post" action="{{ url_for('preferences') }}" id="search_form" autocomplete="off">
 
         <!-- Nav tabs -->
         <ul class="nav nav-tabs nav-justified hide_if_nojs" role="tablist">

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -98,7 +98,7 @@
 {% block content %}
 <h1>{{ _('Preferences') }}</h1>
 
-<form id="search_form" method="post" action="{{ url_for('preferences') }}">
+<form id="search_form" method="post" action="{{ url_for('preferences') }}" autocomplete="off">
 
 {{ tabs_open() }}
 

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -186,7 +186,7 @@ class ViewsTestCase(SearxTestCase):
     def test_preferences(self):
         result = self.app.get('/preferences')
         self.assertEqual(result.status_code, 200)
-        self.assertIn(b'<form method="post" action="/preferences" id="search_form">', result.data)
+        self.assertIn(b'<form method="post" action="/preferences" id="search_form" autocomplete="off">', result.data)
         self.assertIn(b'<label class="col-sm-3 col-md-2" for="categories">Default categories</label>', result.data)
         self.assertIn(b'<label class="col-sm-3 col-md-2" for="locale">Interface language</label>', result.data)
 


### PR DESCRIPTION
Otherwise you can change the value of a select,
refresh the page and the preferences stay changed,
leaving the wrong impression that they were saved.
