### PR TITLE
Fix wikidata info box images

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -4,7 +4,7 @@
 """
 
 
-from urllib.parse import urlencode
+from urllib.parse import urlencode, unquote
 from json import loads
 
 from dateutil.parser import isoparse
@@ -202,13 +202,13 @@ def get_thumbnail(img_src):
     """
     logger.debug('get_thumbnail(): %s', img_src)
     if not img_src is None and _IMG_SRC_DEFAULT_URL_PREFIX in img_src.split()[0]:
-        img_src_name = (
-            img_src.replace(_IMG_SRC_DEFAULT_URL_PREFIX, "")
-            .split("?", 1)[0]
-            .replace("%20", "_")
-            .replace("%28", "(")
-            .replace("%29", ")")
-        )
+        img_src_name = unquote(img_src.replace(_IMG_SRC_DEFAULT_URL_PREFIX, "").split("?", 1)[0].replace("%20", "_"))
+        img_src_name_first = img_src_name
+        img_src_name_second = img_src_name
+
+        if ".svg" in img_src_name.split()[0]:
+            img_src_name_second = img_src_name + ".png"
+
         img_src_size = img_src.replace(_IMG_SRC_DEFAULT_URL_PREFIX, "").split("?", 1)[1]
         img_src_size = img_src_size[img_src_size.index("=") + 1 : img_src_size.index("&")]
         img_src_name_md5 = md5(img_src_name.encode("utf-8")).hexdigest()
@@ -218,11 +218,11 @@ def get_thumbnail(img_src):
             + "/"
             + img_src_name_md5[0:2]
             + "/"
-            + img_src_name
+            + img_src_name_first
             + "/"
             + img_src_size
             + "px-"
-            + img_src_name
+            + img_src_name_second
         )
         logger.debug('get_thumbnail() redirected: %s', img_src)
 

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -187,7 +187,7 @@ def response(resp):
 
 
 _IMG_SRC_DEFAULT_URL_PREFIX = "https://commons.wikimedia.org/wiki/Special:FilePath/"
-_IMG_SRC_NEW_URL_PREFIX = "https://upload.wikimedia.org/wikipedia/commons/"
+_IMG_SRC_NEW_URL_PREFIX = "https://upload.wikimedia.org/wikipedia/commons/thumb/"
 
 
 def get_thumbnail(img_src):
@@ -209,8 +209,21 @@ def get_thumbnail(img_src):
             .replace("%28", "(")
             .replace("%29", ")")
         )
+        img_src_size = img_src.replace(_IMG_SRC_DEFAULT_URL_PREFIX, "").split("?", 1)[1]
+        img_src_size = img_src_size[img_src_size.index("=") + 1 : img_src_size.index("&")]
         img_src_name_md5 = md5(img_src_name.encode("utf-8")).hexdigest()
-        img_src = _IMG_SRC_NEW_URL_PREFIX + img_src_name_md5[0] + "/" + img_src_name_md5[0:2] + "/" + img_src_name
+        img_src = (
+            _IMG_SRC_NEW_URL_PREFIX
+            + img_src_name_md5[0]
+            + "/"
+            + img_src_name_md5[0:2]
+            + "/"
+            + img_src_name
+            + "/"
+            + img_src_size
+            + "px-"
+            + img_src_name
+        )
         logger.debug('get_thumbnail() redirected: %s', img_src)
 
     return img_src

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -238,7 +238,7 @@ def get_results(attribute_result, attributes, language):
     infobox_attributes = []
     infobox_content = attribute_result.get('itemDescription', [])
     img_src = None
-    img_src_priority = 100
+    img_src_priority = 0
 
     for attribute in attributes:
         value = attribute.get_str(attribute_result, language)
@@ -264,7 +264,7 @@ def get_results(attribute_result, attributes, language):
                 # this attribute is an image.
                 # replace the current image only the priority is lower
                 # (the infobox contain only one image).
-                if attribute.priority < img_src_priority:
+                if attribute.priority > img_src_priority:
                     img_src = get_thumbnail(value)
                     img_src_priority = attribute.priority
             elif attribute_type == WDGeoAttribute:

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Wikidata
 """
- Wikidata
-"""
+# pylint: disable=missing-class-docstring
 
-
+from hashlib import md5
 from urllib.parse import urlencode, unquote
 from json import loads
 
@@ -18,7 +19,6 @@ from searx.engines.wikipedia import (  # pylint: disable=unused-import
     _fetch_supported_languages,
     supported_languages_url,
 )
-from hashlib import md5
 
 # about
 about = {
@@ -230,6 +230,7 @@ def get_thumbnail(img_src):
 
 
 def get_results(attribute_result, attributes, language):
+    # pylint: disable=too-many-branches
     results = []
     infobox_title = attribute_result.get('itemLabel')
     infobox_id = attribute_result['item']
@@ -322,6 +323,7 @@ def get_query(query, language):
 
 
 def get_attributes(language):
+    # pylint: disable=too-many-statements
     attributes = []
 
     def add_value(name):
@@ -462,7 +464,7 @@ def get_attributes(language):
 
 
 class WDAttribute:
-
+    # pylint: disable=no-self-use
     __slots__ = ('name',)
 
     def __init__(self, name):
@@ -483,7 +485,7 @@ class WDAttribute:
     def get_group_by(self):
         return ""
 
-    def get_str(self, result, language):
+    def get_str(self, result, language):  # pylint: disable=unused-argument
         return result.get(self.name + 's')
 
     def __repr__(self):
@@ -624,6 +626,7 @@ class WDImageAttribute(WDURLAttribute):
 
 
 class WDDateAttribute(WDAttribute):
+    # pylint: disable=no-self-use
     def get_select(self):
         return '?{name} ?{name}timePrecision ?{name}timeZone ?{name}timeCalendar'.replace('{name}', self.name)
 
@@ -644,7 +647,7 @@ class WDDateAttribute(WDAttribute):
     def get_group_by(self):
         return self.get_select()
 
-    def format_8(self, value, locale):
+    def format_8(self, value, locale):  # pylint: disable=unused-argument
         # precision: less than a year
         return value
 
@@ -717,7 +720,7 @@ class WDDateAttribute(WDAttribute):
                     else:
                         value = t[0]
                 return format_method(value, language)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 return value
         return value
 
@@ -731,7 +734,7 @@ def debug_explain_wikidata_query(query, method='GET'):
     return http_response.content
 
 
-def init(engine_settings=None):
+def init(engine_settings=None):  # pylint: disable=unused-argument
     # WIKIDATA_PROPERTIES : add unit symbols
     WIKIDATA_PROPERTIES.update(WIKIDATA_UNITS)
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the wikidata info box images when the image proxy is enabled.

## Why is this change important?

Without the fix info box images from wikidata are not loaded correctly.


## How to test this PR locally?

- `make run`
- Search `!wd test`

## Related issues

Closes #875 
