### PR TITLE
[fix] openstreatmap: load thumbnail from uploads.wikimedia.org

### DIFF
--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -14,7 +14,7 @@ from flask_babel import gettext
 from searx.data import OSM_KEYS_TAGS, CURRENCIES
 from searx.utils import searx_useragent
 from searx.external_urls import get_external_url
-from searx.engines.wikidata import send_wikidata_query, sparql_string_escape
+from searx.engines.wikidata import send_wikidata_query, sparql_string_escape, get_thumbnail
 
 # about
 about = {
@@ -168,7 +168,7 @@ def response(resp):
             continue
 
         url, osm, geojson = get_url_osm_geojson(result)
-        img_src = get_img_src(result)
+        img_src = get_thumbnail(get_img_src(result))
         links, link_keys = get_links(result, user_language)
         data = get_data(result, user_language, link_keys)
 


### PR DESCRIPTION
Openstreatmap images are now loaded from uploads.wikimedia.org instead of
commons.wikimedia.org to prevent redirects.

With `image_proxy` enabled images from commons.wikimedia.org cant be loaded
since they are redirected.  We already discussed this issue [875] and
@tiekoetter fixed this issue in PR [878].

Related-to:
- [875] https://github.com/searxng/searxng/issues/875
- [878] https://github.com/searxng/searxng/pull/878


-----

With `image_proxy` enabled, search for `!osm paris`

before:

![grafik](https://user-images.githubusercontent.com/554536/152786167-5289d8fa-e961-4375-933e-327054ddb93e.png)

after:

![grafik](https://user-images.githubusercontent.com/554536/152786310-f9eb9af1-f5fe-461c-a850-485ccddc29cc.png)


