### PR TITLE
[mod] disable deezer engine by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -407,6 +407,7 @@ engines:
   - name: deezer
     engine: deezer
     shortcut: dz
+    disabled: true
 
   - name: deviantart
     engine: deviantart


### PR DESCRIPTION
To play content from deezer a account is needed, the majority of the SearXNG won't have.
