### PR TITLE
[mod] mediathekviewweb engine: add data_src and use videos template

### DIFF
--- a/searx/engines/mediathekviewweb.py
+++ b/searx/engines/mediathekviewweb.py
@@ -68,6 +68,8 @@ def response(resp):
                 'title': "%(channel)s: %(title)s (%(hms)s)" % item,
                 'length': item['hms'],
                 'content': "%(description)s" % item,
+                'iframe_src': item['url_video_hd'],
+                'template': 'videos.html',
             }
         )
 


### PR DESCRIPTION
## What does this PR do?

[mod] mediathekviewweb engine: add data_src and use videos template

## Why is this change important?

Look videos from the german-speaking public broadcasters directly in the result list:

![grafik](https://user-images.githubusercontent.com/554536/153722441-b88a309f-c598-470c-84d2-d3ac5519c712.png)

## How to test this PR locally?

Search for `!mvw anstalt` and press _show video_ button
