### PR TITLE
[fix] replace peer.tube by peertube.biz

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1580,9 +1580,12 @@ engines:
     engine: peertube
     shortcut: ptb
     paging: true
-    base_url: https://peer.tube/
+    # https://instances.joinpeertube.org/instances
+    base_url: https://peertube.biz/
+    # base_url: https://tube.tardis.world/
     categories: videos
     disabled: true
+    timeout: 6.0
 
   - name: mediathekviewweb
     engine: mediathekviewweb


### PR DESCRIPTION
More peertube instances are listed at [1]

[1] https://instances.joinpeertube.org/instances

Closes: https://github.com/searxng/searxng/issues/881
