### PR TITLE
[limiter] update

### DIFF
--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -42,19 +42,16 @@ def is_accepted_request(inc_get_counter) -> bool:
             return False
         return True
 
-    if request.path == '/search' and ('q' in request.args or 'q' in request.form):
-        c = inc_get_counter(interval=20, keys=[b'IP limit, burst', x_forwarded_for])
-        if c > 30:
-            return False
-
-        c = inc_get_counter(interval=600, keys=[b'IP limit, 10 minutes', x_forwarded_for])
-        if c > 300:
+    if request.path == '/search':
+        c_burst = inc_get_counter(interval=20, keys=[b'IP limit, burst', x_forwarded_for])
+        c_10min = inc_get_counter(interval=600, keys=[b'IP limit, 10 minutes', x_forwarded_for])
+        if c_burst > 15 or c_10min > 150:
             return False
 
         if re_bot.match(user_agent):
             return False
 
-        if 'Accept-Language' not in request.headers:
+        if len(request.headers.get('Accept-Language', '').strip()) == '':
             return False
 
         if request.headers.get('Connection') == 'close':
@@ -113,7 +110,6 @@ def create_pre_request(get_aggregation_count):
 
 
 def init(app, settings):
-
     if not settings['server']['limiter']:
         return False
 


### PR DESCRIPTION
## What does this PR do?

New update of the limiter code / rules based on testing on paulgo public instance and on my personal instance.

Changes:
* The limitation only applies to `/search`
* the two sliding window counter are always updated even if the request is going to denied

## Why is this change important?

While it is far for perfect, it seems to be at least comparable to filtron.

## How to test this PR locally?

* configure redis
* enable the limiter
* checks the various rules:
  * curl
  * send multiple requests (use the `sha256 dummy` to avoid a quick response without sending outgoing HTTP request)

## Author's checklist

In this case a lot of thing can be simplified:
* remove `searxng/utils/filtron.sh` and `searxng/utils/morty.sh`.
* remove filtron & morty from the searxng-docker project, and add redis (so the project supports multiple architectures)
* perhaps cleanup [uwsgi.ini](https://github.com/searxng/searxng/blob/288e3086d2a67aaee45576f13b032f31ab782b45/dockerfiles/uwsgi.ini#L43-L44)

What can be fixed later:
* I'm not sure the limiter should be a plugin: even if the user could enable / disable the plugin, this wouldn't matter: the code hooks the Flask application at loading. 
* The current code initialize the redis connection: it works because this is the only module to use redis. The initialization of the connection should be done in the `searx.shared` module.

## Related issues

* https://github.com/searxng/searxng/pull/618
* https://github.com/searxng/searxng/pull/892