### PR TITLE
[fix] google images engine: Fix 'scrap_img_by_id' function

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1132,7 +1132,7 @@ def image_proxy():
             'DNT': '1',
         }
         set_context_network_name('image_proxy')
-        resp, stream = http_stream(method='GET', url=url, headers=request_headers)
+        resp, stream = http_stream(method='GET', url=url, headers=request_headers, allow_redirects=True)
         content_length = resp.headers.get('Content-Length')
         if content_length and content_length.isdigit() and int(content_length) > maximum_size:
             return 'Max size', 400


### PR DESCRIPTION
## What does this PR do?

The 'scrap_img_by_id' function didn't return anything useful. This fix allows the google images engine to present the full source image instead of only the thumbnail.

## How to test this PR locally?

- `make run`
- Search `!goi land`
- Check if full image is loaded in result card view

## Author's checklist

Note: If an image is redirected image proxy fails.

```
DEBUG   searx.network.image_proxy     : HTTP Request: GET https://www.pik-potsdam.de/en/institute/departments/activities/resolveuid/1921254915ba45a9a661fd8228588a90 "HTTP/1.1 301 Moved Permanently"
DEBUG   searx.webapp                  : image-proxy: wrong response code: 301
INFO    werkzeug                      : 192.168.178.129 - - [19/Feb/2022 01:37:55] "GET /image_proxy?url=https%3A%2F%2Fwww.pik-potsdam.de%2Fen%2Finstitute%2Fdepartments%2Factivities%2Fresolveuid%2F1921254915ba45a9a661fd8228588a90&h=89c65601c562be381d299b79447c42899f3d68b7939ba5691a1513822d763bf0 HTTP/1.0" 400 -
```

## Related issues

Closes #909 
