### PR TITLE
static files: add a hash as a query

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -44,9 +44,9 @@ logto = /var/log/uwsgi/uwsgi.log
 add-header = Connection: close
 
 # uwsgi serves the static files
-# expires set to one day as Flask does
+# expires set to one year since there are hashes
 static-map = /static=/usr/local/searxng/searx/static
-static-expires = /* 864000
+static-expires = /* 31557600
 static-gzip-all = True
 offload-threads = %k
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -16,7 +16,7 @@ from timeit import default_timer
 from html import escape
 from io import StringIO
 import typing
-from typing import List, Dict, Iterable
+from typing import List, Dict, Iterable, Optional
 
 import urllib
 import urllib.parse
@@ -348,7 +348,7 @@ def code_highlighter(codelines, language=None):
     return html_code
 
 
-def get_current_theme_name(override: str = None) -> str:
+def get_current_theme_name(override: Optional[str] = None) -> str:
     """Returns theme name.
 
     Checks in this order:
@@ -373,14 +373,16 @@ def get_result_template(theme_name: str, template_name: str):
     return 'result_templates/' + template_name
 
 
-def url_for_theme(endpoint: str, override_theme: str = None, **values):
+def url_for_theme(endpoint: str, override_theme: Optional[str] = None, **values):
+    suffix = ""
     if endpoint == 'static' and values.get('filename'):
         theme_name = get_current_theme_name(override=override_theme)
         filename_with_theme = "themes/{}/{}".format(theme_name, values['filename'])
-        if filename_with_theme in static_files:
+        file_hash = static_files.get(filename_with_theme)
+        if file_hash:
             values['filename'] = filename_with_theme
-    url = url_for(endpoint, **values)
-    return url
+            suffix = "?" + file_hash
+    return url_for(endpoint, **values) + suffix
 
 
 def proxify(url: str):

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -23,6 +23,11 @@ class ViewsTestCase(SearxTestCase):
         webapp.app.config['TESTING'] = True  # to get better error messages
         self.app = webapp.app.test_client()
 
+        # remove sha for the static file
+        # so the tests don't have to care about the changing URLs
+        for k in webapp.static_files:
+            webapp.static_files[k] = None
+
         # set some defaults
         test_results = [
             {


### PR DESCRIPTION
## What does this PR do?

When the app starts, the hash of each static file (*) is read (sha1).

Then the URL of the static files contains this hash as query.

(*) hidden files, the directories `src` and `node_modules` are ignored.

---

Also, in a second commit, `uwsgi.ini` in the docker image is updated to ask the browser to cache the static files for one year.

## Why is this change important?

* Avoid disappointing UX (most important)
* (???) reduce bandwidth

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

The best solution is to change the file name at build time, but the grunt plugins are rather old (4 years old for the most recent one).

## Related issues

This PR is an updated version of https://github.com/searx/searx/pull/2242

- see [label:"clear browser cache"](https://github.com/search?q=repo%3Asearxng%2Fsearxng+label%3A%22clear+browser+cache%22)