### PR TITLE
README.rst: add a link to the screenshots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ User experience
   * usable on desktop, tablet and mobile
   * light and dark versions (you can choose in the preferences)
   * support right-to-left languages
+  * `see the screenshots <https://dev.searxng.org/screenshots.html>`_
 
 - the translations are up to date, you can contribute on `Weblate`_
 - the preferences page has been updated:


### PR DESCRIPTION
## What does this PR do?

Add a link to the screenshots.
Feel free to suggest better wording.

## Why is this change important?

Some images are better than just text.

## How to test this PR locally?

N/A

## Author's checklist

May be we should keep https://github.com/searxng/searxng-browser-tests as a dev tool, and reference only few screenshots in README.md

## Related issues

<!--
Closes #234
-->
