### PR TITLE
[revert interim] bump sphinx-tabs from interim fix to 3.3.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ Pallets-Sphinx-Themes==2.0.2
 Sphinx==4.4.0
 sphinx-issues==3.0.1
 sphinx-jinja==2.0.1
-sphinx-tabs @ git+https://github.com/return42/sphinx-tabs.git@fix-152#egg=fix-152
+sphinx-tabs==3.3.1
 sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14
 myst-parser==0.17.0


### PR DESCRIPTION
The bugfix of sphinx-tabs issue 152 [1] has been released, we can bump the
version and remove the interim return42/sphinx-tabs.git@fix-152 branch.

[1] https://github.com/executablebooks/sphinx-tabs/issues/152
[2] https://github.com/searxng/searxng/pull/954#issuecomment-1064888261

Closes: https://github.com/searxng/searxng/pull/954
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>
