### PR TITLE
docker: log to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ENTRYPOINT ["/sbin/tini","--","/usr/local/searxng/dockerfiles/docker-entrypoint.
 EXPOSE 8080
 VOLUME /etc/searx
 VOLUME /etc/searxng
-VOLUME /var/log/uwsgi
 
 ARG SEARXNG_GID=977
 ARG SEARXNG_UID=977

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -165,8 +165,6 @@ if [ $DRY_RUN -eq 1 ]; then
     exit
 fi
 
-touch /var/run/uwsgi-logrotate
-chown -R searxng:searxng /var/log/uwsgi /var/run/uwsgi-logrotate
 unset MORTY_KEY
 
 # Start uwsgi

--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -27,17 +27,12 @@ chdir = /usr/local/searxng/searx/
 # automatically set processes name to something meaningful
 auto-procname = true
 
-# Disable logging for privacy
+# Disable request logging for privacy
 disable-logging = true
+log-5xx = true
 
 # Set the max size of a request (request-body excluded)
 buffer-size = 8192
-
-# But keep errors for 2 days
-touch-logrotate = /run/uwsgi-logrotate
-unique-cron = 15 0 -1 -1 -1 { touch /run/uwsgi-logrotate  }
-log-backupname = /var/log/uwsgi/uwsgi.log.1
-logto = /var/log/uwsgi/uwsgi.log
 
 # No keep alive
 # See https://github.com/searx/searx-docker/issues/24


### PR DESCRIPTION
## What does this PR do?

previously the log (only the exceptions) were log
into /var/log/uwsgi/uwsgi.log

this is disturbing for the admins:
* they see an internal error on HTTP port
* no log where they are expected (docker logs)

this commit fixes this issue

## Why is this change important?

Many times admins can't figure out why the application is not starting.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

We may want to add a log rotation in searxng-docker:
https://docs.docker.com/config/containers/logging/configure/#configure-the-default-logging-driver

## Related issues

<!--
Closes #234
-->
