### PR TITLE
settings.yml: allow to base_url with the SEARXNG_BASE_URL env variable

### DIFF
--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -165,7 +165,7 @@ SCHEMA = {
         'bind_address': SettingsValue(str, '127.0.0.1', 'SEARXNG_BIND_ADDRESS'),
         'limiter': SettingsValue(bool, False),
         'secret_key': SettingsValue(str, environ_name='SEARXNG_SECRET'),
-        'base_url': SettingsValue((False, str), False),
+        'base_url': SettingsValue((False, str), False, 'SEARXNG_BASE_URL'),
         'image_proxy': SettingsValue(bool, False),
         'http_protocol_version': SettingsValue(('1.0', '1.1'), '1.0'),
         'method': SettingsValue(('POST', 'GET'), 'POST'),


### PR DESCRIPTION
## What does this PR do?

In https://github.com/searxng/searxng-docker/pull/12 everything is configured using settings.yml except:
* the hostname
* the email address for the certificate

From the hostname, docker-compose.yml provides the base_url.
The idea is not to ask the admin to repeat the same information.

However, the calls to sed in [docker-entrypoint.sh](https://github.com/searxng/searxng/blob/master/dockerfiles/docker-entrypoint.sh) to copy and replace base_url becomes obsolete.

This PR allows to set the SEARXNG_BASE_URL environment variable to define the base_url.

## Why is this change important?

One step further to remove morty / filtron.

## How to test this PR locally?

* set SEARXNG_BASE_URL  to `http://127.0.1.1/`
* start the application
* checks the links use `http://127.0.1.1/`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
