### PR TITLE
[interim fix] static files can't be delivered by HTTP.

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -70,6 +70,7 @@ redis:
 ui:
   # Custom static path - leave it blank if you didn't change
   static_path: ""
+  static_use_hash: false
   # Custom templates path - leave it blank if you didn't change
   templates_path: ""
   # query_in_title: When true, the result page's titles contains the query

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -176,6 +176,7 @@ SCHEMA = {
     },
     'ui': {
         'static_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'static')),
+        'static_use_hash': SettingsValue(bool, False),
         'templates_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'templates')),
         'default_theme': SettingsValue(str, 'simple'),
         'default_locale': SettingsValue(str, ''),

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -350,10 +350,11 @@ def custom_url_for(endpoint: str, override_theme: Optional[str] = None, **values
     if endpoint == 'static' and values.get('filename'):
         theme_name = get_current_theme_name(override=override_theme)
         filename_with_theme = "themes/{}/{}".format(theme_name, values['filename'])
-        file_hash = static_files.get(filename_with_theme)
-        if file_hash:
-            values['filename'] = filename_with_theme
-            suffix = "?" + file_hash
+        values['filename'] = filename_with_theme
+        if get_setting('ui.static_use_hash', False):
+            file_hash = static_files.get(filename_with_theme)
+            if file_hash:
+                suffix = "?" + file_hash
     if endpoint == 'info' and 'locale' not in values:
         locale = request.preferences.get_value('locale')
         if _INFO_PAGES.get_page(values['pagename'], locale) is None:


### PR DESCRIPTION
Since PR 932 [1][2] static files can't be delivered by HTTP server any longer.

This patch makes the hash paramter in the URL of static files:

    /static/themes/simple/css/searxng.min.css?5fde34a74bc438c7b56ec8c6501e131cc9914bd8

optional.  By default the hash parameter is disabled.

HINT:

  Instances that do not deliver static files by their HTTP server and have a
  long expire time [3] should enable this option.

----

This is only a interim solution, on the long run:

    make static.build.commit

creates files including the file name:

    css/searxng-5fde34a74bc438c7b56ec8c6501e131cc9914bd8.min.css

and a mapping.json with this content[4]

[1] https://github.com/searxng/searxng/issues/964
[2] https://github.com/searxng/searxng/pull/932#issuecomment-1067039518
[3] https://github.com/searxng/searxng/pull/932/commits/55833364401ed72c30b3e85c16824a75de6b547a
[4] https://github.com/searxng/searxng/pull/932#issuecomment-1067216426
