### PR TITLE
Add rate limiting per engine

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -422,6 +422,9 @@ engine is shown.  Most of the options have a default value or even are optional.
      max_connections: 100
      max_keepalive_connections: 10
      keepalive_expiry: 5.0
+     rate_limit:
+        max_requests: 200
+        interval: 60
      proxies:
        http:
          - http://proxy1:8080
@@ -486,6 +489,15 @@ engine is shown.  Most of the options have a default value or even are optional.
 
   - ``ipv4`` set ``local_addresses`` to ``0.0.0.0`` (use only IPv4 local addresses)
   - ``ipv6`` set ``local_addresses`` to ``::`` (use only IPv6 local addresses)
+
+``rate_limit``: optional
+  Limit how many outgoing requests is SearXNG going to send to the engines.
+  Requires :ref:`Redis <settings redis>`.
+
+  - ``max_requests`` is the maximum number of requests that will be sent to this
+    engine per interval.
+  - ``interval`` (optional) is the number of seconds before this engine's rate
+    limiter is reset. Defaults to 1 second if unspecified.
 
 .. note::
 

--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -423,8 +423,8 @@ engine is shown.  Most of the options have a default value or even are optional.
      max_keepalive_connections: 10
      keepalive_expiry: 5.0
      rate_limit:
-        max_requests: 200
-        interval: 60
+        - max_requests: 200
+          interval: 60
      proxies:
        http:
          - http://proxy1:8080

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -44,6 +44,7 @@ ENGINE_DEFAULT_ARGS = {
     "enable_http": False,
     "using_tor_proxy": False,
     "display_error_messages": True,
+    "rate_limit": { "max_requests": float('inf'), "interval": 1 },
     "tokens": [],
     "about": {},
 }
@@ -168,6 +169,11 @@ def update_engine_attributes(engine: Engine, engine_data):
             engine.categories = param_value
         elif hasattr(engine, 'about') and param_name == 'about':
             engine.about = {**engine.about, **engine_data['about']}
+        elif hasattr(engine, 'rate_limit') and param_name == 'rate_limit':
+            engine.rate_limit = {
+                'max_requests': int(param_value.get('max_requests')),
+                'interval': int(param_value.get('interval', 1))
+            }
         else:
             setattr(engine, param_name, param_value)
 

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -44,7 +44,7 @@ ENGINE_DEFAULT_ARGS = {
     "enable_http": False,
     "using_tor_proxy": False,
     "display_error_messages": True,
-    "rate_limit": { "max_requests": float('inf'), "interval": 1 },
+    "rate_limit": [{ "max_requests": float('inf'), "interval": 1 }],
     "tokens": [],
     "about": {},
 }
@@ -170,10 +170,10 @@ def update_engine_attributes(engine: Engine, engine_data):
         elif hasattr(engine, 'about') and param_name == 'about':
             engine.about = {**engine.about, **engine_data['about']}
         elif hasattr(engine, 'rate_limit') and param_name == 'rate_limit':
-            engine.rate_limit = {
-                'max_requests': int(param_value.get('max_requests')),
-                'interval': int(param_value.get('interval', 1))
-            }
+            engine.rate_limit = [{
+                'max_requests': int(rate_limit.get('max_requests')),
+                'interval': int(rate_limit.get('interval', 1))
+            } for rate_limit in param_value]
         else:
             setattr(engine, param_name, param_value)
 

--- a/searx/plugins/engine_rate_limiter.py
+++ b/searx/plugins/engine_rate_limiter.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+# pyright: basic
+"""Rate limit outgoing requests per engine
+
+Enable ``settings.yml``:
+
+- ``redis.url: ...`` check the value, see :ref:`settings redis`
+- ``rate_limit: ...`` max_requests and interval, as specified below
+- ``max_requests: ...`` max number of requests for that engine per interval
+- ``interval: ...`` number of seconds before rate limiting resets (optional, by default 1 second)
+"""
+
+import hmac
+
+from searx import settings
+from searx.engines import engines
+from searx.shared import redisdb
+
+name = "Engine rate limiter"
+description = "Limit the number of outgoing requests per engine"
+default_on = True
+preference_section = 'service'
+
+
+def check_rate_limiter(engine_name, limit, interval):
+    redis_client = redisdb.client()
+    lua_script = """
+    local engine = KEYS[1]
+    local limit = ARGV[1]
+    local interval = ARGV[2]
+
+    local count = redis.call('GET', engine)
+    if count and count > limit then
+        return count
+    else
+        local newCount = redis.call('INCR', engine)
+        if newCount == 1 then
+            redis.call('EXPIRE', engine, interval)
+        end
+        return newCount
+    end
+    """
+    script_sha = redis_client.script_load(lua_script)
+
+    secret_key_bytes = bytes(settings['server']['secret_key'], encoding='utf-8')
+    m = hmac.new(secret_key_bytes, digestmod='sha256')
+    m.update(bytes(engine_name, encoding='utf-8'))
+    key = m.digest()
+
+    requestsCounter = redis_client.evalsha(script_sha, 1, key, limit, interval)
+    return int(requestsCounter)
+
+
+def below_rate_limit(engine_name):
+    engine = engines[engine_name]
+    max_requests = engine.rate_limit['max_requests']
+    interval = engine.rate_limit['interval']
+
+    if max_requests == float('inf'):
+        return True
+    if max_requests >= check_rate_limiter(engine_name, max_requests, interval):
+        return True
+    logger.debug(f"{engine_name} exceeded rate limit of {max_requests} requests per {interval} seconds")  # pylint: disable=undefined-variable
+    return False
+
+
+def pre_search(_, search):
+    allowed_engines = list(filter(lambda e: below_rate_limit(e.name), search.search_query.engineref_list))
+    search.search_query.engineref_list = allowed_engines
+    return bool(allowed_engines)
+
+
+def init(*args, **kwargs):  # pylint: disable=unused-argument
+    logger.debug("init engine rate limiter DB")  # pylint: disable=undefined-variable
+    if not redisdb.init():
+        logger.error("init engine rate limiter DB failed!!!")  # pylint: disable=undefined-variable
+        return False
+    return True


### PR DESCRIPTION
## What does this PR do?

Add a plugin that limits how many outgoing requests is SearXNG going to send per engine.

This is very similar to the [limiter](https://github.com/searxng/searxng/blob/master/searx/plugins/limiter.py) plugin and I actually based my code on that, but this one works in the opposite direction.

This plugin is always "on", but it doesn't do anything unless Redis is used and an engine has a `rate_limit` setting. If an engine doesn't have the setting, the plugin should skip (always pass) that engine without writing anything in Redis.

## Why is this change important?

Some engines are more strict than others when dealing with our traffic. For example, you can throw Wikipedia over a hundred requests per second with no problems, but other engines will throw you a CAPTCHA as soon as you send a few requests in rapid succession *\*cough\*cough\*Google\**.

## How to test this PR locally?

1. Run Redis.
1. Point the `redis: url` setting to your Redis db in `settings.yml`.
1. In `settings.yml` add the following to any engine:
```yml
  # This would limit that engine to a maximum of 2 requests per minute.
  rate_limit:
    - max_requests: 2
      interval: 60
```
4. Run queries with both the rate limited engine and an engine without the setting.
5. Rate limited engine should stop sending requests after reaching limit and other engines should still work as usual.
6. Engine should be usable again after time interval has passed.

## Author's checklist
* Are the plugin and setting names clear enough? Could instance maintainers be confused between this and the `limiter` plugin?
* ~~Am I using the correct formatting in the documentation? The ref link doesn't do anything for me, but nor do any of the other ones in the same page.~~
* I've only tested this locally with very light traffic.