### PR TITLE
[docs] document settings.yml: search.languages

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -123,6 +123,24 @@ Global Settings
   Default search language - leave blank to detect from browser information or
   use codes from :origin:`searx/languages.py`.
 
+``languages``:
+  List of available languages - leave unset to use all codes from
+  :origin:`searx/languages.py`.  Otherwise list codes of available languages.
+  The ``all`` value is shown as the ``Default language`` in the user interface
+  (in most cases, it is meant to send the query without a language parameter ;
+  in some cases, it means the English language) Example:
+
+  .. code:: yaml
+
+     languages:
+       - all
+       - en
+       - en-US
+       - de
+       - it-IT
+       - fr
+       - fr-BE
+
 ``ban_time_on_fail``:
   Ban time in seconds after engine errors.
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -21,6 +21,15 @@ search:
   # Default search language - leave blank to detect from browser information or
   # use codes from 'languages.py'
   default_lang: ""
+  # Available languages
+  # languages:
+  #   - all
+  #   - en
+  #   - en-US
+  #   - de
+  #   - it-IT
+  #   - fr
+  #   - fr-BE
   # ban time in seconds after engine errors
   ban_time_on_fail: 5
   # max ban time in seconds after engine errors


### PR DESCRIPTION
Requested-by: @dalf https://github.com/searxng/searxng/pull/996#discussion_r830858139

I did not documented the language option `all` since it is unclear to me /  or it is not implemented in all engines in a common manner.

What is the meaning of `all`in the `search.languages` setting? ..

- Does it mean: _"the default language from the browser information is used"_ or
- does it mean: _"the `search.default_language` is used"_ or
- does it mean: _"if there is no language from browser information the `search.default_language` is used"_ or
- ...