### PR TITLE
[fix] pylint issue in py3.10

### DIFF
--- a/searxng_extra/update/update_firefox_version.py
+++ b/searxng_extra/update/update_firefox_version.py
@@ -13,7 +13,7 @@ import json
 import re
 from os.path import join
 from urllib.parse import urlparse, urljoin
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=deprecated-module
 
 import requests
 from lxml import html


### PR DESCRIPTION
searxng_extra/update/update_firefox_version.py:16:0: W0402:
Uses of a deprecated module 'distutils.version' (deprecated-module)

[1] https://github.com/searxng/searxng/pull/1007
