### PR TITLE
[fix] jinja/babel: WithExtension and AutoEscapeExtension are built-iin now

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -3,5 +3,4 @@ searxng_msg = searx.babel_extract.extract
 [ignore: **/node_modules/**]
 [python: **.py]
 [jinja2: **/templates/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_
 [searxng_msg: **/searxng.msg]


### PR DESCRIPTION
[1] https://github.com/pallets/jinja/pull/1544

## Related issues

- https://github.com/searxng/searxng/pull/1008