### PR TITLE
[mod] add test.pybabel to cover issues in translation tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ search.checker.%: install
 	$(Q)./manage pyenv.cmd searx-checker -v "$(subst _, ,$(patsubst search.checker.%,%,$@))"
 
 PHONY += test ci.test test.shell
-ci.test: test.yamllint test.black test.pyright test.pylint test.unit test.robot test.rst
+ci.test: test.yamllint test.black test.pyright test.pylint test.unit test.robot test.rst test.pybabel
 test:    test.yamllint test.black test.pyright test.pylint test.unit test.robot test.rst test.shell
 test.shell:
 	$(Q)shellcheck -x -s dash \
@@ -86,7 +86,7 @@ MANAGE += py.build py.clean
 MANAGE += pyenv pyenv.install pyenv.uninstall
 MANAGE += pypi.upload pypi.upload.test
 MANAGE += format.python
-MANAGE += test.yamllint test.pylint test.pyright test.black test.unit test.coverage test.robot test.rst test.clean
+MANAGE += test.yamllint test.pylint test.pyright test.black test.pybabel test.unit test.coverage test.robot test.rst test.clean
 MANAGE += themes.all themes.oscar themes.simple themes.simple.test pygments.less
 MANAGE += static.build.commit static.build.drop static.build.restore
 MANAGE += nvm.install nvm.clean nvm.status nvm.nodejs

--- a/manage
+++ b/manage
@@ -745,6 +745,13 @@ test.rst() {
     done
 }
 
+test.pybabel() {
+    TEST_BABEL_FOLDER="build/test/pybabel"
+    build_msg TEST "[extract messages] pybabel"
+    mkdir -p "${TEST_BABEL_FOLDER}"
+    pyenv.cmd pybabel extract -F babel.cfg -o "${TEST_BABEL_FOLDER}/messages.pot" searx
+}
+
 test.clean() {
     build_msg CLEAN  "test stuff"
     rm -rf geckodriver.log .coverage coverage/


### PR DESCRIPTION
We need to cover issue related to pybabel/translation tasks.  By example there
was an issue [1] (fixed [2]) when upgrading jinja2 from 3.0.3 to 3.1.0 [3] that
has not been covered by the CI tests.

- [1] https://github.com/searxng/searxng/runs/5688624325?check_suite_focus=true#step:6:348
- [2] https://github.com/searxng/searxng/pull/1011
- [3] https://github.com/searxng/searxng/pull/1008
