### PR TITLE
[fix] return correct plugin path

### DIFF
--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -103,7 +103,7 @@
             data-infinite-scroll="{% if infinite_scroll %}true{% else %}false{% endif %}"
             data-translations="{{ translations }}"></script>
     {% for script in scripts %}
-    {{""}}<script src="{{ url_for('plugins', filename=script) }}"></script>
+    {{""}}<script src="{{ url_for('static', filename=script) }}"></script>
     {% endfor %}
     <noscript>
       <style>

--- a/searx/templates/oscar/base.html
+++ b/searx/templates/oscar/base.html
@@ -103,7 +103,7 @@
             data-infinite-scroll="{% if infinite_scroll %}true{% else %}false{% endif %}"
             data-translations="{{ translations }}"></script>
     {% for script in scripts %}
-    {{""}}<script src="{{ url_for('static', filename=script) }}"></script>
+    {{""}}<script src="{{ url_for('plugins', filename=script) }}"></script>
     {% endfor %}
     <noscript>
       <style>

--- a/searx/templates/oscar/macros.html
+++ b/searx/templates/oscar/macros.html
@@ -5,7 +5,7 @@
 
 <!-- Draw favicon -->
 {% macro draw_favicon(favicon) -%}
-    <img width="32" height="32" class="favicon" src="{{ url_for('static', filename='themes/oscar/img/icons/' + favicon + '.png') }}" alt="{{ favicon }}" />
+    <img width="32" height="32" class="favicon" src="{{ url_for('static', filename='img/icons/' + favicon + '.png') }}" alt="{{ favicon }}" />
 {%- endmacro %}
 
 {%- macro result_link(url, title, classes='', id='') -%}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -355,6 +355,12 @@ def custom_url_for(endpoint: str, override_theme: Optional[str] = None, **values
             file_hash = static_files.get(filename_with_theme)
             if file_hash:
                 suffix = "?" + file_hash
+    if endpoint == 'plugins' and values.get('filename'):
+        endpoint = 'static'
+        if get_setting('ui.static_use_hash', False):
+            file_hash = static_files.get(values['filename'])
+            if file_hash:
+                suffix = "?" + file_hash
     if endpoint == 'info' and 'locale' not in values:
         locale = request.preferences.get_value('locale')
         if _INFO_PAGES.get_page(values['pagename'], locale) is None:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -348,19 +348,15 @@ def get_result_template(theme_name: str, template_name: str):
 def custom_url_for(endpoint: str, override_theme: Optional[str] = None, **values):
     suffix = ""
     if endpoint == 'static' and values.get('filename'):
-        theme_name = get_current_theme_name(override=override_theme)
-        filename_with_theme = "themes/{}/{}".format(theme_name, values['filename'])
-        values['filename'] = filename_with_theme
-        if get_setting('ui.static_use_hash', False):
+        file_hash = static_files.get(values['filename'])
+        if not file_hash:
+            # try file in the current theme
+            theme_name = get_current_theme_name(override=override_theme)
+            filename_with_theme = "themes/{}/{}".format(theme_name, values['filename'])
             file_hash = static_files.get(filename_with_theme)
-            if file_hash:
-                suffix = "?" + file_hash
-    if endpoint == 'plugins' and values.get('filename'):
-        endpoint = 'static'
-        if get_setting('ui.static_use_hash', False):
-            file_hash = static_files.get(values['filename'])
-            if file_hash:
-                suffix = "?" + file_hash
+            values['filename'] = filename_with_theme
+        if get_setting('ui.static_use_hash') and file_hash:
+            suffix = "?" + file_hash
     if endpoint == 'info' and 'locale' not in values:
         locale = request.preferences.get_value('locale')
         if _INFO_PAGES.get_page(values['pagename'], locale) is None:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -354,7 +354,8 @@ def custom_url_for(endpoint: str, override_theme: Optional[str] = None, **values
             theme_name = get_current_theme_name(override=override_theme)
             filename_with_theme = "themes/{}/{}".format(theme_name, values['filename'])
             file_hash = static_files.get(filename_with_theme)
-            values['filename'] = filename_with_theme
+            if file_hash:
+                values['filename'] = filename_with_theme
         if get_setting('ui.static_use_hash') and file_hash:
             suffix = "?" + file_hash
     if endpoint == 'info' and 'locale' not in values:


### PR DESCRIPTION
## What does this PR do?

Fix a bug on oscar themes that results in the category selection breaking, because the incorrect path `/static/themes/oscar/plugins/js/search_on_category_select.js` is returned for the plugin script `/static/plugins/js/search_on_category_select.js`. Similarly this fixes the source thumbnail in image/video/etc. searches.
 
## Why is this change important?

Bugfix

## How to test this PR locally?

Run as usual, launch the homepage

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes #1021.
