### PR TITLE
limiter fixes && implement general.log_level

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -13,19 +13,20 @@ import searx.settings_loader
 from searx.settings_defaults import settings_set_defaults
 
 
-# Debug
-LOG_FORMAT_DEBUG = '%(levelname)-7s %(name)-30.30s: %(message)s'
-
-# Production
-LOG_FORMAT_PROD = '%(asctime)-15s %(levelname)s:%(name)s: %(message)s'
-LOG_LEVEL_PROD = logging.WARNING
-
 searx_dir = abspath(dirname(__file__))
 searx_parent_dir = abspath(dirname(dirname(__file__)))
 settings, settings_load_message = searx.settings_loader.load_settings()
 
 if settings is not None:
     settings = settings_set_defaults(settings)
+
+# Debug
+LOG_FORMAT_DEBUG = '%(levelname)-7s %(name)-30.30s: %(message)s'
+
+# Production
+LOG_FORMAT_PROD = '%(asctime)-15s %(levelname)s:%(name)s: %(message)s'
+LOG_LEVEL_PROD  = (settings['general']).get("log_level", "info").upper()
+LOG_LEVEL_PROD  = logging.getLevelName(LOG_LEVEL_PROD)
 
 _unset = object()
 

--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -79,6 +79,8 @@ def is_accepted_request(inc_get_counter) -> bool:
         c_burst = inc_get_counter(interval=20, keys=[b'IP limit, burst', client_ip])
         c_10min = inc_get_counter(interval=600, keys=[b'IP limit, 10 minutes', client_ip])
 
+        logger.debug(f"counts of [{client_ip}]: c_burst={c_burst}, c_10min={c_10min}")
+
         if c_burst > c_burst_limit or c_10min > c_10min_limit:
             logger.warning(f"reject [{client_ip}]: c_burst({c_burst})>{c_burst_limit} or c_10min({c_10min})>{c_10min_limit}")
             return False

--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -71,7 +71,7 @@ def is_accepted_request(inc_get_counter) -> bool:
 
     if request.path == '/image_proxy':
         if re_bot.match(user_agent):
-            logger.info(f"reject [{client_ip}]: client may be a bot described by UA=\"{user_agent}\"")
+            logger.warning(f"reject [{client_ip}]: client may be a bot described by UA=\"{user_agent}\"")
             return False
         return True
 
@@ -80,15 +80,15 @@ def is_accepted_request(inc_get_counter) -> bool:
         c_10min = inc_get_counter(interval=600, keys=[b'IP limit, 10 minutes', client_ip])
 
         if c_burst > c_burst_limit or c_10min > c_10min_limit:
-            logger.info(f"reject [{client_ip}]: c_burst({c_burst})>{c_burst_limit} or c_10min({c_10min})>{c_10min_limit}")
+            logger.warning(f"reject [{client_ip}]: c_burst({c_burst})>{c_burst_limit} or c_10min({c_10min})>{c_10min_limit}")
             return False
 
         if re_bot.match(user_agent):
-            logger.info(f"reject [{client_ip}]: client may be a bot described by UA=\"{user_agent}\"")
+            logger.warning(f"reject [{client_ip}]: client may be a bot described by UA=\"{user_agent}\"")
             return False
 
         if request.headers.get('Accept-Language', '').strip():
-            logger.info(f"reject [{client_ip}]: empty Accept-Language")
+            logger.warning(f"reject [{client_ip}]: empty Accept-Language")
             return False
 
         # If SearXNG is behind Cloudflare, all requests will get 429 because
@@ -102,7 +102,7 @@ def is_accepted_request(inc_get_counter) -> bool:
         #     return False
 
         if 'text/html' not in request.accept_mimetypes:
-            logger.info(f"reject [{client_ip}]: non-html request to /search")
+            logger.warning(f"reject [{client_ip}]: non-html request to /search")
             return False
 
         # IDK but maybe api limit should based on path not format?

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1,5 +1,5 @@
 general:
-  debug: false              # Debug mode, only for development
+  log_level: info           # notset/debug/info/warning/error/critical
   instance_name: "SearXNG"  # displayed name
   contact_url: false        # mailto:contact@example.com
   enable_metrics: true      # record stats

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -47,6 +47,7 @@ SEARX_ENVIRON_VARIABLES = {
     'SEARX_DISABLE_ETC_SETTINGS': 'SEARXNG_DISABLE_ETC_SETTINGS',
     'SEARX_SETTINGS_PATH': 'SEARXNG_SETTINGS_PATH',
     'SEARX_DEBUG': 'SEARXNG_DEBUG',
+    'SEARX_LOGLEVEL': 'SEARXNG_LOGLEVEL',
     'SEARX_PORT': 'SEARXNG_PORT',
     'SEARX_BIND_ADDRESS': 'SEARXNG_BIND_ADDRESS',
     'SEARX_SECRET': 'SEARXNG_SECRET',
@@ -140,6 +141,7 @@ def apply_schema(settings, schema, path_list):
 SCHEMA = {
     'general': {
         'debug': SettingsValue(bool, False, 'SEARXNG_DEBUG'),
+        'log_level': SettingsValue(str, 'info', 'SEARXNG_LOGLEVEL'),
         'instance_name': SettingsValue(str, 'SearXNG'),
         'contact_url': SettingsValue((None, False, str), None),
         'enable_metrics': SettingsValue(bool, True),

--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+import pprint
 
 from os import environ
 from os.path import dirname, join, abspath, isfile
@@ -139,6 +140,13 @@ def load_settings(load_user_setttings=True):
                 default_settings_path, user_settings_path
             ),
         )
+
+    # Consider to deprecate general.debug in the future.
+    # To make everything work correctly, set general.debug = general.log_level=="debug"
+    if "log_level" not in user_settings['general']: user_settings['general']['log_level'] = 'info'
+    user_settings['general']['debug'] = (user_settings['general']['log_level']=="debug")
+
+    pprint.pprint(user_settings['general'], indent=4, sort_dicts=True)
 
     # the user settings, fully replace the default configuration
     return (user_settings, 'load the user settings from {}'.format(user_settings_path))


### PR DESCRIPTION
## What does this PR do?

### 1. Fix: 429 Too Many Requests when using Cloudflare
When SearXNG is deployed behind Cloudflare CDN, all search requests will be rejected with code 429 because Cloudflare seems to use `Connection: close` by default.
https://github.com/searxng/searxng/blob/4135a7400143cc934480afced3f6858c0d671fc6/searx/plugins/limiter.py#L61-L62

I am not sure whether `Connection: close` is set by Cloudflare or my browser, but there are some if conditions under `request.path == '/search'` making me feel uncertain... Considering they may not be that related to "rate limit", I also commented them arbitrarily. :P

### 2. Implement general.log_level in settings.yml
During fix 2, I added some debug&warning logs, and then I found that I cannot change log level conviniently using `settings.yml`.

Currently, SearXNG only have 2 log levels -- debug & warning(as LOG_LEVEL_PROD), and it is controlled by `settings.general.debug`. I added a new item `settings.general.log_level`, so `settings.general.debug` is deprecated.

To make other things consistent, `settings.general.debug` is now set as `settings.general.log_level=="debug"` implicitly:
```python
if "log_level" not in user_settings['general']: user_settings['general']['log_level'] = 'info'
user_settings['general']['debug'] = (user_settings['general']['log_level']=="debug")
```
