### PR TITLE
fix: %2F in path will be converted to " › " in searx/webapp.py

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -434,7 +434,7 @@ def _get_enable_categories(all_categories: Iterable[str]):
 def get_pretty_url(parsed_url: urllib.parse.ParseResult):
     path = parsed_url.path
     path = path[:-1] if len(path) > 0 and path[-1] == '/' else path
-    path = unquote(path).replace("/", " › ")
+    path = unquote(path.replace("/", " › "))
     return [parsed_url.scheme + "://" + parsed_url.netloc, path]
 
 


### PR DESCRIPTION
Seperated from [#PR 1061](https://github.com/searxng/searxng/pull/1061)