### PR TITLE
[fix] Search language or region

### DIFF
--- a/searx/templates/simple/filters/languages.html
+++ b/searx/templates/simple/filters/languages.html
@@ -1,4 +1,4 @@
-<select class="language" id="language" name="language" aria-label="{{ _('Search language') }}">{{- '' -}}
+<select class="language" id="language" name="language" aria-label="{{ _('Search language or region') }}">{{- '' -}}
 	<option value="all" {% if current_language == 'all' %}selected="selected"{% endif %}>{{ _('Default language') }}</option>
 	{%- for lang_id,lang_name,country_name,english_name,flag in language_codes | sort(attribute=1) -%}
 	<option value="{{ lang_id }}" {% if lang_id == current_language %}selected="selected"{% endif %}>

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -112,7 +112,7 @@
     {% endif %}
     {% if 'language' not in locked_preferences %}
     <fieldset>
-      <legend id="pref_language">{{ _('Search language') }}</legend>
+      <legend id="pref_language">{{ _('Search language or region') }}</legend>
       <p class="value">{{- '' -}}
         <select name='language' aria-labelledby="pref_language" aria-describedby="desc_language">{{- '' -}}
           <option value="all" {% if current_language == 'all' %}selected="selected"{% endif %}>{{ _('Default language') }}</option>
@@ -121,7 +121,7 @@
           {%- endfor -%}
         </select>{{- '' -}}
       </p>
-      <div class="description" id="desc_language">{{ _('What language do you prefer for search?') }}</div>
+      <div class="description" id="desc_language">{{ _('What language or region do you prefer for search?') }}</div>
     </fieldset>
     {% endif %}
     {% if 'autocomplete' not in locked_preferences %}


### PR DESCRIPTION
The name 'language' is misleading, in the filter the user selects a language or a region.
