### PR TITLE
don't reinstall existing packages on arch

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -1535,7 +1535,7 @@ pkg_install() {
             ;;
         arch)
             # shellcheck disable=SC2068
-            pacman --noprogressbar -Sy --noconfirm $@
+            pacman --noprogressbar -Sy --noconfirm --needed $@
             ;;
         fedora)
             # shellcheck disable=SC2068


### PR DESCRIPTION
## What does this PR do?

adds the `--needed` flag to the pacman install script, which tells pacman not to fetch and reinstall packages that are already on the system.

## Why is this change important?

it might not be important for most uses, but downloading ~200mb of packages that were already installed can be troublesome for slow networks

## How to test this PR locally?

execute `sudo -H ./utils/searx.sh install all` on an archlinux installation.

## Author's checklist

N/A

