### PR TITLE
change "Wolfram|Alpha" to "WolframAlpha" in search results

### DIFF
--- a/searx/engines/wolframalpha_api.py
+++ b/searx/engines/wolframalpha_api.py
@@ -123,7 +123,7 @@ def response(resp):
     if not result_chunks:
         return []
 
-    title = "Wolfram|Alpha (%s)" % infobox_title
+    title = "Wolfram Alpha (%s)" % infobox_title
 
     # append infobox
     results.append(


### PR DESCRIPTION
## What does this PR do?

changes the text in results from Wolfram|Alpha to WolframAlpha

## Why is this change important?

the default font makes it look similar to an `l`. there's also no real reason to use the pipe since it's one word.
<img width="519" alt="Screenshot 2022-04-12 at 10 53 27" src="https://user-images.githubusercontent.com/29015942/162933819-6f2a2f0c-cca5-423e-bb4f-d9b998884b43.png">


## How to test this PR locally?

- install searxng
- search for something like `!wa tower of london height`

## Author's checklist

N/A
