### PR TITLE
[enh] Allow passing headers/cookies from settings.yml

### DIFF
--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -85,6 +85,11 @@ suggestion_xpath = ''
 cached_xpath = ''
 cached_url = ''
 
+cookies = {}
+headers = {}
+'''Some engines might offer different result based on cookies or headers.
+Possible use-case: To set safesearch cookie or header to moderate.'''
+
 paging = False
 '''Engine supports paging [True or False].'''
 
@@ -166,6 +171,9 @@ def request(query, params):
         'safe_search': safe_search,
     }
 
+    params['cookies'] = cookies
+    params['headers'] = headers
+    
     params['url'] = search_url.format(**fargs)
     params['soft_max_redirects'] = soft_max_redirects
 

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -171,8 +171,8 @@ def request(query, params):
         'safe_search': safe_search,
     }
 
-    params['cookies'] = cookies
-    params['headers'] = headers
+    params['cookies'].update(cookies)
+    params['headers'].update(headers)
 
     params['url'] = search_url.format(**fargs)
     params['soft_max_redirects'] = soft_max_redirects

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -173,7 +173,7 @@ def request(query, params):
 
     params['cookies'] = cookies
     params['headers'] = headers
-    
+
     params['url'] = search_url.format(**fargs)
     params['soft_max_redirects'] = soft_max_redirects
 


### PR DESCRIPTION
Example:

```
   - name: example
     engine: xpath
     search_url: example.org
     headers: {'example_header': 'example_header'}
     cookies: {'safesearch': 'off'}
```
## What does this PR do?

<!-- MANDATORY -->
Allows passing cookies or headers to xpath engine from ```settings.yml```.
<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->
Some engine which use xpath can not use safesearch or pass headers to receive different results.
This will add that option.

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

You can temporary print out params on ```engines/xpath.py```.

## Author's checklist

<!-- additional notes for reviewiers -->
N/A

## Related issues
N/A
<!--
Closes #234
-->
