### PR TITLE
[mod] Pass desired ebay domain in settings

### DIFF
--- a/searx/engines/ebay.py
+++ b/searx/engines/ebay.py
@@ -20,8 +20,10 @@ about = {
 categories = ['shopping']
 paging = True
 
-url = 'https://www.ebay.com'
-search_url = url + '/sch/i.html?_nkw={query}&_sacat={pageno}'
+# Set base_url in settings.yml in order to
+# have the desired local TLD.
+base_url = None
+search_url = '/sch/i.html?_nkw={query}&_sacat={pageno}'
 
 results_xpath = '//li[contains(@class, "s-item")]'
 url_xpath = './/a[@class="s-item__link"]/@href'
@@ -34,7 +36,7 @@ thumbnail_xpath = './/img[@class="s-item__image-img"]/@src'
 
 
 def request(query, params):
-    params['url'] = search_url.format(query=quote(query), pageno=params['pageno'])
+    params['url'] = f'{base_url}' + search_url.format(query=quote(query), pageno=params['pageno'])
     return params
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -514,6 +514,7 @@ engines:
   # - name: ebay
   #   engine: ebay
   #   shortcut: eb
+  #   base_url: 'https://www.ebay.com'
   #   disabled: true
   #   timeout: 5
 


### PR DESCRIPTION
Make it possible to add local ebay domain.
Which must be given in ```settings.yml``` as ```base_url```

Example:
```base_url: 'https://www.ebay.de'```

## What does this PR do?

<!-- MANDATORY -->
Make it possible to add local ebay domain.
<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

More options.
<!-- explain the motivation behind your PR -->

## How to test this PR locally?
Enable ebay and search with ```!ebay test```

<!-- commands to run the tests or instructions to test the changes-->
## Author's checklist
N/A
<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
