### PR TITLE
Added support for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  searxng:
+    container_name: searxng
+    image: searxng/searxng
+    restart: unless-stopped
+    environment:
+      - BASE_URL=http://localhost:8080
+      - INSTANCE_NAME=my-instance
+    volumes:
+      - ./searxng:/etc/searxng
+    ports:
+      - 8080:8080


### PR DESCRIPTION
## What does this PR do?

Added support for docker-compose.

## Why is this change important?

Makes it much easier for beginners to spin up their own SearXNG instance.

## How to test this PR locally?
```yaml
docker-compose up -d
```
Only this command is required to spin up your own SearXNG instance.
Make sure your file is in your directory when you execute your command.

Let's say we start with empty Debian / Ubuntu server:
```yaml
# Install docker
curl -sSL https://get.docker.com/ | CHANNEL=stable bash
# Start docker on boot
sudo systemctl enable --now docker
# Install docker compose
sudo apt install docker-compose -y
```
Now we can install docker-compose.yml file from your github repository.
```yaml
# Create directory
mkdir searxng
# Switch directory
cd searxng
# Download docker-compose.yml file from your Github
wget https://raw.githubusercontent.com/searxng/searxng/master/docker-compose.yml
# You can now edit docker-compose.yml file for example port and some ENV variables or just start your container with:
docker-compose up -d
```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
