### PR TITLE
"regions & languages" boilerplate

### DIFF
--- a/docs/admin/engines/configured_engines.rst
+++ b/docs/admin/engines/configured_engines.rst
@@ -42,7 +42,7 @@ Explanation of the :ref:`general engine configuration` shown in the table
         - Timeout
         - Weight
         - Paging
-        - Language
+        - Language, Region
         - Safe search
         - Time range
 

--- a/manage
+++ b/manage
@@ -57,7 +57,7 @@ PYLINT_SEARXNG_DISABLE_OPTION="\
 I,C,R,\
 W0105,W0212,W0511,W0603,W0613,W0621,W0702,W0703,W1401,\
 E1136"
-PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES="supported_languages,language_aliases,logger,categories"
+PYLINT_ADDITIONAL_BUILTINS_FOR_ENGINES="supported_properties,supported_languages,language_aliases,logger,categories"
 PYLINT_OPTIONS="-m pylint -j 0 --rcfile .pylintrc"
 
 help() {

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -15,7 +15,7 @@ from searx.data import ENGINES_LANGUAGES
 from searx.network import get as http_get
 from searx.exceptions import SearxEngineResponseException
 
-# a fetch_supported_languages() for XPath engines isn't available right now
+# a _fetch_supported_properites() for XPath engines isn't available right now
 # _brave = ENGINES_LANGUAGES['brave'].keys()
 
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -11,9 +11,9 @@ from lxml import etree
 from httpx import HTTPError
 
 from searx import settings
-from searx.data import ENGINES_LANGUAGES
 from searx.network import get as http_get
 from searx.exceptions import SearxEngineResponseException
+from searx.engines import engines
 
 # a _fetch_supported_properites() for XPath engines isn't available right now
 # _brave = ENGINES_LANGUAGES['brave'].keys()
@@ -103,9 +103,11 @@ def seznam(query, _lang):
 
 def startpage(query, lang):
     # startpage autocompleter
-    lui = ENGINES_LANGUAGES['startpage'].get(lang, 'english')
+    engine = engines['startpage']
+    _, engine_language, _ = engine.get_engine_locale(lang)
+
     url = 'https://startpage.com/suggestions?{query}'
-    resp = get(url.format(query=urlencode({'q': query, 'segment': 'startpage.udog', 'lui': lui})))
+    resp = get(url.format(query=urlencode({'q': query, 'segment': 'startpage.udog', 'lui': engine_language})))
     data = resp.json()
     return [e['text'] for e in data.get('suggestions', []) if 'text' in e]
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -89,22 +89,28 @@ def seznam(query, _lang):
     # seznam search autocompleter
     url = 'https://suggest.seznam.cz/fulltext/cs?{query}'
 
-    resp = get(url.format(query=urlencode(
-        {'phrase': query, 'cursorPosition': len(query), 'format': 'json-2', 'highlight': '1', 'count': '6'}
-    )))
+    resp = get(
+        url.format(
+            query=urlencode(
+                {'phrase': query, 'cursorPosition': len(query), 'format': 'json-2', 'highlight': '1', 'count': '6'}
+            )
+        )
+    )
 
     if not resp.ok:
         return []
 
     data = resp.json()
-    return [''.join(
-        [part.get('text', '') for part in item.get('text', [])]
-    ) for item in data.get('result', []) if item.get('itemType', None) == 'ItemType.TEXT']
+    return [
+        ''.join([part.get('text', '') for part in item.get('text', [])])
+        for item in data.get('result', [])
+        if item.get('itemType', None) == 'ItemType.TEXT'
+    ]
+
 
 def startpage(query, lang):
     # startpage autocompleter
-    engine = engines['startpage']
-    _, engine_language, _ = engine.get_engine_locale(lang)
+    _, engine_language, _ = engines['startpage'].supported_locales.get(lang)
 
     url = 'https://startpage.com/suggestions?{query}'
     resp = get(url.format(query=urlencode({'q': query, 'segment': 'startpage.udog', 'lui': engine_language})))

--- a/searx/data/engines_languages.json
+++ b/searx/data/engines_languages.json
@@ -1561,6 +1561,7 @@
     "zh-HK"
   ],
   "startpage": {
+    "all_language": "en-US",
     "languages": {
       "af": "afrikaans",
       "am": "amharic",
@@ -1693,8 +1694,7 @@
       "zh-CN": "zh-CN_CN",
       "zh-HK": "zh-TW_HK",
       "zh-TW": "zh-TW_TW"
-    },
-    "type": "engine_properties"
+    }
   },
   "wikidata": {
     "ab": {

--- a/searx/data/engines_languages.json
+++ b/searx/data/engines_languages.json
@@ -1561,255 +1561,140 @@
     "zh-HK"
   ],
   "startpage": {
-    "af": {
-      "alias": "afrikaans"
-    },
-    "am": {
-      "alias": "amharic"
-    },
-    "ar": {
-      "alias": "arabic"
-    },
-    "az": {
-      "alias": "azerbaijani"
-    },
-    "be": {
-      "alias": "belarusian"
-    },
-    "bg": {
-      "alias": "bulgarian"
-    },
-    "bn": {
-      "alias": "bengali"
-    },
-    "bs": {
-      "alias": "bosnian"
-    },
-    "ca": {
-      "alias": "catalan"
-    },
-    "cs": {
-      "alias": "czech"
-    },
-    "cy": {
-      "alias": "welsh"
-    },
-    "da": {
-      "alias": "dansk"
-    },
-    "de": {
-      "alias": "deutsch"
-    },
-    "el": {
-      "alias": "greek"
-    },
-    "en": {
-      "alias": "english"
-    },
-    "en-GB": {
-      "alias": "english_uk"
-    },
-    "eo": {
-      "alias": "esperanto"
-    },
-    "es": {
-      "alias": "espanol"
-    },
-    "et": {
-      "alias": "estonian"
-    },
-    "eu": {
-      "alias": "basque"
-    },
-    "fa": {
-      "alias": "persian"
-    },
-    "fi": {
-      "alias": "suomi"
-    },
-    "fo": {
-      "alias": "faroese"
-    },
-    "fr": {
-      "alias": "francais"
-    },
-    "fy": {
-      "alias": "frisian"
-    },
-    "ga": {
-      "alias": "irish"
-    },
-    "gd": {
-      "alias": "gaelic"
-    },
-    "gl": {
-      "alias": "galician"
-    },
-    "gu": {
-      "alias": "gujarati"
-    },
-    "he": {
-      "alias": "hebrew"
-    },
-    "hi": {
-      "alias": "hindi"
-    },
-    "hr": {
-      "alias": "croatian"
-    },
-    "hu": {
-      "alias": "hungarian"
-    },
-    "ia": {
-      "alias": "interlingua"
-    },
-    "id": {
-      "alias": "indonesian"
-    },
-    "is": {
-      "alias": "icelandic"
-    },
-    "it": {
-      "alias": "italiano"
-    },
-    "ja": {
-      "alias": "nihongo"
-    },
-    "jv": {
-      "alias": "javanese"
-    },
-    "ka": {
-      "alias": "georgian"
-    },
-    "kn": {
-      "alias": "kannada"
-    },
-    "ko": {
-      "alias": "hangul"
-    },
-    "la": {
-      "alias": "latin"
-    },
-    "lt": {
-      "alias": "lithuanian"
-    },
-    "lv": {
-      "alias": "latvian"
-    },
-    "mai": {
-      "alias": "bihari"
-    },
-    "mk": {
-      "alias": "macedonian"
-    },
-    "ml": {
-      "alias": "malayalam"
-    },
-    "mr": {
-      "alias": "marathi"
-    },
-    "ms": {
-      "alias": "malay"
-    },
-    "mt": {
-      "alias": "maltese"
-    },
-    "nb": {
-      "alias": "norsk"
-    },
-    "ne": {
-      "alias": "nepali"
-    },
-    "nl": {
-      "alias": "nederlands"
-    },
-    "oc": {
-      "alias": "occitan"
-    },
-    "pa": {
-      "alias": "punjabi"
-    },
-    "pl": {
-      "alias": "polski"
-    },
-    "pt": {
-      "alias": "portugues"
-    },
-    "ro": {
-      "alias": "romanian"
-    },
-    "ru": {
-      "alias": "russian"
-    },
-    "si": {
-      "alias": "sinhalese"
-    },
-    "sk": {
-      "alias": "slovak"
-    },
-    "sl": {
-      "alias": "slovenian"
-    },
-    "sq": {
-      "alias": "albanian"
-    },
-    "sr": {
-      "alias": "serbian"
-    },
-    "su": {
-      "alias": "sudanese"
-    },
-    "sv": {
-      "alias": "svenska"
-    },
-    "sw": {
-      "alias": "swahili"
-    },
-    "ta": {
-      "alias": "tamil"
-    },
-    "te": {
-      "alias": "telugu"
-    },
-    "th": {
-      "alias": "thai"
-    },
-    "ti": {
-      "alias": "tigrinya"
-    },
-    "tl": {
-      "alias": "tagalog"
-    },
-    "tr": {
-      "alias": "turkce"
-    },
-    "uk": {
-      "alias": "ukrainian"
-    },
-    "ur": {
-      "alias": "urdu"
-    },
-    "uz": {
-      "alias": "uzbek"
-    },
-    "vi": {
-      "alias": "vietnamese"
-    },
-    "xh": {
-      "alias": "xhosa"
-    },
-    "zh": {
-      "alias": "jiantizhongwen"
-    },
-    "zh-HK": {
-      "alias": "fantizhengwen"
-    },
-    "zh-TW": {
-      "alias": "fantizhengwen"
-    },
-    "zu": {
-      "alias": "zulu"
-    }
+    "languages": {
+      "af": "afrikaans",
+      "am": "amharic",
+      "ar": "arabic",
+      "az": "azerbaijani",
+      "be": "belarusian",
+      "bg": "bulgarian",
+      "bn": "bengali",
+      "bs": "bosnian",
+      "ca": "catalan",
+      "cs": "czech",
+      "cy": "welsh",
+      "da": "dansk",
+      "de": "deutsch",
+      "el": "greek",
+      "en": "english_uk",
+      "eo": "esperanto",
+      "es": "espanol",
+      "et": "estonian",
+      "eu": "basque",
+      "fa": "persian",
+      "fi": "suomi",
+      "fo": "faroese",
+      "fr": "francais",
+      "fy": "frisian",
+      "ga": "irish",
+      "gd": "gaelic",
+      "gl": "galician",
+      "gu": "gujarati",
+      "he": "hebrew",
+      "hi": "hindi",
+      "hr": "croatian",
+      "hu": "hungarian",
+      "ia": "interlingua",
+      "id": "indonesian",
+      "is": "icelandic",
+      "it": "italiano",
+      "ja": "nihongo",
+      "jv": "javanese",
+      "ka": "georgian",
+      "kn": "kannada",
+      "ko": "hangul",
+      "la": "latin",
+      "lt": "lithuanian",
+      "lv": "latvian",
+      "mai": "bihari",
+      "mk": "macedonian",
+      "ml": "malayalam",
+      "mr": "marathi",
+      "ms": "malay",
+      "mt": "maltese",
+      "nb": "norsk",
+      "ne": "nepali",
+      "nl": "nederlands",
+      "oc": "occitan",
+      "pa": "punjabi",
+      "pl": "polski",
+      "pt": "portugues",
+      "ro": "romanian",
+      "ru": "russian",
+      "si": "sinhalese",
+      "sk": "slovak",
+      "sl": "slovenian",
+      "sq": "albanian",
+      "sr": "serbian",
+      "su": "sudanese",
+      "sv": "svenska",
+      "sw": "swahili",
+      "ta": "tamil",
+      "te": "telugu",
+      "th": "thai",
+      "ti": "tigrinya",
+      "tl": "tagalog",
+      "tr": "turkce",
+      "uk": "ukrainian",
+      "ur": "urdu",
+      "uz": "uzbek",
+      "vi": "vietnamese",
+      "xh": "xhosa",
+      "zh": "jiantizhongwen",
+      "zh_Hant": "fantizhengwen",
+      "zu": "zulu"
+    },
+    "regions": {
+      "ar-EG": "ar_EG",
+      "bg-BG": "bg_BG",
+      "ca-ES": "ca_ES",
+      "cs-CZ": "cs_CZ",
+      "da-DK": "da_DK",
+      "de-AT": "de_AT",
+      "de-CH": "de_CH",
+      "de-DE": "de_DE",
+      "el-GR": "el_GR",
+      "en-AU": "en_AU",
+      "en-CA": "en_CA",
+      "en-GB": "en-GB_GB",
+      "en-IE": "en_IE",
+      "en-MY": "en_MY",
+      "en-NZ": "en_NZ",
+      "en-US": "en_US",
+      "en-ZA": "en_ZA",
+      "es-AR": "es_AR",
+      "es-CL": "es_CL",
+      "es-ES": "es_ES",
+      "es-US": "es_US",
+      "es-UY": "es_UY",
+      "fi-FI": "fi_FI",
+      "fil-PH": "fil_PH",
+      "fr-BE": "fr_BE",
+      "fr-CA": "fr_CA",
+      "fr-CH": "fr_CH",
+      "fr-FR": "fr_FR",
+      "hi-IN": "hi_IN",
+      "it-CH": "it_CH",
+      "it-IT": "it_IT",
+      "ja-JP": "ja_JP",
+      "ko-KR": "ko_KR",
+      "ms-MY": "ms_MY",
+      "nb-NO": "no_NO",
+      "nl-BE": "nl_BE",
+      "nl-NL": "nl_NL",
+      "pl-PL": "pl_PL",
+      "pt-BR": "pt-BR_BR",
+      "pt-PT": "pt_PT",
+      "ro-RO": "ro_RO",
+      "ru-BY": "ru_BY",
+      "ru-RU": "ru_RU",
+      "sv-SE": "sv_SE",
+      "tr-TR": "tr_TR",
+      "zh-CN": "zh-CN_CN",
+      "zh-HK": "zh-TW_HK",
+      "zh-TW": "zh-TW_TW"
+    },
+    "type": "engine_properties"
   },
   "wikidata": {
     "ab": {

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -19,8 +19,7 @@ from os.path import realpath, dirname
 from babel.localedata import locale_identifiers
 from searx import logger, settings
 from searx.data import ENGINES_LANGUAGES
-from searx.network import get
-from searx.utils import load_module, match_language, gen_useragent
+from searx.utils import load_module, match_language
 
 
 logger = logger.getChild('engines')
@@ -36,8 +35,7 @@ ENGINE_DEFAULT_ARGS = {
     "timeout": settings["outgoing"]["request_timeout"],
     "shortcut": "-",
     "categories": ["general"],
-    "supported_languages": [],
-    "language_aliases": {},
+    "language_support" : False,
     "paging": False,
     "safesearch": False,
     "time_range_support": False,
@@ -58,10 +56,10 @@ class Engine:  # pylint: disable=too-few-public-methods
     engine: str
     shortcut: str
     categories: List[str]
-    supported_languages: List[str]
     about: dict
     inactive: bool
     disabled: bool
+    # language support, either by selecting a region or by selecting a language
     language_support: bool
     paging: bool
     safesearch: bool
@@ -143,6 +141,25 @@ def load_engine(engine_data: dict) -> Optional[Engine]:
 
     return engine
 
+def engine_properties_template():
+    """A dictionary with languages and regions to map from SearXNG' languages &
+    region tags to engine's language & region tags::
+
+      engine_properties = {
+          'type' : 'engine_properties',
+          'regions': {
+              # 'ca-ES' : <engine's region name>
+          },
+          'languages': {
+              # 'ca' : <engine's language name>
+          },
+      }
+    """
+    return {
+        'type' : 'engine_properties',
+        'regions': {},
+        'languages': {},
+    }
 
 def set_loggers(engine, engine_name):
     # set the logger for engine
@@ -179,8 +196,11 @@ def update_engine_attributes(engine: Engine, engine_data):
 
 def set_language_attributes(engine: Engine):
     # assign supported languages from json file
+
+    supported_properties = None
+
     if engine.name in ENGINES_LANGUAGES:
-        engine.supported_languages = ENGINES_LANGUAGES[engine.name]
+        supported_properties = ENGINES_LANGUAGES[engine.name]
 
     elif engine.engine in ENGINES_LANGUAGES:
         # The key of the dictionary ENGINES_LANGUAGES is the *engine name*
@@ -188,47 +208,48 @@ def set_language_attributes(engine: Engine):
         # settings.yml to use the same origin engine (python module) these
         # additional engines can use the languages from the origin engine.
         # For this use the configured ``engine: ...`` from settings.yml
-        engine.supported_languages = ENGINES_LANGUAGES[engine.engine]
+        supported_properties = ENGINES_LANGUAGES[engine.engine]
 
-    if hasattr(engine, 'language'):
-        # For an engine, when there is `language: ...` in the YAML settings, the
-        # engine supports only one language, in this case
-        # engine.supported_languages should contains this value defined in
-        # settings.yml
-        if engine.language not in engine.supported_languages:
-            raise ValueError(
-                "settings.yml - engine: '%s' / language: '%s' not supported" % (engine.name, engine.language)
-            )
+    if not supported_properties:
+        return
 
-        if isinstance(engine.supported_languages, dict):
-            engine.supported_languages = {engine.language: engine.supported_languages[engine.language]}
-        else:
-            engine.supported_languages = [engine.language]
+    if isinstance(supported_properties, dict) and supported_properties.get('type') == 'engine_properties':
+        engine.supported_properties = supported_properties
+        engine.language_support = len(supported_properties['languages']) or len(supported_properties['regions'])
 
-    # find custom aliases for non standard language codes
-    for engine_lang in engine.supported_languages:
-        iso_lang = match_language(engine_lang, BABEL_LANGS, fallback=None)
-        if (
-            iso_lang
-            and iso_lang != engine_lang
-            and not engine_lang.startswith(iso_lang)
-            and iso_lang not in engine.supported_languages
-        ):
-            engine.language_aliases[iso_lang] = engine_lang
+    else:
+        # depricated: does not work for engines that do support languages
+        # based on a region.
+        engine.supported_languages = supported_properties
+        engine.language_support = len(engine.supported_languages) > 0
 
-    # language_support
-    engine.language_support = len(engine.supported_languages) > 0
+        if hasattr(engine, 'language'):
+            # For an engine, when there is `language: ...` in the YAML settings, the
+            # engine supports only one language, in this case
+            # engine.supported_languages should contains this value defined in
+            # settings.yml
+            if engine.language not in engine.supported_languages:
+                raise ValueError(
+                    "settings.yml - engine: '%s' / language: '%s' not supported" % (engine.name, engine.language)
+                )
 
-    # assign language fetching method if auxiliary method exists
-    if hasattr(engine, '_fetch_supported_languages'):
-        headers = {
-            'User-Agent': gen_useragent(),
-            'Accept-Language': "en-US,en;q=0.5",  # bing needs to set the English language
-        }
-        engine.fetch_supported_languages = (
-            # pylint: disable=protected-access
-            lambda: engine._fetch_supported_languages(get(engine.supported_languages_url, headers=headers))
-        )
+            if isinstance(engine.supported_languages, dict):
+                engine.supported_languages = {engine.language: engine.supported_languages[engine.language]}
+            else:
+                engine.supported_languages = [engine.language]
+
+        if not hasattr(engine, 'language_aliases'):
+            engine.language_aliases = {}
+        # find custom aliases for non standard language codes
+        for engine_lang in engine.supported_languages:
+            iso_lang = match_language(engine_lang, BABEL_LANGS, fallback=None)
+            if (
+                    iso_lang
+                    and iso_lang != engine_lang
+                    and not engine_lang.startswith(iso_lang)
+                    and iso_lang not in engine.supported_languages
+            ):
+                engine.language_aliases[iso_lang] = engine_lang
 
 
 def update_attributes_for_tor(engine: Engine) -> bool:

--- a/searx/engines/google_scholar.py
+++ b/searx/engines/google_scholar.py
@@ -48,7 +48,6 @@ about = {
 # engine dependent config
 categories = ['science']
 paging = True
-language_support = True
 use_locale_domain = True
 time_range_support = True
 safesearch = False

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -56,7 +56,6 @@ about = {
 
 categories = ['videos', 'web']
 paging = False
-language_support = True
 use_locale_domain = True
 time_range_support = True
 safesearch = True

--- a/searx/engines/yahoo_news.py
+++ b/searx/engines/yahoo_news.py
@@ -32,7 +32,6 @@ about = {
     "results": 'HTML',
 }
 
-language_support = False
 time_range_support = False
 safesearch = False
 paging = True

--- a/searx/engines/youtube_noapi.py
+++ b/searx/engines/youtube_noapi.py
@@ -21,7 +21,6 @@ about = {
 # engine dependent config
 categories = ['videos', 'music']
 paging = True
-language_support = False
 time_range_support = True
 
 # search-url

--- a/searx/search/checker/impl.py
+++ b/searx/search/checker/impl.py
@@ -293,13 +293,6 @@ class ResultContainerTests:
         if len(self.result_container.answers) == 0:
             self._record_error('No answer')
 
-    def has_language(self, lang):
-        """Check at least one title or content of the results is written in the `lang`.
-
-        Detected using pycld3, may be not accurate"""
-        if lang not in self.languages:
-            self._record_error(lang + ' not found')
-
     def not_empty(self):
         """Check the ResultContainer has at least one answer or infobox or result"""
         result_types = set()

--- a/searx/search/processors/abstract.py
+++ b/searx/search/processors/abstract.py
@@ -157,6 +157,18 @@ class EngineProcessor(ABC):
             params['language'] = self.engine.language
         else:
             params['language'] = search_query.lang
+
+        params['locale'], params['engine_language'], params['engine_region'] = self.engine.supported_locales.get(
+            params['language']
+        )
+        if params['engine_language']:
+            self.logger.debug(
+                'language:"%s" --> %s, engine_language:"%s", engine_region:"%s"',
+                params['language'],
+                repr(params['locale']),
+                params['engine_language'],
+                params['engine_region'],
+            )
         return params
 
     @abstractmethod

--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -196,16 +196,6 @@ class OnlineProcessor(EngineProcessor):
                 'test': ['unique_results'],
             }
 
-        if getattr(self.engine, 'supported_languages', []):
-            tests['lang_fr'] = {
-                'matrix': {'query': 'paris', 'lang': 'fr'},
-                'result_container': ['not_empty', ('has_language', 'fr')],
-            }
-            tests['lang_en'] = {
-                'matrix': {'query': 'paris', 'lang': 'en'},
-                'result_container': ['not_empty', ('has_language', 'en')],
-            }
-
         if getattr(self.engine, 'safesearch', False):
             tests['safesearch'] = {'matrix': {'query': 'porn', 'safesearch': (0, 2)}, 'test': ['unique_results']}
 

--- a/searx/templates/oscar/preferences.html
+++ b/searx/templates/oscar/preferences.html
@@ -344,7 +344,6 @@
                                     <th scope="col">{{ _("Allow") }}</th>
                                     <th scope="col">{{ _("Engine name") }}</th>
                                     <th scope="col">{{ _("Shortcut") }}</th>
-                                    <th scope="col" class="col-stat">{{ _("Selected language") }}</th>
                                     <th scope="col" class="col-stat">{{ _("SafeSearch") }}</th>
                                     <th scope="col" class="col-stat">{{ _("Time range") }}</th>
                                     <th scope="col">{{ _("Response time") }}</th>
@@ -356,7 +355,6 @@
                                     <th scope="col" class="text-right">{{ _("Response time") }}</th>
                                     <th scope="col" class="text-right">{{ _("Time range") }}</th>
                                     <th scope="col" class="text-right">{{ _("SafeSearch") }}</th>
-                                    <th scope="col" class="text-right">{{ _("Selected language") }}</th>
                                     <th scope="col" class="text-right">{{ _("Shortcut") }}</th>
                                     <th scope="col" class="text-right">{{ _("Engine name") }}</th>
                                     <th scope="col" class="text-right">{{ _("Allow") }}</th>
@@ -383,7 +381,6 @@
                                             {{- engine_about(search_engine, 'tooltip_' + categ + '_' + search_engine.name) -}}
                                         </th>
                                         <td class="name">{{ shortcuts[search_engine.name] }}</td>
-                                        <td>{{ support_toggle(supports[search_engine.name]['supports_selected_language']) }}</td>
                                         <td>{{ support_toggle(supports[search_engine.name]['safesearch']) }}</td>
                                         <td>{{ support_toggle(supports[search_engine.name]['time_range_support']) }}</td>
                                         {{ engine_time(search_engine.name, 'text-right') }}
@@ -395,7 +392,6 @@
                                         {{ engine_time(search_engine.name, 'text-left') }}
                                         <td>{{ support_toggle(supports[search_engine.name]['time_range_support']) }}</td>
                                         <td>{{ support_toggle(supports[search_engine.name]['safesearch']) }}</td>
-                                        <td>{{ support_toggle(supports[search_engine.name]['supports_selected_language']) }}</td>
                                         <td>{{ shortcuts[search_engine.name] }}</td>
                                         <th scope="row" data-engine-name="{{ search_engine.name }}"><span>{% if search_engine.enable_http %}{{ icon('exclamation-sign', 'No HTTPS') }}{% endif %}{{ search_engine.name }}</span>{{ engine_about(search_engine) }}</th>
                                         <td class="onoff-checkbox">

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -297,7 +297,7 @@
         <th class="engine_checkbox">{{ _("Allow") }}</th>{{- "" -}}
         <th class="name">{{ _("Engine name") }}</th>{{- "" -}}
         <th class="shortcut">{{ _("Shortcut") }}</th>{{- "" -}}
-        <th>{{ _("Supports selected language") }}</th>{{- "" -}}
+        <th>{{ _("Language / Region") }}</th>{{- "" -}}
         <th>{{ _("SafeSearch") }}</th>{{- "" -}}
         <th>{{ _("Time range") }}</th>{{- "" -}}
         <th>{{ _("Response time") }}</th>{{- "" -}}
@@ -323,7 +323,7 @@
           {{- engine_about(search_engine) -}}
         </th>{{- "" -}}
         <td class="shortcut">{{ shortcuts[search_engine.name] }}</td>{{- "" -}}
-        <td>{{ checkbox(None, supports[search_engine.name]['supports_selected_language'], true) }}</td>{{- "" -}}
+        <td>{{ checkbox(None, supports[search_engine.name]['language_support'], true) }}</td>{{- "" -}}
         <td>{{ checkbox(None, supports[search_engine.name]['safesearch'], true) }}</td>{{- "" -}}
         <td>{{ checkbox(None, supports[search_engine.name]['time_range_support'], true) }}</td>{{- "" -}}
         {{- engine_time(search_engine.name) -}}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the startpage CAPTCHA and more .. for this SearXNG needs a differentiated view on the languages and regions. In the first and second commit a boilerplate to handle languages & regions has been added 

- [mod] engines_languages.json: add new type engine_properties
- [fix] replace language_support by a language/region view

In the third commit the startpage engine is fixed:

- [fix] startpage engine: language/region & time support & fix CAPTCHA

---

One reason for the often seen CAPTCHA of the startpage requests are the
incomplete requests SearXNG sends to startpage.com.  To avoid CAPTCHA we need to
send a well formed HTTP POST request with a cookie, we need to form a request
that is identical to the request build by startpage.com itself:

- in the cookie the **region** is selected
- in the POST arguments the **language** is selected

Based on the *engine_properties* boilerplate, SearXNG's startpage engine now
implements a `_fetch_engine_properties()` function to fetch regions & languages
from startpage.com.

This patch is a complete new implementation of the request() function, reversed
engineered from the startpage.com page.  The new implementation adds

- time-range support
- save-search support

to the startpage engine which has been missed in the past.

## Why is a "regions & languages" boilerplate important?

Most engines response best results if a region is selected, most often choosing
a language has a minor effect on the result list (e.g. startpage needs a region
to return results that match a language).

To summarize:

Some engines have language codes (e.g. `ca`) in their properties, some have
region codes (e.g. `ca-ES`), some have regions and languages in their properties
and other engine do not have any language or region support.

In the past we generalized *language* over all kind of engines without taking
into mind that most engines gave best result when there is a region selected.

  This *language-centric* view in SearXNG is misleading when we need
  region-codes to parameterize engine request!

The "regions & languages" boilerplate replaces the *language-centric* view by a "language / region" view.

Conclusions:

With regions we can't say any longer that a engine supports *this or that*
language, by example: when the user selects 'zh' and a engine supports only
region codes like 'zh-TW' or 'zh-CN' we do not know what results the user expects /
similar with 'en' or 'fr' when the engine needs a region tag.

- Since it is unclear what the user expects by his language selection, we can't
  assert a property that says: "supports_selected_language"

  The feature is replaced in the UI by the wider sense of "language_support",
  what stands for:

  _The engine has some kind of language support, either by a region tag or by a language tag._

- A list of "supported_languages" does not make sense when there are regions
  responsible for the result of an engine.

  The "supported_languages" has been removed from the /config URL

- The `has_language` test in the `searx/search/checker/impl.py` has been removed
  since it does not cover engines with region support.

  If there is a need for such a test we can implement new tests after all
  engines with language (region) support has been moved to the *supported
  properites* scheme (see searxng_extra/update/update_languages.py)

## How to test this PR locally?

Start `make run` and test `!startpage foo` queries in different languages & regions.  Since autocomplete has been touched also, don't forget to test the autocompletion from startpage.

## Related issues

Closes: https://github.com/searxng/searxng/issues/1081
