### PR TITLE
[fix] since git v2.35.2 root can't read from unsafe repository

### DIFF
--- a/utils/lib_install.sh
+++ b/utils/lib_install.sh
@@ -92,6 +92,10 @@ init_SEARX_SRC_INIT_FILES(){
 
     local fname
     local msg=""
+    local _prefix=""
+    if [[ -n ${SUDO_USER} ]]; then
+        _prefix="sudo -u ${SUDO_USER}"
+    fi
 
     # Monitor local modified files from the repository, only if the local file
     # differs to the corresponding file in the instance
@@ -108,7 +112,7 @@ init_SEARX_SRC_INIT_FILES(){
                 msg="to update use:  sudo -H ./utils/searx.sh install init-src"
             fi
         fi
-    done <<< "$(git diff --name-only)"
+    done <<< "$($_prefix git diff --name-only)"
     [ -n "$msg" ] &&  info_msg "$msg"
 }
 


### PR DESCRIPTION
Git v2.35.2 closes a security issue, it is no longer possible that root uses a
git repo that is owned by someone else, the error message is::

    fatal: unsafe repository ('/share/darmarit.org/cache/searxng' is owned by someone else)

The fix is to run the `git diff --name-only` not as root in a sudo command.

[1] https://github.blog/2022-04-12-git-security-vulnerability-announced/
