### PR TITLE
[fix] format.python: regexp argument '--include' in BLACK_TARGETS

### DIFF
--- a/manage
+++ b/manage
@@ -30,7 +30,7 @@ GECKODRIVER_VERSION="v0.30.0"
 export NODE_MINIMUM_VERSION="16.13.0"
 # SPHINXOPTS=
 BLACK_OPTIONS=("--target-version" "py37" "--line-length" "120" "--skip-string-normalization")
-BLACK_TARGETS=("--exclude" "searx/static,searx/languages.py" "--include" "searxng.msg" "searx" "searxng_extra" "tests")
+BLACK_TARGETS=("--exclude" "searx/static,searx/languages.py" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")
 
 pylint.FILES() {
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -89,17 +89,24 @@ def seznam(query, _lang):
     # seznam search autocompleter
     url = 'https://suggest.seznam.cz/fulltext/cs?{query}'
 
-    resp = get(url.format(query=urlencode(
-        {'phrase': query, 'cursorPosition': len(query), 'format': 'json-2', 'highlight': '1', 'count': '6'}
-    )))
+    resp = get(
+        url.format(
+            query=urlencode(
+                {'phrase': query, 'cursorPosition': len(query), 'format': 'json-2', 'highlight': '1', 'count': '6'}
+            )
+        )
+    )
 
     if not resp.ok:
         return []
 
     data = resp.json()
-    return [''.join(
-        [part.get('text', '') for part in item.get('text', [])]
-    ) for item in data.get('result', []) if item.get('itemType', None) == 'ItemType.TEXT']
+    return [
+        ''.join([part.get('text', '') for part in item.get('text', [])])
+        for item in data.get('result', [])
+        if item.get('itemType', None) == 'ItemType.TEXT'
+    ]
+
 
 def startpage(query, lang):
     # startpage autocompleter

--- a/searx/engines/dailymotion.py
+++ b/searx/engines/dailymotion.py
@@ -30,7 +30,7 @@ number_of_results = 10
 
 time_range_support = True
 time_delta_dict = {
-    "day":  timedelta(days=1),
+    "day": timedelta(days=1),
     "week": timedelta(days=7),
     "month": timedelta(days=31),
     "year": timedelta(days=365),
@@ -58,7 +58,7 @@ search_url = (
     'fields={fields}&password_protected={password_protected}&private={private}&sort={sort}&limit={limit}'
 ).format(
     fields=','.join(result_fields),
-    password_protected= 'false',
+    password_protected='false',
     private='false',
     sort='relevance',
     limit=number_of_results,
@@ -93,7 +93,7 @@ def request(query, params):
     query_args = {
         'search': query,
         'languages': language_iso639,
-        'page':  params['pageno'],
+        'page': params['pageno'],
     }
 
     if locale.territory:
@@ -170,7 +170,4 @@ def response(resp):
 # get supported languages from their site
 def _fetch_supported_languages(resp):
     response_json = resp.json()
-    return [
-        item['locale']
-        for item in response_json['list']
-    ]
+    return [item['locale'] for item in response_json['list']]

--- a/searx/engines/jisho.py
+++ b/searx/engines/jisho.py
@@ -53,7 +53,7 @@ def response(resp):
                 if 'reading' in title_raw:
                     title += ' (' + title_raw['reading'] + ')'
                 alt_forms.append(title)
-        
+
         #
         result_url = urljoin(BASE_URL, page['slug'])
         definitions = get_definitions(page)
@@ -61,11 +61,9 @@ def response(resp):
         # For results, we'll return the URL, all alternative forms (as title),
         # and all definitions (as description) truncated to 300 characters.
         content = " ".join(f"{engdef}." for _, engdef, _ in definitions)
-        results.append({
-            'url': result_url,
-            'title': ", ".join(alt_forms),
-            'content': content[:300] + (content[300:] and '...')
-        })
+        results.append(
+            {'url': result_url, 'title': ", ".join(alt_forms), 'content': content[:300] + (content[300:] and '...')}
+        )
 
         # Like Wordnik, we'll return the first result in an infobox too.
         if first_result:
@@ -93,11 +91,13 @@ def get_definitions(page):
             extra.append(', '.join(defn_raw['info']).capitalize() + '. ')
         if defn_raw.get('restrictions'):
             extra.append('Only applies to: ' + ', '.join(defn_raw['restrictions']) + '. ')
-        definitions.append((
-            ', '.join(defn_raw['parts_of_speech']),
-            '; '.join(defn_raw['english_definitions']),
-            ''.join(extra)[:-1],
-        ))
+        definitions.append(
+            (
+                ', '.join(defn_raw['parts_of_speech']),
+                '; '.join(defn_raw['english_definitions']),
+                ''.join(extra)[:-1],
+            )
+        )
     return definitions
 
 
@@ -109,12 +109,14 @@ def get_infobox(alt_forms, result_url, definitions):
         infobox_content.append(f'<p><i>Other forms:</i> {", ".join(alt_forms[1:])}</p>')
 
     # definitions
-    infobox_content.append('''
+    infobox_content.append(
+        '''
         <small><a href="https://www.edrdg.org/wiki/index.php/JMdict-EDICT_Dictionary_Project">JMdict</a> 
         and <a href="https://www.edrdg.org/enamdict/enamdict_doc.html">JMnedict</a> 
         by <a href="https://www.edrdg.org/edrdg/licence.html">EDRDG</a>, CC BY-SA 3.0.</small>
         <ul>
-    ''')
+    '''
+    )
     for pos, engdef, extra in definitions:
         if pos == 'Wikipedia definition':
             infobox_content.append('</ul><small>Wikipedia, CC BY-SA 3.0.</small><ul>')
@@ -132,5 +134,5 @@ def get_infobox(alt_forms, result_url, definitions):
                 'title': 'Jisho.org',
                 'url': result_url,
             }
-        ]
+        ],
     }

--- a/searx/infopage/__init__.py
+++ b/searx/infopage/__init__.py
@@ -77,11 +77,9 @@ class InfoPage:
         .. _markdown-it-py: https://github.com/executablebooks/markdown-it-py
 
         """
-        return MarkdownIt(
-            "commonmark", {"typographer": True}
-        ).enable(
-            ["replacements", "smartquotes"]
-        ).render(self.content)
+        return (
+            MarkdownIt("commonmark", {"typographer": True}).enable(["replacements", "smartquotes"]).render(self.content)
+        )
 
     def get_ctx(self):  # pylint: disable=no-self-use
         """Jinja context to render :py:obj:`InfoPage.content`"""


### PR DESCRIPTION
[fix] format.python: regexp argument '--include' in BLACK_TARGETS

--include TEXT

  A regular expression that matches files and directories that should be
  included on recursive searches. An empty value means all files are included
  regardless of the name.  ...  Exclusions are calculated first, inclusions
  later.  [default: \.pyi?$]

Closes: https://github.com/searxng/searxng/issues/1142
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>
