### PR TITLE
[enh] Add pagination to Brave

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1667,8 +1667,9 @@ engines:
   - name: brave
     shortcut: brave
     engine: xpath
-    paging: false
-    search_url: https://search.brave.com/search?q={query}
+    paging: true
+    first_page_num: 0
+    search_url: https://search.brave.com/search?q={query}&offset={pageno}&spellcheck=1
     url_xpath: //div[@class="snippet fdb"]/a/@href
     title_xpath: //span[@class="snippet-title"]
     content_xpath: //p[1][@class="snippet-description"]


### PR DESCRIPTION
Also added ```&spellcheck=1``` because now it is disabled by default, not returning any ```suggestion_xpath```.

## What does this PR do?

Add pagination support, just like the upstream engine itself.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Set ```paging: true``` and made sure spellchecks (suggestions) are returned with ```&spellcheck=1```.
## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

!brave rfind()
<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

See also:
https://brave.com/discussions-in-brave-search/
<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
