### PR TITLE
[fix] library genesis engine: xpath and url

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -813,8 +813,8 @@ engines:
 
   - name: library genesis
     engine: xpath
-    search_url: https://libgen.rs/search.php?req={query}
-    url_xpath: //a[contains(@href,"bookfi.net/md5")]/@href
+    search_url: https://libgen.fun/search.php?req={query}
+    url_xpath: //a[contains(@href,"get.php?md5")]/@href
     title_xpath: //a[contains(@href,"book/")]/text()[1]
     content_xpath: //td/a[1][contains(@href,"=author")]/text()
     categories: files
@@ -822,7 +822,7 @@ engines:
     disabled: true
     shortcut: lg
     about:
-      website: https://libgen.rs/
+      website: https://libgen.fun/
       wikidata_id: Q22017206
       official_api_documentation:
       use_official_api: false


### PR DESCRIPTION
## What does this PR do?
Changed the xpath to use the official download mirror.

Changed the URL to libgen.fun as this is the official instance. (https://en.wikipedia.org/wiki/Library_Genesis)

## Why is this change important?

Fixing the library genesis engine.

## How to test this PR locally?

1. `make run`
2. Search for `!lg test`