### PR TITLE
[fix] autocomplete and infinite scroll persistence in preferences

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -454,6 +454,8 @@ def render(template_name: str, **kwargs):
 
     # values from the preferences
     kwargs['preferences'] = request.preferences
+    kwargs['autocomplete'] = request.preferences.get_value('autocomplete')
+    kwargs['infinite_scroll'] = request.preferences.get_value('infinite_scroll')
     kwargs['results_on_new_tab'] = request.preferences.get_value('results_on_new_tab')
     kwargs['advanced_search'] = request.preferences.get_value('advanced_search')
     kwargs['query_in_title'] = request.preferences.get_value('query_in_title')


### PR DESCRIPTION
## What does this PR do?

Autocomplete and infinite scroll settings reset themselves to the default value when reloading `/preferences`. This PR adds back those prefs to `webapp.py` since they are also needed in simple theme and not only oscar.

## Why is this change important?

Fixes autocomplete and infinite scroll preferences to be persistent over page reloads.

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

```make run```

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
