### PR TITLE
[fix] PR 1186: autocomplete

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -459,6 +459,7 @@ def render(template_name: str, **kwargs):
     kwargs['query_in_title'] = request.preferences.get_value('query_in_title')
     kwargs['safesearch'] = str(request.preferences.get_value('safesearch'))
     kwargs['theme'] = request.preferences.get_value('theme')
+    kwargs['autocomplete'] = request.preferences.get_value('autocomplete')
     kwargs['method'] = request.preferences.get_value('method')
     kwargs['categories_as_tabs'] = list(settings['categories_as_tabs'].keys())
     kwargs['categories'] = _get_enable_categories(categories.keys())


### PR DESCRIPTION
PR https://github.com/searxng/searxng/pull/1186 prevented autocomplete from being selected.

## How to test this PR locally?

1. `make run`
2. select an autocomplete engine (e.g. google) in preferences -> Autocomplete