### PR TITLE
Preferences URL in preferences

### DIFF
--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -406,6 +406,11 @@
        <pre>{{ url_for('index', _external=True) }}?preferences={{ preferences_url_params|e }}{% raw %}&amp;q=%s{% endraw %}</pre>
      </div>
      <p class="small_font">{{ _('Note: specifying custom settings in the search URL can reduce privacy by leaking data to the clicked result sites.') }}</p>
+     <h4>{{ _('URL to restore your preferences in another browser') }} :</h4>
+     <div class="selectable_url">
+       <pre>{{ url_for('preferences', _external=True) }}?preferences={{ preferences_url_params|e }}&amp;save=1</pre>
+     </div>
+     <p class="small_font">{{ _('Specifying custom settings in the preferences URL can be used to sync preferences across devices.') }}</p>
   {{ tab_footer() }}
 
 {{ tabs_close() }}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -971,6 +971,11 @@ def preferences():
     # pylint: disable=too-many-locals, too-many-return-statements, too-many-branches
     # pylint: disable=too-many-statements
 
+    # save preferences using the link the /preferences?preferences=...&save=1
+    if request.args.get('save') == '1':
+        resp = make_response(redirect(url_for('index', _external=True)))
+        return request.preferences.save(resp)
+
     # save preferences
     if request.method == 'POST':
         resp = make_response(redirect(url_for('index', _external=True)))


### PR DESCRIPTION
## What does this PR do?

This PR adds a direct link to the preferences of the instance, with the custom settings defined by the user appended to the URL and automatically saved.

![image](https://user-images.githubusercontent.com/43753131/168425220-57754a37-1b78-453f-bfaa-56a0e4f1582b.png) 

## Why is this change important?

This change would allow users to quickly and easily sync settings across their devices, with options such as Firefox's send link to device feature.

## How to test this PR locally?

`make run`

## Related issues

Would contribute towards closing #984, along the lines of https://github.com/searxng/searxng/issues/984#issuecomment-1110324579
