### PR TITLE
[fix] remove .github/ISSUE_TEMPLATE/discuss.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Answers (Q&A)
+    url: https://github.com/searxng/searxng/discussions/categories/q-a
+    about: Ask questions and find answers

--- a/.github/ISSUE_TEMPLATE/discuss.md
+++ b/.github/ISSUE_TEMPLATE/discuss.md
@@ -1,8 +1,0 @@
----
-name: Question
-about: Ask questions or start a discussion
-title: '[question]'
-labels: question
-assignees: ''
-
----


### PR DESCRIPTION
In 2021 we did not used github-discussions, see commit message of 272c9d6b.
Theses days we use github-discussions and have a Q&A category in there [1].

[1] https://github.com/searxng/searxng/discussions/categories/q-a