### PR TITLE
Template images.html: always use JS to lazy load the full size images

### DIFF
--- a/searx/templates/simple/result_templates/images.html
+++ b/searx/templates/simple/result_templates/images.html
@@ -9,11 +9,7 @@
                 <a class="result-detail-previous" href="#">{{ icon('chevron-left') }}</a>{{- "" -}}
                 <a class="result-detail-next" href="#">{{ icon('chevron-right') }}</a>{{- "" -}}
                 <a class="result-images-source" {% if results_on_new_tab %}target="_blank" rel="noopener noreferrer"{% else %}rel="noreferrer"{% endif %} href="{{ result.img_src }}">
-                        {%- if result.thumbnail_src -%}
-                                <img src="" data-src="{{ image_proxify(result.img_src) }}" alt="{{ result.title|striptags }}">
-                        {%- else -%}
-                                <img src="{{ image_proxify(result.img_src) }}" alt="{{ result.title|striptags }}" loading="lazy" width="200" height="200">
-                        {%- endif -%}
+                        <img src="" data-src="{{ image_proxify(result.img_src) }}" alt="{{ result.title|striptags }}">{{- "" -}}
                 </a>{{- "" -}}
                 <div class="result-images-labels">{{- "" -}}
                         <h4>{{ result.title|striptags }}</h4>{{- "" -}}


### PR DESCRIPTION
## What does this PR do?

Remove lazy loading by browser / width / height:
JS is required to display this HTML fragment anyway.

## Why is this change important?

Simplify the HTML template.

## How to test this PR locally?

Check two engines in the image category with and without thumbnails

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

https://github.com/searxng/searxng/issues/898#issuecomment-1129584487
