### PR TITLE
Feature: bang & external bang can be written in upper case

### DIFF
--- a/searx/query.py
+++ b/searx/query.py
@@ -153,7 +153,7 @@ class ExternalBangParser(QueryPartParser):
         return raw_value.startswith('!!')
 
     def __call__(self, raw_value):
-        value = raw_value[2:]
+        value = raw_value[2:].lower()
         found, bang_ac_list = self._parse(value) if len(value) > 0 else (False, [])
         if self.enable_autocomplete:
             self._autocomplete(bang_ac_list)
@@ -180,7 +180,7 @@ class BangParser(QueryPartParser):
         return raw_value[0] == '!'
 
     def __call__(self, raw_value):
-        value = raw_value[1:].replace('-', ' ').replace('_', ' ')
+        value = raw_value[1:].replace('-', ' ').replace('_', ' ').lower()
         found = self._parse(value) if len(value) > 0 else False
         if found and raw_value[0] == '!':
             self.raw_text_query.specific = True
@@ -221,7 +221,7 @@ class BangParser(QueryPartParser):
 
         # check if query starts with category name
         for category in categories:
-            if category.startswith(value):
+            if category.lower().startswith(value):
                 self._add_autocomplete(first_char + category.replace(' ', '_'))
 
         # check if query starts with engine name
@@ -231,7 +231,7 @@ class BangParser(QueryPartParser):
 
         # check if query starts with engine shortcut
         for engine_shortcut in engine_shortcuts:
-            if engine_shortcut.startswith(value):
+            if engine_shortcut.lower().startswith(value):
                 self._add_autocomplete(first_char + engine_shortcut)
 
 


### PR DESCRIPTION
## What does this PR do?

See #1223 : currently `!DDG` or `!Dgg` is not seen as bang, however on phone keyboard might switch to upper case as a exclamation mark.

## Why is this change important?

Easier usage on a phone.

## How to test this PR locally?

Try `!DDG time` or `!Dgg time`.

## Author's checklist

engine name are already forced in lower case: https://github.com/searxng/searxng/blob/fddbc5ed00ded5f28ef3b643686e7c177a3a75ce/searx/engines/__init__.py#L113-L116

## Related issues

Close #1223
