### PR TITLE
Add Indonesian translations of about.md and search-syntax.md

### DIFF
--- a/searx/infopage/id/about.md
+++ b/searx/infopage/id/about.md
@@ -1,0 +1,66 @@
+# Tentang SearXNG
+
+SearXNG adalah sebuah [mesin pencari meta], yang mendapatkan hasil dari {{link('mesin pencari', 'preferences')}}
+lainnya sambil tidak melacak penggunanya.
+
+Proyek SearXNG diarahkan oleh sebuah komunitas terbuka, bergabung dengan kami
+di Matrix jika Anda memiliki pertanyaan atau ingin mengobrol tentang SearXNG di [#searxng:matrix.org]
+
+Buat SearXNG lebih baik.
+
+- Anda dapat membuat terjemahan SearXNG lebih baik di [Weblate], atau...
+- Lacak pengembangan, kirim kontribusi, dan laporkan masalah di [sumber SearXNG].
+- Untuk mendapatkan informasi lanjut, kunjungi dokumentasi proyek SearXNG di [dokumentasi SearXNG].
+
+## Kenapa menggunakan SearXNG?
+
+- SearXNG mungkin tidak menawarkan Anda hasil yang dipersonalisasikan seperti Google, tetapi tidak membuat sebuah profil tentang Anda.
+- SearXNG tidak peduli apa yang Anda cari, tidak akan membagikan apa pun dengan pihak ketiga, dan tidak dapat digunakan untuk mengkompromikan Anda.
+- SearXNG adalah perangkat lunak bebas, kodenya 100% terbuka, dan semuanya dipersilakan untuk membuatnya lebih baik.
+
+Jika Anda peduli dengan privasi, ingin menjadi pengguna yang sadar, ataupun percaya
+dalam kebebasan digital, buat SearXNG sebagai mesin pencari bawaan atau jalankan di server Anda sendiri!
+
+
+## Bagaimana saya dapat membuat SearXNG sebagai mesin pencari bawaan?
+
+SearXNG mendukung [OpenSearch].  Untuk informasi lanjut tentang mengubah mesin pencari
+bawaan Anda, lihat dokumentasi peramban Anda:
+
+- [Firefox]
+- [Microsoft Edge] - Dibalik tautan, Anda juga akan menemukan beberapa instruksi berguna untuk Chrome dan Safari.
+- Peramban berbasis [Chromium] hanya menambahkan situs web yang dikunjungi oleh pengguna tanpa sebuah jalur.
+
+
+## Bagaimana caranya SearXNG bekerja?
+
+SearXNG adalah sebuah *fork* dari [mesin pencari meta] [searx] yang banyak dikenal
+yang diinspirasi oleh [proyek Seeks].  SearXNG menyediakan privasi dasar dengan mencampur kueri
+Anda dengan pencarian pada *platform* lainnya tanpa menyimpan data pencarian.
+SearXNG dapat ditambahkan ke bilah pencarian peramban Anda; lain lagi, SearXNG dapat diatur sebagai
+mesin pencarian bawaan.
+
+{{link('Laman statistik', 'stats')}} berisi beberapa statistik penggunaan anonim berguna tentang mesin pencarian yang digunakan.
+
+
+## Bagaimana caranya untuk membuat SearXNG milik saya?
+
+SearXNG menghargai kekhawatiran Anda tentang pencatatan (*log*), jadi ambil kodenya dari
+[sumber SearXNG] dan jalankan sendiri!
+
+Tambahkan instansi Anda ke [daftar instansi
+publik]({{get_setting('brand.public_instances')}}) ini untuk membantu orang lain
+mendapatkan kembali privasi mereka dan membuat internet lebih bebas.  Lebih terdesentralisasinya internet, lebih banyak kebebasan yang kita punya!
+
+
+[sumber SearXNG]: {{GIT_URL}}
+[#searxng:matrix.org]: https://matrix.to/#/#searxng:matrix.org
+[dokumentasi SearXNG]: {{get_setting('brand.docs_url')}}
+[searx]: https://github.com/searx/searx
+[mesin pencari meta]: https://id.wikipedia.org/wiki/Mesin_pencari_web#Mesin_Pencari_dan_Mesin_Pencari-meta
+[Weblate]: https://weblate.bubu1.eu/projects/searxng/
+[proyek Seeks]: https://beniz.github.io/seeks/
+[OpenSearch]: https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md
+[Firefox]: https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox
+[Microsoft Edge]: https://support.microsoft.com/en-us/help/4028574/microsoft-edge-change-the-default-search-engine
+[Chromium]: https://www.chromium.org/tab-to-search

--- a/searx/infopage/id/search-syntax.md
+++ b/searx/infopage/id/search-syntax.md
@@ -1,0 +1,70 @@
+# Sintaks pencarian
+
+SearXNG mempunyai sintaks pencarian memungkinkan Anda untuk mengubah kategori,
+mesin pencari, bahasa dan lainnya.  Lihat {{link('preferensi', 'preferences')}} untuk
+daftar mesin pencari, kategori dan bahasa.
+
+## `!` pilih mesin pencari dan kategori
+
+Untuk menetapkan nama kategori dan/atau mesin pencari gunakan awalan `!`.  Sebagai contoh:
+
+- cari di wikipedia tentang **Jakarta**
+
+  - {{search('!wp Jakarta')}}
+  - {{search('!wikipedia Jakarta')}}
+
+- cari dalam kategori **peta** untuk **Jakarta**
+
+  - {{search('!map Jakarta')}}
+
+- pencarian gambar
+
+  - {{search('!images kucing')}}
+
+Singkatan mesin pencari dan bahasa juga diterima.  Pengubah
+mesin/kategori dapat dirantai dan inklusif.  Misalnya dengan pencarian {{search('!map !ddg !wp
+Jakarta')}} dalam kategori peta dan duckduckgo dan wikipedia tentang **Jakarta**.
+
+## `:` pilih bahasa
+
+Untuk memilih saringan bahasa gunakan awalan `:`.  Sebagai contoh:
+
+- cari wikipedia dengan bahasa lain
+
+  - {{search(':en !wp Jakarta')}}
+
+## `!!` mesin pencarian (*bangs*) eksternal
+
+SearXNG mendukung mesin pencarian eksternal (*bangs*) dari [ddg].  Untuk langsung lompat ke sebuah
+laman pencarian eksternal gunakan awalan `!!`.  Sebagai contoh:
+
+- cari wikipedia dengan bahasa yang lain
+
+  - {{search('!!wen cat')}}
+
+Diingat, pencarian Anda akan dilakukan secara langsung di mesin pencari eksternal,
+SearXNG tidak dapat melindungi privasi Anda di sana.
+
+[ddg]: https://duckduckgo.com/bang
+
+## Kueri Khusus
+
+Dalam laman {{link('preferensi', 'preferences')}} Anda akan menemukan kata kunci
+_kueri khusus_.  Sebagai contoh:
+
+- buat sebuah UUID acak
+
+  - {{search('random uuid')}}
+
+- temukan rata-rata
+
+  - {{search('avg 123 548 2.04 24.2')}}
+
+- tampilkan _user agent_ (agen pengguna) dari peramban Anda (harus diaktifkan)
+
+  - {{search('user-agent')}}
+
+- ubah _string_ (teks) ke intisari *hash* yang berbeda (harus diaktifkan)
+
+  - {{search('md5 kucing sphynx')}}
+  - {{search('sha512 kucing sphynx')}}


### PR DESCRIPTION
## What does this PR do?

This PR adds Indonesian translations of about.md and search-syntax.md for the infopage

## How to test this PR locally?

Add the Markdown files in `searx/infopage/id`

…or see the pages below in my SearXNG instance
- https://searxng.linerly.tk/info/id/about
- https://searxng.linerly.tk/info/id/search-syntax

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

#1045 