### PR TITLE
[translation] add DE translation of the info pages

### DIFF
--- a/searx/infopage/de/about.md
+++ b/searx/infopage/de/about.md
@@ -1,0 +1,80 @@
+# Über SearXNG
+
+SearXNG ist eine [Metasuchmaschine], welche die Ergebnisse anderer
+{{link('Suchmaschinen', 'preferences')}} sammelt und aufbereitet ohne dabei
+Informationen über seine Benutzer zu sammeln oder an andere Suchmaschinen weiter
+zu geben.
+
+Das SearXNG Projekt wird von einer offenen Gemeinschaft entwickelt; wenn Sie
+Fragen haben oder einfach nur über SearXNG plaudern möchten, besuchen Sie uns
+auf Matrix unter: [#searxng:matrix.org]
+
+Werden Sie Teil des Projekts und unterstützen Sie SearXNG:
+
+- Sie können die SearXNG Übersetzungen ergänzen oder korrigieren: [Weblate]
+- oder folgen Sie den Entwicklungen, senden Sie Beiträge und melden Sie Fehler:
+  [SearXNG Quellen]
+- Mehr Informationen sind in der [SearXNG Dokumentation] zu finden.
+
+## Warum sollte ich SearXNG benutzen?
+
+- SearXNG bietet Ihnen vielleicht nicht so personalisierte Ergebnisse wie
+  Google, aber es erstellt auch kein Profil über Sie.
+- SearXNG kümmert sich nicht darum, wonach Sie suchen, gibt niemals etwas an
+  Dritte weiter und kann nicht dazu verwendet werden Sie zu kompromittieren.
+- SearXNG ist freie Software, der Code ist zu 100% offen und jeder ist
+  willkommen ihn zu verbessern.
+
+Wenn Ihnen die Privatsphäre wichtig ist, Sie ein bewusster Nutzer sind und Sie
+an die digitale Freiheit glauben, sollten Sie SearXNG zu Ihrer
+Standardsuchmaschine machen oder eine SearXNG Instanz auf Ihrem eigenen Server
+betreiben.
+
+## Wie kann ich SearXNG als Standardsuchmaschine festlegen?
+
+SearXNG unterstützt [OpenSearch].  Weitere Informationen zum Ändern Ihrer
+Standardsuchmaschine finden Sie in der Dokumentation zu Ihrem [WEB-Browser]:
+
+- [Firefox]
+- [Microsoft Edge] - Hinter dem Link finden sich auch nützliche Hinweise zu
+  Chrome und Safari.
+- [Chromium]-basierte Browser fügen nur Websites hinzu, zu denen der Benutzer
+  ohne Pfadangabe navigiert.
+
+## Wie funktioniert SearXNG?
+
+SearXNG ist ein Fork der bekannten [searx] [Metasuchmaschine], die durch das
+[Seeks-Projekt] inspiriert wurde (diese beide Projekte werden heute nicht mehr
+aktiv weiterentwickelt).  SearXNG bietet einen grundlegenden Schutz der
+Privatsphäre, indem es die Suchanfragen der Benutzer mit Suchen auf anderen
+Plattformen vermischt ohne dabei Suchdaten zu speichern.  SearXNG kann im
+[WEB-Browser] als weitere oder Standard-Suchmaschine hinzugefügt werden.
+
+Die {{link('Suchmaschinenstatistik', 'stats')}} enthält einige nützliche
+Statistiken über die verwendeten Suchmaschinen.
+
+## Wie kann ich einen eigenen SearXNG Server betreiben?
+
+Jeder der mit dem Betrieb von WEB-Servern vertraut ist kann sich eine eigene
+Instanz einrichten; die Software dazu kann über die [SearXNG Quellen] bezogen
+werden. Weitere Informationen zur Installation und zum Betrieb finden sich in
+der [SearXNG Dokumentation].
+
+Fügen Sie Ihre Instanz zu der [Liste der öffentlich zugänglichen
+Instanzen]({{get_setting('brand.public_instances')}}) hinzu um auch anderen
+Menschen zu helfen ihre Privatsphäre zurückzugewinnen und das Internet freier zu
+machen.  Je dezentraler das Internet ist, desto mehr Freiheit haben wir!
+
+
+[SearXNG Quellen]: {{GIT_URL}}
+[#searxng:matrix.org]: https://matrix.to/#/#searxng:matrix.org
+[SearXNG Dokumentation]: {{get_setting('brand.docs_url')}}
+[searx]: https://github.com/searx/searx
+[Metasuchmaschine]: https://de.wikipedia.org/wiki/Metasuchmaschine
+[Weblate]: https://weblate.bubu1.eu/projects/searxng/
+[Seeks-Projekt]: https://beniz.github.io/seeks/
+[OpenSearch]: https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md
+[Firefox]: https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox
+[Microsoft Edge]: https://support.microsoft.com/en-us/help/4028574/microsoft-edge-change-the-default-search-engine
+[Chromium]: https://www.chromium.org/tab-to-search
+[WEB-Browser]: https://de.wikipedia.org/wiki/Webbrowser

--- a/searx/infopage/de/search-syntax.md
+++ b/searx/infopage/de/search-syntax.md
@@ -1,0 +1,77 @@
+# Suchbegriffe
+
+SearXNG verfügt über eine Syntax mit der in einer Suchanfrage die Kategorien,
+Suchmaschinen, Sprachen und mehr geändert werden können.  In den
+{{link('Eigenschaften','preferences')}} sind die Kategorien, Suchmaschinen und
+Sprachen zu finden, die zur Verfügung stehen.
+
+## `!` Suchmaschine und Kategorie auswählen
+
+Zum Festlegen von Kategorie- und/oder Suchmaschinen dient das Präfix `!`.  Um
+ein paar Beispiele zu geben:
+
+- in der Wikipedia nach dem Begriff **paris** suchen
+
+  - {{search('!wp paris')}}
+  - {{search('!wikipedia paris')}}
+
+- in der Kategorie **Karte** nach dem Begriff **paris** suchen:
+
+  - {{search('!map paris')}}
+
+- in der Kategorie **Bilder** suchen
+
+  - {{search('!images Wau Holland')}}
+
+Abkürzungen der Suchmaschinen und Kategorien sind ebenfalls möglich und können
+auch kombiniert werden.  So wird z.B. mit {{search('!map !ddg !wp paris')}} in
+der Kategorie **Karte** als auch mit den Suchmaschinen DuckDuckGo und Wikipedia
+nach dem Begriff **paris** gesucht.
+
+## `:` Sprache auswählen
+
+Um einen Sprachfilter auszuwählen, verwenden Sie das Präfix`:`.  Um ein
+einfaches Beispiel zu geben:
+
+- Wikipedia mit einer benutzerdefinierten Sprache durchsuchen
+
+  - {{search(':de !wp Wau Holland')}}
+
+## `!!` external bangs
+
+SearXNG unterstützt die _external bangs_ von [ddg].  Das Präfix `!!` kann
+verwendet werden um direkt zu einer externen Suchseite zu springen.  Um ein
+Beispiel zu geben:
+
+- In Wikipedia mit einer benutzerdefinierten Sprache eine Suche durchführen
+
+  - {{search('!!wde Wau Holland')}}
+
+Bitte beachten; die Suche wird direkt in der externen Suchmaschine durchgeführt.
+SearXNG kann die Privatsphäre des Benutzers in diesem Fall nur eingeschränkt
+schützen, dennoch wird diese Funktion von manchen Benutzern als sehr nützlich
+empfunden.
+
+[ddg]: https://duckduckgo.com/bang
+
+## Besondere Abfragen
+
+In den {{link('Eigenschaften', 'preferences')}} finden sich Schlüsselwörter für
+_besondere Abfragen_.  Um ein paar Beispiele zu geben:
+
+- Zufallsgenerator für eine UUID
+
+  - {{search('random uuid')}}
+
+- Bestimmung des Mittelwerts
+
+  - {{search('avg 123 548 2.04 24.2')}}
+
+- anzeigen des _user agent_ Ihres WEB-Browsers (muss aktiviert sein)
+
+  - {{search('user-agent')}}
+
+- Zeichenketten in verschiedene Hash-Digests umwandeln  (muss aktiviert sein)
+
+  - {{search('md5 lorem ipsum')}}
+  - {{search('sha512 lorem ipsum')}}


### PR DESCRIPTION
## What does this PR do?

DE translation of the info pages.

## How to test this PR locally?

Start local instance `make run`, in preferences set UI language to DE and visit the info pages ("Suchbegriffe" and "Über SearXNG").

