### PR TITLE
data-update.yml: updated on the 28th of the month

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -1,7 +1,7 @@
 name: "Update searx.data"
 on:
   schedule:
-    - cron: "05 06 1 * *"
+    - cron: "05 06 28 * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

Administrators of public instances are incentivized to update their instances on the 1st of the month.

## Why is this change important?

With this commit, the data are up to date by the 1st of the next month.

## How to test this PR locally?

N/A

## Author's checklist

For reference [Firefox Release Calendar](https://wiki.mozilla.org/Release_Management/Calendar):

* 2022-06-28 	Firefox 102
* 2022-07-26 	Firefox 103
* 2022-08-23 	Firefox 104
* 2022-09-20 	Firefox 105 
* 2022-10-18 	Firefox 106
* 2022-11-15 	Firefox 107 
* 2022-12-13 	Firefox 108

## Related issues

<!--
Closes #234
-->
