### PR TITLE
Add rate limiting per engine (using SharedDict)

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -473,6 +473,9 @@ engine is shown.  Most of the options have a default value or even are optional.
      max_connections: 100
      max_keepalive_connections: 10
      keepalive_expiry: 5.0
+     rate_limit:
+        - max_requests: 200
+          interval: 60
      proxies:
        http:
          - http://proxy1:8080
@@ -544,6 +547,15 @@ engine is shown.  Most of the options have a default value or even are optional.
 
   - ``ipv4`` set ``local_addresses`` to ``0.0.0.0`` (use only IPv4 local addresses)
   - ``ipv6`` set ``local_addresses`` to ``::`` (use only IPv6 local addresses)
+
+``rate_limit``: optional
+  Limit how many outgoing requests is SearXNG going to send to the engines.
+  It is a list where each element has:
+
+  - ``max_requests`` is the maximum number of requests that will be sent to this
+    engine per interval.
+  - ``interval`` (optional) is the number of seconds before this engine's rate
+    limiter is reset. Defaults to 1 second if unspecified.
 
 .. note::
 

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -45,6 +45,7 @@ ENGINE_DEFAULT_ARGS = {
     "using_tor_proxy": False,
     "display_error_messages": True,
     "send_accept_language_header": False,
+    "rate_limit": [{"max_requests": float('inf'), "interval": 1}],
     "tokens": [],
     "about": {},
 }

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -45,7 +45,7 @@ ENGINE_DEFAULT_ARGS = {
     "using_tor_proxy": False,
     "display_error_messages": True,
     "send_accept_language_header": False,
-    "rate_limit": [{"max_requests": float('inf'), "interval": 1}],
+    "rate_limit": [{"max_requests": None, "interval": 1}],
     "tokens": [],
     "about": {},
 }

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -98,6 +98,10 @@ class Search:
             if request_params is None:
                 continue
 
+            # stop request if it exceeds engine's rate limit
+            if processor.exceeds_rate_limit():
+                continue
+
             counter_inc('engine', engineref.name, 'search', 'count', 'sent')
 
             # append request to list

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -98,10 +98,6 @@ class Search:
             if request_params is None:
                 continue
 
-            # stop request if it exceeds engine's rate limit
-            if processor.exceeds_rate_limit():
-                continue
-
             counter_inc('engine', engineref.name, 'search', 'count', 'sent')
 
             # append request to list

--- a/searx/shared/__init__.py
+++ b/searx/shared/__init__.py
@@ -11,7 +11,7 @@ try:
     uwsgi = importlib.import_module('uwsgi')
 except:
     # no uwsgi
-    from .shared_simple import SimpleSharedDict as SharedDict, schedule
+    from .shared_simple import SimpleSharedDict as SharedDict, schedule, run_locked
 
     logger.info('Use shared_simple implementation')
 else:
@@ -32,7 +32,7 @@ else:
 
     else:
         # uwsgi
-        from .shared_uwsgi import UwsgiCacheSharedDict as SharedDict, schedule
+        from .shared_uwsgi import UwsgiCacheSharedDict as SharedDict, schedule, run_locked
 
         logger.info('Use shared_uwsgi implementation')
 

--- a/searx/shared/shared_abstract.py
+++ b/searx/shared/shared_abstract.py
@@ -10,7 +10,7 @@ class SharedDict(ABC):
         pass
 
     @abstractmethod
-    def set_int(self, key: str, value: int):
+    def set_int(self, key: str, value: int, expire: Optional[int] = None):
         pass
 
     @abstractmethod
@@ -18,5 +18,5 @@ class SharedDict(ABC):
         pass
 
     @abstractmethod
-    def set_str(self, key: str, value: str):
+    def set_str(self, key: str, value: str, expire: Optional[int] = None):
         pass

--- a/searx/shared/shared_abstract.py
+++ b/searx/shared/shared_abstract.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pyright: strict
+import hmac
 from abc import ABC, abstractmethod
 from typing import Optional
+
+from searx import get_setting
 
 
 class SharedDict(ABC):
@@ -20,3 +23,23 @@ class SharedDict(ABC):
     @abstractmethod
     def set_str(self, key: str, value: str, expire: Optional[int] = None):
         pass
+
+    def incr_counter(self, name: str, limit: int = 0, expire: int = 0) -> int:
+        # generate dict key from name
+        m = hmac.new(bytes(name, encoding='utf-8'), digestmod='sha256')
+        m.update(bytes(get_setting('server.secret_key'), encoding='utf-8'))
+        key = 'SearXNG_counter_' + m.hexdigest()
+
+        # check requests count
+        count = self.get_int(key)
+        if count is None:
+            # initialize counter with expiration time
+            self.set_int(key, 1, expire)
+            return 1
+        elif limit >= count or not limit:
+            # update counter
+            new_count = count + 1
+            self.set_int(key, new_count, expire)
+            return new_count
+        else:
+            return count

--- a/searx/shared/shared_simple.py
+++ b/searx/shared/shared_simple.py
@@ -16,14 +16,28 @@ class SimpleSharedDict(shared_abstract.SharedDict):
     def get_int(self, key: str) -> Optional[int]:
         return self.d.get(key, None)
 
-    def set_int(self, key: str, value: int):
+    def set_int(self, key: str, value: int, expire: Optional[int] = None):
         self.d[key] = value
+        if expire:
+            self._expire(key, expire)
 
     def get_str(self, key: str) -> Optional[str]:
         return self.d.get(key, None)
 
-    def set_str(self, key: str, value: str):
+    def set_str(self, key: str, value: str, expire: Optional[int] = None):
         self.d[key] = value
+        if expire:
+            self._expire(key, expire)
+
+    def _expire(self, key: str, expire: int):
+        t = threading.Timer(expire, lambda k, d: d.pop(k), args=[key, self.d])
+        t.daemon = True
+        t.start()
+
+
+def run_locked(func, *args):
+    # SimpleSharedDict is not actually shared, so no locking needed
+    return func(*args)
 
 
 def schedule(delay, func, *args):


### PR DESCRIPTION
## What does this PR do?

Add a feature that limits how many outgoing requests is SearXNG going to send per engine.

This is a rewrite of #998 using our SharedDict objects instead of Redis.

## Why is this change important?

Some engines are more strict than others when dealing with our traffic. For example, you can throw Wikipedia over a hundred requests per second with no problems, but other engines will throw you a CAPTCHA as soon as you send a few requests in rapid succession *\*cough\*cough\*Google\**.

## How to test this PR locally?

1. In `settings.yml` add the following to any engine:
```yml
  # This would limit that engine to a maximum of 2 requests per minute.
  rate_limit:
    - max_requests: 2
      interval: 60
```
2. Run queries with both the rate limited engine and an engine without the setting.
1. Rate limited engine should stop sending requests after reaching limit and other engines should still work as usual.
1. Engine should be usable again after time interval has passed.
1. This is supposed to work both when running SearXNG locally or when it's running as `uwsgi` threads.

## Author's checklist

I've only tested this locally with very light traffic.

This only works by blocking an engine as a whole, it doesn't block by proxy. I tried to do that, but I couldn't find a way to find out which proxy is being used by our network client before a request. The code that picks which proxy to use is buried too deep down into `httpx` itself.

## Related issues

Rewrite of #998
