### PR TITLE
[fix] version.py: git format '%cs' is not downward compatible

### DIFF
--- a/searx/version.py
+++ b/searx/version.py
@@ -58,7 +58,7 @@ def get_git_url_and_branch():
 
 
 def get_git_version():
-    git_commit_date_hash = subprocess_run(r"git show -s --format='%cs-%h'").replace("-", ".", 2)
+    git_commit_date_hash = subprocess_run(r"git show -s --date='format:%Y.%m.%d' --format='%cd-%h'")
     tag_version = git_version = git_commit_date_hash
 
     # add "-dirty" suffix if there are uncommited changes except searx/settings.yml


### PR DESCRIPTION
## What does this PR do?

Committer date, short format YYYY-MM-DD ('%cs') [1] is not supported by older git
versions.  Instead use '%cd' committer date (format respects --date= option) [2].

[1] https://www.git-scm.com/docs/git-show#Documentation/git-show.txt-emcsem
[2] https://www.git-scm.com/docs/git-show#Documentation/git-show.txt-emcdem

Suggested-by: @ravermeister https://github.com/searxng/searxng/issues/1251#issuecomment-1146282429
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>
