### PR TITLE
Add helm chart for SearXNG

### DIFF
--- a/kubernetes/chart/.helmignore
+++ b/kubernetes/chart/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS
+# helm-docs templates
+*.gotmpl

--- a/kubernetes/chart/Chart.yaml
+++ b/kubernetes/chart/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+appVersion: latest
+description: SearXNG is a free internet metasearch engine which aggregates results from various search services and databases.
+name: searxng
+version: 1.0.0
+kubeVersion: ">=1.16.0-0"
+keywords:
+  - searx
+  - searxng
+  - search engine
+  - privacy
+icon: https://github.com/searxng/searxng/blob/master/searx/static/themes/simple/img/favicon.png?raw=true
+sources:
+  - https://github.com/searxng/searxng
+  - https://docs.searxng.org
+  - https://hub.docker.com/r/searxng/searxng
+maintainers:
+  - name: unixfox
+    email: searxngatunixfoxdoteu
+dependencies:
+  - name: common
+    repository: https://library-charts.k8s-at-home.com
+    version: 4.4.2
+  - name: redis
+    version: 0.0.3
+    repository: https://charts.pascaliske.dev
+    condition: redis.enabled

--- a/kubernetes/chart/README.md
+++ b/kubernetes/chart/README.md
@@ -1,0 +1,83 @@
+# searxng
+
+ SearXNG is a free internet metasearch engine which aggregates results from various search services and databases. Users are neither tracked nor profiled.
+
+## Source Code
+
+* https://github.com/searxng/searxng
+* https://docs.searxng.org
+* https://hub.docker.com/r/searxng/searxng
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Dependencies
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://library-charts.k8s-at-home.com | common | 4.4.2 |
+| https://charts.pascaliske.dev | redis | 0.0.3 |
+
+## Installing the Chart
+
+To install the chart with the release name `searxng`
+
+```console
+git clone https://github.com/searxng/searxng.git
+cd kubernetes/chart
+helm install searxng .
+```
+
+## Uninstalling the Chart
+
+To uninstall the `searx` deployment
+
+```console
+helm uninstall searxng
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install searxng \
+  --set env.TZ="America/New York" \
+    .
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install searxng . -f values.yaml
+```
+
+## Custom configuration
+
+Through the parameter `searxng.config`, you can set the settings in settings.yaml.
+
+The default values are in https://github.com/searxng/searxng/blob/master/searx/settings.yml
+
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| searxng.config | object | See values.yaml | Set parameters for the file `settings.yml` |
+| env.INSTANCE_NAME | string | `"my-instance"` | Your instance name |
+| env.BASE_URL | string | `"http://localhost:8080/"` | The base URL of your instance |
+| env.AUTOCOMPLETE | string | `"false"` | Enable or not the autocomplete by default |
+| redis.enable | bool | `false` | Deploy redis |
+
+## Changelog
+
+### Version 1.1.0
+
+Initial version

--- a/kubernetes/chart/README.md.gotmpl
+++ b/kubernetes/chart/README.md.gotmpl
@@ -1,0 +1,99 @@
+{{- define "custom.repository.organization" -}}
+k8s-at-home
+{{- end -}}
+
+{{- define "custom.repository.url" -}}
+https://github.com/k8s-at-home/charts
+{{- end -}}
+
+{{- define "custom.helm.url" -}}
+https://k8s-at-home.com/charts/
+{{- end -}}
+
+{{- define "custom.helm.path" -}}
+{{ template "custom.repository.organization" . }}/{{ template "chart.name" . }}
+{{- end -}}
+
+{{- define "custom.notes" -}}
+{{- end -}}
+
+{{- define "custom.requirements" -}}
+## Requirements
+
+{{ template "chart.kubeVersionLine" . }}
+{{- end -}}
+
+{{- define "custom.dependencies" -}}
+## Dependencies
+
+{{ template "chart.requirementsTable" . }}
+{{- end -}}
+
+{{- define "custom.install" -}}
+## Installing the Chart
+
+This is a [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm).
+
+**WARNING: THIS CHART IS NOT MEANT TO BE INSTALLED DIRECTLY**
+{{- end -}}
+
+{{- define "custom.usage" -}}
+{{- end -}}
+
+{{- define "custom.configuration.header" -}}
+## Configuration
+{{- end -}}
+
+{{- define "custom.configuration.readValues" -}}
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+{{- end -}}
+
+{{- define "custom.valuesSection" -}}
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+{{ template "chart.valuesTable" . }}
+{{- end -}}
+
+{{- define "custom.support" -}}
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+{{- end -}}
+
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "custom.notes" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "custom.requirements" . }}
+
+{{ template "custom.dependencies" . }}
+
+{{ template "custom.install" . }}
+
+{{ template "custom.usage" . }}
+
+{{ template "custom.configuration.header" . }}
+
+{{ template "custom.configuration.readValues" . }}
+
+{{ template "custom.custom.configuration" . }}
+
+{{ template "custom.valuesSection" . }}
+
+{{ template "custom.changelog" . }}
+
+{{ template "custom.support" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/kubernetes/chart/README_CHANGELOG.md.gotmpl
+++ b/kubernetes/chart/README_CHANGELOG.md.gotmpl
@@ -1,0 +1,29 @@
+{{- define "custom.notes" -}}
+Since a lot of the {{ template "custom.repository.organization" . }} charts follow a similar pattern, this library was built to reduce maintenance cost between the charts that use it and try achieve a goal of being DRY.
+{{- end -}}
+
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+N/A
+{{- end -}}
+
+{{- define "custom.usage" }}
+## Using this library
+
+Include this chart as a dependency in your `Chart.yaml` e.g.
+
+```yaml
+# Chart.yaml
+dependencies:
+- name: common
+  version: 3.0.0
+  repository: {{ template "custom.helm.url" }}
+```
+
+For more information, take a look at the [Docs](http://docs.k8s-at-home.com/our-helm-charts/common-library/).
+{{- end -}}

--- a/kubernetes/chart/README_CONFIG.md.gotmpl
+++ b/kubernetes/chart/README_CONFIG.md.gotmpl
@@ -1,0 +1,14 @@
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+---
+**NOTE**
+
+If you get `Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...` it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
+{{- end -}}

--- a/kubernetes/chart/templates/NOTES.txt
+++ b/kubernetes/chart/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/kubernetes/chart/templates/common.yaml
+++ b/kubernetes/chart/templates/common.yaml
@@ -1,0 +1,17 @@
+{{/* First Make sure all variables are set and merged properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the configMap volume to the volumes */}}
+{{- define "searxng.settingsVolume" -}}
+enabled: "true"
+mountPath: "/etc/searxng/settings.yml"
+subPath: "settings.yml"
+type: "custom"
+volumeSpec:
+  secret:
+    secretName: {{ include "common.names.fullname" . }}-config
+{{- end -}}
+{{- $_ := set .Values.persistence "searxng-config" (include "searxng.settingsVolume" . | fromYaml) -}}
+
+{{/* Render the templates */}}
+{{ include "common.all" . }}

--- a/kubernetes/chart/templates/configmap.yaml
+++ b/kubernetes/chart/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- include "common.values.setup" . -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-config
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  settings.yml: |-
+{{ toYaml .Values.searxng.config | b64enc | indent 4 }}

--- a/kubernetes/chart/values.yaml
+++ b/kubernetes/chart/values.yaml
@@ -1,0 +1,83 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+#
+
+image:
+  # -- image repository
+  repository: searxng/searxng
+  # -- image tag
+  tag: latest
+  # -- image pull policy
+  pullPolicy: Always
+
+# Explanation about each environment variables here:
+# https://docs.searxng.org/admin/installation-docker.html#command-line
+env:
+  INSTANCE_NAME: "my-instance"
+  BASE_URL: "http://localhost:8080/"
+  AUTOCOMPLETE: "false"
+  # MORTY_URL: "http://morty:8080"
+  # MORTY_KEY: "mysecretkey"
+  # BIND_ADDRESS: "0.0.0.0:8080"
+
+controller:
+  strategy: "RollingUpdate"
+
+# -- Configures service settings for the chart.
+# @default -- See values.yaml
+service:
+  main:
+    ports:
+      http:
+        port: 8080
+
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
+persistence:
+  config:
+    enabled: false
+
+ingress:
+  # -- Enable and configure ingress settings for the chart under this key.
+  # @default -- See values.yaml
+  main:
+    enabled: false
+
+searxng:
+  config:
+    use_default_settings: true
+    server:
+      secret_key: pleasechangeme
+    # Uncomment when using the builtin rate limiter
+    # See https://docs.searxng.org/src/searx.plugins.limiter.html#limiter-plugin
+    # server.limiter: true
+    # redis.url: redis://@searxng-redis:6379/0
+
+probes:
+  readiness:
+    custom: true
+    spec:
+      httpGet:
+        path: /healthz
+        port: 8080
+  liveness:
+    custom: true
+    spec:
+      httpGet:
+        path: /healthz
+        port: 8080
+  startup:
+    custom: true
+    spec:
+      httpGet:
+        path: /healthz
+        port: 8080
+
+# Enable when using searxng builtin rate limiter
+# Values: https://github.com/pascaliske/helm-charts/tree/master/charts/redis
+redis:
+  enabled: false
+  


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This adds a helm chart for easily installing SearXNG on Kubernetes.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Make things easy for Kubernetes users.

## How to test this PR locally?

1. Install a Kubernetes cluster. You can use k3s: https://k3s.io/
2. Install Helm: https://helm.sh/docs/intro/install/
3. Install the helm chart by following https://github.com/searxng/searxng/blob/c52fb8a65787e50d0ca7bf0d739d6fd93a5eca12/kubernetes/chart/README.md#installing-the-chart
4. The helm chart should be deployed, you can test it by following the NOTES at the end of the output of the command.

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

The chart is located in kubernetes/chart because it's commonly placed like this in most of the projects that have an helm chart. 

I didn't write any documentation for docs.searxng.org because I'm a bit lazy (and I don't really like reST), but feel free to add a page that points towards the README file of the helm chart.

## Related issues

Closes #1256
