### PR TITLE
[mod] source code url: GIT_URL + '/tree/' + GIT_BRANCH

### DIFF
--- a/searx/infopage/__init__.py
+++ b/searx/infopage/__init__.py
@@ -33,7 +33,7 @@ from markdown_it import MarkdownIt
 
 from .. import get_setting
 from ..compat import cached_property
-from ..version import GIT_URL
+from ..version import GIT_URL, GIT_BRANCH
 from ..locales import LOCALE_NAMES
 
 
@@ -93,7 +93,7 @@ class InfoPage:
             return '[%s](%s)' % (query, url)
 
         ctx = {}
-        ctx['GIT_URL'] = GIT_URL
+        ctx['GIT_URL'] = get_setting('general.git_url_format').format(GIT_URL=GIT_URL, GIT_BRANCH=GIT_BRANCH)
         ctx['get_setting'] = get_setting
         ctx['link'] = _md_link
         ctx['search'] = _md_search

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -3,6 +3,7 @@ general:
   instance_name: "SearXNG"  # displayed name
   contact_url: false        # mailto:contact@example.com
   enable_metrics: true      # record stats
+  git_url_format: "{GIT_URL}/tree/{GIT_BRANCH}"
 
 brand:
   new_issue_url: https://github.com/searxng/searxng/issues/new

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -141,6 +141,7 @@ SCHEMA = {
         'debug': SettingsValue(bool, False, 'SEARXNG_DEBUG'),
         'instance_name': SettingsValue(str, 'SearXNG'),
         'contact_url': SettingsValue((None, False, str), None),
+        'git_url_format': SettingsValue(str, "{GIT_URL}/tree/{GIT_BRANCH}"),
         'enable_metrics': SettingsValue(bool, True),
     },
     'brand': {

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -52,7 +52,7 @@
   <footer>
     <p>
     {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searxng_version }} — {{ _('a privacy-respecting, hackable metasearch engine') }}<br/>
-        <a href="{{ GIT_URL + '/tree/' + GIT_BRANCH }}">{{ _('Source code') }}</a> |
+        <a href="{{ git_url_format.format(GIT_URL=GIT_URL, GIT_BRANCH=GIT_BRANCH) }}">{{ _('Source code') }}</a> |
         <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a> |
         <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a> |
         <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>{% if get_setting('general.contact_url') %} |

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="description" content="SearXNG — a privacy-respecting, hackable metasearch engine">
   <meta name="keywords" content="SearXNG, search, search engine, metasearch, meta search">
-  <meta name="generator" content="searxng/{{ searx_version }}">
+  <meta name="generator" content="searxng/{{ searxng_version }}">
   <meta name="referrer" content="no-referrer">
   <meta name="robots" content="noarchive">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -51,8 +51,8 @@
   </main>
   <footer>
     <p>
-    {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searx_version }} — {{ _('a privacy-respecting, hackable metasearch engine') }}<br/>
-        <a href="{{ searx_git_url }}">{{ _('Source code') }}</a> |
+    {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searxng_version }} — {{ _('a privacy-respecting, hackable metasearch engine') }}<br/>
+        <a href="{{ GIT_URL + '/tree/' + GIT_BRANCH }}">{{ _('Source code') }}</a> |
         <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a> |
         <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a> |
         <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>{% if get_setting('general.contact_url') %} |

--- a/searx/templates/simple/new_issue.html
+++ b/searx/templates/simple/new_issue.html
@@ -6,10 +6,10 @@
     <textarea name="body" class="issue-hide">{{- '' -}}
 
 **Version of SearXNG, commit number if you are using on master branch and stipulate if you forked SearXNG**
-{% if searx_git_url and searx_git_url != 'unknow' %}
-Repository: {{ searx_git_url }}
-Branch: {{ searx_git_branch }}
-Version: {{ searx_version }}
+{% if GIT_URL and GIT_URL != 'unknow' %}
+Repository: {{ GIT_URL }}
+Branch: {{ GIT_BRANCH }}
+Version: {{ searxng_version }}
 <!-- Check if these values are correct -->
 
 {% else %}

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -61,8 +61,8 @@ _NOTSET = _NotSetClass()
 
 def searx_useragent() -> str:
     """Return the searx User Agent"""
-    return 'searx/{searx_version} {suffix}'.format(
-        searx_version=VERSION_TAG, suffix=settings['outgoing']['useragent_suffix']
+    return 'searx/{searxng_version} {suffix}'.format(
+        searxng_version=VERSION_TAG, suffix=settings['outgoing']['useragent_suffix']
     ).strip()
 
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -448,8 +448,9 @@ def render(template_name: str, **kwargs):
     # values from settings
     kwargs['search_formats'] = [x for x in settings['search']['formats'] if x != 'html']
     kwargs['instance_name'] = get_setting('general.instance_name')
-    kwargs['searx_version'] = VERSION_STRING
-    kwargs['searx_git_url'] = GIT_URL
+    kwargs['searxng_version'] = VERSION_STRING
+    kwargs['GIT_URL'] = GIT_URL
+    kwargs['GIT_BRANCH'] = GIT_BRANCH  # url: GIT_URL + '/tree/' + GIT_BRANCH
     kwargs['get_setting'] = get_setting
     kwargs['get_pretty_url'] = get_pretty_url
 
@@ -1241,7 +1242,6 @@ def stats():
         engine_stats = engine_stats,
         engine_reliabilities = engine_reliabilities,
         selected_engine_name = selected_engine_name,
-        searx_git_branch = GIT_BRANCH,
         # fmt: on
     )
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -450,7 +450,8 @@ def render(template_name: str, **kwargs):
     kwargs['instance_name'] = get_setting('general.instance_name')
     kwargs['searxng_version'] = VERSION_STRING
     kwargs['GIT_URL'] = GIT_URL
-    kwargs['GIT_BRANCH'] = GIT_BRANCH  # url: GIT_URL + '/tree/' + GIT_BRANCH
+    kwargs['GIT_BRANCH'] = GIT_BRANCH
+    kwargs['git_url_format'] = get_setting('general.git_url_format')
     kwargs['get_setting'] = get_setting
     kwargs['get_pretty_url'] = get_pretty_url
 


### PR DESCRIPTION
The link 'Source code' in the footer should link to the branch URL:

    GIT_URL + '/tree/' + GIT_BRANCH

This URL fits at least for github and gitlab.

BTW clear the naming and replace:

- `searx_git_url` and `searx_git_branch` by `GIT_URL` and `GIT_BRANCH`
- `searx_version` by `searxng_version`

----

To test create a clone of this PR:

```
$ cd /tmp
$ git clone https://github.com/return42/searxng/
$ cd searxng/
$ git checkout git-url-branch
$ make buildenv
$ git diff
```

```diff
diff --git a/utils/brand.env b/utils/brand.env
index 31afce53..6fd66ebe 100644
--- a/utils/brand.env
+++ b/utils/brand.env
@@ -1,5 +1,5 @@
 export SEARXNG_URL=''
 export SEARXNG_PORT='8888'
 export SEARXNG_BIND_ADDRESS='127.0.0.1'
-export GIT_URL='https://github.com/searxng/searxng'
-export GIT_BRANCH='master'
+export GIT_URL='https://github.com/return42/searxng/'
+export GIT_BRANCH='git-url-branch'
```

```
make run
```

The source code link in the footer should link to this branch https://github.com/return42/searxng/tree/git-url-branch