### PR TITLE
[enh] Add yep.com via json_engine

### DIFF
--- a/searx/engines/json_engine.py
+++ b/searx/engines/json_engine.py
@@ -16,6 +16,11 @@ paging = False
 suggestion_query = ''
 results_query = ''
 
+cookies = {}
+headers = {}
+'''Some engines might offer different result based on cookies or headers.
+Possible use-case: To set safesearch cookie or header to moderate.'''
+
 # parameters for engines with paging support
 #
 # number of results on each page
@@ -87,6 +92,9 @@ def request(query, params):
     fp = {'query': query}
     if paging and search_url.find('{pageno}') >= 0:
         fp['pageno'] = (params['pageno'] - 1) * page_size + first_page_num
+
+    params['cookies'].update(cookies)
+    params['headers'].update(headers)
 
     params['url'] = search_url.format(**fp)
     params['query'] = query

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -402,6 +402,30 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name: yep
+    engine: json_engine
+    shortcut: yep
+    categories: general
+    disabled: true
+    paging: false
+    page_size: 10
+    content_html_to_text: true
+    title_html_to_text: true
+    search_url: https://api.yep.com/fs/1/?type=web&q={query}&no_correct=false
+    results_query: 1/results
+    title_query: title
+    url_query: url
+    content_query: snippet
+    timeout: 12.0
+    headers:
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
+      'Sec-Fetch-Dest': 'document'
+    about:
+      website: https://yep.com
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
   - name: currency
     engine: currency_convert
     categories: general


### PR DESCRIPTION
## What does this PR do?
Add no paging support for Yep.com
Allow passing cookies/headers from ```settings.yml``` to ```engines/json_engine.py```.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
Engine could have the second largest index rn.

[1] https://ahrefs.com/robot
[2] https://www.incapsula.com/blog/most-active-good-bots.html
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->
Do a search with it, like so:

```!yep test```
## Author's checklist
GH GUI is junky.
<!-- additional notes for reviewiers -->

## Related issues
N/A
<!--
Closes #234
-->
