### PR TITLE
add "warn" message to notify the admin that use_mobile_ui parameter exist

### DIFF
--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -162,6 +162,8 @@ class OnlineProcessor(EngineProcessor):
             self.handle_exception(result_container, e, suspend=True)
             self.logger.exception('CAPTCHA')
         except SearxEngineTooManyRequestsException as e:
+            if "google" in self.engine_name:
+                self.logger.warn("We recommend enabling the use_mobile_ui parameter if google is blocked for you.")
             self.handle_exception(result_container, e, suspend=True)
             self.logger.exception('Too many requests')
         except SearxEngineAccessDeniedException as e:


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This notifies the user of the existence of the `use_mobile_ui` parameter.

## Why is this change important?

Too many people don't know about this parameter.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

1. Run searx on a server where google is blocked (usually servers in datacenters).
2. Expect the message help message in the logs.

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related https://github.com/searxng/searxng/issues/774#issuecomment-1152284014
