### PR TITLE
Autocomplete: don't suggest the current query.

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -909,7 +909,8 @@ def autocompleter():
         for result in raw_results:
             # attention: this loop will change raw_text_query object and this is
             # the reason why the sug_prefix was stored before (see above)
-            results.append(raw_text_query.changeQuery(result).getFullQuery())
+            if result != sug_prefix:
+                results.append(raw_text_query.changeQuery(result).getFullQuery())
 
     if len(raw_text_query.autocomplete_list) > 0:
         for autocomplete_text in raw_text_query.autocomplete_list:


### PR DESCRIPTION
## What does this PR do?

Example of minor issue before this commit:
the autocompletion can suggest "Test" if the query is "Test".

## Why is this change important?

Remove an useless choice from the autocompletion.

## How to test this PR locally?

* enable google autocompletion
* type `test`: the autocompletion list should not contain a `test` item (as it is now the case).

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
