### PR TITLE
[doc] fix some leftovers from ad964562c

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,6 +135,7 @@ suppress_warnings = ['myst.domains']
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "flask": ("https://flask.palletsprojects.com/", None),
+    "flask_babel": ("https://flask-babel.tkte.ch/", None),
     # "werkzeug": ("https://werkzeug.palletsprojects.com/", None),
     "jinja": ("https://jinja.palletsprojects.com/", None),
     "linuxdoc" : ("https://return42.github.io/linuxdoc/", None),

--- a/searx/locales.py
+++ b/searx/locales.py
@@ -72,7 +72,7 @@ def localeselector():
 
 
 def get_translations():
-    """Monkey patch of flask_babel.get_translations"""
+    """Monkey patch of :py:obj:`flask_babel.get_translations`"""
     if has_request_context() and flask.request.form.get('use-translation') == 'oc':
         babel_ext = flask_babel.current_app.extensions['babel']
         return Translations.load(next(babel_ext.translation_directories), 'oc')
@@ -117,7 +117,7 @@ def _get_locale_descr(locale, language_code):
 def locales_initialize(directory=None):
     """Initialize locales environment of the SearXNG session.
 
-    - monkey patch :py:obj:`flask_babel.get_translations` by :obj:py:`get_translations`
+    - monkey patch :py:obj:`flask_babel.get_translations` by :py:obj:`get_translations`
     - init global names :py:obj:`LOCALE_NAMES`, :py:obj:`RTL_LOCALES`
     """
 

--- a/searxng_extra/docs_prebuild
+++ b/searxng_extra/docs_prebuild
@@ -9,7 +9,7 @@ import sys
 import os.path
 import time
 from contextlib import contextmanager
-from searx import settings, get_setting
+from searx import settings, get_setting, locales
 from searx.infopage import InfoPageSet, InfoPage
 
 
@@ -17,6 +17,7 @@ _doc_user = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'docs'
 
 
 def main():
+    locales.locales_initialize()
     base_url = get_setting('server.base_url', None)
     if base_url:
         infopageset_ctx = _instance_infosetset_ctx(base_url)


### PR DESCRIPTION
fixes:

```
$ make docs.clean docs.live 
...
Traceback (most recent call last):
  File "searxng_extra/docs_prebuild", line 84, in <module>
    sys.exit(main())
  File "searxng_extra/docs_prebuild", line 28, in main
    fname = os.path.join(_doc_user, os.path.basename(page.fname))
AttributeError: 'NoneType' object has no attribute 'fname'
ERROR: docs.prebuild exit with error (1)
...
WARNING: unknown directive or role name: obj:py
/800GBPCIex4/share/SearXNG/searx/locales.py:docstring of searx.locales.locales_initialize:3: ERROR: Unknown interpreted text role "obj:py".
```
