### PR TITLE
add pub.dev engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1091,6 +1091,26 @@ engines:
   #    query_str: 'SELECT * from my_table WHERE my_column = %(query)s'
   #    shortcut : psql
 
+  - name: pub.dev
+    engine: xpath
+    shortcut: pd
+    search_url: https://pub.dev/packages?q={query}&page={pageno}
+    paging: true
+    results_xpath: /html/body/main/div/div[@class="search-results"]/div[@class="packages"]/div
+    url_xpath: ./div/h3/a/@href
+    title_xpath: ./div/h3/a
+    content_xpath: ./p[@class="packages-description"]
+    categories: [packages, it]
+    timeout: 3.0
+    disabled: true
+    first_page_num: 1
+    about:
+      website: https://pub.dev/
+      official_api_documentation: https://pub.dev/help/api
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name: pubmed
     engine: pubmed
     shortcut: pub


### PR DESCRIPTION
## What does this PR do?

add the pub.dev engine

## Why is this change important?

imo this would be convenient for flutter/dart users so they can search for packages directly

## How to test this PR locally?

search `!dart test`
___
(I moved this from searx, sorry if I'm bothering you)