### PR TITLE
[fix] test.yamllint: return non-zero exit code on warnings

### DIFF
--- a/manage
+++ b/manage
@@ -661,7 +661,8 @@ format.python() {
 
 test.yamllint() {
     build_msg TEST "[yamllint] \$YAMLLINT_FILES"
-    pyenv.cmd yamllint --format parsable "${YAMLLINT_FILES[@]}"
+    pyenv.cmd yamllint --strict --format parsable "${YAMLLINT_FILES[@]}"
+    dump_return $?
 }
 
 test.pylint() {


### PR DESCRIPTION
SearXNG's YAML files should be free of any warnings. This will stop the test
when there are warnings like::

     [warning] truthy value should be one of [false, true] (truthy)
