### PR TITLE
Add privacypolicy_url option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -163,3 +163,4 @@ features or generally made searx better:
 - @xenrox
 - @OliveiraHermogenes
 - Paul Alcock @Guilvareux
+- Sam A. `<https://samsapti.dev>`_

--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -72,11 +72,15 @@ Global Settings
    general:
      debug: false               # Debug mode, only for development
      instance_name:  "SearXNG"  # displayed name
+     privacypolicy_url: false   # https://example.com/privacy
      contact_url: false         # mailto:contact@example.com
 
 ``debug`` : ``$SEARXNG_DEBUG``
   Allow a more detailed log if you run SearXNG directly. Display *detailed* error
   messages in the browser too, so this must be deactivated in production.
+
+``privacypolicy_url``:
+  Link to privacy policy.
 
 ``contact_url``:
   Contact ``mailto:`` address or WEB form.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ SEARXNG_URL = get_setting('server.base_url') or 'https://example.org/searxng'
 ISSUE_URL = get_setting('brand.issue_url')
 DOCS_URL = get_setting('brand.docs_url')
 PUBLIC_INSTANCES = get_setting('brand.public_instances')
+PRIVACYPOLICY_URL = get_setting('general.privacypolicy_url')
 CONTACT_URL = get_setting('general.contact_url')
 WIKI_URL = get_setting('brand.wiki_url')
 
@@ -172,6 +173,8 @@ if PUBLIC_INSTANCES:
     html_context["project_links"].append(ProjectLink("Public instances", PUBLIC_INSTANCES))
 if ISSUE_URL:
     html_context["project_links"].append(ProjectLink("Issue Tracker", ISSUE_URL))
+if PRIVACYPOLICY_URL:
+    html_context["project_links"].append(ProjectLink("Privacy Policy", PRIVACYPOLICY_URL))
 if CONTACT_URL:
     html_context["project_links"].append(ProjectLink("Contact", CONTACT_URL))
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1,6 +1,7 @@
 general:
   debug: false              # Debug mode, only for development
   instance_name: "SearXNG"  # displayed name
+  privacypolicy_url: false  # https://example.com/privacy
   contact_url: false        # mailto:contact@example.com
   enable_metrics: true      # record stats
 

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -140,6 +140,7 @@ SCHEMA = {
     'general': {
         'debug': SettingsValue(bool, False, 'SEARXNG_DEBUG'),
         'instance_name': SettingsValue(str, 'SearXNG'),
+        'privacypolicy_url': SettingsValue((None, False, str), None),
         'contact_url': SettingsValue((None, False, str), None),
         'enable_metrics': SettingsValue(bool, True),
     },

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -55,8 +55,13 @@
         <a href="{{ searx_git_url }}">{{ _('Source code') }}</a> |
         <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a> |
         <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a> |
-        <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>{% if get_setting('general.contact_url') %} |
-        <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact instance maintainer') }}</a>{% endif %}
+        <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>
+        {% if get_setting('general.privacypolicy_url') %}
+        | <a href="{{ get_setting('general.privacypolicy_url') }}">{{ _('Privacy policy') }}</a>
+        {% endif %}
+        {% if get_setting('general.contact_url') %}
+        | <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact instance maintainer') }}</a>
+        {% endif %}
     </p>
   </footer>
   <!--[if gte IE 9]>-->

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1355,6 +1355,7 @@ def config():
             'default_theme': settings['ui']['default_theme'],
             'version': VERSION_STRING,
             'brand': {
+                'PRIVACYPOLICY_URL': get_setting('general.privacypolicy_url'),
                 'CONTACT_URL': get_setting('general.contact_url'),
                 'GIT_URL': GIT_URL,
                 'GIT_BRANCH': GIT_BRANCH,


### PR DESCRIPTION
## What does this PR do?

This PR adds a `privacypolicy_url` option to `settings.yml`. It allows the instance maintainer to optionally link to a privacy policy for their instance.

## Why is this change important?

It is important for the end user to know about the particular instance's data practices.

## How to test this PR locally?

By changing the `general.privacypolicy_url` setting.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes none, but related to #1285.