### PR TITLE
Fix: use sys.modules.copy() to avoid RuntimeError

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -149,7 +149,11 @@ def set_loggers(engine, engine_name):
     engine.logger = logger.getChild(engine_name)
     # the engine may have load some other engines
     # may sure the logger is initialized
-    for module_name, module in sys.modules.items():
+    # use sys.modules.copy() to avoid "RuntimeError: dictionary changed size during iteration"
+    # see https://github.com/python/cpython/issues/89516
+    # and https://docs.python.org/3.10/library/sys.html#sys.modules
+    modules = sys.modules.copy()
+    for module_name, module in modules.items():
         if (
             module_name.startswith("searx.engines")
             and module_name != "searx.engines.__init__"


### PR DESCRIPTION
## What does this PR do?

use sys.modules.copy() to avoid "RuntimeError: dictionary changed size during iteration"
see https://github.com/python/cpython/issues/89516
and https://docs.python.org/3.10/library/sys.html#sys.modules

The documentation suggests two ways to copy the dictionary: `.copy()` and `tuple(...)`.
I choose `.copy()` because `tuple(...)` could be overlooked.

## Why is this change important?

Avoid crash when the server stats

## How to test this PR locally?

??

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

close https://github.com/searxng/searxng/issues/1342