### PR TITLE
Workaround: index.html: remove image preload

### DIFF
--- a/searx/templates/simple/index.html
+++ b/searx/templates/simple/index.html
@@ -1,8 +1,5 @@
 {% extends "simple/base.html" %}
 {% from 'simple/icons.html' import icon_big %}
-{% block meta %}
-	<link rel="preload" href="{{ url_for('static', filename='img/searxng.png') }}" as="image" />
-{% endblock %}
 {% block content %}
 <div class="index">
     <div class="title"><h1>SearXNG</h1></div>


### PR DESCRIPTION
## What does this PR do?

URL for the logo is referenced twice:
* in index.html for preloading: it contains the hash for cache busting (when there is `static_use_hash: true` in `settings.yml`)
* in searxng.min.css: to actually display the image. The URL doesn't contain the hash.

So the image preload actually loads twice the same image.

This commit removed the image preloading.
This is workaround: the real fix is to be able to use the URL with the hash in the CSS.

## Why is this change important?

When there is `static_use_hash: true` in `settings.yml`, the logo is loaded twice.

## How to test this PR locally?

* set `static_use_hash: true`
* check the logo is loaded only once.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to https://github.com/searxng/searxng/issues/1326
