### PR TITLE
[fix] clean up templates / remove import of result_footer_rtl macro

### DIFF
--- a/searx/templates/simple/result_templates/code.html
+++ b/searx/templates/simple/result_templates/code.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_footer_rtl with context %}
+{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer with context %}
 
 {{ result_header(result, favicons, image_proxify) -}}
 {{- result_sub_header(result) -}}

--- a/searx/templates/simple/result_templates/default.html
+++ b/searx/templates/simple/result_templates/default.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_footer_rtl with context %}
+{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer with context %}
 
 {{ result_header(result, favicons, image_proxify) -}}
 {{- result_sub_header(result) -}}

--- a/searx/templates/simple/result_templates/map.html
+++ b/searx/templates/simple/result_templates/map.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_footer_rtl with context %}
+{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer with context %}
 {% from 'simple/icons.html' import icon_small %}
 
 {{ result_header(result, favicons, image_proxify) -}}

--- a/searx/templates/simple/result_templates/products.html
+++ b/searx/templates/simple/result_templates/products.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_footer_rtl with context %}
+{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer with context %}
 
 {{ result_header(result, favicons, image_proxify) -}}
 {{- result_sub_header(result) -}}

--- a/searx/templates/simple/result_templates/torrent.html
+++ b/searx/templates/simple/result_templates/torrent.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_footer_rtl, result_link with context %}
+{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_link with context %}
 
 {{ result_header(result, favicons, image_proxify) -}}
 {{- result_sub_header(result) -}}

--- a/searx/templates/simple/result_templates/videos.html
+++ b/searx/templates/simple/result_templates/videos.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_footer_rtl with context %}
+{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer with context %}
 
 {{ result_header(result, favicons, image_proxify) }}
 {{ result_sub_header(result) }}


### PR DESCRIPTION
A macro named 'result_footer_rtl' does not exists.
