### PR TITLE
Add curlie.org engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -426,6 +426,26 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name: curlie
+    engine: xpath
+    shortcut: cl
+    categories: general
+    disabled: true
+    paging: true
+    lang_all: ''
+    search_url: https://curlie.org/search?q={query}&lang={lang}&start={pageno}&stime=92452189
+    page_size: 20
+    results_xpath: //div[@id="site-list-content"]/div[@class="site-item"]
+    url_xpath: ./div[@class="title-and-desc"]/a/@href
+    title_xpath: ./div[@class="title-and-desc"]/a/div
+    content_xpath: ./div[@class="title-and-desc"]/div[@class="site-descr"]
+    about:
+      website: https://curlie.org/
+      wikidata_id: Q60715723
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name: currency
     engine: currency_convert
     categories: general


### PR DESCRIPTION
## What does this PR do?

Adds the curlie.org engine using xpath

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

I think most web search engines that searx has uses a crawler, while curlie.org is human-edited

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

search `!cl test`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes #1190