### PR TITLE
[doc] intersphinx: fix https://python-babel.github.io/flask-babel

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,7 +136,7 @@ suppress_warnings = ['myst.domains']
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "flask": ("https://flask.palletsprojects.com/", None),
-    "flask_babel": ("https://flask-babel.tkte.ch/", None),
+    "flask_babel": ("https://python-babel.github.io/flask-babel/", None),
     # "werkzeug": ("https://werkzeug.palletsprojects.com/", None),
     "jinja": ("https://jinja.palletsprojects.com/", None),
     "linuxdoc" : ("https://return42.github.io/linuxdoc/", None),


### PR DESCRIPTION
The URL https://flask-babel.tkte.ch/ is no longer valid [1].

[1] https://github.com/python-babel/flask-babel/commit/0847cc6284
