### PR TITLE
Dockerfile: use alpine 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 ENTRYPOINT ["/sbin/tini","--","/usr/local/searxng/dockerfiles/docker-entrypoint.sh"]
 EXPOSE 8080
 VOLUME /etc/searx


### PR DESCRIPTION
## What does this PR do?

* Use Alpine 3.16 : https://www.alpinelinux.org/posts/Alpine-3.16.0-released.html
* Use Python 3.10 instead of 3.9 currently in Alpine 3.15

## Why is this change important?

Up to date dependency

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

After some tests locally, it doesn't show any issues.

## Related issues

<!--
Closes #234
-->
