### PR TITLE
Move donation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,3 +137,9 @@ https://weblate.bubu1.eu/projects/searxng/searxng/
 
 .. figure:: https://weblate.bubu1.eu/widgets/searxng/-/multi-auto.svg
    :target: https://weblate.bubu1.eu/projects/searxng/
+
+
+Make a donation
+===============
+
+Follow the `donate <https://docs.searxng.org/donate.html>`_ link.

--- a/README.rst
+++ b/README.rst
@@ -142,4 +142,4 @@ https://weblate.bubu1.eu/projects/searxng/searxng/
 Make a donation
 ===============
 
-Follow the `donate <https://docs.searxng.org/donate.html>`_ link.
+You can support the SearXNG project by clicking on the donation page: `https://docs.searxng.org/donate.html <https://docs.searxng.org/donate.html>`_

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -1,0 +1,40 @@
+Donate to searxng.org
+=====================
+
+Why donating?
+-------------
+
+If you want to support the SearXNG team you can make a donation.
+
+This will help us to pay the costs for:
+
+- the two VPS servers for searx.space
+- the domain names (searxng.org and searx.space)
+- the protonmail account
+
+If there is enough fund we can ask for a security audit or pay an UX designer.
+
+Payment methods
+---------------
+
+-  Credit/debit card and bank transfer
+
+   -  `Liberapay`_ (recurrent donation)
+   -  `Buy Me a Coffee`_ (one time donation)
+
+-  Cryptocurrency
+
+   -  Bitcoin: `bc1qn3rw8t86h05cs3grx2kmwmptw9k4kt4hyzktqj`_ (Segwit
+      compatible)
+   -  Bitcoin cash: `qpead2yu482e3h9amy5zk45l8qrfhk59jcpw3cth9e`_
+   -  Ethereum: `0xCf82c7eb915Ee70b5B69C1bBB5525e157F35FA43`_
+   -  Dogecoin: `DBCYS9issTt84pddXSsTHpQxyQDTFp1TE4`_
+   -  Litecoin: `ltc1q5j6x6f4f2htldhq570e353clc8fmw44ra5er5q`_
+
+.. _Liberapay: https://liberapay.com/SearXNG/
+.. _Buy Me a Coffee: https://buymeacoffee.com/searxng
+.. _bc1qn3rw8t86h05cs3grx2kmwmptw9k4kt4hyzktqj: bitcoin:bc1qn3rw8t86h05cs3grx2kmwmptw9k4kt4hyzktqj
+.. _qpead2yu482e3h9amy5zk45l8qrfhk59jcpw3cth9e: bitcoincash:qpead2yu482e3h9amy5zk45l8qrfhk59jcpw3cth9e
+.. _0xCf82c7eb915Ee70b5B69C1bBB5525e157F35FA43: ethereum:0xCf82c7eb915Ee70b5B69C1bBB5525e157F35FA43
+.. _DBCYS9issTt84pddXSsTHpQxyQDTFp1TE4: dogecoin:DBCYS9issTt84pddXSsTHpQxyQDTFp1TE4
+.. _ltc1q5j6x6f4f2htldhq570e353clc8fmw44ra5er5q: litecoin:ltc1q5j6x6f4f2htldhq570e353clc8fmw44ra5er5q

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -12,7 +12,7 @@ This will help us to pay the costs for:
 - the domain names (searxng.org and searx.space)
 - the protonmail account
 
-If there is enough fund we can ask for a security audit or pay an UX designer.
+If there is enough fund we can ask for a security audit or pay an User Experience (UX) designer.
 
 Payment methods
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,5 +36,6 @@ If you don't trust anyone, you can set up your own, see :ref:`installation`.
    dev/index
    utils/index
    src/index
+   donate
 
 .. _searx.space: https://searx.space

--- a/searx/infopage/__init__.py
+++ b/searx/infopage/__init__.py
@@ -157,10 +157,9 @@ class InfoPageSet:  # pylint: disable=too-few-public-methods
             return None
 
         cache_key = (pagename, locale)
-        page = self.CACHE.get(cache_key)
 
-        if page is not None:
-            return page
+        if cache_key in self.CACHE:
+            return self.CACHE[cache_key]
 
         # not yet instantiated
 
@@ -183,4 +182,6 @@ class InfoPageSet:  # pylint: disable=too-few-public-methods
             if fallback_to_default and page is None:
                 page_locale = self.locale_default
                 page = self.get_page(page_name, self.locale_default)
-            yield page_name, page_locale, page
+            if page is not None:
+                # page is None if the page was deleted by the administrator
+                yield page_name, page_locale, page

--- a/searx/infopage/en/donate.md
+++ b/searx/infopage/en/donate.md
@@ -1,3 +1,3 @@
 # Donate to searxng.org
 
-You can support the developpers of SearXNG following this [link](https://docs.searxng.org/donate.html)
+You can support the SearXNG project by clicking on the donation page: [https://docs.searxng.org/donate.html](https://docs.searxng.org/donate.html)

--- a/searx/infopage/en/donate.md
+++ b/searx/infopage/en/donate.md
@@ -1,20 +1,3 @@
-# Donate to SearXNG
+# Donate to searxng.org
 
-* Credit/debit card and bank transfer
-    * [Liberapay] (recurrent donation)
-    * [Buy Me a Coffee] (one time donation)
-
-* Cryptocurrency
-    * Bitcoin: [bc1qn3rw8t86h05cs3grx2kmwmptw9k4kt4hyzktqj] (Segwit compatible)
-    * Bitcoin cash: [qpead2yu482e3h9amy5zk45l8qrfhk59jcpw3cth9e]
-    * Ethereum: [0xCf82c7eb915Ee70b5B69C1bBB5525e157F35FA43]
-    * Dogecoin: [DBCYS9issTt84pddXSsTHpQxyQDTFp1TE4]
-    * Litecoin: [ltc1q5j6x6f4f2htldhq570e353clc8fmw44ra5er5q]
-
-[Liberapay]: https://liberapay.com/SearXNG/
-[Buy Me a Coffee]: https://buymeacoffee.com/searxng
-[bc1qn3rw8t86h05cs3grx2kmwmptw9k4kt4hyzktqj]: bitcoin:bc1qn3rw8t86h05cs3grx2kmwmptw9k4kt4hyzktqj
-[qpead2yu482e3h9amy5zk45l8qrfhk59jcpw3cth9e]: bitcoincash:qpead2yu482e3h9amy5zk45l8qrfhk59jcpw3cth9e
-[0xCf82c7eb915Ee70b5B69C1bBB5525e157F35FA43]: ethereum:0xCf82c7eb915Ee70b5B69C1bBB5525e157F35FA43
-[DBCYS9issTt84pddXSsTHpQxyQDTFp1TE4]: dogecoin:DBCYS9issTt84pddXSsTHpQxyQDTFp1TE4
-[ltc1q5j6x6f4f2htldhq570e353clc8fmw44ra5er5q]: litecoin:ltc1q5j6x6f4f2htldhq570e353clc8fmw44ra5er5q
+You can support the developpers of SearXNG following this [link](https://docs.searxng.org/donate.html)


### PR DESCRIPTION
## What does this PR do?

* The first commit allows an administrator to delete donate.md (or any .md file) without crashing the application. Note: the "Donate" link on the top right corner will still be there.
* The second commit implement the request from  #1378 (README.rst contains a link to the new donate.html page)

## Why is this change important?

In master branch, donate.md creates a confusion: the user don't know who is supported, the instance administrator or the SearXNG developpers.

## How to test this PR locally?

* `make docs.live`
* `make run`: 
  * follow the donate link.
  * delete `donate.md`, see there is no crash (only a 404 page).

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #1378
