### PR TITLE
openstreetmap: localized results.

### DIFF
--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -29,6 +29,7 @@ about = {
 # engine dependent config
 categories = ['map']
 paging = False
+language_support = True
 
 # search-url
 base_url = 'https://nominatim.openstreetmap.org/'
@@ -141,6 +142,9 @@ def request(query, params):
     params['url'] = base_url + search_string.format(query=urlencode({'q': query}))
     params['route'] = route_re.match(query)
     params['headers']['User-Agent'] = searx_useragent()
+
+    accept_language = 'en' if params['language'] == 'all' else params['language']
+    params['headers']['Accept-Language'] = accept_language
     return params
 
 
@@ -223,7 +227,7 @@ def fetch_wikidata(nominatim_json, user_langage):
                 wd_to_results.setdefault(wd_id, []).append(result)
 
     if wikidata_ids:
-        user_langage = 'en' if user_langage == 'all' else user_langage
+        user_langage = 'en' if user_langage == 'all' else user_langage.split('-')[0]
         wikidata_ids_str = " ".join(wikidata_ids)
         query = wikidata_image_sparql.replace('%WIKIDATA_IDS%', sparql_string_escape(wikidata_ids_str)).replace(
             '%LANGUAGE%', sparql_string_escape(user_langage)

--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -206,7 +206,7 @@ def get_wikipedia_image(raw_value):
     return get_external_url('wikimedia_image', raw_value)
 
 
-def fetch_wikidata(nominatim_json, user_langage):
+def fetch_wikidata(nominatim_json, user_language):
     """Update nominatim_json using the result of an unique to wikidata
 
     For result in nominatim_json:
@@ -227,10 +227,10 @@ def fetch_wikidata(nominatim_json, user_langage):
                 wd_to_results.setdefault(wd_id, []).append(result)
 
     if wikidata_ids:
-        user_langage = 'en' if user_langage == 'all' else user_langage.split('-')[0]
+        user_language = 'en' if user_language == 'all' else user_language.split('-')[0]
         wikidata_ids_str = " ".join(wikidata_ids)
         query = wikidata_image_sparql.replace('%WIKIDATA_IDS%', sparql_string_escape(wikidata_ids_str)).replace(
-            '%LANGUAGE%', sparql_string_escape(user_langage)
+            '%LANGUAGE%', sparql_string_escape(user_language)
         )
         wikidata_json = send_wikidata_query(query)
         for wd_result in wikidata_json.get('results', {}).get('bindings', {}):
@@ -245,7 +245,7 @@ def fetch_wikidata(nominatim_json, user_langage):
                 # overwrite wikipedia link
                 wikipedia_name = wd_result.get('wikipediaName', {}).get('value')
                 if wikipedia_name:
-                    result['extratags']['wikipedia'] = user_langage + ':' + wikipedia_name
+                    result['extratags']['wikipedia'] = user_language + ':' + wikipedia_name
                 # get website if not already defined
                 website = wd_result.get('website', {}).get('value')
                 if (

--- a/searx/templates/simple/result_templates/map.html
+++ b/searx/templates/simple/result_templates/map.html
@@ -35,7 +35,7 @@
     <tr><th scope="row">{{ info.label }}</th><td>{{ info.value|safe }}</td></tr>
     {%- endfor -%}
     {%- for link in result.links -%}
-    <tr><th scope="row">{{ link.label }}</th><td><a class="text-info cursor-pointer" href="{{ link.url }}">{{ link.url|safe }}</a></td></tr>
+    <tr><th scope="row">{{ link.label }}</th><td><a class="text-info cursor-pointer" href="{{ link.url }}">{{ link.url_label|safe }}</a></td></tr>
     {%- endfor -%}
 </table>
 


### PR DESCRIPTION
## What does this PR do?

Master branch:
![image](https://user-images.githubusercontent.com/1594191/176507950-f97034fd-5c58-4193-ab13-0e406aa7cf9f.png)

This PR:
![image](https://user-images.githubusercontent.com/1594191/176508002-b065e3d0-b3b5-4acd-82a7-229453219b8c.png)

* The results are the language the user has selected (English if the query language is English and if there is an English name, otherwise it falls back to the native name)
* HTML template: the wikidata & wikipedia links contains only the titles not the full link.

## Why is this change important?

Improve the usuability

## How to test this PR locally?

* search for `!osm seoul`
* Note: I'm not sure about the traditional Chinese if well supported.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
