### PR TITLE
Donation link: default value to searxng.org, can be hidden or custom

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -70,14 +70,22 @@ Global Settings
 .. code:: yaml
 
    general:
-     debug: false               # Debug mode, only for development
-     instance_name:  "SearXNG"  # displayed name
-     privacypolicy_url: false   # https://example.com/privacy
-     contact_url: false         # mailto:contact@example.com
+     debug: false
+     instance_name:  "SearXNG"
+     privacypolicy_url: false
+     donation_url: https://docs.searxng.org/donate.html
+     contact_url: false
+     enable_metrics: true
 
 ``debug`` : ``$SEARXNG_DEBUG``
   Allow a more detailed log if you run SearXNG directly. Display *detailed* error
   messages in the browser too, so this must be deactivated in production.
+
+``donation_url`` :
+  At default the donation link points to the `SearXNG project
+  <https://docs.searxng.org/donate.html>`_.  Set value to ``true`` to use your
+  own donation page written in the :ref:`searx/info/en/donate.md
+  <searx.infopage>` and use ``false`` to disable the donation link altogether.
 
 ``privacypolicy_url``:
   Link to privacy policy.

--- a/searx/infopage/en/donate.md
+++ b/searx/infopage/en/donate.md
@@ -1,3 +1,0 @@
-# Donate to searxng.org
-
-You can support the SearXNG project by clicking on the donation page: [https://docs.searxng.org/donate.html](https://docs.searxng.org/donate.html)

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1,9 +1,17 @@
 general:
-  debug: false              # Debug mode, only for development
-  instance_name: "SearXNG"  # displayed name
-  privacypolicy_url: false  # https://example.com/privacy
-  contact_url: false        # mailto:contact@example.com
-  enable_metrics: true      # record stats
+  # Debug mode, only for development
+  debug: false
+  # displayed name
+  instance_name: "SearXNG"
+  # For example: https://example.com/privacy
+  privacypolicy_url: false
+  # use true to use your own donation page written in searx/info/en/donate.md
+  # use false to disable the donation link
+  donation_url: https://docs.searxng.org/donate.html
+  # mailto:contact@example.com
+  contact_url: false
+  # record stats
+  enable_metrics: true
 
 brand:
   new_issue_url: https://github.com/searxng/searxng/issues/new

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -142,6 +142,7 @@ SCHEMA = {
         'instance_name': SettingsValue(str, 'SearXNG'),
         'privacypolicy_url': SettingsValue((None, False, str), None),
         'contact_url': SettingsValue((None, False, str), None),
+        'donation_url': SettingsValue((bool, str), "https://docs.searxng.org/donate.html"),
         'enable_metrics': SettingsValue(bool, True),
     },
     'brand': {

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -46,7 +46,9 @@
         <a href="{{ url_for('info', pagename='about') }}" class="link_on_top_about">{{ icon_big('information-circle-outline') }}<span>{{ _('About') }}</span></a>
       {%- endblock -%}
       {%- block linkto_donate -%}
-        <a href="{{ url_for('info', pagename='donate') }}" class="link_on_top_donate">{{ icon_big('heart-outline') }}<span>{{ _('Donate') }}</span></a>
+        {%- if donation_url -%}
+        <a href="{{ donation_url }}" class="link_on_top_donate">{{ icon_big('heart-outline') }}<span>{{ _('Donate') }}</span></a>
+        {%- endif -%}
       {%- endblock -%}
       {%- block linkto_preferences -%}
         <a href="{{ url_for('preferences') }}" class="link_on_top_preferences">{{ icon_big('menu-outline') }}<span>{{ _('Preferences') }}</span></a>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -453,6 +453,12 @@ def render(template_name: str, **kwargs):
     kwargs['get_setting'] = get_setting
     kwargs['get_pretty_url'] = get_pretty_url
 
+    # values from settings: donation_url
+    donation_url = get_setting('general.donation_url')
+    if donation_url is True:
+        donation_url = custom_url_for('info', pagename='donate')
+    kwargs['donation_url'] = donation_url
+
     # helpers to create links to other pages
     kwargs['url_for'] = custom_url_for  # override url_for function in templates
     kwargs['image_proxify'] = image_proxify


### PR DESCRIPTION
## What does this PR do?

Add a new setting: `general.donation_url`

The default value is https://docs.searxng.org/donate.html

When the value is `false`, the link is hidden

When the value is `true`, the link goes to the infopage `donation.md`,
the administrator can create a custom page.

Note: this PR deletes `donation.md`.

## Why is this change important?

Currently the infopage donation is just a link to https://docs.searxng.org/donate.html

In addition, some administrators want to hide the donation link.

This PR let administrators write a custom page using the infopage donation.md

## How to test this PR locally?

* `make run` without changing `settings.yml` : check the donation links goes to searxng.org
* change for `general.donation_url: false`, checks the link is hidden
* change for `general.donation_url: true` and create `searx/infopages/en/donation.md`, checks the link goes to this info page.

## Author's checklist

The TOC of the infopages still contains `donation` : if the page does not exist the page is skipped.

We can do the same thing for the privacy URL :
* `general.privacypolicy_url: true` creates a link to the page `infopages/en/privacy.md`
* `general.privacypolicy_url: https://example.com/privacy_policy.html` creates a link to this URL
* `general.privacypolicy_url: false` hides the link

## Related issues

Related to:
* https://github.com/searxng/searxng/pull/1380#issuecomment-1172521973
* https://github.com/searxng/searxng/pull/1369
* https://github.com/searxng/searxng/pull/1402
