### PR TITLE
Public instances can be set to hidden

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -164,3 +164,4 @@ features or generally made searx better:
 - @OliveiraHermogenes
 - Paul Alcock @Guilvareux
 - Sam A. `<https://samsapti.dev>`_
+- @XavierHorwood

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -149,7 +149,7 @@ SCHEMA = {
         'issue_url': SettingsValue(str, 'https://github.com/searxng/searxng/issues'),
         'new_issue_url': SettingsValue(str, 'https://github.com/searxng/searxng/issues/new'),
         'docs_url': SettingsValue(str, 'https://docs.searxng.org'),
-        'public_instances': SettingsValue(str, 'https://searx.space'),
+        'public_instances': SettingsValue((False, str), 'https://searx.space'),
         'wiki_url': SettingsValue(str, 'https://github.com/searxng/searxng/wiki'),
     },
     'search': {

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -64,8 +64,10 @@
     {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searx_version }} — {{ _('a privacy-respecting, hackable metasearch engine') }}<br/>
         <a href="{{ searx_git_url }}">{{ _('Source code') }}</a> |
         <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a> |
-        <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a> |
-        <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>
+        <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a>
+        {% if get_setting('brand.public_instances') %}
+        | <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>
+        {% endif %}
         {% if get_setting('general.privacypolicy_url') %}
         | <a href="{{ get_setting('general.privacypolicy_url') }}">{{ _('Privacy policy') }}</a>
         {% endif %}


### PR DESCRIPTION
## What does this PR do?

Change setting: `brand.public_instances`

When the value is `false`, the link is hidden

When the value is anything but `false`, it works like it did before this PR

## Why is this change important?
Some administrators may want to hide the link to `public_instances`

## How to test this PR locally?

`make run` without changing `settings.yml`: check public_instances still shows
Change for `brand.public_instances: false`: the link is hidden