### PR TITLE
fix typo and document preference 'center_alignment' in the 'ui' section

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -230,6 +230,7 @@ Global Settings
    ui:
      default_locale: ""
      query_in_title: false
+     center_alignment: false
      default_theme: simple
      theme_args:
        simple_style: auto
@@ -240,15 +241,20 @@ Global Settings
   specific instance of searx, a locale can be defined using an ISO language
   code, like ``fr``, ``en``, ``de``.
 
+``query_in_title`` :
+  When true, the result page's titles contains the query it decreases the
+  privacy, since the browser can records the page titles.
+
+``center_alignment`` : default ``false``
+  When enabled, the results are centered instead of being in the left (or RTL)
+  side of the screen.  This setting only affects the *desktop layout*
+  (:origin:`min-width: @tablet <searx/static/themes/simple/src/less/definitions.less>`)
+
 ``default_theme`` :
   Name of the theme you want to use by default on your SearXNG instance.
 
 ``theme_args.simple_style``:
   Style of simple theme: ``auto``, ``light``, ``dark``
-
-``query_in_title`` :
-  When true, the result page's titles contains the query it decreases the
-  privacy, since the browser can records the page titles.
 
 ``results_on_new_tab``:
   Open result links in a new tab by default.

--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -365,9 +365,9 @@ class Preferences:
                 locked=is_locked('simple_style'),
                 choices=['', 'auto', 'light', 'dark']
             ),
-            'center_aligment': MapSetting(
-                settings['ui']['center_aligment'],
-                locked=is_locked('center_aligment'),
+            'center_alignment': MapSetting(
+                settings['ui']['center_alignment'],
+                locked=is_locked('center_alignment'),
                 map={
                     '0': False,
                     '1': True,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -92,7 +92,7 @@ ui:
   # ui theme
   default_theme: simple
   # center the results ?
-  center_aligment: false
+  center_alignment: false
   # Default interface locale - leave blank to detect from browser information or
   # use codes from the 'locales' config section
   default_locale: ""

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -185,7 +185,7 @@ SCHEMA = {
         'theme_args': {
             'simple_style': SettingsValue(SIMPLE_STYLE, 'auto'),
         },
-        'center_aligment': SettingsValue(bool, False),
+        'center_alignment': SettingsValue(bool, False),
         'results_on_new_tab': SettingsValue(bool, False),
         'advanced_search': SettingsValue(bool, False),
         'query_in_title': SettingsValue(bool, False),

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js theme-{{ preferences.get_value('simple_style') or 'auto' }} center-aligment-{{ preferences.get_value('center_aligment') and 'yes' or 'no' }}" lang="{{ locale_rfc5646 }}" {% if rtl %} dir="rtl"{% endif %}>
+<html class="no-js theme-{{ preferences.get_value('simple_style') or 'auto' }} center-aligment-{{ preferences.get_value('center_alignment') and 'yes' or 'no' }}" lang="{{ locale_rfc5646 }}" {% if rtl %} dir="rtl"{% endif %}>
 <head>
   <meta charset="UTF-8" />
   <meta name="description" content="SearXNG — a privacy-respecting, hackable metasearch engine">

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -214,11 +214,11 @@
       <div class="description">{{ _('Choose auto to follow your browser settings') }}</div>
     </fieldset>
     <fieldset>
-      <legend id="pref_center_aligment">{{ _('Center Alignment') }}</legend>
+      <legend id="pref_center_alignment">{{ _('Center Alignment') }}</legend>
       <p class="value">
-        <select name="center_aligment" aria-labelledby="pref_center_aligment">
-            <option value="1" {% if preferences.get_value('center_aligment') %}selected="selected"{% endif %}>{{ _('On') }}</option>
-            <option value="0" {% if not preferences.get_value('center_aligment') %}selected="selected"{% endif %}>{{ _('Off')}}</option>
+        <select name="center_alignment" aria-labelledby="pref_center_alignment">
+            <option value="1" {% if preferences.get_value('center_alignment') %}selected="selected"{% endif %}>{{ _('On') }}</option>
+            <option value="0" {% if not preferences.get_value('center_alignment') %}selected="selected"{% endif %}>{{ _('Off')}}</option>
         </select>
       </p>
       <div class="description">{{ _('Displays results in the center of the page (Oscar layout).') }}</div>


### PR DESCRIPTION
## What does this PR do?

```
- [fix] typo: add missing 'n' in center_aligment --> center_alignment
- [docs] document preference 'center_alignment' in the 'ui' section.
```
## How to test this PR locally?

- `make docs.live` --> read http://0.0.0.0:8000/admin/engines/settings.html#ui
- `make run` --> check `center_alignment` works by enabling

## Related issues

See https://github.com/searxng/searxng/pull/1281#issuecomment-1172976049 from @amalgame21

Closes: https://github.com/searxng/searxng/issues/1420