### PR TITLE
[fix] online_dictionary: regular expression

### DIFF
--- a/searx/search/processors/online_dictionary.py
+++ b/searx/search/processors/online_dictionary.py
@@ -9,7 +9,7 @@ import re
 from searx.utils import is_valid_lang
 from .online import OnlineProcessor
 
-parser_re = re.compile('.*?([a-z]+)-([a-z]+) ([^ ]+)$', re.I)
+parser_re = re.compile('.*?([a-z]+)-([a-z]+) (.+)$', re.I)
 
 
 class OnlineDictionaryProcessor(OnlineProcessor):


### PR DESCRIPTION
The query term of a engine-type `online_dictionary` can consist of more than one word.