### PR TITLE
Bump sphinx-jinja from 2.0.1 to 2.0.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ twine==4.0.1
 Pallets-Sphinx-Themes==2.0.2
 Sphinx==4.5.0
 sphinx-issues==3.0.1
-sphinx-jinja==2.0.1
+sphinx-jinja==2.0.2
 sphinx-tabs==3.3.1
 sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14


### PR DESCRIPTION
## What does this PR do?

Bump sphinx-jinja from 2.0.1 to 2.0.2