### PR TITLE
[fix] engine z-zlibrary https URL

### DIFF
--- a/searx/engines/zlibrary.py
+++ b/searx/engines/zlibrary.py
@@ -39,7 +39,7 @@ def init(engine_settings=None):
         resp = http_get('https://z-lib.org', timeout=5.0)
         if resp.ok:
             dom = html.fromstring(resp.text)
-            base_url = "https:" + extract_text(
+            base_url = extract_text(
                 eval_xpath(dom, './/a[contains(@class, "domain-check-link") and @data-mode="books"]/@href')
             )
     logger.debug("using base_url: %s" % base_url)


### PR DESCRIPTION
## What does this PR do?

[fix] engine z-zlibrary https URL ...

before this patch:

    DEBUG   searx.engines.z-library : using base_url: https:https://de1lib.org

with this patch URL is fixed to:

    DEBUG   searx.engines.z-library : using base_url: https://de1lib.org

## How to test this PR locally?

- start `make run` see DEBUG messages from  z-library engine's initialization.
- test queries: `!zlib mathematics`

## Related issues

Closes: https://github.com/searxng/searxng/issues/1435
