### PR TITLE
fix: return body on limiter block so there is not just a blank page

### DIFF
--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -85,7 +85,7 @@ def is_accepted_request() -> bool:
 
 def pre_request():
     if not is_accepted_request():
-        return '', 429
+        return 'Too Many Requests', 429
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

Add a body to the block response of the limiter plugin. The body is the definition of HTTP 429: `Too Many Requests`

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

There where a lot of issues of blank pages reported in the last view days. The limiter does not work with cloudflare for example and there are some configs which it can (falsely) block as another example. This will give the user some context that SearXNG is working and blocking the request.

## How to test this PR locally?

* ```docker run -it --rm --name redis -p 6379:6379 redis:alpine redis-server --save "" --appendonly "no"``` -> to run a local redis
* enable limiter in settings and add this to redis: `redis://127.0.0.1:6379/0`
* ```make run```
* ```curl http://127.0.0.1:8888/search?q=time```
=>should return a body:
`Too Many Requests`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
