### PR TITLE
[mod] Add engine for Emojipedia

### DIFF
--- a/searx/data/engine_descriptions.json
+++ b/searx/data/engine_descriptions.json
@@ -53,6 +53,7 @@
    "currency:nl-BE",
    "ref"
   ],
+  "emojipedia":"Emojipedia is een online naslagwerk voor emoji dat de betekenis en het gemeenschappelijk gebruik van emoji-tekens in de Unicode-Standaard documenteert. De site werd in 2013 opgestart door de Australiër Jeremy Burge.",
   "tineye":"TinEye is een zoekmachine voor afbeeldingen. TinEye is eigendom van het in Canada gesitueerde bedrijf Idée, Inc. Met de webapplicatie TinEye kunnen gebruikers naar afbeeldingen zoeken. Afbeeldingen kunnen geüpload worden op de website van TinEye of door een URL in te voeren naar een bestaande afbeelding.",
   "flickr":"Flickr is een website voor het delen van foto's en videofragmenten. Net als Delicious wordt het gezien als een Web 2.0-applicatie die tagging (trefwoorden) gebruikt om een niet-hiërarchische classificering mogelijk te maken (folksonomie).",
   "free software directory":"De Free Software Directory is een website opgericht door de Free Software Foundation (FSF) en de UNESCO. Het biedt een overzicht van vrije software, met name software voor vrije besturingssystemen, zoals Linux en BSD. Voordat besloten wordt tot de opname van een programma in de Free Software Directory, wordt nagegaan of de aangeduide licentie wel degelijk de juiste licentie is.",
@@ -118,6 +119,7 @@
   "archive is":"archive.today又稱archive.is，是一個私人資助的網頁存檔網站，資料中心位於歐洲法國的北部-加來海峽。這個網站典藏檔案館使用Apache Hadoop與Apache Accumulo軟體。它可以一次取回一個類似於WebCite的小於50MB的頁面，並能收錄Google地圖與Twitter。",
   "arxiv":"arXiv 是一個收集物理學、數學、計算機科學、生物學與數理經濟學的論文預印本的網站，始於1991年8月14日。截至2008年10月，arXiv.org已收集超過50萬篇預印本；至2014年底，藏量達到1百萬篇。截至2016年10月，提交率已達每月超過10,000篇。",
   "bandcamp":"Bandcamp是一家美國線上音樂公司， 由前Oddpost聯合創始人Ethan Diamond與程序員Shawn Grunberger、Joe Holt和Neal Tucker於2008年創立，總部位於加利福尼亞。",
+  "wikipedia":"維基百科 是維基媒體基金會運營的一個多語言的線上百科全書，並以創建和維護作為開放式協同合作項目，特點是自由內容、自由編輯、自由版權。目前是全球網絡上最大且最受大眾歡迎的參考工具書，名列全球二十大最受歡迎的網站，其在搜尋引擎中排名亦較為靠前。維基百科目前由非營利組織維基媒體基金會負責營運。Wikipedia是混成詞，分別取自於網站核心技術「Wiki」以及英文中百科全書之意的「encyclopedia」。截至2021年初，所有語種的維基百科條目數量達5,500萬。",
   "bing":"是一款由微軟公司推出的網路搜尋引擎。Bing的歷史可追溯至於1998年的第三個季度發布的MSN Search，它的由Looksmart和Inktomi等提供；2006年3月8日，微軟發布了Windows Live Search的公測版，並於同年9月11日讓其取代了MSN Search，該引擎開始使用搜尋選項卡；次年3月，微軟將其與Windows Live分開並更名Live Search，在此期間，其子服務曾經多次重組、關閉。到了2009年6月3日，微軟將Live Search改造成了今天的Bing並正式發布。微軟認為Bing一詞簡單明了、易於拼寫，容易被人記住；它源自成語「有求必應」。微軟聲稱，此款搜尋引擎將以全新的姿態面世並帶來革命。Bing的內測代號為Kumo，其後才被命名為Bing。2020年10月5日，Bing更名為Microsoft Bing。",
   "bing images":[
    "bing:zh-HK",
@@ -126,6 +128,7 @@
   "crossref":"Crossref （曾用名CrossRef）是國際DOI基金會 旗下的一個DOI注冊機構，它的成員來自2,000個不同的出版商。Crossref由Publishers International Linking Association Inc.負責運營。該機構於2000年初成立。",
   "deezer":"Deezer是一家法國在線音樂流媒體服務提供商。它允許用戶在各種設備上在線或離線收聽來自包括環球音樂集團、索尼音樂和華納音樂集團在內的各家唱片公司的音樂。2007年，Deezer創建於法國巴黎，截至2019年1月，Deezer擁有5600萬首授權曲目，擁有超過3萬個電台頻道，月活躍用戶達1400萬，付費用戶為700萬。該服務適用於Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",
   "wikidata":"維基數據 是一個可協同編輯的知識庫，是繼2006年的維基學院之後，第一個新的維基媒體基金會項目。這一項目與維基共享資源的工作方式類似，將為其他維基計劃及各語種維基百科中的信息框、列表及跨語言連結等提供統一存放的數據，該項目在2012年10月30日投入使用。維基數據藉由軟體Wikibase運行。",
+  "emojipedia":"表情圖標百科 是一個表情圖標參考網站，記載了Unicode標准中各個表情圖標的編碼、含義、演變等信息。",
   "etymonline":"在線詞源詞典 是免費的在線詞典，由道格拉斯·哈珀 編纂和撰寫，用於描述英語單詞的詞源。",
   "fdroid":"F-Droid是一個Android應用程序的軟件資源庫（或應用商店）；其功能類似於Google Play商店，但只包含自由及開放源代碼軟件。應用可從F-Droid網站或直接從F-Droid客戶端應用瀏覽及安裝，F-Droid客戶端應用會自動更新其應用。F-Droid不要求用戶注冊賬號。如果應用包含廣告、用戶分析器，追蹤器或倚賴非自由軟件，會被標記存在「負功能」（antifeatures）。運行F-Droid的服務器也均使用自由及開放源代碼軟件，從而允許任何人創建自己的軟件庫。",
   "flickr":"Flickr為一家提供圖片分享的網路相簿，是Web 2.0的最佳利用例子之一。",
@@ -225,6 +228,7 @@
    "currency:ar",
    "ref"
   ],
+  "emojipedia":"إيموجي بيديا ‏ هو موقع على الإنترنت مختص بمراجع الإيموجي، قام بإنشائه متخصص الإيموجي جيرمي بورج في 2013.",
   "tineye":"تن آي ‏ هو محرك البحث للصور وهي خدمة أنشأتها شركة ‏ مقرها في تورونتو كندا. حيث يقوم المستخدم بإرسال الصورة الي الموقع لكي يقوم محرك بالبحث عن مصدرها.",
   "etymonline":"قاموس علم اشتقاق الألفاظ هو قاموس حر على الانترنت يصف أصول الكلمات باللغة الإنجليزية.",
   "fdroid":"إف-درويد ‏ هو مستودع برامج أو \"متجر تطبيقات\" لتطبيقات الأندرويد، مماثل ومشابه ل جوجل بلاي ستور . المستودع الرئيسي مستضاف من طرف مشروع يحتوي فقط على تطبيقات ذات برامج حرة أو مفتوحة المصدر. التطبيقات يمكن تصفحها وتحميلها من الموقع الرسمي ل إف-درويد بدون حاجة المستخدم إلى تسجيل أو فتح حساب. «مضاد الميزات» على غرار الإعلانات تستعمل التتبع أو أنها تعتمد على برامج غير حرة ويتم ذكر هذا في الوصف. يقدم الموقع أيضا مصدر الكود للتطبيقات ، حيث أن مضيفي البرامج يستعملون خادم ف-درويد، وبالتالي يسمحون لأي شخص من المجموعة في أن يصبح ملك تطبيق معين في المستودع.",
@@ -404,7 +408,7 @@
   "reddit":"রেডিট একটি সামাজিক নেটওয়ার্ক সংহতি, ওয়েব বিষয়বস্তু রেটিং, এবং আলোচনার ওয়েবসাইট। নিবন্ধিত সদস্যরা বিভিন্ন কন্টেন্ট যেমনঃ লিঙ্ক, লিখা, এবং ছবি জমা দিতে পারে, যেগুলো পরে অন্য সদস্যদের ভোটে উপরে উঠে বা নিচে নামে। রেডিট এক বৈচিত্রময় সংকলন যার হাজারো ভাগ রয়েছে, যেগুলোকে বলা হয় “সাবরেডিট”। বেশি আপভোট পাওয়া সাবমিশনগুলো তাদের সাবরেডিটের উপরের দিকে জায়গা করে নেয় এবং যদি যথেষ্ট পরিমাণ ভোট পায় তবে শেষ পর্যন্ত সাইটের প্রথম পাতায় জায়গা করে নেয়।",
   "soundcloud":"সাউন্ডক্লাউড হল জার্মানির রাজধানী বার্লিন-এ স্থাপিত একটি অনলাইন অডিও বণ্টন ভিত্তিক প্রচারের মাধ্যম, যেটি ব্যবহারকারীকে তার নিজেস্ব তৈরীকৃত শব্দ বা সঙ্গীত আপলোড, রেকর্ড, এর উন্নীতকরণ এবং সবার উদ্দেশ্যে তা প্রচারের অধিকার প্রদান করে।",
   "startpage":"স্টার্টপেজ হল গোপনীয়তা নির্ভর সার্চ ইঞ্জিন। এটি আগে মেটাসার্চ এবং আইএক্সকুইক নামে ভিন্ন দুটি সার্চ ইঞ্জিন ছিল। ২০১৬ সালে দুটি কোম্পানি একীভূত হয়। পূর্বে এটি আইএক্স কুইক অনুসন্ধান ইঞ্জিন নামে পরিচিত ছিলো।",
-  "youtube":"ইউটিউব হলো সান ব্রুনো, ক্যালিফোর্নিয়া ভিত্তিক একটি মার্কিন অনলাইন ভিডিও হোস্টিং সেবার সাইট, যা ২০০৫ সালের ফেব্রুয়ারিতে প্রকাশিত হয়। ২০০৬ সালের অক্টোবরে, গুগল সাইটটিকে ১.৬৫ বিলিয়ন মার্কিন ডলারের বিনিময়ে ক্রয় করে নেয়। ইউটিউব বর্তমানে গুগলের অন্যতম অধীনস্থ প্রতিষ্ঠান হিসেবে পরিচালিত হচ্ছে।",
+  "youtube":"ইউটিউব হলো সান ব্রুনো, ক্যালিফোর্নিয়া ভিত্তিক একটি মার্কিন অনলাইন ভিডিও প্ল্যাটফর্ম সেবার সাইট, যা ২০০৫ সালের ফেব্রুয়ারিতে প্রকাশিত হয়। ইউটিউব বর্তমানে গুরুত্বপূর্ণ একটি প্ল্যাটফর্ম। ২০০৬ সালের অক্টোবরে, গুগল সাইটটিকে ১.৬৫ বিলিয়ন মার্কিন ডলারের বিনিময়ে ক্রয় করে নেয়। ইউটিউব বর্তমানে গুগলের অন্যতম অধীনস্থ প্রতিষ্ঠান হিসেবে পরিচালিত হচ্ছে।",
   "wikibooks":"উইকিবই হল উইকি-ভিত্তিক পরিবারের একটি উইকিমিডিয়া প্রকল্প যা মিডিয়াউইকি সফটওয়্যারের মাধ্যমে চালিত এবং উইকিমিডিয়া ফাউন্ডেশন কর্তৃক হোস্টকৃত। এটি একটি প্রকল্প, যেখানে বিভিন্ন প্রকার পাঠ্যপুস্তক পঠনযোগ্য আকারে সংরক্ষণ করা হয়।",
   "wikinews":"উইকিনিউজ বা উইকিসংবাদ হল উইকি মুক্ত বিষয়বস্তুর আলোকে পরিচালিত সংবাদ বিষয়ক ওয়েবসাইট এবং উইকিমিডিয়া ফাউন্ডেশনের একটি প্রকল্প যা বিশ্বব্যাপী সহযোগিতামুলক সাংবাদিকতার মাধ্যমে কাজ করে থাকে। উইকিপিডিয়ার সহ-প্রতিষ্ঠাতা জিমি ওয়েলস উইকিপিডিয়া থেকে উইকিসংবাদ আলাদা করার প্রসঙ্গে বলেন, \"উইকিসংবাদে, প্রতিটি গল্প বিশ্বকোষীয় নিবন্ধ থেকে ভিন্ন আঙ্গিকে মুলতঃ একটি সংবাদ হিসেবে লেখা হবে।\" উইকিসংবাদ নিরপেক্ষ দৃষ্টিভঙ্গি নীতি অনুসরণের মাধ্যমে সাংবাদিকতায় বস্তুনিষ্ঠতার ধারণা প্রতিষ্ঠা করে যা অন্যান্য নাগরিক সাংবাদিকতা চর্চার ওয়েবসাইট যেমন, ইন্ডেমিডিয়া ও ওহমাইনিউজ থেকে ভিন্নতর।",
   "wikiquote":"উইকিউক্তি উইকি-ভিত্তিক পরিবারের একটি প্রকল্প যা মিডিয়াউইকি সফটওয়্যারের মাধ্যমে চালিত এবং উইকিমিডিয়া ফাউন্ডেশন কর্তৃক পরিচালিত। এটি ড্যানিয়েল অ্যালস্টনের ধারণার উপর ভিত্তি করে এবং ব্রিয়ন ভিবের কর্তৃক বাস্তবায়িত। উইকিউক্তি পাতাসমূহ উইকিপিডিয়ার উল্লেখযোগ্য ব্যক্তিত্ব সম্পর্কে নিবন্ধে ক্রস-সংযুক্ত করা হয়।",
@@ -777,6 +781,7 @@
    "currency:de",
    "ref"
   ],
+  "emojipedia":"Die Emojipedia ist ein englischsprachiges Online-Nachschlagewerk für Emojis. Sie wurde am 14. Juli 2013 vom australischen Emoji-Experten Jeremy Burge gegründet und ist die führende Ressource zu Emojis im Internet.",
   "tineye":"Idée Inc. ist ein als Aktiengesellschaft eingetragenes Unternehmen aus Toronto, das Bildidentifizierungs- und Suchsoftware entwickelt und anbietet. Das Unternehmen gilt als einer der Pioniere in der Bildüberwachungsindustrie.",
   "fdroid":"F-Droid ist ein alternativer App Store für das mobile Betriebssystem Android. Die Besonderheit von F-Droid besteht darin, dass im offiziellen und standardmäßig aktivierten Repository ausschließlich freie Software angeboten wird, üblicherweise nach GNU GPL oder Apache-Lizenz. Der Quellcode jeder App im F-Droid-Repositorium steht nicht nur dem Endnutzer zur Einsichtnahme und Modifikation zur Verfügung, sondern es wird auch garantiert, dass die heruntergeladene apk-Datei vom F-Droid-Server aus diesen Quellen generiert wurde. Entsprechend ist diese Datei auch von F-Droid signiert und nicht wie üblich vom ursprünglichen Entwickler. Dieses Konzept soll für Transparenz und Sicherheit sorgen.",
   "flickr":"Flickr ist ein kommerzieller Onlinedienst mit Community-Elementen, der es Benutzern erlaubt, digitale und digitalisierte Bilder sowie kurze Videos von maximal zehn Minuten Dauer mit Kommentaren und Notizen auf die Website zu laden und so anderen Nutzern zugänglich zu machen. Neben dem herkömmlichen Hochladen über die Website können die Bilder auch per E-Mail oder vom Mobiltelefon aus übertragen und später von anderen Webauftritten aus verlinkt werden.",
@@ -801,7 +806,7 @@
    "ref"
   ],
   "hoogle":"Haskell ist eine rein funktionale Programmiersprache, benannt nach dem US-amerikanischen Mathematiker Haskell Brooks Curry, dessen Arbeiten zur mathematischen Logik eine Grundlage funktionaler Programmiersprachen bilden. Haskell basiert auf dem Lambda-Kalkül, weshalb auch der griechische Buchstabe Lambda als Logo verwendet wird. Die wichtigste Implementierung ist der Glasgow Haskell Compiler (GHC).",
-  "imdb":"Die Internet Movie Database ist eine Datenbank zu Filmen, Fernsehserien, Videoproduktionen und Computerspielen sowie über Personen, die daran mitgewirkt haben. Im Januar 2020 gab es Einträge zu über 7,55 Millionen Filmproduktionen und zu über 11,21 Millionen Film- und Fernsehschaffenden. Betrieben wird die Datenbank seit 1998 von Amazon.",
+  "imdb":"Die Internet Movie Database ist eine US-amerikanische Datenbank zu Filmen, Fernsehserien, Videoproduktionen und Computerspielen sowie über Personen, die daran mitgewirkt haben. Im Januar 2020 gab es Einträge zu über 7,55 Millionen Filmproduktionen und zu über 11,21 Millionen Film- und Fernsehschaffenden. Betrieben wird die Datenbank seit 1998 von Amazon.",
   "ina":"Das Institut national de l’audiovisuel (INA) ist ein öffentlich-rechtliches französisches Unternehmen. Das INA war das erste digitalisierte Archiv Europas. Sein Auftrag ist es, alle französischen Rundfunk- und Fernsehproduktionen zu sammeln, zu bewahren und öffentlich zugänglich zu machen, in etwa vergleichbar dem Auftrag der Bibliothèque nationale de France (BnF), geschriebene und gedruckte Dokumente aller Art zu archivieren. Die Sammlungen des INA sind über seine Website für die Öffentlichkeit teilweise kostenlos zugänglich, der Rest unterliegt urheberrechtlichen Beschränkungen.",
   "invidious":[
    "alternatives Frontend für YouTube",
@@ -984,7 +989,7 @@
    "Arch Linux documentation on the web",
    "wikidata"
   ],
-  "archive is":"archive.today is a web archiving site, founded in 2012, that saves snapshots on demand, and has support for JavaScript-heavy sites such as Google Maps and progressive web applications such as Twitter. Archive.today records two snapshots: one replicates the original webpage including any functional live links; the other is binary image screenshot of the page.",
+  "archive is":"archive.today is a web archiving site, founded in 2012, that saves snapshots on demand, and has support for JavaScript-heavy sites such as Google Maps and progressive web applications such as Twitter. archive.today records two snapshots: one replicates the original webpage including any functional live links; the other is a screenshot of the page.",
   "artic":"The Art Institute of Chicago in Chicago's Grant Park, founded in 1879, is one of the oldest and largest art museums in the world. Recognized for its curatorial efforts and popularity among visitors, the museum hosts approximately 1.5 million people annually. Its collection, stewarded by 11 curatorial departments, is encyclopedic, and includes iconic works such as Georges Seurat's A Sunday on La Grande Jatte, Pablo Picasso's The Old Guitarist, Edward Hopper's Nighthawks, and Grant Wood's American Gothic. Its permanent collection of nearly 300,000 works of art is augmented by more than 30 special exhibitions mounted yearly that illuminate aspects of the collection and present cutting-edge curatorial and scientific research.",
   "arxiv":"arXiv is an open-access repository of electronic preprints and postprints approved for posting after moderation, but not peer review. It consists of scientific papers in the fields of mathematics, physics, astronomy, electrical engineering, computer science, quantitative biology, statistics, mathematical finance and economics, which can be accessed online. In many fields of mathematics and physics, almost all scientific papers are self-archived on the arXiv repository before publication in a peer-reviewed journal. Some publishers also grant permission for authors to archive the peer-reviewed postprint. Begun on August 14, 1991, arXiv.org passed the half-million-article milestone on October 3, 2008, and had hit a million by the end of 2014. As of April 2021, the submission rate is about 16,000 articles per month.",
   "bandcamp":"Bandcamp is an American online audio distribution platform founded in 2007 by Oddpost co-founder Ethan Diamond and programmers Shawn Grunberger, Joe Holt and Neal Tucker, with headquarters in Oakland, California, US.",
@@ -1032,6 +1037,7 @@
    "currency:en",
    "ref"
   ],
+  "emojipedia":"Emojipedia is an emoji reference website which documents the meaning and common usage of emoji characters in the Unicode Standard. Most commonly described as an emoji encyclopedia or emoji dictionary, Emojipedia also publishes articles and provides tools for tracking new emoji characters, design changes and usage trends. It is owned by Zedge since 2021.",
   "tineye":"TinEye is a reverse image search engine developed and offered by Idée, Inc., a company based in Toronto, Ontario, Canada. It is the first image search engine on the web to use image identification technology rather than keywords, metadata or watermarks. TinEye allows users to search not using keywords but with images. Upon submitting an image, TinEye creates a \"unique and compact digital signature or fingerprint\" of the image and matches it with other indexed images. This procedure is able to match even heavily edited versions of the submitted image, but will not usually return similar images in the results.",
   "etymonline":"The Online Etymology Dictionary is a free online dictionary, written and compiled by Douglas R. Harper, that describes the origins of English-language words.",
   "1x":[
@@ -1150,7 +1156,7 @@
    "A search engine of PeerTube videos, channels and playlists, developed by Framasoft",
    "https://sepiasearch.org"
   ],
-  "soundcloud":"SoundCloud is an online audio distribution platform and music sharing website that enables its users to upload, promote, and share audio, as well as a digital signal processor enabling listeners to stream audio. Founded in 2007 by Alexander Ljung and Eric Wahlforss, SoundCloud has grown to be one of the largest music streaming services in the world and is available in 190 countries and territories. Audience-wise, there are over 76 million active monthly users, with over 175 million global users that SoundCloud reaches, as of November 2021. While its competitors report having roughly 70 million tracks in their systems, SoundCloud supersedes this with over 300 million. SoundCloud offers both free and paid memberships on the platform, available for mobile, desktop and Xbox devices.",
+  "soundcloud":"SoundCloud is an online audio distribution platform and music sharing website that enables its users to upload, promote, and share audio, as well as a digital signal processor enabling listeners to stream audio. Founded in 2007 by Alexander Ljung and Eric Wahlforss, SoundCloud has grown to be one of the largest music streaming services in the world and is available in 190 countries and territories. Audience-wise, there are over 76 million active monthly users, with over 175 million global users that SoundCloud reaches, as of November 2021. While its competitors report having roughly 70 million tracks in their systems, SoundCloud has over 300 million. SoundCloud offers both free and paid memberships on the platform, available for mobile, desktop and Xbox devices.",
   "stackoverflow":"Stack Exchange is a network of question-and-answer (Q&A) websites on topics in diverse fields, each site covering a specific topic, where questions, answers, and users are subject to a reputation award process. The reputation system allows the sites to be self-moderating. As of August 2019, the three most actively-viewed sites in the network are Stack Overflow, Super User, and Ask Ubuntu.",
   "askubuntu":[
    "stackoverflow:en",
@@ -1225,7 +1231,7 @@
    "wikidata"
   ],
   "brave":"Brave Search is a search engine developed by Brave Software, Inc. and is set as the default search engine for Brave browser users in certain countries.",
-  "petalsearch":"Petal Search is a search engine, developed by Huawei in the second half of 2020, it is available on mobile and desktop platforms. Inspired by Huawei’s logo, the search engine was named Petal as in flower petals.",
+  "petalsearch":"Petal Search is a worldwide search engine, developed by Huawei in the second half of 2020, it is available on mobile and desktop platforms. Inspired by Huawei's logo, the search engine was named Petal as in flower petals.",
   "petalsearch images":[
    "petalsearch:en",
    "ref"
@@ -1373,7 +1379,7 @@
   "gitlab":"Gitlab Inc. es una compañía de núcleo abierto y es la principal proveedora del software GitLab, un servicio web de forja, control de versiones y DevOps basado en Git. Además de gestor de repositorios, el servicio ofrece también alojamiento de wikis y un sistema de seguimiento de errores, todo ello publicado bajo una licencia de código abierto, principalmente.",
   "github":"GitHub es una forja para alojar proyectos utilizando el sistema de control de versiones Git. Se utiliza principalmente para la creación de código fuente de programas de ordenador. El software que opera GitHub fue escrito en Ruby on Rails. Desde enero de 2010, GitHub opera bajo el nombre de GitHub, Inc. Anteriormente era conocida como Logical Awesome LLC. El código de los proyectos alojados en GitHub se almacena generalmente de forma pública.",
   "google":"El buscador de Google o buscador web de Google es un motor de búsqueda en la web propiedad de Alphabet Inc. Es el motor de búsqueda más utilizado en la Web y recibe cientos de millones de consultas cada día a través de sus diferentes servicios. El objetivo principal del buscador de Google es buscar texto en las páginas web, en lugar de otro tipo de datos. Fue desarrollado originalmente por Larry Page y Sergey Brin en 1997.",
-  "google images":"Google Imágenes es una especialización del buscador principal para imágenes, que fue implementado en el año 2001. Contiene en su interfaz distintas herramientas de búsqueda, que sirven para filtrar los resultados de las imágenes. Estos pueden ser según su tamaño, tipo, formatos, por coloración, por color, por fecha, y por imágenes similares.",
+  "google images":"Google Imágenes es una especialización del buscador principal para imágenes, se introdujo el 12 de julio de 2001 debido a la demanda de imágenes del vestido verde de Versace que usó Jennifer López en febrero de 2000. En 2011, se agregó la función de búsqueda inversa de imágenes.",
   "google news":"Google Noticias, conocido en España como Google News, es un agregador y buscador de noticias automatizado que rastrea de forma constante la información de los principales medios de comunicación en línea.",
   "google videos":"Google Videos fue un servicio de Google que hasta enero de 2009 permitía subir clips de video a sus servidores para que cualquier persona los pudiera buscar y ver directamente desde su navegador. Inicialmente nació como competencia de YouTube, a la que terminó comprando el 10 de octubre de 2006. Finalmente, Google Video pasó a funcionar como un mero buscador de vídeos en la red, pasando a ser YouTube el único servicio de estos dos que permite la subida de vídeos.",
   "google scholar":"Google Académico es un motor de búsqueda de Google enfocado y especializado en la búsqueda de contenido y bibliografía científico-académica. El sitio indexa editoriales, bibliotecas, repositorios, bases de datos bibliográficas, entre otros; y entre sus resultados se pueden encontrar citas, enlaces a libros, artículos de revistas científicas, comunicaciones y congresos, informes científico-técnicos, tesis, tesinas y archivos depositados en repositorios.",
@@ -1884,7 +1890,7 @@
   "piratebay":"The Pirate Bay est un site web créé en 2003 en Suède, indexant des liens Magnets de fichiers numériques, permettant le partage de fichiers en pair à pair à l’aide du protocole de communication BitTorrent. Le site se finance par les dons et la publicité, il a été créé dans l’esprit d’une « culture libre ».",
   "pubmed":"MEDLINE est une base de données bibliographiques regroupant la littérature relative aux sciences biologiques et biomédicales. La base est gérée et mise à jour par la Bibliothèque américaine de médecine (NLM).",
   "pypi":"PyPI est le dépôt tiers officiel du langage de programmation Python. Son objectif est de doter la communauté des développeurs Python d'un catalogue complet recensant tous les paquets Python libres. Il est analogue au dépôt CPAN pour Perl.",
-  "qwant":"Qwant est un moteur de recherche français. Mis en ligne le 16 février 2013 en version bêta, puis en version définitive le 4 juillet 2013, il annonce depuis son lancement ne pas tracer ses utilisateurs, ni vendre leurs données personnelles, afin de garantir leur vie privée, et se veut neutre dans l'affichage des résultats. Dans les faits, des données sont cependant partagées avec Microsoft.",
+  "qwant":"Qwant est un moteur de recherche français. Mis en ligne le 16 février 2013 en version bêta, puis en version définitive le 4 juillet 2013, il annonce depuis son lancement[citation nécessaire] ne pas tracer ses utilisateurs, ni vendre leurs données personnelles, afin de garantir leur vie privée, et se veut neutre dans l'affichage des résultats. Dans les faits, des données sont cependant partagées avec Microsoft.",
   "qwant news":[
    "qwant:fr",
    "ref"
@@ -2027,6 +2033,7 @@
    "currency:he",
    "ref"
   ],
+  "emojipedia":"אמוג'יפדיה הוא אתר אנציקלופדי המבוסס על אמוג'ים, שנוצר על ידי ג'רמי בורג בשנת 2013. האתר אחראי לשינוי ולחידוש הסמלים, האמוג'ים ומשמעותם על פי תקן יוניקוד. האתר משתייך לארגונים המשתפים פעולה בעניינים כלכליים-חברתיים ומכונה \"משאב האמוג'י מספר אחת בעולם\".",
   "fdroid":[
    "מאגר של תכניות חופשיות ל־Android",
    "wikidata"
@@ -2550,7 +2557,7 @@
    "https://www.bing.com/news"
   ],
   "bing videos":[
-   "Bing을 사용하면 정보를 기반으로 작업을 수행할 수 있고 검색에서 작업 수행까지 더 빠르고 쉽게 진행할 수 있습니다.",
+   "Bing 可協助您將資訊轉化為行動，從開始搜尋到採取行動更快、更輕鬆。",
    "https://www.bing.com/videos"
   ],
   "bitbucket":"빗버킷(Bitbucket)은 아틀라시안 소유의 웹 기반 버전 관리 저장소 호스팅 서비스로서, 깃(2011년 10월 이후) 버전 관리 시스템을 사용하는 소스 코드 및 개발 프로젝트를 대상으로 한다. 빗버킷은 상용 플랜과 무료 계정을 동시에 제공한다. 2010년 9월 기준으로 무료 계정의 경우 무제한 수의 개인 저장소(무료 계정의 경우 최대 5명의 사용자 보유 가능)를 제공한다. 빗버킷은 지라, 힙챗, 컨플루언스, 밤부 등의 기타 아틀라시안 소프트웨어와 연동된다.",
@@ -2860,6 +2867,10 @@
   ],
   "duckduckgo images":[
    "currency:en",
+   "ref"
+  ],
+  "emojipedia":[
+   "emojipedia:en",
    "ref"
   ],
   "tineye":[
@@ -3256,6 +3267,10 @@
    "currency:nl-BE",
    "ref"
   ],
+  "emojipedia":[
+   "emojipedia:nl-BE",
+   "ref"
+  ],
   "tineye":[
    "tineye:nl-BE",
    "ref"
@@ -3638,10 +3653,6 @@
    "ref"
   ],
   "openstreetmap":"OpenStreetMap (OSM) é um projeto de mapeamento colaborativo para criar um mapa livre e editável do mundo, inspirado por sites como a Wikipédia. Traduzindo para português o nome significa Mapa Aberto de Ruas. Ele fornece dados a centenas de sites na internet, aplicações de celular e outros dispositivos.",
-  "pdbe":[
-   "PDBe home < Node < EMBL-EBI",
-   "https://www.ebi.ac.uk/pdbe"
-  ],
   "piratebay":"The Pirate Bay (TPB), autointitulado \"O tracker BitTorrent mais resiliente da galáxia\", contém magnet links, sendo também o índice para os arquivos .torrent. Um magnet link ou um arquivo .torrent, em conjunto com um cliente BitTorrent, proporciona ao cliente as informações necessárias para se copiar um arquivo ou conjunto de arquivos de outras pessoas que estão copiando ou compartindo o mesmo arquivo.",
   "pubmed":"MEDLINE® é uma sigla em inglês para Sistema Online de Busca e Análise de Literatura Médica é a base de dados bibliográficos da Biblioteca Nacional de Medicina dos Estados Unidos da América. Contém mais de 18 milhões de referências a artigos de jornais científicos, com maior concentração em biomedicina, mas contém também artigos sobre enfermagem, veterinária, farmacologia, odontologia, entre outros. Uma característica marcante da MEDLINE é que os dados gravados no sistema são indexados com palavras-chave específicas de um sistema chamado MeSH.",
   "pypi":"O Python Package Index, abreviado como PyPI e também conhecido como Cheese Shop, é o repositório de software oficial de terceiros para Python. É análogo ao CPAN, o repositório para Perl. Alguns gerenciadores de pacotes, incluindo o pip, usam o PyPI como a fonte padrão para os pacotes e suas dependências. Mais de 113.000 pacotes Python podem ser acessados por meio do PyPI.",
@@ -4384,6 +4395,7 @@
    "currency:sv",
    "ref"
   ],
+  "emojipedia":"Emojipedia är ett digitalt lexikon för emojier. Lexikonet dokumenterar alla emojier som finns i standarden Unicode och deras betydelse. Emojipedia har kallats för världens främsta resurs om emojier.",
   "etymonline":"Online Etymology Dictionary är en nätbaserad engelskspråkig etymologisk ordbok, framtagen och publicerad 2001 av historikern Douglas R. Harper.",
   "fdroid":[
    "pakethanterare som innehåller fri programvara samt open source för Android plattformen",
@@ -4440,7 +4452,7 @@
  },
  "ta":{
   "artic":"ஆர்ட் இன்ஸ்டியூட் ஆப் சிகாகோ என்பது ஐக்கிய அமெரிக்காவின் சிகாகோ நகரில் அமைந்துள்ள கலைக்களஞ்சிய அருங்காட்சியகம் ஆகும். இவ்வருங்காட்சியகம் மிகப்பிரம்மாண்டமான மூன்று கட்டடங்களில் இயங்குகிறது. இம்மூன்று கட்டடங்களும் முதல் தளத்துடன் இணைக்கப்பட்டுள்ளன.",
-  "wikipedia":"விக்கிப்பீடியா என்பது, வணிக நோக்கற்ற விக்கிமீடியா நிறுவனத்தின் உதவியுடன் நடத்தப்படும், கூட்டாகத் தொகுக்கப்படும், பன்மொழி, கட்டற்ற இணையக் கலைக்களஞ்சியமாகும். தமிழ் விக்கிப்பீடியாவின் 1,00,000க்கும் மேற்பட்ட கட்டுரைகளுடன் சேர்த்து இதன் மொத்தக் கட்டுரைகளான 24 மில்லியன் கட்டுரைகளும் உலகெங்கிலுமுள்ள தன்னார்வலர்களால் கூட்டாக எழுதப்படுகின்றன. பெரும்பாலும் இதன் எல்லாக் கட்டுரைகளும், இதனைப் பயன்படுத்தும் எவராலும், தொகுக்கப்படக் கூடுவன. மேலும் இது கிட்டத்தட்ட 100,000 முனைப்பான பங்களிப்பாளர்களையும் கொண்டுள்ளது. சூன் 2022 வரையில், விக்கிப்பீடியா 285 மொழிகளில் செயற்படுகிறது. இது இணையத்தளத்தில் இயங்கும் உசாத்துணைப் பகுதிகளிலேயே மிகவும் பெரியதும், அதிகப் புகழ்பெற்றதுமாகும். மேலும், இது அலெக்சா இணையத்தளத்தில் காணப்படும் இணையத்தளங்களின் தரவரிசையில் ஆறாவது இடத்தில் உள்ளதோடு, உலகளவில் அண்ணளவாக 365 மில்லியன் வாசகர்களையும் கொண்டுள்ளது.",
+  "wikipedia":"விக்கிப்பீடியா என்பது, வணிக நோக்கற்ற விக்கிமீடியா நிறுவனத்தின் உதவியுடன் நடத்தப்படும், கூட்டாகத் தொகுக்கப்படும், பன்மொழி, கட்டற்ற இணையக் கலைக்களஞ்சியமாகும். தமிழ் விக்கிப்பீடியாவின் 1,00,000க்கும் மேற்பட்ட கட்டுரைகளுடன் சேர்த்து இதன் மொத்தக் கட்டுரைகளான 24 மில்லியன் கட்டுரைகளும் உலகெங்கிலுமுள்ள தன்னார்வலர்களால் கூட்டாக எழுதப்படுகின்றன. பெரும்பாலும் இதன் எல்லாக் கட்டுரைகளும், இதனைப் பயன்படுத்தும் எவராலும், தொகுக்கப்படக் கூடுவன. மேலும் இது கிட்டத்தட்ட 100,000 முனைப்பான பங்களிப்பாளர்களையும் கொண்டுள்ளது. சூலை 2022 வரையில், விக்கிப்பீடியா 285 மொழிகளில் செயற்படுகிறது. இது இணையத்தளத்தில் இயங்கும் உசாத்துணைப் பகுதிகளிலேயே மிகவும் பெரியதும், அதிகப் புகழ்பெற்றதுமாகும். மேலும், இது அலெக்சா இணையத்தளத்தில் காணப்படும் இணையத்தளங்களின் தரவரிசையில் ஆறாவது இடத்தில் உள்ளதோடு, உலகளவில் அண்ணளவாக 365 மில்லியன் வாசகர்களையும் கொண்டுள்ளது.",
   "bing":"பிங் (Bing) என்பது மைக்ரோசாப்ட் நிறுவத்திற்குச் சொந்தமான வலைத் தேடல் பொறி ஆகும். இத்தேடல் பொறியானது முன்னர் லைவ் சேர்ச், வின்டோசு லைவ் சேர்ச், எம்எஸ்என் சேர்ச் ஆகிய பெயர்களைக் கொண்டு அமைந்திருந்தது. இத்தேடல் பொறி மைக்ரோசாப்ட் நிறுவனத்தினால் முடிவெடுக்கும் பொறியாக விளம்பரப்படுத்தப்பட்டது. 2009 ஆம் ஆண்டு மே மாதம் 28 ஆம் திகதியன்று சான் டியேகோ நகரில் இடம்பெற்ற ஆல் திங்ஸ் டிஜிட்டல் (All Things Digital) மாநாட்டின் போது மைக்ரோசாப்ட் நிறுவனத்தின் முன்னாள் தலைமை நிர்வாக அதிகாரி இசுட்டீவ் பால்மரால் இத்தேடல் பொறி அறிமுகப்படுத்தப்பட்டு சூன் 1 இல் வெளியிடப்படும் எனவும் அறிவிக்கப்பட்டது.. 2009 ஆம் ஆண்டு சூன், 29 ஆம் திகதியன்று யாகூ! தேடல் பொறியினை பிங் தேடல் பொறி நிர்வகிக்கும் என அறிவிக்கப்பட்டது.",
   "bing images":[
    "bing:ta",
@@ -4530,10 +4542,6 @@
   ],
   "imdb":"ఇంటర్నెట్ మూవీ డేటాబేసు వీడియోలకి సంబంధించిన ఒక వెబ్ సైటు. ఇది సినిమాలు, TV షోలు, నటులు, సాంకేతిక నిపుణుల వివరాలతో కూడిన అతి పెద్ద ఆన్ లైన్ సమాచార నిధి (డేటాబేసు). ఇది ప్రస్తుతం Amazon.com సంస్థ ఆధ్వర్వంలో నడుస్తుంది. ఇది అందుబాటులో ఉన్న ఏకైక భాష ఆంగ్లం.",
   "library of congress":"ప్రపంచంలోని అతి పెద్ద గ్రంథాలయం యునైటెడ్ స్టేట్స్ లైబ్రరీ ఆఫ్ కాంగ్రెస్, వాషింగ్టన్, డి.సి. లోని కాపిటల్ హిల్ పైన స్థాపించారు. ఇది 1800వ సంవత్సరం ఏప్రిల్ 24న స్థాపితమైంది.",
-  "openstreetmap":[
-   "OpenStreetMap is the free wiki world map.",
-   "https://www.openstreetmap.org/"
-  ],
   "youtube":"యూట్యూబ్ అనేది అంతర్జాలంలో వీడియోలను ఇతరులతో పంచుకోవడాని వీలుకల్పించే ఒక అంతర్జాతీయ సేవ. దీని ప్రధాన కార్యాలయం అమెరికాలోని, కాలిఫోర్నియా రాష్ట్రం, శాన్ బ్రూనో అనే నగరంలో ఉంది.",
   "wikibooks":"వికీబుక్స్ స్వేచ్ఛానకలుహక్కులతో సమష్టిగా తయారు చేయగల పుస్తకాల జాల స్థలి. ఇది 2004 ఆగస్టు 13న ప్రారంభమైంది. వికీ ప్రాజెక్టులన్నిటిలోఅతితక్కువ వ్యాసపేజీలు ఉన్నాయి. దీనిలో ఉబుంటు వాడుకరి మార్గదర్శిని పూర్తికాబడిన పుస్తకం. దీనిలో ఉబుంటుతో తెలుగులో టైపు చేయడం దగ్గరనుండి, ఉత్తరములు వ్రాయుట, ప్రదర్శన పత్రములు చేయుట, వివిధ రకాల ధ్వని, దృశ్య శ్రవణ మాధ్యమములను నడుపుట, వాడబడే విహరిణులు లాంటివన్నీ ఎలా చేయవచ్చో వివరించటమైనది. ఇంకా వంట పుస్తకం ప్రారంభించబడింది. వికీసోర్స్ లో ఉండవలసిన కొన్ని వ్యాసాలు పొరపాటున వికీబుక్స్ లో సృష్టించబడినవి. ఈ ప్రాజెక్టు ప్రధాన ఉద్దేశం పాఠ్యపుస్తకాలు సమష్టిగా వృద్ధిచేయటం. ఏప్రిల్ 2010 అలెక్సా లెక్కల ప్రకారం ప్రపంచంలోని జాలస్థలులన్నిటిలో 2,462వ స్థానములోఉన్నది.",
   "wikiquote":"వికీకోట్ అనగా వికీవ్యాఖ్య .వికీమీడియా ఫౌండేషను ఆధ్వర్యములో మీడియావికీ సాఫ్టువేరుతో నడిచే వికీ ఆధారిత ప్రాజెక్టు కుటుంబములో ఒక ప్రాజెక్టు. డేనియల్ ఆల్స్టన్ యొక్క ఆలోచనను బ్రయన్ విబ్బర్ కార్యాచరణలో పెట్టగా రూపొందిన ఈ ప్రాజెక్టు యొక్క లక్ష్యం సమిష్టి సమన్వయ కృషితో వివిధ ప్రముఖ వ్యక్తులు, పుస్తకాలు, సామెతలనుండి సేకరించిన వ్యాఖ్యల యొక్క విస్తృత వనరును తయారుచేసి వాటికి సంబంధించిన వివరాలు పొందుపరచడం. అనేక అన్లైన్ వ్యాఖ్యల సేకరణలు ఉన్నప్పటికీ సందర్శకులను సేకరణ ప్రక్రియలో పాలుపంచుకొనే అవకాశము ఇస్తున్న అతికొద్ది వాటిల్లో వికీవ్యాఖ్య ఒకటిగా విశిష్ఠత సంపాదించుకొన్నది.",
@@ -4847,8 +4855,8 @@
    "ref"
   ],
   "bing videos":[
-   "Bing 可協助您將資訊轉化為行動，從開始搜尋到採取行動更快、更輕鬆。",
-   "https://www.bing.com/videos"
+   "bing videos:ko",
+   "ref"
   ],
   "crossref":"Crossref （曾用名CrossRef）是國際DOI基金會 旗下的一個DOI注册机构，它的成員來自2,000個不同的出版商。Crossref由Publishers International Linking Association Inc.負責运营。該機構于2000年初成立。",
   "deezer":"Deezer是一家法国在线音乐流媒体服务提供商。它允许用户在各种设备上在线或离线收听来自包括环球音乐集团、索尼音乐和华纳音乐集团在內的各家唱片公司的音乐。2007年，Deezer创建于法国巴黎，截至2019年1月，Deezer拥有5600万首授权曲目，拥有超过3万个电台频道，月活跃用户達1400万，付费用户為700万。该服务适用于Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",

--- a/searx/engines/emojipedia.py
+++ b/searx/engines/emojipedia.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Emojipedia
+
+Emojipedia is an emoji reference website which documents the meaning and
+common usage of emoji characters in the Unicode Standard.  It is owned by Zedge
+since 2021. Emojipedia is a voting member of The Unicode Consortium.[1]
+
+[1] https://en.wikipedia.org/wiki/Emojipedia
+"""
+
+from urllib.parse import urlencode
+from lxml import html
+
+from searx.utils import (
+    eval_xpath_list,
+    eval_xpath_getindex,
+    extract_text,
+)
+
+about = {
+    "website": 'https://emojipedia.org',
+    "wikidata_id": 'Q22908129',
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+
+categories = []
+paging = False
+time_range_support = False
+
+base_url = 'https://emojipedia.org'
+search_url = base_url + '/search/?{query}'
+
+
+def request(query, params):
+    params['url'] = search_url.format(
+        query=urlencode({'q': query}),
+    )
+    return params
+
+
+def response(resp):
+    results = []
+
+    dom = html.fromstring(resp.text)
+
+    for result in eval_xpath_list(dom, "/html/body/div[2]/div[1]/ol/li"):
+
+        extracted_desc = extract_text(eval_xpath_getindex(result, './/p', 0))
+
+        if 'No results found.' in extracted_desc:
+            break
+
+        link = eval_xpath_getindex(result, './/h2/a', 0)
+
+        url = base_url + link.attrib.get('href')
+        title = extract_text(link)
+        content = extracted_desc
+
+        res = {'url': url, 'title': title, 'content': content}
+
+        results.append(res)
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -542,6 +542,12 @@ engines:
     timeout: 3.0
     disabled: true
 
+  - name: emojipedia
+    engine: emojipedia
+    timeout: 4.0
+    shortcut: em
+    disabled: true
+
   - name: tineye
     engine: tineye
     shortcut: tin


### PR DESCRIPTION
## What does this PR do?

Add Emojipedia

## Why is this change important?

Emojipedia is an emoji reference website which documents the meaning and
common usage of emoji characters in the Unicode Standard.  It is owned by Zedge
since 2021. Emojipedia is a voting member of The Unicode Consortium.[1]

[1] https://en.wikipedia.org/wiki/Emojipedia

## How to test this PR locally?

    !em facepalm

## Related issues

Cherry picked from @james-still [2[3] and slightly modified to fit SearXNG's
quality gates.

[2] https://github.com/james-still/searx/commit/2fc01eb20f8de5f9cac492dcdfb817a6f0636580
[3] https://github.com/searx/searx/pull/3278
