### PR TITLE
feat: Add tor check plugin

### DIFF
--- a/docs/src/searx.plugins.tor_check.rst
+++ b/docs/src/searx.plugins.tor_check.rst
@@ -1,0 +1,9 @@
+.. _tor check plugin:
+
+================
+Tor check plugin
+================
+
+.. automodule:: searx.plugins.tor_check
+  :members:
+

--- a/searx/plugins/tor_check.py
+++ b/searx/plugins/tor_check.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""A plugin to check if the ip address of the request is a TOR exit node if the
+user searches for ``tor-check``.  It fetches the tor exit node list from
+https://check.torproject.org/exit-addresses and parses all the IPs into a list,
+then checks if the user's IP address is in it.
+
+Enable in ``settings.yml``:
+
+.. code:: yaml
+
+  enabled_plugins:
+    ..
+    - 'Tor check plugin'
+
+"""
+
+import re
+from flask_babel import gettext
+from httpx import HTTPError
+from searx.network import get
+
+default_on = False
+
+name = gettext("Tor check plugin")
+'''Translated name of the plugin'''
+
+description = gettext(
+    "This plugin checks if the address of the request is a TOR exit node, and"
+    " informs the user if it is, like check.torproject.org but from searxng."
+)
+'''Translated description of the plugin.'''
+
+preference_section = 'query'
+'''The preference section where the plugin is shown.'''
+
+query_keywords = ['tor-check']
+'''Query keywords shown in the preferences.'''
+
+query_examples = ''
+'''Query examples shown in the preferences.'''
+
+# Regex for exit node addresses in the list.
+reg = re.compile(r"(?<=ExitAddress )\S+")
+
+
+def post_search(request, search):
+
+    if search.search_query.pageno > 1:
+        return True
+
+    if search.search_query.query.lower() == "tor-check":
+
+        # Request the list of tor exit nodes.
+        try:
+            resp = get("https://check.torproject.org/exit-addresses")
+            node_list = re.findall(reg, resp.text)
+
+        except HTTPError:
+            # No answer, return error
+            search.result_container.answers["tor"] = {
+                "answer": gettext(
+                    "The TOR exit node list (https://check.torproject.org/exit-addresses) is unreachable."
+                )
+            }
+            return True
+
+        x_forwarded_for = request.headers.getlist("X-Forwarded-For")
+
+        if x_forwarded_for:
+            ip_address = x_forwarded_for[0]
+        else:
+            ip_address = request.remote_addr
+
+        if ip_address in node_list:
+            search.result_container.answers["tor"] = {
+                "answer": gettext(
+                    "You are using TOR. Your IP address seems to be: {ip_address}.".format(ip_address=ip_address)
+                )
+            }
+        else:
+            search.result_container.answers["tor"] = {
+                "answer": gettext(
+                    "You are not using TOR. Your IP address seems to be: {ip_address}.".format(ip_address=ip_address)
+                )
+            }
+
+    return True

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -187,6 +187,7 @@ outgoing:
 #   - 'Hostname replace'  # see hostname_replace configuration below
 #   - 'Open Access DOI rewrite'
 #   - 'Vim-like hotkeys'
+#   - 'Tor check plugin'
 
 # Configuration of the "Hostname replace" plugin:
 #


### PR DESCRIPTION
Add tor_check plugin which allows convenient tor checking trough searxng

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This PR adds a tor_check plugin to conveniently check if you are using tor,
the plugin returns whether you are using tor or not if you search for "tor", "tor check", or "check tor" as well as your own ip
like check.torproject.org does.
Sort of like the self_info plugin but for tor checking.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
It's IMO convenient to be able to check if you're using tor from your search engine,
like it is convenient to be able to check your IP or user agent from it.
I think it would be overall a nice thing to add and would improve the UE of some people including me.


## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

Uncomment "Tor check plugin" in settings.yml
(optional) Set the IP variable to a TOR exit node's ip address if you don't want to port forward to access your test instance from tor.
make run.
Search for "tor".


## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
