### PR TITLE
Add infinite scroll as a setting in settings.yml

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -230,6 +230,7 @@ Global Settings
    ui:
      default_locale: ""
      query_in_title: false
+     infinite_scroll: false
      center_alignment: false
      default_theme: simple
      theme_args:
@@ -244,6 +245,9 @@ Global Settings
 ``query_in_title`` :
   When true, the result page's titles contains the query it decreases the
   privacy, since the browser can records the page titles.
+
+``infinite_scroll``:
+  When true, automatically loads the next page when scrolling to bottom of the current page.
 
 ``center_alignment`` : default ``false``
   When enabled, the results are centered instead of being in the left (or RTL)

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -89,6 +89,8 @@ ui:
   # query_in_title: When true, the result page's titles contains the query
   # it decreases the privacy, since the browser can records the page titles.
   query_in_title: false
+  # infinite_scroll: When true, automatically loads the next page when scrolling to bottom of the current page.
+  infinite_scroll: false
   # ui theme
   default_theme: simple
   # center the results ?


### PR DESCRIPTION
## What does this PR do?

<!-- explain the changes in your PR, algorithms, design, architecture -->
Added the `infinite_scroll:` bool to searx/settings.yml. This is currently a hidden setting.

## Why is this change important?

Would help the people asking how to enable infinite scroll in the settings such as in this discussion: https://github.com/searxng/searxng/discussions/1333.

<!-- explain the motivation behind your PR -->
It also makes it easier to enable `infinite_scroll` in the settings.yml with tools like sed.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->
Nothing should be change as infinite scroll is still disabled by default.

Changing the setting to true will enable infinite scroll.