### PR TITLE
config page

### DIFF
--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -225,7 +225,7 @@ SCHEMA = {
     'doi_resolvers': {},
     'security': {
         'config_page': SettingsValue(bool, True),
-    }
+    },
 }
 
 

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -223,6 +223,9 @@ SCHEMA = {
     'categories_as_tabs': SettingsValue(dict, CATEGORIES_AS_TABS),
     'engines': SettingsValue(list, []),
     'doi_resolvers': {},
+    'security': {
+        'config_page': SettingsValue(bool, True),
+    }
 }
 
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1319,6 +1319,8 @@ def clear_cookies():
 
 @app.route('/config')
 def config():
+    if not get_setting('security.config_page'):
+        flask.abort(403)
     """Return configuration in JSON format."""
     _engines = []
     for name, engine in engines.items():


### PR DESCRIPTION
## What does this PR do?

Adds `security.config_page`

When the value is `false` `/config` will return 403

When the value is `true` `/config` will return the config as it did before

## Why is this change important?

Some administrators may not want there config values to be public.

## How to test this PR locally?

`make run` without changing settings.yml: check the `/config` page is still accessible 
Change for security.config_page: false: the `/config` page will return 403