### PR TITLE
Add onion url to duckduckgo engine.

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -239,6 +239,8 @@ def update_attributes_for_tor(engine: Engine) -> bool:
     if using_tor_proxy(engine) and hasattr(engine, 'onion_url'):
         engine.search_url = engine.onion_url + getattr(engine, 'search_path', '')
         engine.timeout += settings['outgoing'].get('extra_proxy_timeout', 0)
+        if hasattr(engine, 'ping_url'):
+            engine.ping_url = engine.onion_url + getattr(engine, 'ping_path', '')
 
 
 def is_missing_required_attributes(engine):

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -29,7 +29,7 @@ about = {
 # engine dependent config
 categories = ['general', 'web']
 paging = True
-supported_languages_url = 'https://duckduckgo.com/util/u588.js'
+supported_languages_url = 'https://duckduckgo.com/util/u588.js' # <-- ISSUE/FIXME: searx.engines.__init__ won't update this URL.
 time_range_support = True
 
 language_aliases = {
@@ -45,8 +45,13 @@ language_aliases = {
 time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
 
 # search-url
-url = 'https://lite.duckduckgo.com/lite'
-url_ping = 'https://duckduckgo.com/t/sl_l'
+base_url = 'https://lite.duckduckgo.com'
+onion_url = 'https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion'
+search_path = '/lite?'
+ping_path = '/t/sl_l'
+
+search_url = base_url + search_path
+ping_url = base_url + ping_path
 
 # match query's language to a region code that duckduckgo will accept
 def get_region_code(lang, lang_list=None):
@@ -118,7 +123,7 @@ def request(query, params):
 def response(resp):
 
     headers_ping = dict_subset(resp.request.headers, ['User-Agent', 'Accept-Encoding', 'Accept', 'Cookie'])
-    get(url_ping, headers=headers_ping)
+    get(ping_url, headers=headers_ping)
 
     if resp.status_code == 303:
         return []

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -29,7 +29,8 @@ about = {
 # engine dependent config
 categories = ['general', 'web']
 paging = True
-supported_languages_url = 'https://duckduckgo.com/util/u588.js' # <-- ISSUE/FIXME: searx.engines.__init__ won't update this URL.
+# ISSUE/FIXME: searx.engines.__init__ won't update this URL.
+supported_languages_url = 'https://duckduckgo.com/util/u588.js'
 time_range_support = True
 
 language_aliases = {
@@ -47,11 +48,11 @@ time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
 # search-url
 base_url = 'https://lite.duckduckgo.com'
 onion_url = 'https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion'
-search_path = '/lite?'
+search_path = '/lite'
 ping_path = '/t/sl_l'
 
 search_url = base_url + search_path
-ping_url = base_url + ping_path
+ping_url = 'https://duckduckgo.com' + ping_path
 
 # match query's language to a region code that duckduckgo will accept
 def get_region_code(lang, lang_list=None):
@@ -67,7 +68,7 @@ def get_region_code(lang, lang_list=None):
 
 def request(query, params):
 
-    params['url'] = url
+    params['url'] = search_url
     params['method'] = 'POST'
 
     params['data']['q'] = query


### PR DESCRIPTION
## What does this PR do?
Adds the ddg onion url to the ddg engine.

## Why is this change important?
Keeping communication within Tor is theoretically more private than using the clearnet version of the site over Tor.

## How to test this PR locally?
Run it with a tor proxy specified (e.g. `socks5h://localhost:9050`) and `using_tor_proxy: true`

## Related issues

Closes #1505 
