### PR TITLE
[fix] preferences: missing option value

### DIFF
--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -270,7 +270,7 @@
       <p class="value">
         <select name='image_proxy' aria-labelledby="pref_image_proxy">
           <option value="1" {% if image_proxy %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
-          <option value="" {% if not image_proxy %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>
+          <option value="0" {% if not image_proxy %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>
         </select>
       </p>
       <div class="description">{{ _('Proxying image results through SearXNG') }}</div>
@@ -282,7 +282,7 @@
       <p class="value">
         <select name='query_in_title' aria-labelledby="pref_query_in_title">
           <option value="1" {% if query_in_title %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>
-          <option value="" {% if not query_in_title %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>
+          <option value="0" {% if not query_in_title %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>
         </select>
       </p>
       <div class="description">{{ _("When enabled, the result page's title contains your query. Your browser can record this title") }}</div>


### PR DESCRIPTION
## What does this PR do?

Fix missing option value "0".

## Why is this change important?

Image proxy and Query in the page's title setting could not be disabled by the user.

## How to test this PR locally?

1. `make run`
2. change Image proxy and/or Query in the page's title setting

## Related issues

https://github.com/searxng/searxng/issues/1503
