### PR TITLE
pass morty key as env variable

### DIFF
--- a/utils/templates/lib/systemd/system/morty.service
+++ b/utils/templates/lib/systemd/system/morty.service
@@ -10,10 +10,10 @@ Type=simple
 User=${SERVICE_USER}
 Group=${SERVICE_GROUP}
 WorkingDirectory=${SERVICE_HOME}
-ExecStart=${SERVICE_HOME}/go-apps/bin/morty -key '${MORTY_KEY}' -listen '${MORTY_LISTEN}' -timeout ${MORTY_TIMEOUT}
+ExecStart=${SERVICE_HOME}/go-apps/bin/morty -listen '${MORTY_LISTEN}' -timeout ${MORTY_TIMEOUT}
 
 Restart=always
-Environment=USER=${SERVICE_USER} HOME=${SERVICE_HOME} DEBUG=${SERVICE_ENV_DEBUG}
+Environment=USER=${SERVICE_USER} HOME=${SERVICE_HOME} DEBUG=${SERVICE_ENV_DEBUG} MORTY_KEY=${MORTY_KEY}
 
 # Some distributions may not support these hardening directives.  If you cannot
 # start the service due to an unknown option, comment out the ones not supported


### PR DESCRIPTION
## What does this PR do?

It modify the way we give the MORTY_KEY to morty service, previously we were passing it as a command line argument, now we are passing it as an environment variable.

## Why is this change important?

I installed a searxng instance and image proxying wasn't working, all the images were returning 403 with this error : 

```
Error: invalid "mortyhash" parameter
```

so it meant that the hash verification wasn't working and I couldn't figure out why.

I checked that the key setup in settings.yml was the same in the searx service and the morty service and it was, but still didn't work.

After some research I found out that you could pass this key to morty as an environment variable, I tested it and it worked for me.

Also passing it as a command line argument will likely be logged by the system somewhere, so it's probably better to do it this way ?