### PR TITLE
[fix] sjp engine - convert enginename to a latin1 compliance name

### DIFF
--- a/searx/engines/sjp.py
+++ b/searx/engines/sjp.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Słownik Języka Polskiego (general)
+# lint: pylint
+"""Słownik Języka Polskiego
 
+Dictionary of the polish language from PWN (sjp.pwn)
 """
 
 from lxml.html import fromstring

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1732,7 +1732,7 @@ engines:
       results: HTML
       language: de
 
-  - name: słownik języka polskiego
+  - name: sjp.pwn
     engine: sjp
     shortcut: sjp
     base_url: https://sjp.pwn.pl/


### PR DESCRIPTION
The engine name is not only a *name* its also a identifier that is used in logs, HTTP headers and more.  Unicode characters in the name of an engine could cause various issues.

Closes: https://github.com/searxng/searxng/issues/1544
