### PR TITLE
Increase lingva engine timeout

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -889,6 +889,7 @@ engines:
   - name: lingva
     engine: lingva
     shortcut: lv
+    timeout: 5.0
     # set lingva instance in url, by default it will use the official instance
     # url: https://lingva.ml
 


### PR DESCRIPTION
## What does this PR do?

This PR increases the timeout of the lingva engine

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

3 seconds isn't enough for lingva (returns timeout), so this PR increases it to 5 seconds

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

search `!lv en-ja test`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
