### PR TITLE
Fix pyright errors

### DIFF
--- a/manage
+++ b/manage
@@ -698,7 +698,8 @@ test.pyright() {
         | grep -v '/engines/.*.py.* - warning: "logger" is not defined'\
         | grep -v '/plugins/.*.py.* - error: "logger" is not defined'\
         | grep -v '/engines/.*.py.* - warning: "supported_languages" is not defined' \
-        | grep -v '/engines/.*.py.* - warning: "language_aliases" is not defined'
+        | grep -v '/engines/.*.py.* - warning: "language_aliases" is not defined' \
+        | grep -v '/engines/.*.py.* - warning: "categories" is not defined'
     dump_return $?
 }
 

--- a/searx/compat.py
+++ b/searx/compat.py
@@ -7,8 +7,11 @@
 # pylint: disable=C,R
 
 
+__all__ = ('cached_property',)
+
+
 try:
-    from functools import cached_property  # pylint: disable=unused-import
+    from functools import cached_property  # type: ignore
 
 except ImportError:
 

--- a/searx/engines/mongodb.py
+++ b/searx/engines/mongodb.py
@@ -5,7 +5,7 @@
 """
 
 import re
-from pymongo import MongoClient  # pylint: disable=import-error
+from pymongo import MongoClient  # pyright: ignore # pylint: disable=import-error
 
 engine_type = 'offline'
 

--- a/searx/engines/mysql_server.py
+++ b/searx/engines/mysql_server.py
@@ -6,7 +6,7 @@
 
 # import error is ignored because the admin has to install mysql manually to use
 # the engine
-import mysql.connector  # pylint: disable=import-error
+import mysql.connector  # pyright: ignore # pylint: disable=import-error
 
 engine_type = 'offline'
 auth_plugin = 'caching_sha2_password'

--- a/searx/engines/postgresql.py
+++ b/searx/engines/postgresql.py
@@ -6,7 +6,7 @@
 
 # import error is ignored because the admin has to install mysql manually to use
 # the engine
-import psycopg2  # pylint: disable=import-error
+import psycopg2  # pyright: ignore # pylint: disable=import-error
 
 engine_type = 'offline'
 host = "127.0.0.1"

--- a/searx/search/__init__.py
+++ b/searx/search/__init__.py
@@ -2,10 +2,11 @@
 # lint: pylint
 # pylint: disable=missing-module-docstring, too-few-public-methods
 
-import typing
 import threading
 from timeit import default_timer
 from uuid import uuid4
+
+import flask
 
 from searx import settings
 from searx.answerers import ask
@@ -181,7 +182,7 @@ class SearchWithPlugins(Search):
 
     __slots__ = 'ordered_plugin_list', 'request'
 
-    def __init__(self, search_query: SearchQuery, ordered_plugin_list, request: "flask.Request"):
+    def __init__(self, search_query: SearchQuery, ordered_plugin_list, request: flask.Request):
         super().__init__(search_query)
         self.ordered_plugin_list = ordered_plugin_list
         self.result_container.on_result = self._on_result

--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -16,7 +16,7 @@ from searx import logger, settings, searx_debug
 from searx.exceptions import SearxSettingsException
 from searx.search.processors import PROCESSORS
 from searx.search.checker import Checker
-from searx.shared import schedule, storage
+from searx.shared import schedule, storage  # pyright: ignore
 
 
 CHECKER_RESULT = 'CHECKER_RESULT'

--- a/searx/shared/__init__.py
+++ b/searx/shared/__init__.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import logging
+import importlib
 
 logger = logging.getLogger('searx.shared')
 
+__all__ = ['SharedDict', 'schedule']
+
 try:
-    import uwsgi
+    uwsgi = importlib.import_module('uwsgi')
 except:
     # no uwsgi
     from .shared_simple import SimpleSharedDict as SharedDict, schedule

--- a/searx/shared/shared_uwsgi.py
+++ b/searx/shared/shared_uwsgi.py
@@ -2,7 +2,7 @@
 
 import time
 from typing import Optional
-import uwsgi  # pylint: disable=E0401
+import uwsgi  # pyright: ignore # pylint: disable=E0401
 from . import shared_abstract
 
 

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -66,7 +66,7 @@ def searx_useragent() -> str:
     ).strip()
 
 
-def gen_useragent(os_string: str = None) -> str:
+def gen_useragent(os_string: Optional[str] = None) -> str:
     """Return a random browser User Agent
 
     See searx/data/useragents.json
@@ -570,7 +570,7 @@ def eval_xpath(element: ElementBase, xpath_spec: XPathSpecType):
         raise SearxEngineXPathException(xpath_spec, arg) from e
 
 
-def eval_xpath_list(element: ElementBase, xpath_spec: XPathSpecType, min_len: int = None):
+def eval_xpath_list(element: ElementBase, xpath_spec: XPathSpecType, min_len: Optional[int] = None):
     """Same as eval_xpath, check if the result is a list
 
     Args:

--- a/searx/version.py
+++ b/searx/version.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import subprocess
 import logging
+import importlib
 
 # fallback values
 # if there is searx.version_frozen module, and it is not possible to get the git tag
@@ -73,7 +74,8 @@ def get_git_version():
 
 
 try:
-    from searx.version_frozen import VERSION_STRING, VERSION_TAG, GIT_URL, GIT_BRANCH
+    vf = importlib.import_module('searx.version_frozen')
+    VERSION_STRING, VERSION_TAG, GIT_URL, GIT_BRANCH = vf.VERSION_STRING, vf.VERSION_TAG, vf.GIT_URL, vf.GIT_BRANCH
 except ImportError:
     try:
         try:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1303,7 +1303,7 @@ def opensearch():
 def favicon():
     theme = request.preferences.get_value("theme")
     return send_from_directory(
-        os.path.join(app.root_path, settings['ui']['static_path'], 'themes', theme, 'img'),
+        os.path.join(app.root_path, settings['ui']['static_path'], 'themes', theme, 'img'),  # pyright: ignore
         'favicon.png',
         mimetype='image/vnd.microsoft.icon',
     )


### PR DESCRIPTION
## What does this PR do?

<details>

<summary>fix pyright repported errors:</summary>

```
  /home/alexandre/code/searxng/searx/compat.py:11:27 - error: Expression of type "Type[cached_property[_T@cached_property]]" cannot be assigned to declared type "Type[cached_property]"
    "Type[cached_property[_T@cached_property]]" is incompatible with "Type[cached_property]"
    Type "Type[cached_property[_T@cached_property]]" cannot be assigned to type "Type[cached_property]" (reportGeneralTypeIssues)
  /home/alexandre/code/searxng/searx/utils.py:69:36 - error: Expression of type "None" cannot be assigned to parameter of type "str"
    Type "None" cannot be assigned to type "str" (reportGeneralTypeIssues)
  /home/alexandre/code/searxng/searx/utils.py:573:85 - error: Expression of type "None" cannot be assigned to parameter of type "int"
    Type "None" cannot be assigned to type "int" (reportGeneralTypeIssues)
  /home/alexandre/code/searxng/searx/webapp.py:1306:22 - error: Argument of type "str" cannot be assigned to parameter "__a" of type "BytesPath" in function "join"
    Type "str" cannot be assigned to type "BytesPath"
      "str" is incompatible with "bytes"
      "str" is incompatible with protocol "PathLike[bytes]"
        "__fspath__" is not present (reportGeneralTypeIssues)
  /home/alexandre/code/searxng/searx/webapp.py:1306:68 - error: Argument of type "Literal['themes']" cannot be assigned to parameter "paths" of type "BytesPath" in function "join"
    Type "Literal['themes']" cannot be assigned to type "BytesPath"
      "Literal['themes']" is incompatible with "bytes"
      "Literal['themes']" is incompatible with protocol "PathLike[bytes]"
        "__fspath__" is not present (reportGeneralTypeIssues)
  /home/alexandre/code/searxng/searx/webapp.py:1306:78 - error: Argument of type "str | Any | None" cannot be assigned to parameter "paths" of type "BytesPath" in function "join"
    Type "str | Any | None" cannot be assigned to type "BytesPath"
      Type "str" cannot be assigned to type "BytesPath"
        "str" is incompatible with "bytes"
        "str" is incompatible with protocol "PathLike[bytes]"
          "__fspath__" is not present (reportGeneralTypeIssues)
  /home/alexandre/code/searxng/searx/webapp.py:1306:85 - error: Argument of type "Literal['img']" cannot be assigned to parameter "paths" of type "BytesPath" in function "join"
    Type "Literal['img']" cannot be assigned to type "BytesPath"
      "Literal['img']" is incompatible with "bytes"
      "Literal['img']" is incompatible with protocol "PathLike[bytes]"
        "__fspath__" is not present (reportGeneralTypeIssues)
  /home/alexandre/code/searxng/searx/engines/mongodb.py:8:6 - warning: Import "pymongo" could not be resolved (reportMissingImports)
  /home/alexandre/code/searxng/searx/engines/mysql_server.py:9:8 - warning: Import "mysql.connector" could not be resolved (reportMissingImports)
  /home/alexandre/code/searxng/searx/engines/postgresql.py:9:8 - warning: Import "psycopg2" could not be resolved from source (reportMissingModuleSource)
  /home/alexandre/code/searxng/searx/engines/xpath.py:187:28 - warning: "categories" is not defined (reportUndefinedVariable)
  /home/alexandre/code/searxng/searx/search/__init__.py:184:82 - warning: "flask" is not defined (reportUndefinedVariable)
  /home/alexandre/code/searxng/searx/search/checker/background.py:19:26 - error: Type of "schedule" is partially unknown
    Type of "schedule" is "(delay: Any, func: Any, *args: Any) -> Literal[True]" (reportUnknownVariableType)
  /home/alexandre/code/searxng/searx/shared/__init__.py:8:12 - warning: Import "uwsgi" could not be resolved (reportMissingImports)
  /home/alexandre/code/searxng/searx/shared/shared_uwsgi.py:5:8 - warning: Import "uwsgi" could not be resolved (reportMissingImports)
```

</details>

## Why is this change important?

The errors make pyright usage useless since a new error won't be seen.

## How to test this PR locally?

* `make test.pyright`

## Author's checklist

The [`| grep`](https://github.com/searxng/searxng/blob/50ec821e8c5b099947d657722b1879fc8c03bcfa/manage#L699-L703) in `./manage` removes the colored output.


Without grep (the errors in the screenshot are hidden by `./manage`) :

![image](https://user-images.githubusercontent.com/1594191/181491198-22915dad-bb0d-4467-afb5-28d0cf151007.png)

With a `| cat` (or any pipe):

![image](https://user-images.githubusercontent.com/1594191/181491580-08445874-d8ab-4f9f-977b-7ce0f2f38d0e.png)


## Related issues

<!--
Closes #234
-->
