### PR TITLE
[fix] uWSGI: increase buffer-size

### DIFF
--- a/docs/admin/update-searxng.rst
+++ b/docs/admin/update-searxng.rst
@@ -75,6 +75,13 @@ uninstalled.
    have old filtron, morty or searx setup you should consider complete
    uninstall/reinstall.
 
+Here you will find a list of changes that affect the infrastructure.  Please
+check to what extent it is necessary to update your installations:
+
+:pull:`1595`: ``[fix] uWSGI: increase buffer-size``
+  Re-install uWSGI (:ref:`searxng.sh`) or fix your uWSGI ``searxng.ini``
+  file manually.
+
 
 remove obsolete services
 ------------------------

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
@@ -70,6 +70,7 @@ pythonpath = ${SEARXNG_SRC}
 # Native HTTP support: https://uwsgi-docs.readthedocs.io/en/latest/HTTP.html
 
 http = ${SEARXNG_INTERNAL_HTTP}
+buffer-size = 8192
 
 # uWSGI serves the static files and in settings.yml we use::
 #

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
@@ -67,6 +67,7 @@ pythonpath = ${SEARXNG_SRC}
 # -----------------
 
 socket = ${SEARXNG_UWSGI_SOCKET}
+buffer-size = 8192
 
 # uWSGI serves the static files and in settings.yml we use::
 #

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini
@@ -73,6 +73,7 @@ pythonpath = ${SEARXNG_SRC}
 # Native HTTP support: https://uwsgi-docs.readthedocs.io/en/latest/HTTP.html
 
 http = ${SEARXNG_INTERNAL_HTTP}
+buffer-size = 8192
 
 # uWSGI serves the static files and in settings.yml we use::
 #

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
@@ -70,6 +70,7 @@ pythonpath = ${SEARXNG_SRC}
 # -----------------
 
 socket = ${SEARXNG_UWSGI_SOCKET}
+buffer-size = 8192
 
 # uWSGI serves the static files and in settings.yml we use::
 #


### PR DESCRIPTION
## What does this PR do?

4096 as buffer-size is too small and will result in the preference urls not working.

## How to test this PR locally?

1. Install with uWSGI
2. Try importing the "Search URL of the currently saved preferences" and/or "URL to restore your preferences in another browser" URL.
