### PR TITLE
[fix] pycodestyle has been replaced by black in 3c77412d3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ mock==4.0.3
 nose2[coverage_plugin]==0.12.0
 cov-core==1.15.0
 black==22.6.0
-pycodestyle==2.9.1
 pylint==2.14.5
 splinter==0.18.1
 selenium==4.3.0


### PR DESCRIPTION
## What does this PR do?

remove no longer needed dependence / pycodestyle has been replaced by black in 3c77412d3

## Related issues

https://github.com/searxng/searxng/pull/619
