### PR TITLE
[mod] engine yep.com: show all 100 results yep.com has

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -422,18 +422,13 @@ engines:
     categories: general
     disabled: true
     paging: false
-    page_size: 10
     content_html_to_text: true
     title_html_to_text: true
-    search_url: https://api.yep.com/fs/1/?type=web&q={query}&no_correct=false
+    search_url: https://api.yep.com/fs/1/?type=web&q={query}&no_correct=false&limit=100
     results_query: 1/results
     title_query: title
     url_query: url
     content_query: snippet
-    timeout: 12.0
-    headers:
-      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
-      'Sec-Fetch-Dest': 'document'
     about:
       website: https://yep.com
       use_official_api: false


### PR DESCRIPTION

## What does this PR do?

engine yep.com: show all 100 results yep.com has

yep.com is still in beta, the api.yep.com does not have paging support.  There
is only a 'limit' argument with a maximum of 100 results.

yep.com seems fast; there is nor need for a timeout of 12 sec.

The API returns JSON nevertheless what the HTTP header is, the "show more"
button on yep.com's web site does not set a special HTTP Accept header.

FYI: The index does not support languages, the WEB UI does not offer a language
selection of the results and the entire index seems in English.

Closes: https://github.com/searxng/searxng/issues/1619
