### PR TITLE
[fix] typo in uWSGI cache: searxcache --> searxngcache

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -210,7 +210,7 @@ checker:
 
   # to activate the scheduler:
   # * uncomment "scheduling" section
-  # * add "cache2 = name=searxcache,items=2000,blocks=2000,blocksize=4096,bitmap=1"
+  # * add "cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1"
   #   to your uwsgi.ini
 
   # scheduling:

--- a/searx/shared/__init__.py
+++ b/searx/shared/__init__.py
@@ -23,7 +23,7 @@ else:
         # uwsgi.ini configuration problem: disable all scheduling
         logger.error(
             'uwsgi.ini configuration error, add this line to your uwsgi.ini\n'
-            'cache2 = name=searxcache,items=2000,blocks=2000,blocksize=4096,bitmap=1'
+            'cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1'
         )
         from .shared_simple import SimpleSharedDict as SharedDict
 


### PR DESCRIPTION
## What does this PR do?

Fix a typo about the uWSGI cache. 

## Author's checklist

The uWSGI cache is only needed for the scheduler and the only scheduler application we have is the engine checker.

This PR just fixes a typo, on the long term the uWSGI cache needed by the scheduler will be replaced by a redis cache (see https://github.com/searxng/searxng/pull/1513 )

