### PR TITLE
Revert Google XPath.

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -113,7 +113,7 @@ filter_mapping = {0: 'off', 1: 'medium', 2: 'high'}
 # ------------------------
 
 # google results are grouped into <div class="jtfYYd ..." ../>
-results_xpath = '//div[contains(@class, "kvH3mc")]'
+results_xpath = '//div[contains(@class, "jtfYYd")]'
 
 # google *sections* are no usual *results*, we ignore them
 g_section_with_header = './g-section-with-header'


### PR DESCRIPTION
## What does this PR do?

Reverts the XPath from yesterday. Google changed it back recently and the Google Engine is currently not working.

Reverts https://github.com/searxng/searxng/pull/1633

## How to test this PR locally?

1. `make run`
2. `Search !go test`