### PR TITLE
[mod] add deepl translation engine

### DIFF
--- a/searx/engines/deepl.py
+++ b/searx/engines/deepl.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Deepl translation engine"""
+
+from json import loads
+
+about = {
+    "website": 'https://deepl.com',
+    "wikidata_id": 'Q43968444',
+    "official_api_documentation": 'https://www.deepl.com/docs-api',
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": 'JSON',
+}
+
+engine_type = 'online_dictionary'
+categories = ['general']
+
+url = 'https://api-free.deepl.com/v2/translate'
+api_key = None
+
+
+def request(_query, params):
+    '''pre-request callback
+
+    params<dict>:
+
+    - ``method`` : POST/GET
+    - ``headers``: {}
+    - ``data``: {}  # if method == POST
+    - ``url``: ''
+    - ``category``: 'search category'
+    - ``pageno``: 1  # number of the requested page
+    '''
+
+    params['url'] = url
+    params['method'] = 'POST'
+    params['data'] = {'auth_key': api_key, 'text': params['query'], 'target_lang': params['to_lang'][1]}
+
+    return params
+
+
+def response(resp):
+    results = []
+    result = loads(resp.text)
+    translations = result['translations']
+
+    infobox = "<dl>"
+
+    for translation in translations:
+        infobox += f"<dd>{translation['text']}</dd>"
+
+    infobox += "</dl>"
+
+    results.append(
+        {
+            'infobox': 'Deepl',
+            'content': infobox,
+        }
+    )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1626,6 +1626,15 @@ engines:
     engine: seznam
     disabled: true
 
+  # - name: deepl
+  #   engine: deepl
+  #   shortcut: dpl
+  #   # You can use the engine using the official stable API, but you need an API key
+  #   # See: https://www.deepl.com/pro-api?cta=header-pro-api
+  #   api_key: ''  # required!
+  #   timeout: 5.0
+  #   disabled: true
+
   - name: mojeek
     shortcut: mjk
     engine: xpath


### PR DESCRIPTION
## What does this PR do?

Cherry pick of @cy8aer's ce167a1 commit.  The commit implements the Deepl Translation engine and was send as PR to the searx project.

It works nearly like lingva but directly to the deepl API.  This api only needs a to-lang, from-lang is a fake by now. [ce167a1]

To fit into SearXNG I slightly modified the commit.

[ce167a1] https://github.com/searx/searx/pull/3332/commits/ce167a18001b9b060cd4d5bb381b68f585de5c9b

## Why is this change important?

You will have deepl in searx with full phrase and sentence translations

## How to test this PR locally?

Api key needed. Put api key into settings.yml - enable deepl.

Start `make run` and type search queries:

    de-en Dies ist ein großartiger Test
    en-es This is deepl.

## Author's checklist

I can't test since I do not have a deepl API key.

@cy8aer do like to test deepl engine here in the SearXNG project?

