### PR TITLE
output format protobuf to HTML for google mobile

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -112,21 +112,14 @@ filter_mapping = {0: 'off', 1: 'medium', 2: 'high'}
 # specific xpath variables
 # ------------------------
 
-# google results are grouped into <div class="jtfYYd ..." ../>
-results_xpath = '//div[contains(@class, "jtfYYd")]'
+results_xpath = '//div[contains(@class, "MjjYud")]'
+title_xpath = './/h3[1]'
+href_xpath = './/a/@href'
+content_xpath = './/div[@data-content-feature=1]'
 
 # google *sections* are no usual *results*, we ignore them
 g_section_with_header = './g-section-with-header'
 
-# the title is a h3 tag relative to the result group
-title_xpath = './/h3[1]'
-
-# in the result group there is <div class="yuRUbf" ../> it's first child is a <a
-# href=...>
-href_xpath = './/div[@class="yuRUbf"]//a/@href'
-
-# in the result group there is <div class="VwiC3b ..." ../> containing the *content*
-content_xpath = './/div[contains(@class, "VwiC3b")]'
 
 # Suggestions are links placed in a *card-section*, we extract only the text
 # from the links not the links itself.

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -261,7 +261,7 @@ def request(query, params):
     if use_mobile_ui:
         additional_parameters = {
             'asearch': 'arc',
-            'async': 'use_ac:true,_fmt:pc',
+            'async': 'use_ac:true,_fmt:html',
         }
 
     # https://www.google.de/search?q=corona&hl=de&lr=lang_de&start=0&tbs=qdr%3Ad&safe=medium


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This switch the output format from protobuf to HTML for the Google Mobile UI.

## Why is this change important?

Previously with the protobuf output, the HTML parser had to take into account things that were not HTML data. With this new parameter the output is a "clean" HTML output that the parser can "easily" parse.

On top of that the size returned is so much smaller, like 4 times smaller, but the response time is still the same.

## How to test this PR locally?

Launch SearXNG with the parameter `use_mobile_ui` set to `true` for google engine:
```yml
- name: google 
   engine: google 
   shortcut: go
   # see https://docs.searxng.org/src/searx.engines.google.html#module-searx.engines.google 
   use_mobile_ui: true 
```

## Additional info

The URL used by SearXNG in the `use_mobile_ui` mode (example: `https://www.google.com/search?q=ok&start=0&asearch=arc&async=use_ac:true,_fmt:html`) can now also be used in order to diagnose any breakage in the XPath parsing.

## Author's checklist

N/A

## Related issues

N/A
