### PR TITLE
Add sourcehut engine

### DIFF
--- a/searx/data/engine_descriptions.json
+++ b/searx/data/engine_descriptions.json
@@ -135,44 +135,42 @@
   ]
  },
  "zh-HK":{
-  "archive is":"archive.today又稱archive.is，是一個私人資助的網頁存檔網站，資料中心位於歐洲法國的北部-加來海峽。這個網站典藏檔案館使用Apache Hadoop與Apache Accumulo軟體。它可以一次取回一個類似於WebCite的小於50MB的頁面，並能收錄Google地圖與Twitter。",
-  "artic":"芝加哥藝術博物館，是一座位於美國伊利諾州芝加哥的美術館，於1879年成立，是世界上最古老、規模最大的藝術博物館之一。該博物館因其策展與展示大量藝術家的作品而受到歡迎，每年共有約150萬人參觀。該博物館的收藏由11個策展部門管理，並保存了喬治·秀拉的《大碗島的星期天下午》、巴勃羅·畢卡索的《老吉他手》 、愛德華·霍普的《夜遊者》和格蘭特·伍德的《美國哥特式》等名作，博物館永久收藏近300,000件藝術品，每年舉辦30多個特展。",
-  "arxiv":"arXiv 是一個收集物理學、數學、計算機科學、生物學與數理經濟學的論文預印本的網站，始於1991年8月14日。截至2008年10月，arXiv.org已收集超過50萬篇預印本；至2014年底，藏量達到1百萬篇。截至2016年10月，提交率已達每月超過10,000篇。",
-  "bandcamp":"Bandcamp是一家美國線上音樂公司， 由前Oddpost聯合創始人Ethan Diamond與程序員Shawn Grunberger、Joe Holt和Neal Tucker於2008年創立，總部位於加利福尼亞。",
-  "bing":"是一款由微軟公司推出的網路搜尋引擎。Bing的歷史可追溯至於1998年的第三個季度發布的MSN Search，它的由Looksmart和Inktomi等提供；2006年3月8日，微軟發布了Windows Live Search的公測版，並於同年9月11日讓其取代了MSN Search，該引擎開始使用搜尋選項卡；次年3月，微軟將其與Windows Live分開並更名Live Search，在此期間，其子服務曾經多次重組、關閉。到了2009年6月3日，微軟將Live Search改造成了今天的Bing並正式發布。微軟認為Bing一詞簡單明了、易於拼寫，容易被人記住；它源自成語「有求必應」。微軟聲稱，此款搜尋引擎將以全新的姿態面世並帶來革命。Bing的內測代號為Kumo，其後才被命名為Bing。2020年10月5日，Bing更名為Microsoft Bing。",
+  "archive is":"archive.today又称archive.is，是一個私人資助的网页存档網站，資料中心位於歐洲法國的北部-加来海峡。這個網站典藏檔案館使用Apache Hadoop與Apache Accumulo軟體。它可以一次取回一個類似於WebCite的小於50MB的頁面，並能收錄Google地圖與Twitter。",
+  "artic":"芝加哥藝術博物館（英語：），是一座位於美國伊利諾州芝加哥的美術館，於1879年成立，是世界上最古老、規模最大的藝術博物館之一。該博物館因其策展與展示大量藝術家的作品而受到歡迎，每年共有約150萬人參觀。該博物館的收藏由11個策展部門管理，並保存了喬治·秀拉的《大碗岛的星期天下午》、巴勃羅·畢卡索的《老吉他手》 、愛德華·霍普的《夜遊者》和格兰特·伍德的《美国哥特式》等名作，博物館永久收藏近300,000件藝術品，每年舉辦30多個特展。",
+  "arxiv":"arXiv 是一個收集物理學、數學、計算機科學、生物學與數理經濟學的論文預印本的網站，始于1991年8月14日。截至2008年10月，arXiv.org已收集超過50萬篇預印本；至2014年底，藏量達到1百萬篇。截至2016年10月，提交率已達每月超過10,000篇。",
+  "bandcamp":"Bandcamp是一家美国線上音乐公司， 由前Oddpost联合创始人Ethan Diamond与程序员Shawn Grunberger、Joe Holt和Neal Tucker于2008年创立，总部位于加利福尼亚。",
+  "wikipedia":"維基百科 是维基媒体基金会运营的一个多语言的線上百科全書，并以创建和维护作为开放式协同合作项目，特点是自由內容、自由编辑、自由版权。目前是全球網絡上最大且最受大眾歡迎的参考工具书，名列全球二十大最受歡迎的網站，其在搜尋引擎中排名亦較為靠前。維基百科目前由非營利組織維基媒體基金會負責營運。Wikipedia是混成詞，分别取自於網站核心技術「Wiki」以及英文中百科全書之意的「encyclopedia」。截至2021年初，所有語種的維基百科條目數量達5,500萬。",
+  "bing":"是一款由微软公司推出的網路搜尋引擎。Bing的历史可追溯至于1998年的第三个季度发布的MSN Search，它的由Looksmart和Inktomi等提供；2006年3月8日，微软发布了Windows Live Search的公测版，并于同年9月11日让其取代了MSN Search，该引擎开始使用搜尋選項卡；次年3月，微软将其与Windows Live分开并更名Live Search，在此期间，其子服务曾经多次重组、关闭。到了2009年6月3日，微软将Live Search改造成了今天的Bing并正式发布。微软认为一词简单明了、易于拼写，容易被人记住；它源自成语「有求必应」。微软声称，此款搜尋引擎将以全新的姿态面世並带来革命。Bing的内测代号为Kumo，其后才被命名为。2020年10月5日，Bing更名為Microsoft Bing。",
   "bing images":[
    "bing:zh-HK",
    "ref"
   ],
-  "crossref":"Crossref （曾用名CrossRef）是國際DOI基金會 旗下的一個DOI注冊機構，它的成員來自2,000個不同的出版商。Crossref由Publishers International Linking Association Inc.負責運營。該機構於2000年初成立。",
-  "deezer":"Deezer是一家法國在線音樂流媒體服務提供商。它允許用戶在各種設備上在線或離線收聽來自包括環球音樂集團、索尼音樂和華納音樂集團在內的各家唱片公司的音樂。2007年，Deezer創建於法國巴黎，截至2019年1月，Deezer擁有5600萬首授權曲目，擁有超過3萬個電台頻道，月活躍用戶達1400萬，付費用戶為700萬。該服務適用於Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",
-  "wikidata":"維基數據 是一個可協同編輯的知識庫，是繼2006年的維基學院之後，第一個新的維基媒體基金會項目。這一項目與維基共享資源的工作方式類似，將為其他維基計劃及各語種維基百科中的信息框、列表及跨語言連結等提供統一存放的數據，該項目在2012年10月30日投入使用。維基數據藉由軟體Wikibase運行。",
-  "emojipedia":"表情圖標百科 是一個表情圖標參考網站，記載了Unicode標准中各個表情圖標的編碼、含義、演變等信息。",
-  "etymonline":"在線詞源詞典 是免費的在線詞典，由道格拉斯·哈珀 編纂和撰寫，用於描述英語單詞的詞源。",
-  "fdroid":"F-Droid是一個Android應用程序的軟件資源庫（或應用商店）；其功能類似於Google Play商店，但只包含自由及開放源代碼軟件。應用可從F-Droid網站或直接從F-Droid客戶端應用瀏覽及安裝，F-Droid客戶端應用會自動更新其應用。F-Droid不要求用戶注冊賬號。如果應用包含廣告、用戶分析器，追蹤器或倚賴非自由軟件，會被標記存在「負功能」（antifeatures）。運行F-Droid的服務器也均使用自由及開放源代碼軟件，從而允許任何人創建自己的軟件庫。",
+  "crossref":"Crossref （曾用名CrossRef）是國際DOI基金會 旗下的一個DOI注册机构，它的成員來自2,000個不同的出版商。Crossref由Publishers International Linking Association Inc.負責运营。該機構于2000年初成立。",
+  "deezer":"Deezer是一家法国在线音乐流媒体服务提供商。它允许用户在各种设备上在线或离线收听来自包括环球音乐集团、索尼音乐和华纳音乐集团在內的各家唱片公司的音乐。2007年，Deezer创建于法国巴黎，截至2019年1月，Deezer拥有5600万首授权曲目，拥有超过3万个电台频道，月活跃用户達1400万，付费用户為700万。该服务适用于Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",
+  "etymonline":"在线词源词典（英語：）是免费的在线词典，由道格拉斯·哈珀 编纂和撰写，用于描述英语单词的词源。",
+  "fdroid":"是一个Android应用程序的软件资源库（或应用商店）；其功能类似于Google Play商店，但只包含自由及开放源代码软件。应用可从F-Droid网站或直接从F-Droid客户端应用浏览及安装，F-Droid客户端应用会自动更新其应用。F-Droid不要求用户注册账号。如果应用包含广告、用户分析器，追踪器或倚赖非自由软件，会被标记存在「负功能」（antifeatures）。运行F-Droid的服务器也均使用自由及开放源代码软件，从而允许任何人创建自己的软件库。",
   "flickr":"Flickr為一家提供圖片分享的網路相簿，是Web 2.0的最佳利用例子之一。",
-  "free software directory":"自由軟件目錄是一個自由軟件基金會（FSF）和聯合國教育、科學及文化組織（ UNESCO ）的項目。自由軟件目錄包含自由操作系統下運行的有用自由軟件。",
-  "genius":"Genius 是一家北美數字媒體公司，於2009年8月由湯姆·雷曼、伊蘭·澤科里和馬胡德·莫哈代姆建立。該網站允許使用者對歌曲歌詞、新聞故事、詩歌和文件等提供注釋和解釋。",
-  "github":"GitHub是一個在線軟件源代碼托管服務平台，使用Git作為版本控制軟件，由開發者Chris Wanstrath、P. J. Hyett和湯姆·普雷斯頓·沃納使用Ruby on Rails編寫而成。在2018年，GitHub被微軟公司收購。",
-  "google images":"Google圖片搜索是Google公司於2001年7月推出的圖片搜索服務。Google Chrome及Firefox提供擴充功能搜索網絡圖像。",
-  "google news":"Google新聞是Google開發的一款Web新聞聚合器，由Google首席工程師克里希納·巴拉特 創造與領導開發。",
-  "google videos":"Google影片 是由Google提供的一項視訊共享和搜索服務。與YouTube類似，「Google影片」向用戶提供必要的HTML代碼，允許用戶將選定的視訊嵌入到其它的網站的頁面中。這種方法可以使用戶在網站中嵌入大量的視訊而無需考慮頻寬和儲存容量限制的問題。在2006年10月9日，Google收購了前競爭對手YouTube，並在2007年6月13日發表聲明，「Google影片」的搜索結果將包含由網絡蜘蛛在其它托管服務、YouTube和用戶上傳中抓取的內容。",
-  "google scholar":"Google學術搜索 是一個可以免費搜索學術文章的網絡搜索引擎，由計算機專家阿努拉·阿查雅開發。2004年11月，Google第一次發布了Google學術搜索的試用版。該項索引包括了世界上絕大部分出版的學術期刊。",
-  "google play apps":"Google Play又稱Play 商店，前身為Android Market。是由Google為Android作業系統所開發的流動應用程式數位發行平台，包括數位媒體商店。它作為Android作業系統的官方應用商店，允許用戶瀏覽和下載使用Android SDK開發並透過Google發布的應用程式。 Google Play也是數位媒體商店，提供音樂，雜誌，書籍，電影和電視節目。它之前提供了Google硬件裝置，直到2015年3月11日推出一個單獨的線上硬件零售商Google Store。",
+  "free software directory":"自由软件目录是一个自由软件基金会（FSF）和联合国教育、科学及文化组织（ UNESCO ）的项目。自由软件目录包含自由操作系统下运行的有用自由软件。",
+  "genius":"Genius 是一家北美数字媒体公司，於2009年8月由湯姆·雷曼、伊兰·泽科里和马胡德·莫哈代姆建立。該網站允許使用者對歌曲歌词、新闻故事、诗歌和文件等提供注釋和解释。",
+  "github":"GitHub是一个在线软件源代码托管服务平台，使用Git作为版本控制软件，由开发者Chris Wanstrath、P. J. Hyett和汤姆·普雷斯顿·沃纳使用Ruby on Rails编写而成。在2018年，GitHub被微软公司收购。",
+  "google images":"Google图片搜索是Google公司於2001年7月推出的图片搜索服務。Google Chrome及Firefox提供擴充功能搜索網絡圖像。",
+  "google news":"Google新闻是Google开发的一款Web新闻聚合器，由Google首席工程師克里希纳·巴拉特 創造與領導開發。",
+  "google videos":"Google影片 是由Google提供的一项視訊共享和搜索服务。与YouTube类似，「Google影片」向用户提供必要的HTML代码，允许用户将选定的視訊嵌入到其它的网站的页面中。这种方法可以使用户在网站中嵌入大量的視訊而无需考虑頻寬和儲存容量限制的问题。在2006年10月9日，Google收购了前競争对手YouTube，并在2007年6月13日发表声明，「Google影片」的搜索结果将包含由网络蜘蛛在其它托管服务、YouTube和用户上传中抓取的内容。",
+  "google play apps":"又稱Play 商店，前身为Android Market。是由Google为Android作業系統所開發的流動應用程式數位發行平台，包括數位媒體商店。它作為Android作業系統的官方應用商店，允許用戶瀏覽和下載使用Android SDK開發並透過Google發布的應用程式。 Google Play也是數位媒體商店，提供音樂，雜誌，書籍，電影和電視節目。它之前提供了Google硬件裝置，直到2015年3月11日推出一個單獨的線上硬件零售商Google Store。",
   "google play movies":[
    "google play apps:zh-HK",
    "ref"
   ],
-  "hoogle":"Haskell 是一種標准化的，通用的純函數式編程語言，有惰性求值和強靜態類型。它的命名源自美國邏輯學家哈斯凱爾·加里，他在數理邏輯方面上的工作使得函數式編程語言有了廣泛的基礎。在Haskell中，「函數是頭等物件」。作為一門函數程式語言，主要控制結構是函數。Haskell語言是1990年在編程語言Miranda的基礎上標准化的，並且以λ演算為基礎發展而來。這也是為什麼Haskell語言以希臘字母「λ」（Lambda）作為自己的標志。Haskell具有「證明即程序、命題為類型」的特征。",
-  "imdb":"網路電影資料庫 是一個關於電影演員、電影、電視節目、電視藝人、電子游戲和電影製作小組的在線數據庫。IMDb開辦於1990年10月17日，從1998年開始成為亞馬遜公司旗下的網站，在2020年10月17日時，IMDb慶祝了他們30週年的紀念。",
-  "library genesis":"創世紀圖書館 是一個影子圖書館，用戶可在此一網站上分享下載學術期刊文章、學術書籍、一般書籍、雜誌、漫畫。此一網站為用戶提供擋在付費牆背後，抑或官方沒釋出電子版本的資料。創世紀圖書館形容自身為「資訊整合連結」網站，為「互聯網上所收集及用戶上載的」資源提供可供查找的資料庫。",
+  "hoogle":"Haskell 是一种标准化的，通用的纯函數式編程語言，有惰性求值和强静态类型。它的命名源自美国逻辑学家哈斯凱爾·加里，他在数理逻辑方面上的工作使得函数式编程语言有了广泛的基础。在Haskell中，“函数是頭等物件”。作为一门函數程式語言，主要控制结构是函数。Haskell语言是1990年在编程语言Miranda的基础上标准化的，并且以λ演算为基础发展而来。这也是为什么Haskell语言以希腊字母「λ」（Lambda）作为自己的标志。Haskell具有“证明即程序、命题为类型”的特征。",
+  "imdb":"網路電影資料庫 是一个关于电影演员、电影、电视节目、电视藝人、电子游戏和電影製作小組的在线数据库。IMDb開辦於1990年10月17日，從1998年開始成為亚马逊公司旗下的网站，在2020年10月17日時，IMDb慶祝了他們30週年的紀念。",
+  "library genesis":"創世紀圖書館 是一個影子圖書館，用戶可在此一網站上分享下載学术期刊文章、学术書籍、一般書籍、雜誌、漫畫。此一網站為用戶提供擋在付費牆背後，抑或官方沒釋出電子版本的資料。創世紀圖書館形容自身為「資訊整合連結」網站，為「互聯網上所收集及用戶上載的」資源提供可供查找的資料庫。",
   "z-library":"Z-Library 是一個影子圖書館和檔案分享計劃，用戶可在此一網站上下載期刊文章以及各種類型的書籍。根據Z-Library的說法，截至2022年6月12日，其共收錄了10,456,034本書和84,837,646篇文章。Z-Library在其電子書搜尋頁面上宣稱自己是「全球最大的數字圖書館」，並在文章搜尋頁面上稱自身是「全球最大的科學文章儲存庫」。它是創世紀圖書館計劃的一部分。",
   "npm":"npm 是Node.js預設的、用JavaScript編寫的軟體套件管理系統。",
   "openstreetmap":"開放街圖 是一個建構自由內容之網上地圖協作計劃，目標是創造一個內容自由且能讓所有人編輯的世界地圖，並且讓一般的行動裝置有方便的導航方案。",
-  "piratebay":"海盜灣 是一個專門儲存、分類及搜尋Bittorrent種子文件及磁力連結的網站，由瑞典的民間反版權組織海盜署於2003年成立，支持35種語言。",
-  "pypi":"PyPI 是Python的正式第三方 軟體套件的軟件存儲庫，它類似於CPAN（Perl的存儲庫）。一些軟件包管理器例如pip，就是默認從PyPI下載軟件包。用戶通過PyPI可以下載超過235,000個Python軟件包。",
-  "reddit":"Reddit（） 是一個娛樂、社交及新聞網站，注冊用戶可以將文字或連結在網站上發布，使它基本上成為了一個電子佈告欄系統。注冊用戶可以對這些帖子進行投票，結果將被用來進行排名和決定它在首頁或子頁的位置。網站上的內容分類被稱為「subreddit」。subreddit的內容包括新聞、電子遊戲、電影、音樂、書籍、健身、食物和圖片分享等。",
-  "stackoverflow":"Stack Exchange是一系列問答網站，每一個網站包含不同領域的問題。這些網站參考Stack Overflow，一個關於程序設計的問答網站，也是Stack Exchange的第一個成員。如同Stack Overflow，這些網站使用聲望獎勵系統，用戶對問題和答案進行投票，並影響用戶聲望。聲望系統使這些網站可以自我控制。",
+  "piratebay":"海盜灣 是一個專門儲存、分類及搜尋Bittorrent种子文件及磁力連結的網站，由瑞典的民間反版權組織海盜署於2003年成立，支持35种语言。",
+  "pypi":"PyPI 是Python的正式第三方 軟體套件的軟件存儲庫，它类似于CPAN（Perl的存储库）。一些软件包管理器例如pip，就是默認從PyPI下載软件包。用戶通过PyPI可以下載超过235,000个Python软件包。",
+  "reddit":"（） 是一个娱乐、社交及新聞网站，注册用户可以将文字或連結在網站上發布，使它基本上成為了一個電子佈告欄系統。注册用户可以对这些帖子进行投票，结果将被用来进行排名和决定它在首页或子页的位置。網站上的內容分類被稱為「subreddit」。subreddit的內容包括新聞、電子遊戲、電影、音樂、書籍、健身、食物和圖片分享等。",
+  "stackoverflow":"Stack Exchange是一系列问答网站，每一个网站包含不同领域的问题。这些网站参考Stack Overflow，一个关于程序设计的问答网站，也是Stack Exchange的第一个成员。如同Stack Overflow，这些网站使用声望奖励系统，用户对问题和答案进行投票，并影响用户声望。声望系统使这些网站可以自我控制。",
   "askubuntu":[
    "stackoverflow:zh-HK",
    "ref"
@@ -181,32 +179,77 @@
    "stackoverflow:zh-HK",
    "ref"
   ],
-  "semantic scholar":"語義學者 是具有人工智能功能的學術出版網絡搜索引擎，由艾倫AI研究所開發，並於2015年11月發布。它能利用自然語言處理技術為學術論文提供摘要。與Google學術搜索和PubMed相比，語義學者提供的結果盡量凸顯出論文中最重要和最有影響力的元素。",
+  "semantic scholar":"语义学者 是具有人工智能功能的学术出版网络搜索引擎，由艾伦AI研究所开发，并于2015年11月发布。它能利用自然语言处理技術为学术论文提供摘要。与Google学术搜索和PubMed相比，语义学者提供的結果盡量凸顯出论文中最重要和最有影响力的元素。",
   "startpage":"Startpage為一荷蘭公司Startpage B.V.所推出的搜尋引擎服務，其前身為元搜尋引擎Ixquick，Startpage當時Ixquick旗下之服務，兩者於2016年改為合併並改為現名。Startpage以強調對客戶隱私的保護聞名。",
-  "unsplash":"Unsplash是一個免費的照片共享網站。攝影師可以將照片上傳到Unsplash，照片編輯者們會對用戶上傳的照片進行整理。Unsplash使用了較為自由的著作權許可條款，這讓Unsplash成為了互聯網上最大的攝影照片供應商之一，其網站上的照片經常在文章配圖中出現。截止至2020年4月，該網站擁有超過18萬名攝影師，圖庫中儲存了超過160萬張照片。Unsplash被《福布斯》、《企業家雜志》、CNET和The Next Web評為全球領先的攝影網站之一。",
-  "yahoo news":"雅虎新聞 是一個美國新聞網站，最初是基於雅虎的新聞聚合服務而建立。該站點最早由雅虎軟件工程師布拉德·克勞斯易 於1996年8月開發完成，而最初的文章則來自其他新聞媒體的服務，例如：美聯社、路透社、福斯新聞台、半島電視台、ABC新聞、《今日美國》、有線電視新聞網和BBC新聞。",
-  "youtube":"YouTube，美國Alphabet旗下的影片分享網站，是目前全球最大的影片搜尋和分享平台，讓使用者上傳、觀看、分享及評論影片。公司於2005年2月14日註冊，網站的口號為「Broadcast Yourself」，網站的標誌意念來自早期的陰極射線管電視機。此網站尚無官方中文名，台灣部分民眾簡稱其為「YT」，中國大陸有時候將其譯為優兔、優途、優管、油管等。",
-  "dailymotion":"Dailymotion 是一家視訊分享網站，總部位於法國巴黎十七區。它的域名在YouTube之後一個月注冊。Dailymotion最廣為人知的特點之一就是其提供支援開放格式ogg的視訊。和同類型的其他Flash視訊分享網站相比，Dailymotion以其短片具有高清晰畫質而聞名。到2008年1月，每天上傳到該站的短片大約是16,000，網頁瀏覽次數平均一天超過2600萬次。2008年1月，Dailymotion的Alexa全球網站排名為38。母公司為威望迪。",
-  "wikibooks":"維基教科書 是維基媒體的一項計劃，於2003年7月10日開放。 此計劃收集自由的教科書，並讓用戶自己編輯教科書——任何人都可以進入「編輯」頁面修改任何一本教科書。",
+  "unsplash":"Unsplash是一个免费的照片共享网站。攝影師可以将照片上传到Unsplash，照片编辑者们会对用户上传的照片进行整理。Unsplash使用了较为自由的著作權许可条款，这让Unsplash成为了互联网上最大的摄影照片供应商之一，其网站上的照片经常在文章配图中出现。截止至2020年4月，该网站拥有超过18万名摄影师，图库中储存了超过160万张照片。Unsplash被《福布斯》、《企业家杂志》、CNET和The Next Web评为全球领先的摄影网站之一。",
+  "dailymotion":"Dailymotion 是一家視訊分享網站，總部位於法國巴黎十七區。它的域名在YouTube之後一個月注冊。Dailymotion最广为人知的特点之一就是其提供支援开放格式ogg的視訊。和同類型的其他Flash視訊分享網站相比，Dailymotion以其短片具有高清晰畫質而聞名。到2008年1月，每天上傳到該站的短片大約是16,000，網頁瀏覽次數平均一天超過2600萬次。2008年1月，Dailymotion的Alexa全球網站排名為38。母公司為威望迪。",
+  "wikibooks":"維基教科書（英語：）是維基媒體的一項計劃，於2003年7月10日開放。 此計劃收集自由的教科書，並讓用戶自己編輯教科書——任何人都可以進入“編輯”頁面修改任何一本教科書。",
   "wikinews":"維基新聞 是由一群志願者、即民間記者運營的網絡媒體。同時是一個自由內容的維基，屬維基媒體計劃項目，由維基媒體基金會負責運營。維基新聞通過協作新聞學的工作模式去運行，同時亦努力通過中性的觀點報導新聞。",
-  "wikiquote":"維基語錄 是維基媒體基金會下屬的一個維基計劃，屬於維基百科的一個姊妹計劃，同樣使用MediaWiki軟件。維基語錄旨在創建一個各種語言的名人名言以及諺語等內容的自由的在線語錄。",
-  "wikisource":"維基文庫 是維基媒體基金會旗下維基百科的姊妹計劃，目的是創建一個自由的、基於Wiki的文獻倉庫，包括每一個語言版本的完整原始文獻，並且把這些文獻翻譯成多種語言。剛開始叫做「Sourceberg」，在2003年12月6日經過投票確定為現在的名稱。",
-  "wiktionary":"維基詞典，粵文版作維基字典，是維基百科的姊妹工程，旨在創建基於所有語言的自由詞典。該項目於2002年12月12日啟動，發起人是維基人Daniel Alston。",
-  "wikiversity":"維基學院 是維基媒體基金會的一項計劃。",
-  "wikivoyage":"維基導游 是基於Wiki系統，由志願者撰寫的免費互聯網旅游指南。項目於2006年9月由德國的同名組織Wikivoyage e.V.發起，於2006年12月10日上線，2012年8月加入維基媒體基金會。項目內容使用知識共享-署名-相同方式共享協議授權，因此可供其他用戶自由地用作商業用途。同時訪客可以免費訪問任何內容，並可以自由下載離線版本。對此類計劃有害的商業性影響，例如來自旅游業的影響，被排斥於計劃之外。",
-  "wolframalpha":"Wolfram Alpha，是由 Wolfram Research 公司推出的一款在線自動問答系統。其特色是可以直接向用戶返回答案，而不是像傳統搜索引擎一樣提供一系列可能含有用戶所需答案的相關網頁。",
-  "naver":"NAVER 是Naver公司旗下韓國著名入口／搜索引擎網站，其Logo為一頂草帽，於1999年6月正式投入使用。它使用獨有的搜尋引擎，並且在韓文搜尋服務中獨佔鰲頭。除了搜尋之外也提供入口網站的許多服務，例如新聞、電子信箱、電子地圖服務（含街景地圖）等。在Alexa排名上是韓國國內第一大的入口網站。 據ComScore統計，Naver在2007年8月收到二十億次搜索，占70％以上的韓國搜索查詢，它是世界上排名第十五的網民最常用的搜索引擎，超過25萬韓國人選擇Naver作為瀏覽器起始頁。",
-  "rubygems":"RubyGems是Ruby的一個包管理器，提供了分發Ruby程序和函式庫的標准格式「gem」，旨在方便地管理gem安裝的工具，以及用於分發gem的服務器。這類似於Python的pip。RubyGems大約創建於2003年11月，從Ruby 1.9版起成為Ruby標准庫的一部分。",
-  "rumble":"Rumble是加拿大的視頻分享網站，讓使用者投稿、觀看、分享及評論視頻，由科技企業家克里斯·帕夫洛夫斯基 於2013年創立。自2020年7月以來，Rumble的月度用戶數經歷了快速增長，從160萬月度用戶增加到2021年第一季度末的3190萬。",
-  "petalsearch":"花瓣搜索 是由華為於2020年下半年開發的搜索引擎，可在桌面和移動平台使用。和華為的徽標類似，它的徽標就是一個花瓣（Petal）。",
-  "petalsearch images":[
-   "petalsearch:zh-HK",
+  "wiktionary":"维基词典（英語：），粵文版作維基字典，是维基百科的姊妹工程，旨在创建基于所有语言的自由词典。该项目于2002年12月12日启动，发起人是维基人Daniel Alston。",
+  "wikivoyage":"维基导游（英語：）是基于Wiki系统，由志愿者撰写的免费互联网旅游指南。项目于2006年9月由德国的同名组织Wikivoyage e.V.发起，于2006年12月10日上线，2012年8月加入维基媒体基金会。项目内容使用知识共享-署名-相同方式共享协议授权，因此可供其他用户自由地用作商业用途。同时访客可以免费访问任何内容，并可以自由下载离线版本。对此类计划有害的商业性影响，例如来自旅游业的影响，被排斥于计划之外。",
+  "wolframalpha":"，是由 Wolfram Research 公司推出的一款在线自动问答系统。其特色是可以直接向用户返回答案，而不是像传统搜索引擎一样提供一系列可能含有用户所需答案的相关网页。",
+  "naver":"NAVER（韓語：）是Naver公司旗下韩国著名入口／搜索引擎网站，其Logo为一顶草帽，于1999年6月正式投入使用。它使用獨有的搜尋引擎，並且在韓文搜尋服務中獨佔鰲頭。除了搜尋之外也提供入口網站的許多服務，例如新聞、電子信箱、電子地圖服務（含街景地圖）等。在Alexa排名上是韓國國內第一大的入口網站。 据ComScore统计，Naver在2007年8月收到二十亿次搜索，占70％以上的韩国搜索查询，它是世界上排名第十五的网民最常用的搜索引擎，超过25万韩国人选择Naver作为浏览器起始页。",
+  "rubygems":"RubyGems是Ruby的一个包管理器，提供了分发Ruby程序和函式庫的标准格式“gem”，旨在方便地管理gem安装的工具，以及用于分发gem的服务器。这类似于Python的pip。RubyGems大约创建于2003年11月，从Ruby 1.9版起成为Ruby标准库的一部分。",
+  "rumble":"Rumble是加拿大的视频分享网站，讓使用者投稿、觀看、分享及評論视频，由科技企業家克里斯·帕夫洛夫斯基 於2013年創立。自2020年7月以來，Rumble的月度用戶數經歷了快速增長，從160萬月度用戶增加到2021年第一季度末的3190萬。"
+ },
+ "af":{
+  "arxiv":"arXiv is ’n versameling elektroniese vooruitgawes van wetenskaplike artikels in die wiskunde, fisika, sterrekunde, informatika, matematiese biologie, statistiek en matematiese ekonomie wat aanlyn geraadpleeg kan word. In bepaalde gebiede van die wiskunde en fisika kan byna alle wetenskaplike artikels op arXiv gevind word. arXiv is op 14 Augustus 1991 begin en het op 3 Oktober 2008 reeds die grens van ’n halfmiljoen artikels verbygesteek.",
+  "wikipedia":"Wikipedia is 'n veeltalige \"kopielinkse\" ensiklopedie ontwerp om deur enigiemand gelees, verbeter en uitgebrei te word. Dit berus op samewerkende verandering en onderhoud deur duisende gebruikers deur middel van wiki-sagteware, en word verskaf en ondersteun deur die nie-winsgewende Wikimedia-stigting. Waarnemers beskou die tweeledige bestuur, waarin 'n informele gemeenskap van aktiewe gebruikers die gesag oor 'n globale digitale projek met 'n stigting deel en sodoende formele met informele organisasiestrukture verbind word, as 'n eksperiment wat steeds aan die gang is.",
+  "bing":"Microsoft Bing is die websoekenjin wat deur die Amerikaanse maatskappy Microsoft besit en bedryf word. Die diens het sy oorsprong in Microsoft se vorige soekenjins: Live Search, Windows Live Search en later Live Search. Bing bied 'n verskeidenheid soekdienste, insluitend web-, video-, beeld- en kaartsoekprodukte. Dit is ontwikkel met behulp van ASP.NET.",
+  "bing images":[
+   "bing:af",
    "ref"
   ],
-  "petalsearch news":[
-   "petalsearch:zh-HK",
+  "bing news":[
+   "Nuus vanaf wêreld-, nasionale en plaaslike nuusbronne, wat georganiseer is om aan jou omvattende nuusdekking van sport, vermaak, besigheid, politiek, weer en meer te verskaf.",
+   "https://www.bing.com/news"
+  ],
+  "currency":"DuckDuckGo is ’n soekenjin op die Internet. Een van hulle grootste trekpleisters is dat hulle meer privaatheidsbewus is en nie op gebruikers spioeneer nie. Die gebruiker se gedrag en profiel beïnvloed dus nie die resultate nie. As gevolg hiervan sal elke gebruiker presies dieselfde resultate vir dieselfde soektog kry.",
+  "ddg definitions":[
+   "currency:af",
    "ref"
-  ]
+  ],
+  "wikidata":"Wikidata is 'n projek van die Wikimedia-stigting wat 'n ​​gesamentlik bewerkbare databasis ter ondersteuning van Wikipedia daarstel. Die projek is deur Wikimedia Duitsland begin en bied 'n gemeenskaplike bron van bepaalde tipes data, soos interwiki-skakels en geboortedata, wat in artikels op Wikipedia en elders gebruik kan word. Dit kan met Wikimedia Commons vergelyk word, maar voorsien data instede van media-lêers aan al Wikipedia se projekte.",
+  "duckduckgo":[
+   "currency:af",
+   "ref"
+  ],
+  "duckduckgo images":[
+   "currency:af",
+   "ref"
+  ],
+  "google":"Die Google-soekenjin is ’n soekenjin wat deur Google besit en bedryf word. Dit kan gebruik word om trefwoorde (teks) op webblaaie te soek. Dit is op 15 September 1997 bekendgestel en het sedertdien die mees gebruikte soekenjin op die wêreldwye web geword. Die woord Google het mettertyd sinoniem met internetsoektogte geword en is sedert 2006 selfs as ’n werkwoord in die Oxford-woordeboek opgeneem. Dit kan ook in Afrikaans as ’n werkwoord gebruik word en wel met ’n kleinletter-g.",
+  "google images":[
+   "Google Images. Die omvattendste prentesoektog op die web.",
+   "https://images.google.com"
+  ],
+  "google play apps":[
+   "Geniet miljoene van die jongste Android-programme en -speletjies, musiek, flieks, TV, boeke, tydskrifte en meer. Enige tyd, enige plek, op al jou toestelle.",
+   "https://play.google.com/"
+  ],
+  "google play movies":[
+   "google play apps:af",
+   "ref"
+  ],
+  "imdb":"Die Internet-rolprentdatabasis is 'n aanlyn databasis met rolprente, televisiereekse, akteurs en rekenaarspeletjies. IMDb behoort sedert 1998 aan Amazon.com.",
+  "library genesis":"Library Genesis of LibGen is 'n soektog vir artikels en boeke oor verskeie onderwerpe, wat toegang bied aan inhoud wat anders agter 'n betaalmuur is, of andersins nie digitaal beskikbaar is nie. Onder andere, dra dit PDFs van Elsevier se ScienceDirect web-portaal.",
+  "library of congress":"Die Biblioteek van die VSA-kongres in Washington, D.C. is die nasionale biblioteek van die Verenigde State en een van die belangrikste biblioteke ter wêreld. Die Library of Congress is formeel 'n agentskap van die Amerikaanse Kongres.",
+  "openstreetmap":"OpenStreetMap (OSM) is 'n \"kopielinkse\" digitale padkaart wat ontwerp is om deur enigiemand gewysig te kan word. Die kaart word geskep uit data wat opgeneem word deur GPS-ontvangers, lugfoto's en ander gratis bronne. Die kaart kan dan geprojekteer word in 'n geografiese koördinatestelsel, gebruik word vir roete beplanning of gebruik word vir geografiese soektogte.",
+  "pdbe":[
+   "Homepage | Protein Data Bank in Europe",
+   "https://www.ebi.ac.uk/pdbe"
+  ],
+  "soundcloud":"SoundCloud is 'n aanlynklankverspreidingsplatform wat in Berlyn, Duitsland gebaseer is en wat gebruikers in staat stel om klank op te laai, op te neem, te bemark, en te deel. SoundCloud is in Augustus 2007 deur Alexander Ljung en Eric Wahlforss gestig.",
+  "semantic scholar":"Semantic Scholar is ’n soekenjin, wat kunsmatige intelligensie gebruik, vir akademiese publikasies. Dit is in November 2015 deur die Allen Institute for Artificial Intelligence begin.",
+  "youtube":"YouTube is 'n webwerf wat gebruikers in staat stel om video's op te laai, koers, kommentaar, deel, en na ander opgelaaide video's te kyk. Die webwerf behels films, musiek videos, nuus, opvoedkundige programme, sowel as video blogs, skyfievertonings, humoristiese video's, en nog baie meer te kyk. YouTube is tans die grootste video webwerf op die Internet.",
+  "vimeo":"Vimeo is 'n video-deel webwerf waar gebruikers videos kan oplaai, deel en kyk. Dit was die eerste videodeelwebblad wat hoëdefinisievideo ondersteun het.",
+  "wikibooks":"Wikibooks is 'n sustersprojek van Wikipedia en is een van die Wikimedia Stigting se webwerwe. Die wikibooks werf is op 10 Julie 2003 van stapel gestuur. Die projek maak 'n versameling van vrye teksboeke wat in samewerkingsverband geskryf word op die Internet beskikbaar. Die werf is net soos Wikipedia 'n wiki, en enge persoon kan dus die inhoud opdateer of nuwe artikels skep.",
+  "wikinews":"Wikinews is 'n projek van die Wikimedia Stigting wat poog om vrye inhoud nuus beskikbaar te stel. Die missie van Wikinews is om 'n \"diverse omgewing te skep waar burger-joernaliste onafhanklik nuusgebeure kan opteken\". Die webwerf is in November 2004 begin.",
+  "wikiquote":"Wikiquote is 'n susterprojek van Wikipedia, en gebruik dieselfde MediaWiki-sagteware. Dit is een van 'n familie van wiki-gebaseerde projekte wat deur die Wikimedia-stigting bedryf word. Wikiquote is gebaseer op 'n idee van Daniel Alston wat deur Brion Vibber geïmplementeer is. Die doel van die projek is om 'n groot verwysingwerk te skep, bestaande uit aanhalings van mense, boeke en gesegdes, en om verdere inligting oor hulle weer te gee.",
+  "wikisource":"Wikisource of Wikibronne is 'n projek van die Wikimedia Stigting wat ten doel het om 'n vrye wiki met bronverwysings daar te stel wat in ander projekte aangehaal kan word.",
+  "wiktionary":"WikiWoordeboek is 'n susterprojek van Wikipedia wat streef om 'n vrye meertalige wiki-woordeboek te skep. Die woordeboek bevat 'n lys van woorde met omskrywings, etimologieë, uitsprake en aanhalings.",
+  "wikiversity":"Wikiversity is 'n projek van die Wikimedia Stigting wat gratis leermateriaal aan besoekers beskikbaar stel.",
+  "wikivoyage":"Wikivoyage is 'n vrye reisgids op die Internet met bestemmings, onderwerpe en taalgidse wat deur onbetaalde outeurs geskryf is. Die naam van die webtuiste is 'n samevoeging van die woorde \"wiki\", 'n sagtewareprogram wat mense toelaat om teks te publiseer en te wysig, en \"voyage\", die Franse en Engelse woord vir reis. Die inhoud word, net soos Wikipedia, onder die Creative Commons Erkenning-InsgelyksDeel-lisensie gepubliseer."
  },
  "ar":{
   "archive is":"أرشيف.تودَي ‏ هو موقع أرشفة يخزن لقطات من صفحات الشبكة العنكبوتية العالمية. وهو يخزن صفحة واحدة كل مرة بشكل مشابه لـويب سايت، وبحدود 50 ميجابايت لكل صفحة، مع دعم لبعض المواقع المعتمدة على جافا سكريبت مثل خرائط جوجل، وتطبيقات الويب التقدمية، وتويتر.",
@@ -221,6 +264,10 @@
   "bing news":[
    "أخبار من مصادر عالمية وإقليمية ومحلية يتم تنظيمها لتقديم تغطية إخبارية شاملة تتضمن أخبار الرياضة والفن والأعمال والسياسية والطقس وأكثر من ذلك.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "يساعدك Bing على تحويل المعلومة إلى إجراء، مما يجعل الانتقال من البحث إلى الفعل أسرع وأسهل.",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":[
    "خدمة استضافة على شبكة الإنترنت لمشاريع تطوير البرمجيات",
@@ -315,6 +362,10 @@
    "Новини от международни, национални и местни източници на новини, организирани така, че да ви предоставят задълбочено информационно покритие от света на спорта, забавленията, бизнеса, политиката, времето и още много други.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing ви помага да прилагате информацията, като прави по бърз и лесен преходът от търсене към действие.",
+   "https://www.bing.com/videos"
+  ],
   "deviantart":"deviantArt е онлайн общност, в която се качват различни видове „произведения на изкуството“, направени от потребителите. Отворен е на 7 август, 2000 от Скот Джаркоф, Матю Стивънс, Анджело Сотира и други. Дружеството на deviantArt се намира в Холивуд, Лос Анджелис, Съединени щати.",
   "wikidata":"Уикиданни е уики проект – база знания създадена от Фондация Уикимедия. Съдържанието е свободно и подобно на повечето проекти на фондацията е достъпно под лицензи „Криейтив Комънс – Признание – Споделяне на споделеното“ (CC-BY-SA) и обществено достояние (CC0).",
   "github":"GitHub e уеб базирана услуга за разполагане на софтуерни проекти и техни съвместни разработки върху отдалечен интернет сървър в т.нар. хранилище. Базира се на Git системите за контрол и управление на версиите. Услугата може да бъде както платена за частни проекти, така и безплатна за т.нар. проекти с общодостъпен код, като и в двата случая потребителите могат да ползват всички възможности на услугата. Към май 2011 г. GitHub се счита за най-популярния сайт за разполагане на съвместни проекти с общодостъпен или наречен още отворен код.",
@@ -324,7 +375,7 @@
    "https://images.google.com"
   ],
   "google news":[
-   "Изчерпателни и актуални новинарски материали, обобщени от източници по целия свят от Google Новини.",
+   "Преди да продължите",
    "https://news.google.com"
   ],
   "google scholar":"Google Наука е специализирана търсачка на научна литература: рецензирани публикации, научни разработки, книги, резюмета и статии от академични издателства, професионални общности, архиви с работни статии, университети и други научни организации.",
@@ -366,7 +417,7 @@
  },
  "bn":{
   "arxiv":"arXiv হল সংশোধনের পর প্রকাশনার জন্য অনুমোদিত ইলেকট্রনিক প্রাক মুদ্রণের একটি সংগ্রহস্থল, যেটি গণিত, পদার্থবিজ্ঞান, জ্যোতির্বিজ্ঞান, কম্পিউটার বিজ্ঞান, পরিমাণগত জীববিদ্যা, পরিসংখ্যান এবং পরিমাণগত অর্থব্যবস্থা বিভাগের বৈজ্ঞানিক কাগজপত্র নিয়ে গঠিত। এগুলিতে অনলাইনের মাধ্যমে প্রবেশ করা যায়।",
-  "wikipedia":"উইকিপিডিয়া একটি সম্মিলিতভাবে সম্পাদিত, বহুভাষিক, মুক্ত প্রবেশাধিকার, মুক্ত কন্টেন্ট সংযুক্ত একটি ইন্টারনেট বিশ্বকোষ, যা অলাভজনক উইকিমিডিয়া ফাউন্ডেশন কর্তৃক সমর্থিত, আয়োজিত এবং পরিচালিত। স্বেচ্ছাসেবীরা বিশ্বব্যাপী সম্মিলিতভাবে ৩০১টি ভাষার উইকিপিডিয়ায় প্রায় ৪০ মিলিয়ন নিবন্ধ রচনা করেছেন, যার মধ্যে শুধু ইংরেজি উইকিপিডিয়ায় রয়েছে ৫৮ লক্ষের অধিক নিবন্ধ। যে কেউ ওয়েবসাইটে প্রবেশের মাধ্যমে যে কোনো নিবন্ধের সম্পাদনা করতে পারেন, যা সম্মিলিতভাবে ইন্টারনেটের সর্ববৃহৎ এবং সর্বাধিক জনপ্রিয় সাধারণ তথ্যসূত্রের ঘাটতি পূরণ করে থাকে। ফেব্রুয়ারি ২০১৪ সালে, দ্য নিউ ইয়র্ক টাইমস জানায় উইকিপিডিয়া সব ওয়েবসাইটের মধ্যে বিশ্বব্যাপী পঞ্চম স্থানে অবস্থান করছে, \"মাসিক প্রায় ১৮ বিলিয়ন পৃষ্ঠা প্রদর্শন এবং প্রায় ৫০০ মিলিয়ন স্বতন্ত্র পরিদর্শক নিয়ে..., উইকিপিডিয়ায় ইয়াহু, ফেসবুক, মাইক্রোসফট এবং গুগলের পথানুসরণ করে, সর্বাধিক ১.২ বিলিয়ন স্বতন্ত্র পরিদর্শক রয়েছে।\"",
+  "wikipedia":"উইকিপিডিয়া সম্মিলিতভাবে সম্পাদিত, বহুভাষিক, মুক্ত প্রবেশাধিকার, মুক্ত কন্টেন্ট সংযুক্ত একটি ইন্টারনেট বিশ্বকোষ, যা অলাভজনক উইকিমিডিয়া ফাউন্ডেশন কর্তৃক সমর্থিত, আয়োজিত এবং পরিচালিত। স্বেচ্ছাসেবীরা বিশ্বব্যাপী সম্মিলিতভাবে ৩০১টি ভাষার উইকিপিডিয়ায় প্রায় ৪০০ লক্ষ নিবন্ধ রচনা করেছেন, যার মধ্যে শুধুমাত্র ইংরেজি উইকিপিডিয়াতেই রয়েছে ৫৮ লক্ষের অধিক নিবন্ধ। যে কেউ উইকিপিডিয়া ওয়েবসাইটে প্রবেশের করে যে কোনো নিবন্ধের সম্পাদনা করতে পারেন, যা সম্মিলিতভাবে ইন্টারনেটের সর্ববৃহৎ এবং সর্বাধিক জনপ্রিয় সাধারণ তথ্যসূত্রের ঘাটতি পূরণ করে থাকে। ফেব্রুয়ারি ২০১৪ সালে, দ্য নিউ ইয়র্ক টাইমস জানায় উইকিপিডিয়া সমস্ত ওয়েবসাইটের মধ্যে বিশ্বব্যাপী পঞ্চম স্থানে অবস্থান করছে, \"মাসিক প্রায় ১৮ বিলিয়ন পৃষ্ঠা প্রদর্শন এবং প্রায় ৫০০ মিলিয়ন স্বতন্ত্র পরিদর্শক রয়েছে। উইকিপিডিয়ায় ইয়াহু, ফেসবুক, মাইক্রোসফট এবং গুগলের পথানুসরণ করে, সর্বাধিক ১.২ বিলিয়ন স্বতন্ত্র পরিদর্শক রয়েছে।\"",
   "bing":"বিং মাইক্রোসফট কর্তৃক নিয়ন্ত্রিত একটি ওয়েব অনুসন্ধান ইঞ্জিন । বিং বিভিন্ন ধরনের অনুসন্ধান সেবা প্রদান করে যেমন - ওয়েব, ভিডিও, চিত্র এবং মানচিত্র ইত্যাদি অনুসন্ধান সরবরাহ করে। এটি এএসপি ডট নেট ব্যবহার করে তৈরি করা।",
   "bing images":[
    "bing:bn",
@@ -375,6 +426,10 @@
   "bing news":[
    "আপনাকে ক্রীড়া, বিনোদন, ব্যবসা, রাজনীতি, আবহাওয়া ইত্যাদি সংক্রান্ত সংবাদের বিস্তারিত কভারেজ প্রদান করার জন্য বিশ্ব, জাতীয় এবং স্থানীয় সংবাদের উৎসগুলি থেকে প্রাপ্ত সংবাদকে সংগঠিত করা হয়।",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing বিভিন্ন তথ্যকে কাজে পরিণত করতে আপনাকে সাহায্য করে, যা সন্ধান করার মাধ্যমে কাজ করার প্রক্রিয়াকে আরও দ্রুত ও সহজতর করে।",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":"বিটবাকেট হল একটি গিট - ভিত্তিক সোর্স কোড রিপোজিটরি হোস্টিং পরিষেবা যা আটলাসিয়ানের মালিকানাধীন । গিটহাব এবং গিটল্যাব এর প্রতিদ্বন্দ্বী । Bitbucket সীমাহীন সংখ্যক ব্যক্তিগত সংগ্রহস্থল সহ বাণিজ্যিক পরিকল্পনা এবং বিনামূল্যে অ্যাকাউন্ট উভয়ই অফার করে।",
   "currency":"ডাকডাকগো, একটি ইন্টারনেট অনুসন্ধান ইঞ্জিন যেটা অনুসন্ধানকারীর ইন্টারনেট গোপনীয়তা এবং ব্যক্তিবিশেষায়িত ফলাফল বর্জনের উপর গুরুত্বারোপ করে। ডাকডাকগো অন্য সার্চ ইঞ্জিনগুলো থেকে নিজেকে স্বকীয় রাখে ব্যবহারকারীদের তথ্য সংগ্রহ না করে এবং একটি নির্দিষ্ট সার্চ টার্মের জন্যে ঢালাওভাবে সমস্ত ব্যবহারকারীর জন্যে একই ফলাফল সরবরাহ করে। এছাড়াও ৪০০ ক্রাউডসোর্স সাইট(যেমন- উইকিপিডিয়া) এবং অন্যান্য সার্চ ইঞ্জিন(যেমন- বিং, ইয়াহু!, ইয়ানডেক্স) থেকে ফলাফল সংগ্রহ করে সবচেয়ে বেশি না বরং সবচেয়ে যৌক্তিক ফলাফল প্রদানের জন্যেও এর খ্যাতি রয়েছে।",
@@ -426,11 +481,7 @@
   "naver":"নেইভার একটি দক্ষিণ কোরীয় ইন্টারনেট ভিত্তিমঞ্চ। কোরিয়ার নেইভার কর্পোরেশন এটির পরিচালক। ১৯৯৯ সালে দক্ষিণ কোরিয়ার স্ব-উদ্ভাবিত অনুসন্ধান ইঞ্জিন ব্যবহারকারী প্রথম আন্তর্জাল প্রবেশদ্বার হিসেবে এটি যাত্রা শুরু করে। এটি ছিল বিশ্বের প্রথম পূর্ণাঙ্গ অনুসন্ধান সুবিধা প্রদানকারী ওয়েবসাইট, যেখানে বিভিন্ন শ্রেণীর অনুসন্ধান ফলাফল সংকলিত একটিমাত্র ফলাফল পাতায় সেগুলিকে প্রকাশ করা হত। এরপর নেইভার আরও বেশ কিছু নতুন সেবা যোগ করেছে, যাদের মধ্যে বৈদ্যুতিন ডাক (ই-মেইল) ও সংবাদের মতো প্রাথমিক সুবিধাগুলি থেকে শুরু করে বিশ্বের প্রথম ইন্টারনেটভিত্তিক প্রশ্নোত্তর ভিত্তিমঞ্চ \"নলেজ ইন\" অন্তর্ভুক্ত।"
  },
  "bo":{
-  "wikipedia":"ཆམ་ཚང་པདྨ་ལྷུན་གྲུབ་ཀྱི་ལོ་རྒྱུས་སྙིང་བསྡུས། ཆམ་ཚང་པདྨ་ལྷུན་གྲུབ",
-  "fdroid":[
-   "ཨེཕ་རོཌ་ནི་འགྲིག་བཅུག་བྱེད་ཐུབ་པའི་ ཕོས་(རིན་མེད་དང་ཕྱི་གསལ་ནང་གསལ་གྱི་ཨང་རྟགས་མཉེན་ཆས་) དང་ཨེན་ཀྲོཌ་བབས་སྟེགས་ཆེད་དུ་བཟོས་པའི་མཉེན་ཆས་ཤིག་རེད། མཉེན་ཆས་འདིས་ཁྱེད་རང་གི་ཡོ་བྱད་སྒང་ལ་ལྟ་བ་དང་། འགྲིག་བཅུག གསར་བསྒྱུར་བྱེད་དགོས་པ་རྣམས་རྗེས་དེད་གཏོང་བ་སོགས་དཀའ་ཚེགས་མེད་པའི་ཐོག་ནས་བྱེད་ཐུབ།",
-   "https://f-droid.org/"
-  ]
+  "wikipedia":"ཆམ་ཚང་པདྨ་ལྷུན་གྲུབ་ཀྱི་ལོ་རྒྱུས་སྙིང་བསྡུས། ཆམ་ཚང་པདྨ་ལྷུན་གྲུབ"
  },
  "ca":{
   "archive is":"archive.today és un lloc web que emmagatzema instantànies de pàgines web. Recupera una pàgina de manera similar a WebCite, de menys de 50 MB cadascuna, però amb suport per a llocs pesants de JavaScript com Google Maps i aplicacions web com Twitter.",
@@ -446,6 +497,10 @@
   "bing news":[
    "Les notícies de fonts mundials, nacionals i locals, organitzades per donar-vos una cobertura informativa a fons sobre esports, entreteniment, economia, política, el temps i molt més.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "El Bing t'ajuda a convertir la informació en acció i et facilita el pas ràpid de la cerca a l'acció.",
+   "https://www.bing.com/videos"
   ],
   "crossref":"Crossref és una agència que publica un registre d'objectes digitals (DOI) de la fundació Internacional DOI Foundation. L'agència Crossref està dirigida per l'associació d'editorials Publishers International Linking Association (PILA). És una iniciativa cooperativa sense ànim de llucre, llançada a principi de l'any 2000. Ha de permettre als editors de crear un enllaç permanent de les citacions entre les revistes científiques en línia.",
   "currency":"DuckDuckGo (DDG) és un motor de cerca que posa l'èmfasi en la protecció de la privacitat. Se'l sol presentar com a l'alternativa a Google Search. L'empresa té la seu a Paoli, Pennsilvània (EUA), i té 20 treballadors. Els servidors eren allotjats inicialment al soterrani de Gabriel Weinberg, el fundador, i ara estan allotjats per Amazon.",
@@ -486,10 +541,6 @@
   "imdb":"La IMDb, Internet Movie Database és una base de dades en línia amb informació sobre actors, pel·lícules, programes de televisió i videojocs. Fundada el 17 d'octubre de 1990, és propietat d'Amazon des de 1998. Inclou ressenyes, votacions populars i comentaris dels usuaris, per tal d'orientar els gustos cinèfils dels visitants o recopilar dades sobre el món audiovisual.",
   "library genesis":"Library Genesis o LibGen és un motor de cerca que permet el lliure accés a continguts que, d'altra manera, són de pagament o no digitalitzats en altres llocs, generalment articles científics o llibres acadèmics, i en menor proporció de ficció. Posseeix contingut lliure en formats PDF, EPUB, MOBI, DJVU, etc. accessible en portals de nombroses editorials acadèmiques com Oxford University Press, Cambridge University Press, ScienceDirect d'Elsevier, Springer, etc.",
   "library of congress":"La Biblioteca del Congrés dels Estats Units, situada a Washington DC, és la biblioteca nacional del país i arxiu administratiu del Congrés. Va ser fundada pel president John Adams el 24 d'abril de l'any 1800, al mateix temps que es traslladava la seu del govern des de Filadèlfia a Washington, i es troba distribuïda en tres edificis: l'Edifici Thomas Jefferson, l'Edifici John Adams i l'Edifici James Madison. És una de les biblioteques més grans del món amb més de 138 milions de documents, dels quals més de deu milions són en llengua catalana.",
-  "azlyrics":[
-   "AZLyrics - request for access",
-   "https://azlyrics.com"
-  ],
   "openstreetmap":"OpenStreetMap és un projecte col·laboratiu per crear mapes de contingut lliure usant dades obtingudes mitjançant dispositius GPS mòbils, ortofotografies i altres fonts de dades. Les dades dels mapes (coordenades) i les imatges obtingudes amb elles es lliuren sota la llicència Open Database License.",
   "piratebay":"The Pirate Bay (TPB) és un directori de torrents suec que data del novembre de 2003. The Pirate Bay serveix com a motor de cerca i, alhora, de rastrejador amb el qual es pot cercar qualsevol tipus de contingut multimèdia.",
   "pubmed":"MEDLINE és una base de dades bibliogràfica de ciències de la vida i d'informació biomèdica. Inclou la informació bibliogràfica d'articles de revistes acadèmiques que cobreixen medicina, infermeria, farmàcia, odontologia, veterinària i assistència sanitària. MEDLINE també cobreix gran part de literatura en biologia i bioquímica, així com camps com ara l'evolució molecular.",
@@ -543,6 +594,10 @@
    "Zpravodajství ze světa a mezinárodní a místní zdroje zpráv uspořádané tak, aby vám poskytly podrobné informace o novinkách o sportu, zábavě, podnikání, politice, počasí a dalších tématech.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Služba Bing vám pomůže prakticky uplatnit informace. S ní strávíte méně času vyhledáváním a více času užitečnou činností.",
+   "https://www.bing.com/videos"
+  ],
   "bitbucket":"Bitbucket je webová služba podporující vývoj softwaru při používání verzovacích nástrojů Git a Mercurial. Bitbucket nabízí bezplatný hosting pro open-source projekty a menší týmy do 5 lidí. Dále nabízí komerční programy, které po zaplacení měsíčního poplatku umožňují ukládat soukromé repositáře.",
   "currency":"DuckDuckGo (DDG) je webový vyhledávač, který klade důraz na soukromí uživatelů, úmyslně nevytváří efekt tzv. filtrovací bubliny a nijak neprofituje prodejem osobních informací uživatelů.",
   "deviantart":"DeviantArt je online umělecká komunita. Poprvé byla spuštěna 7. srpna 2000 díky práci Scotta Jarkoffa, Matthewa Stephense a Angela Sotiry, který je nyní CEO.",
@@ -568,7 +623,7 @@
   "google news":"Zprávy Google je webová stránka a mobilní aplikace vyvinutá společností Google. Zprávy Google nepřetržitě vyhledávají aktuální články od tisíců vydavatelů a nabízejí je uživatelům k přečtení. Zprávy Google jsou k dispozici na platformě Android, iOS a na webu. Betaverze byla spuštěna v září 2002, oficiální stabilní verze byla vydána v lednu 2006. Google Zprávy byly zpracovány na návrh Inda Krishny Bharata.",
   "google videos":"Google Video je internetový server pro sdílení filmových souborů. Tuto službu provozuje společnost Google. Portál obsahuje videa zdarma i placená.[zdroj?]",
   "google scholar":"Google Scholar je volně přístupný webový vyhledávač, spadající pod společnost Google, který indexuje plné texty nebo metadata z odborné literatury přes řadu formátů a oborů. Byl poprvé vydán v beta verzi v listopadu 2004, index služby Google Scholar zahrnuje většinu recenzované online dostupné akademické časopisy, knihy, konferenční příspěvky, diplomové práce a disertace, preprintů, abstrakt, technických zpráv, a jiné odborné literatury, včetně patentů. Výzkumníci odhadují, že v květnu 2014 obsahoval zhruba 160 milionů dokumentů a dřívější statistický odhad zveřejněný v PLOS ONE odhaduje že přibližně 80-90% všech článků bylo publikovaných v angličtině.",
-  "google play apps":"Google Play je online distribuční služba, která vznikla 22. října 2008. V současné době Google Play poskytuje několik druhů digitálního obsahu, ke kterému je možné přistupovat z počítače nebo z mobilního telefonu vybaveného operačním systémem Android nebo prostřednictvím Google TV.",
+  "google play apps":"Google Play je online distribuční služba, která vznikla 22. října 2008. V současné době Google Play poskytuje několik druhů digitálního obsahu, ke kterému je možné přistupovat z počítače nebo z mobilního telefonu vybaveného operačním systémem Android nebo prostřednictvím Android TV.",
   "google play movies":[
    "google play apps:cs",
    "ref"
@@ -635,10 +690,6 @@
    "wikidata"
   ],
   "wikipedia":"Gwyddoniadur rhyngwladol, amlieithog a reolir gan y Wikimedia Foundation yw Wicipedia. Dechreuodd y fersiwn Saesneg ar 15 Ionawr 2001, ac yn ystod y pum mlynedd ddilynol, dechreuwyd fersiynau mewn dros 200 iaith arall. Ar ddiwedd 2001, roedd dros 20,000 erthygl yn y fersiwn Saesneg a 18 o wahanol ieithoedd. Erbyn Mehefin 2010, roedd 3.3 miliwn erthygl.",
-  "bing images":[
-   "Gweld delweddau, papur wal, gifs a syniadau sy'n trendio ar Bing bob dydd.",
-   "https://www.bing.com/images"
-  ],
   "bing news":[
    "Newyddion o ffynonellau newyddion byd, cenedlaethol a lleol, wedi eu trefnu i drafod newyddion chwaraeon, adloniant, busnes, gwleidyddiaeth, tywydd a mwy mewn manylder.",
    "https://www.bing.com/news"
@@ -648,6 +699,10 @@
   "google images":[
    "Lluniau Google.Y chwiliad lluniau mwya cynhwysfawr ar y we.",
    "https://images.google.com"
+  ],
+  "google news":[
+   "Cyn i chi barhau",
+   "https://news.google.com"
   ],
   "imdb":"Cronfa ddata ar-lein o ffilmiau, rhaglenni teledu, a gemau fideos yw'r Internet Movie Database (IMDb). Cafodd ei greu gan Col Needham ym 1990.",
   "ina":[
@@ -677,7 +732,7 @@
    "https://www.bing.com/news"
   ],
   "bing videos":[
-   "Bing video",
+   "Bing hjælper med at omsætte oplysninger til handling, så det bliver hurtigere og nemmere at gå fra at søge til at gøre noget.",
    "https://www.bing.com/videos"
   ],
   "currency":"DuckDuckGo er en onlinesøgemaskine, som lægger vægt på ikke at gemme oplysninger og accepterer brugerens privatsfære.",
@@ -702,6 +757,10 @@
    "Google Billeder. Den mest omfattende billedsøgning på nettet.",
    "https://images.google.com"
   ],
+  "google news":[
+   "Inden du fortsætter",
+   "https://news.google.com"
+  ],
   "google videos":"Google Video var websted, hvor man kunne se og uploade videoer. Tjenesten konkurrerede tidligere med YouTube. Tjenesten blev nedlagt i 2012.",
   "google scholar":"Google Scholar er et søgeværktøj til at finde videnskabelig litteratur. Man kan søge blandt fagområder og i kilder så som: afhandlinger, specialer, bøger, uddrag og artikler anmeldt af fagfolk fra akademiske forlag, faglige sammenslutninger, dokumentdatabaser, universiteter og andre videnskabelige organisationer.",
   "google play apps":"Google Play – tidligere Android Market – er en applikation, der er udviklet af Google til systemet Android. Det giver brugeren mulighed for at finde og downloade applikationer fra tredjepartsudviklere.",
@@ -717,10 +776,6 @@
   "piratebay":"The Pirate Bay er verdens største Bittorrent-indeks. Den blev grundlagt af Gottfrid \"anakata\" Svartholm og Fredrik \"TiAMO\" Neij i slutningen af 2003, som en del af den svenske organisation Piratbyrån, men har siden oktober 2004 været en separat organisation. Trackeren fik for alvor vind i sejlene, da den slovenske hjemmeside Suprnova.org lukkede i slutningen af 2004. Suprnova havde været et af de største piratsites i verden, og The Pirate Bay overtog nu millioner af \"hjemløse\" pirater.",
   "reddit":"Reddit er en social nyheds- og underholdningshjemmeside, hvor registrerede brugere indsender indhold i form af links eller tekst. Brugere stemmer derefter hver indgivelse \"op\" eller \"ned\" for at rangere stillingen og bestemme positionen på webstedets sider. Indholdsgallerier er organiseret af interesseområder ved navn \"subreddits\", blandt andet har Danmark sit eget subreddit.",
   "soundcloud":"SoundCloud er en lyd- og musikdelingsside, som blev oprettet i 2007. I juli 2013 havde den 40 mio. brugere og 200 mio. lyttere.",
-  "startpage":[
-   "Søg og brows på internettet uden at blive tracket eller angrebet. Startpage er verdens mest private søgemaskine. Brug Startpage til at beskytte dine personlige data.",
-   "https://startpage.com"
-  ],
   "youtube":"YouTube er en populær webportal, hvor man frit kan dele sine videoklip. Brugere kan uploade videoer, se andres videoer, kommentere og like hinandens videoer. Dog er det begrænset hvor lange videoerne må være. Videoerne blev vist ved hjælp af Adobe Flash-teknologi men bruger nu HTML5. Indholdet på siden varierer fra film- og tv-indslag, musikvideoer til amatøroptagelser og videoblogging også kaldet vlogging.",
   "vimeo":"Vimeo er en videodelings-hjemmeside, hvor brugeren kan uploade, dele og se videoer. Det var den første videodelingsside, som understøttede high-definition video. Vimeo blev grundlagt i november 2004 af Jake Lodwick og Zach Klein. Siden fokuserer på kortfilm og film solgt via video on demand.",
   "wikibooks":"Wikibooks er et søsterprojekt til Wikipedia, ejet og vedligeholdt af Wikimedia Foundation. Wikibooks fungerer grundlæggende på samme måde som Wikipedia, men i modsætning til at opbygge en encyklopædi, opbygger man i fællesskab lærebøger, manualer, introduktioner, guider m.m. Disse kaldes også åbne lærebøger og adskiller sig fra traditionelle lærebøger på følgende måde:De er normalt gratis De udgives kun som digitale ressourcer og skal ikke trykkes. De er dynamiske og kan løbende udvides eller ændres. De kan sættes sammen af individuelle bidrag.",
@@ -750,6 +805,10 @@
   "bing news":[
    "News aus aller Welt, landesweiten und örtlichen Quellen informieren Sie übersichtlich und ausführlich über Sportereignisse, Unterhaltung, Wirtschaft, Politik, Wetter und vieles mehr.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing unterstützt Sie dabei, Informationen in Aktionen umzusetzen, sodass der Übergang vom Suchen zum Handeln schneller und einfacher erfolgen kann.",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":"Bitbucket ist ein webbasierter Onlinedienst zur Versionsverwaltung für Software-Entwicklungsprojekte. Der Dienst wurde ursprünglich als reines Mercurial-System entwickelt, jedoch am 3. Oktober 2011 um Unterstützung für Git erweitert. Bitbucket wurde 2007 durch den Dänen Jesper Nøhr entwickelt und 2010 von Atlassian gekauft. Seit dem 1. Juli 2020 wird Mercurial nicht mehr unterstützt.",
   "ccc-tv":[
@@ -800,7 +859,7 @@
    "ref"
   ],
   "hoogle":"Haskell ist eine rein funktionale Programmiersprache, benannt nach dem US-amerikanischen Mathematiker Haskell Brooks Curry, dessen Arbeiten zur mathematischen Logik eine Grundlage funktionaler Programmiersprachen bilden. Haskell basiert auf dem Lambda-Kalkül, weshalb auch der griechische Buchstabe Lambda als Logo verwendet wird. Die wichtigste Implementierung ist der Glasgow Haskell Compiler (GHC).",
-  "imdb":"Die Internet Movie Database ist eine US-amerikanische Datenbank zu Filmen, Fernsehserien, Videoproduktionen und Computerspielen sowie über Personen, die daran mitgewirkt haben. Im Januar 2020 gab es Einträge zu über 7,55 Millionen Filmproduktionen und zu über 11,21 Millionen Film- und Fernsehschaffenden. Betrieben wird die Datenbank seit 1998 von Amazon.",
+  "imdb":"Die Internet Movie Database ist eine US-amerikanische Datenbank zu Filmen, Fernsehserien, Videoproduktionen und Computerspielen sowie über Personen, die daran mitgewirkt haben. Im Juni 2022 gab es Einträge zu über elf Millionen Titeln Einträge. Diese verteilen sich unter anderem auf Einträge zu 613.000 verschiedenen Spielfilmproduktionen, über 260.000 Videofilmen, über 136.000 TV-Filmen, 227.000 TV-Serien, fast 6,8 Millionen Serienepisoden und mehr als 1,9 Millionen Einträge zu Podcast-Episoden. Zudem sind über 11,7 Millionen Film- und Fernsehschaffende aufgeführt. Betrieben wird die Datenbank seit 1998 von Amazon.",
   "ina":"Das Institut national de l’audiovisuel (INA) ist ein öffentlich-rechtliches französisches Unternehmen. Das INA war das erste digitalisierte Archiv Europas. Sein Auftrag ist es, alle französischen Rundfunk- und Fernsehproduktionen zu sammeln, zu bewahren und öffentlich zugänglich zu machen, in etwa vergleichbar dem Auftrag der Bibliothèque nationale de France (BnF), geschriebene und gedruckte Dokumente aller Art zu archivieren. Die Sammlungen des INA sind über seine Website für die Öffentlichkeit teilweise kostenlos zugänglich, der Rest unterliegt urheberrechtlichen Beschränkungen.",
   "invidious":[
    "alternatives Frontend für YouTube",
@@ -849,6 +908,14 @@
   ],
   "startpage":"Startpage ist eine Suchmaschine, die die eingegebenen Suchanfragen an die Google-Suchmaschine weiterleitet und dadurch anonymisiert die Suchergebnisse anzeigt. Startpage will damit den Datenschutz ihrer Nutzer gewährleisten. Startpage wird von der niederländischen Startpage B.V. betrieben, die zur Surfboard Holding B.V. gehört.",
   "unsplash":"Unsplash ist eine internationale Website für Fotos, die von ihren Urhebern der Online-Community zur kostenlosen Verwendung zur Verfügung gestellt werden.",
+  "yahoo":[
+   "yahoo:en",
+   "ref"
+  ],
+  "yahoo news":[
+   "yahoo:en",
+   "ref"
+  ],
   "youtube":"YouTube ist ein 2005 gegründetes Videoportal des US-amerikanischen Unternehmens YouTube, LLC, seit 2006 eine Tochtergesellschaft von Google LLC, mit Sitz im kalifornischen San Bruno. Die Benutzer können auf dem Portal kostenlos Videoclips ansehen, bewerten, kommentieren und selbst hochladen. 2019 erzielte YouTube einen Jahresumsatz von 15 Milliarden Dollar. Die Einnahmen werden zum Großteil durch das Abspielen von Werbespots generiert.",
   "dailymotion":"Dailymotion ist ein Videoportal des gleichnamigen französischen Unternehmens, bei dem Videos hochgeladen und öffentlich angeschaut werden können. Dailymotion wurde 2005 in Paris gegründet und gehört heute zu den weltweit führenden Videoportalen im Internet. Heute gibt es mehrere Büros in Paris, Barcelona, London, Athen, Mumbai und New York City. Es gibt elf lokalisierte Portalseiten, die eine eigene Programmplanung enthalten. Insgesamt wurde bisher in 20 Sprachen übersetzt.",
   "vimeo":"Vimeo ist ein 2004 gegründetes Videoportal des US-amerikanischen Unternehmens Vimeo LLC mit Sitz ursprünglich in White Plains im Bundesstaat New York und inzwischen am Hudson River in Manhattan. Es unterstützt seit 2007 das Streaming von Videos in HD und seit 2015 in 4K Ultra HD. Neben der kostenlosen Nutzung des Portals bietet es auch die Möglichkeit, kostenpflichtige Inhalte zu veröffentlichen.",
@@ -886,7 +953,11 @@
    "polnisches Online-Wörterbuch",
    "wikidata"
   ],
-  "brave":"Brave Search ist eine Internet-Suchmaschine des US-amerikanischen Browserherstellers Brave Software Inc. Die Suchmaschine legt dabei ähnlich wie der Webbrowser vom selben Unternehmen Wert auf die Privatsphäre des Nutzers, so dass Tracking und Werbung herausgefiltert werden. Brave Search setzt auf einen eigenen Index, um die Suchergebnisse auszugeben."
+  "brave":"Brave Search ist eine Internet-Suchmaschine des US-amerikanischen Browserherstellers Brave Software Inc. Die Suchmaschine legt dabei ähnlich wie der Webbrowser vom selben Unternehmen Wert auf die Privatsphäre des Nutzers, so dass Tracking und Werbung herausgefiltert werden. Brave Search setzt auf einen eigenen Index, um die Suchergebnisse auszugeben.",
+  "sourcehut":[
+   "Platform für Softwareprojekte",
+   "wikidata"
+  ]
  },
  "el-GR":{
   "archive is":[
@@ -903,6 +974,10 @@
   "bing news":[
    "Ειδήσεις από διεθνείς, εθνικές και τοπικές πηγές ειδήσεων, οργανωμένες έτσι, ώστε να σας παράσχουν λεπτομερή ενημέρωση για θέματα όπως σπορ, ψυχαγωγία, επιχειρήσεις, πολιτική, καιρός και άλλα.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Το Bing σάς βοηθά να μετατρέψετε την πληροφορία σε δράση, επιταχύνοντας και διευκολύνοντας τη μετάβαση από την αναζήτηση στη δράση.",
+   "https://www.bing.com/videos"
   ],
   "currency":"Η DuckDuckGo (DDG) είναι διαδικτυακή μηχανή αναζήτησης που δίνει έμφαση στην προστασία της ιδιωτικής ζωής των χρηστών της και στην αποφυγή του “φίλτρου φυσαλίδας” των εξατομικευμένων αποτελεσμάτων αναζήτησης. Το DuckDuckGo ξεχωρίζει από τις άλλες μηχανές αναζήτησης, μη δημιουργώντας το προφίλ των χρηστών του και εκθέτοντας σκόπιμα σε όλους τους χρήστες τα ίδια αποτελέσματα αναζήτησης για ένα δεδομένο όρο αναζήτησης. Το DuckDuckGo δίνει έμφαση στην επιστροφή των καλύτερων, και όχι απλά των περισσότερων, αποτελεσμάτων. Τα αποτελέσματα αυτά τα παράγει μέσα από περισσότερες από 400 μεμονωμένες πηγές, συμπεριλαμβανομένων γνωστών πληθοπορισμικών (crowdsoursed) σελίδων όπως το Wikipedia και άλλων μηχανών αναζήτησης όπως το Bing, το Yahoo!, το Yandex και το Yummly.",
   "deezer":[
@@ -978,8 +1053,8 @@
   "archive is":"archive.today is a web archiving site, founded in 2012, that saves snapshots on demand, and has support for JavaScript-heavy sites such as Google Maps and progressive web applications such as Twitter. archive.today records two snapshots: one replicates the original webpage including any functional live links; the other is a screenshot of the page.",
   "artic":"The Art Institute of Chicago in Chicago's Grant Park, founded in 1879, is one of the oldest and largest art museums in the world. Recognized for its curatorial efforts and popularity among visitors, the museum hosts approximately 1.5 million people annually. Its collection, stewarded by 11 curatorial departments, is encyclopedic, and includes iconic works such as Georges Seurat's A Sunday on La Grande Jatte, Pablo Picasso's The Old Guitarist, Edward Hopper's Nighthawks, and Grant Wood's American Gothic. Its permanent collection of nearly 300,000 works of art is augmented by more than 30 special exhibitions mounted yearly that illuminate aspects of the collection and present cutting-edge curatorial and scientific research.",
   "arxiv":"arXiv is an open-access repository of electronic preprints and postprints approved for posting after moderation, but not peer review. It consists of scientific papers in the fields of mathematics, physics, astronomy, electrical engineering, computer science, quantitative biology, statistics, mathematical finance and economics, which can be accessed online. In many fields of mathematics and physics, almost all scientific papers are self-archived on the arXiv repository before publication in a peer-reviewed journal. Some publishers also grant permission for authors to archive the peer-reviewed postprint. Begun on August 14, 1991, arXiv.org passed the half-million-article milestone on October 3, 2008, and had hit a million by the end of 2014. As of April 2021, the submission rate is about 16,000 articles per month.",
-  "bandcamp":"Bandcamp is an American online audio distribution platform founded in 2007 by Oddpost co-founder Ethan Diamond and programmers Shawn Grunberger, Joe Holt and Neal Tucker, with headquarters in Oakland, California, US. On March 2, 2022 Bandcamp was acquired by Epic Games.",
-  "wikipedia":"Wikipedia is a multilingual free online encyclopedia written and maintained by a community of volunteers through open collaboration and a wiki-based editing system. Individual contributors, also called editors, are known as Wikipedians. Wikipedia is the largest and most-read reference work in history. It is consistently one of the 10 most popular websites ranked by the Similarweb and former Alexa; as of 2022, Wikipedia was ranked the 7th most popular site. It is hosted by the Wikimedia Foundation, an American non-profit organization funded mainly through donations.",
+  "bandcamp":"Bandcamp is an American online audio distribution platform founded in 2007 by Oddpost co-founder Ethan Diamond and programmers Shawn Grunberger, Joe Holt and Neal Tucker, with headquarters in Oakland, California, US. On March 2, 2022, Bandcamp was acquired by Epic Games.",
+  "wikipedia":"Wikipedia is a multilingual free online encyclopedia written and maintained by a community of volunteers through open collaboration and a wiki-based editing system. Its editors are known as Wikipedians. Wikipedia is the largest and most-read reference work in history. It is consistently one of the 10 most popular websites ranked by the Similarweb and former Alexa; as of 2022, Wikipedia was ranked the 7th most popular site. It is hosted by the Wikimedia Foundation, an American non-profit organization funded mainly through donations.",
   "bing":"Microsoft Bing is a web search engine owned and operated by Microsoft. The service has its origins in Microsoft's previous search engines: MSN Search, Windows Live Search and later Live Search. Bing provides a variety of search services, including web, video, image and map search products. It is developed using ASP.NET.",
   "bing images":[
    "bing:en",
@@ -1041,8 +1116,8 @@
   "genius":"Genius is an American digital media company founded on August 27, 2009, by Tom Lehman, Ilan Zechory, and Mahbod Moghadam. The site allows users to provide annotations and interpretation to song lyrics, news stories, sources, poetry, and documents.",
   "gigablast":"Gigablast is an American free and open-source web search engine and directory. Founded in 2000, it is an independent engine and web crawler, developed and maintained by Matt Wells, a former Infoseek employee and New Mexico Tech graduate.",
   "gentoo":"Gentoo Linux is a Linux distribution built using the Portage package management system. Unlike a binary software distribution, the source code is compiled locally according to the user's preferences and is often optimized for the specific type of computer. Precompiled binaries are available for some larger packages or those with no available source code.",
-  "gitlab":"GitLab Inc. is an open-core company that provides GitLab, a DevOps software package that combines the ability to develop, secure, and operate software in a single application. The open source software project was created by Ukrainian developer Dmitriy Zaporozhets and Dutch developer Sytse Sijbrandij. GitLab Inc. was considered the first partly Ukrainian unicorn valued more than $1 billion in 2018.",
-  "github":"GitHub, Inc. is a provider of Internet hosting for software development and version control using Git. It offers the distributed version control and source code management (SCM) functionality of Git, plus its own features. It provides access control and several collaboration features such as bug tracking, feature requests, task management, continuous integration, and wikis for every project. Headquartered in California, it has been a subsidiary of Microsoft since 2018.",
+  "gitlab":"GitLab Inc. is an open-core company that provides GitLab, a DevOps software package that combines the ability to develop, secure, and operate software in a single application. The open source software project was created by Ukrainian developer Dmitriy Zaporozhets and Dutch developer Sytse Sijbrandij. In 2018, GitLab Inc. was considered the first partly-Ukrainian unicorn.",
+  "github":"GitHub, Inc., is an Internet hosting service for software development and version control using Git. It provides the distributed version control of Git plus access control, bug tracking, software feature requests, task management, continuous integration, and wikis for every project. Headquartered in California, it has been a subsidiary of Microsoft since 2018.",
   "codeberg":[
    "Codeberg is founded as a Non-Profit Organization, with the objective to give the Open-Source code that is running our world a safe and friendly home, and to ensure that free code remains free and secure forever.",
    "https://codeberg.org/"
@@ -1084,6 +1159,10 @@
   "lobste.rs":[
    "social news website focused on computer engineering",
    "wikidata"
+  ],
+  "azlyrics":[
+   "AZLyrics - Song Lyrics from A to Z",
+   "https://azlyrics.com"
   ],
   "mixcloud":"Mixcloud is a popular British online music streaming service that allows for the listening and distribution of radio shows, DJ mixes and podcasts, which are crowdsourced by its registered users.",
   "npm":"npm is a package manager for the JavaScript programming language maintained by npm, Inc. npm is the default package manager for the JavaScript runtime environment Node.js. It consists of a command line client, also called npm, and an online database of public and paid-for private packages, called the npm registry. The registry is accessed via the client, and the available packages can be browsed and searched via the npm website. The package manager and the registry are managed by npm, Inc.",
@@ -1168,7 +1247,7 @@
   ],
   "unsplash":"Unsplash is a website dedicated to sharing stock photography under the Unsplash license. Since 2021, it has been owned by Getty Images. The website claims over 265,000 contributing photographers and generates more than 16 billion photo impressions per month on their growing library of over 3.48 million photos. Unsplash has been cited as one of the world's leading photography websites by Forbes, Entrepreneur Magazine, CNET, Medium and The Next Web.",
   "yahoo":[
-   "The search engine that helps you find exactly what you're looking for. Find the most relevant information, video, images, and answers from all across the Web.",
+   "Yahooist Teil der Yahoo Markenfamilie",
    "https://search.yahoo.com/"
   ],
   "yahoo news":"Yahoo! News is a news website that originated as an internet-based news aggregator by Yahoo!. The site was created by a Yahoo! software engineer named Brad Clawsie in August 1996. Articles originally came from news services such as the Associated Press, Reuters, Fox News, Al Jazeera, ABC News, USA Today, CNN and BBC News.",
@@ -1210,7 +1289,7 @@
   "rubygems":"RubyGems is a package manager for the Ruby programming language that provides a standard format for distributing Ruby programs and libraries, a tool designed to easily manage the installation of gems, and a server for distributing them. It was created by Chad Fowler, Jim Weirich, David Alan Black, Paul Brannan and Richard Kilmer during RubyConf 2004.",
   "peertube":"PeerTube is a free and open-source, decentralized, ActivityPub federated video platform powered by WebTorrent, that uses peer-to-peer technology to reduce load on individual servers when viewing videos.",
   "mediathekviewweb":"MediathekView is a free open-source software designed to manage the online multimedia libraries of several German public broadcasters as well as an Austrian, a Swiss and a Franco-German public broadcaster. The software comes with a German user interface that lists broadcasts available online. In October 2016, the developer announced that maintenance of the project would be discontinued at the end of the year. Three weeks later, the user community had formed a team to continue the project, and the software continues to remain open-source.",
-  "rumble":"Rumble is an online video platform headquartered in Longboat Key, Florida. It was founded in October of 2013 by Chris Pavlovski, a technology entrepreneur from Canada. The site is popular among political conservatives, and some from center and left-wing. Rumble promotes itself as being \"immune to cancel culture.\" As of 2022, according to analytics firm Similarweb, Rumble receives 150 million monthly visitors.",
+  "rumble":"Rumble is an online video platform headquartered in Longboat Key, Florida. It was founded in October of 2013 by Chris Pavlovski, a technology entrepreneur from Canada. The site is popular among American right-leaning users. Rumble promotes itself as being \"immune to cancel culture.\" As of 2022, according to analytics firm Similarweb, Rumble receives 150 million monthly visitors.",
   "wordnik":"Wordnik, a nonprofit organization, is an online English dictionary and language resource that provides dictionary and thesaurus content. Some of the content is based on print dictionaries such as the Century Dictionary, the American Heritage Dictionary, WordNet, and GCIDE. Wordnik has collected a corpus of billions of words which it uses to display example sentences, allowing it to provide information on a much larger set of words than a typical dictionary. Wordnik uses as many real examples as possible when defining a word.",
   "sjp.pwn":[
    "Polish online dictionary",
@@ -1229,6 +1308,14 @@
   "petalsearch news":[
    "petalsearch:en",
    "ref"
+  ],
+  "lib.rs":[
+   "Lib.rs is a catalog of programs and libraries written in the Rust programming language. It includes crates from the crates.io registry, and a few notable projects published only on GitHub or GitLab.",
+   "wikidata"
+  ],
+  "sourcehut":[
+   "software development repository and forge",
+   "wikidata"
   ]
  },
  "eo":{
@@ -1457,6 +1544,10 @@
    "Ülemaailmsetest, riiklikest ja kohalikest uudiste allikatest pärinevad uudised on korrastatud nii, et need annavad põhjaliku ülevaate spordi, meelelahutuse, äri ja poliitika uudiste, ilma ning palju muu kohta.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing aitab teil teavet kasutada, viies teid kiiremini ja hõlpsamini otsingu juurest tegevuse juurde.",
+   "https://www.bing.com/videos"
+  ],
   "deezer":"Deezer on prantsuse veebipõhine muusika voogedastusteenus.",
   "deviantart":"DeviantART on kunstiteemaline veebisait, mis avati 7. augustil 2000.",
   "wikidata":"Wikidata on vabatahtlike kaastööliste koostöös toimetatav teadmusbaas, mis on mõeldud olema Vikipeedia ja selle sõsarprojektide ühiselt jagatud andmeallikas. Kuna baasis olevad andmed litsentsitakse avalikku omandisse, siis on Wikidata piiramatult kasutatavad ka kolmandatele osapooltele. Teadmusbaas kasutab Wikibase tarkvara ning teadmusbaasi haldab Wikimedia Foundation.",
@@ -1514,6 +1605,10 @@
   "bing news":[
    "Munduko eta tokiko albiste-iturburuetako nahiz iturburu nazionaletako albisteak ondo antolatuta, kirol, entretenimendu, negozio, politika eta eguraldiaren berri emateko sakon, besteak beste.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing bilatzaileari esker, informaziotik ekintzetara pasatuko duzu azkar, hots, bilaketa gutxiago eta ekintza gehiago.",
+   "https://www.bing.com/videos"
   ],
   "crossref":[
    "DOI zenbakien kudeaketa agentzia",
@@ -1687,6 +1782,10 @@
    "Uutisia niin maailman ja valtakunnan lähteistä kuin paikallislähteistäkin. Uutiset on järjestetty niin, että saat seikkaperäisiä uutisia urheilusta, viihteestä, taloudesta, politiikasta, säästä ja monesta muusta aiheesta.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing auttaa muuttamaan tiedot toiminnaksi ja siirtymään nopeasti ja helposti hausta tekoihin.",
+   "https://www.bing.com/videos"
+  ],
   "bitbucket":"Bitbucket on lähdekoodin hallinnointiin ja versiohallintaan tarkoitettu sivusto.",
   "currency":"DuckDuckGo on hakukone, joka painottaa yksityisyyttä eikä kerää dataa käyttäjiltä. Se käyttää hakuihinsa oman hakurobottinsa lisäksi useita eri lähteitä, muun muassa joukkoutettuja verkkosivuja, kuten Wikipediaa.",
   "deezer":"Deezer on ranskalainen musiikkipalvelu, jossa käyttäjät voivat kuunnella musiikkia suoratoistona Internetistä. Deezer julkaistiin 24. elokuuta 2007. Palvelua kustannetaan mainostuloilla. Toukokuussa 2013 Deezerissä oli 20 miljoonaa kappaletta. Palvelun käyttö ei vaadi erillistä ohjelmaa, vaan sivustolla olevia kappaleita pystyy kuuntelemaan suoraan verkkosivuston kautta. Palvelu on saatavissa myös älypuhelimille erillisen sovelluksen kautta. Palvelu avattiin Suomessa toukokuussa 2013. Deezer on Spotifyn kilpailija. Deezerissä on tarjolla yli 53 miljoonaa kappaletta",
@@ -1763,10 +1862,6 @@
  "fil":{
   "bandcamp":"Ang Bandcamp ay isang Amerikanong online music company na itinatag noong 2008 ni Oddpost co-founder Ethan Diamond at mga programmer na sina Shawn Grunberger, Joe Holt at Neal Tucker; ang kumpanya ay headquarter sa Oakland, California.",
   "wikipedia":"Ang Wikipedia ay isang ensiklopedya na may basehang wiki at may malayang nilalaman. Ito ay tinatawag na malaya sa kadahilanang ito ay malayang magagamit at mapapalitan ng kung sino man. Ang Wikipedia ay nakasulat sa maraming wika at pinamamahalaan ng Wikimedia Foundation.",
-  "bing images":[
-   "Tingnan ang mga nagte-trend na imahe, wallpaper, gif at ideya sa Bing araw-araw.",
-   "https://www.bing.com/images"
-  ],
   "bing news":[
    "Balita mula sa buong daigdig, bansa, at lokal, organisado para bigyan ka ng malawakang coverage ng sports, entertainment, negosyo, pulitika, panahon, at marami pang iba.",
    "https://www.bing.com/news"
@@ -1776,6 +1871,10 @@
   "google images":[
    "Google Images. Ang pinakamalawak na paghahanap ng imahe sa web.",
    "https://images.google.com"
+  ],
+  "google news":[
+   "Bago ka magpatuloy",
+   "https://news.google.com"
   ],
   "google scholar":[
    "Nagbibigay ang Google Scholar ng simpleng paraan ng malawakang paghahanap ng mga babasahing iskolar. Maghanap sa iba't ibang disiplina at source: mga artikulo, thesis, aklat, abstract, at opinyon ng hukuman.",
@@ -1790,6 +1889,10 @@
    "ref"
   ],
   "imdb":"Ang Internet Movie Database (IMDb) at IMDB, ay isang online database ng impormasyon tungkol sa mga artista, pelikula, palatuntunan sa telebisyon at video games. Ang websayt ng IMDb ay nagsimula noong Setyembre 1993. Naging pagmamay-ari ito ng \"Amazon.com\" mula 1998.",
+  "openstreetmap":[
+   "OpenStreetMap is the free wiki world map.",
+   "https://www.openstreetmap.org/"
+  ],
   "youtube":"Ang YouTube ay isang website na nagbabahagi ng mga bidyo at nagbibigay-daan para sa mga tagagagamit o user nito na mag-upload, makita, at ibahagi ang mga bidyo clip. Ang mga bidyo na ito ay maaaring husgahan; ang dami ng husga at ng mga nakanood ay parehong nakalathala. Maaari ring mag-iwan ng komento ang mga manonood sa karamihan ng video.",
   "vimeo":"Ang Vimeo ay isang Amerikan portal na websayt na bidyo punong abala at namamahagi ang himpilan nito ay matatagpuan sa Lungsod ng Bagong York, Bagong York noong Nobyembre 2004 na inilathala nina Zach Klein, Jake Lodwick katuwang si Anjali Sud (Indian-American), ang (CEO) ng Vimeo.",
   "wikibooks":"Ang Wikibooks ay isang base ng wiki sa Wikimedia project na pag-aari ng Wikimedia Foundation, para sa lumikha ng malayang nilalaman na textbooks o aklat na pwedeng sa lahat na pagbabago.",
@@ -1814,6 +1917,10 @@
   "bing news":[
    "Les actualités internationales, nationales et locales sont organisées de façon à vous donner une vision détaillée du monde du sport, du divertissement, de l'économie, la politique, la météo et bien plus encore.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing permet de transformer les informations en actions, afin de consacrer moins de temps à la recherche et plus de temps à l’action.",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":"Bitbucket est un service web d'hébergement et de gestion de développement logiciel utilisant le logiciel de gestion de versions Git.",
   "crossref":"Crossref est une organisation à but non lucratif de droit américain jouant le rôle d'agence d'enregistrement et de registre des Digital Object Identifier. Lancée au début des années 2000 dans un effort de coopération entre les éditeurs, afin de permettre l'identification des objets numériques, notamment les articles et les revues académiques en ligne. Crossref est le nom commun utilisé par la Publishers International Linking Association (PILA). En 2019, l'agence comptait près de 14 800 adhérents issus de 120 pays.",
@@ -1866,7 +1973,7 @@
   "piratebay":"The Pirate Bay est un site web créé en 2003 en Suède, indexant des liens Magnets de fichiers numériques, permettant le partage de fichiers en pair à pair à l’aide du protocole de communication BitTorrent. Le site se finance par les dons et la publicité, il a été créé dans l’esprit d’une « culture libre ».",
   "pubmed":"MEDLINE est une base de données bibliographiques regroupant la littérature relative aux sciences biologiques et biomédicales. La base est gérée et mise à jour par la Bibliothèque américaine de médecine (NLM).",
   "pypi":"PyPI est le dépôt tiers officiel du langage de programmation Python. Son objectif est de doter la communauté des développeurs Python d'un catalogue complet recensant tous les paquets Python libres. Il est analogue au dépôt CPAN pour Perl.",
-  "qwant":"Qwant est un moteur de recherche européen développé en France et leader en Europe. Mis en ligne en 2013, il annonce depuis son lancement[citation nécessaire] ne pas tracer ses utilisateurs, ni vendre leurs données personnelles, afin de garantir leur vie privée, et se veut impartial dans l'affichage des résultats.",
+  "qwant":"Qwant est un metamoteur de recherche français développé en France. Mis en ligne en 2013, il annonce depuis son lancement[citation nécessaire] ne pas tracer ses utilisateurs, ni vendre leurs données personnelles, afin de garantir leur vie privée, et se veut impartial dans l'affichage des résultats.",
   "qwant news":[
    "qwant:fr",
    "ref"
@@ -1930,6 +2037,10 @@
    "bing:gl",
    "ref"
   ],
+  "bing news":[
+   "Novas procedentes de fontes de noticias mundiais, nacionais e locais, organizadas para ofrecerche unha cobertura en profundidade das novas relacionadas co deporte, o entretemento, os negocios, a política, o tempo e moito máis.",
+   "https://www.bing.com/news"
+  ],
   "wikidata":"O Wikidata é unha base de datos editada de forma colaborativa, parte da Fundación Wikimedia, co obxectivo de proporcionar unha fonte común para certos tipos de datos, como datas de nacemento, que poden utilizar proxectos da Wikimedia como a Wikipedia. Isto é semellante á forma na que a Wikimedia Commons proporciona almacenamento para ficheiros multimedia e acceso a estes ficheiros en tódolos proxectos da Wikimedia.",
   "fdroid":[
    "repositorio de aplicacións para Android que só contén software libre",
@@ -1943,6 +2054,10 @@
   "google images":[
    "Google Imaxes. A busca máis completa de imaxes na rede.",
    "https://images.google.com"
+  ],
+  "google news":[
+   "Antes de continuar",
+   "https://news.google.com"
   ],
   "google play apps":"Google Play é unha plataforma de distribución dixital de aplicacións móbiles para os dispositivos con sistema operativo Android, así como unha tenda en liña desenvolvida e operada por Google. Esta plataforma permítelles aos usuarios navegar e descargar aplicacións, xogos, música, libros, revistas e películas. Tamén se poden adquirir dispositivos móbiles como ordenadores Chromebook, teléfonos intelixentes Nexus, Google Chromecast, entre outros.",
   "google play movies":[
@@ -1988,6 +2103,10 @@
   "bing news":[
    "חדשות ממקורות חדשותיים עולמיים, לאומיים ומקומיים, מאורגנים כדי לספק לך כיסוי חדשותי מעמיק של ספורט, בידור, עסקים, פוליטיקה, מזג אוויר ועוד.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing עוזר לך להפוך מידע לפעולה, ומקצר ומפשט את המעבר מחיפוש לעשייה.",
+   "https://www.bing.com/videos"
   ],
   "currency":"דקדקגו הוא מנוע חיפוש שמדגיש את הגנת פרטיות המשתמש ונמנע מיצירת \"בועת פילטר\" שמנחשת את אופי החיפושים הרלוונטיים למשתמש. דקדקגו נבדל ממנועי חיפוש אחרים בכך שהוא לא מתחקה אחר תוצאות המשתמשים, כמו גם, מאחזר את אותן תוצאות לכל המשתמשים שחיפשו מושג זהה ואינו נותן תוקף לשיקולים זרים בתוצאות החיפוש. יתרה מכך, דקדקגו מעדיף לאחזר מידע ממעט מקורות מידע איכותיים מאשר מהרבה מקורות מידע שאינם איכותיים. תוצאות החיפוש של דקדקגו הן קומפילציה של \"בערך 50\" מקורות מידע (duck.co). בין היתר, הוא מאחזר מידע מאתרי \"מיקור המונים\" כמו ויקיפדיה, ממנועי חיפוש אחרים כמו: Yandex, Yahoo!, Bing ו-Yummly ומזחלן הרשת שלו עצמו, דקדקבוט.",
   "deezer":"דיזר הוא שירות הזרמת מוזיקה מבוסס אינטרנט. השירות מאפשר למשתמשים להאזין לתכנים מוזיקליים המפורסמים תחת חברות תקליטים שונות, ביניהן EMI, סוני, וורנר מיוזיק גרופ ויוניברסל מיוזיק גרופ, על מכשירים שונים באופן מקוון או לא מקוון. דיזר נוצר בפריז, צרפת על ידי דניאל מרלי בשנת 2007. השירות פועל בכ-185 מדינות ומחזיק ברישיון להזרמת כ-90 מיליון שירים בספרייתו. השירות מספק מעל ל-30,000 ערוצי רדיו, ורשומים אליו כ-20 מיליון משתמשים פעילים חודשיים, וכ-9 מיליון מנויים בתשלום, נכון לאפריל 2022. השירות, בנוסף לאתר האינטרנט, זמין עבור אנדרואיד, Kindle Fire HDX HDX, OS X, בלקברי, iOS, Windows Phone וסימביאן.",
@@ -2059,6 +2178,10 @@
    "Novosti iz svjetskih, nacionalnih i lokalnih izvora, organizirane tako da pružaju podrobne informacije o sportu, zabavi, poslovnim temama, politici, vremenu i drugim temama.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing vam pomaže da iskoristite informacije, ubrzavajući i pojednostavljujući prelazak s pretraživanja na djelo.",
+   "https://www.bing.com/videos"
+  ],
   "currency":"DuckDuckGo je mrežna tražilica čije se djelovanje temelji na proširenju korisnikove privatnosti izbjegavanjem osobnog pretraživanja i prikupljanja osobnih podataka korisnika na temelju rezultata njihova istraživanja u svrhu prosljeđivanja tih podataka oglašivačima, kao u slučaju većih pretraživača. Prilikom slaganja rezultata koristi se metodom nabave iz mnoštva (crowdsourcinga), prikupljajući i stvarajući baze podataka više na temelju kakvoće stranice nego li na posjećenosti.",
   "deezer":"Deezer je mrežna usluga za prenošenje glazbenih sadržaja koja korisnicima dopušta slušanje glazbe mrežno ili izvanmrežno te stvaranje i dijeljenje popisa pjesama. Stvoren u Parizu, 2007., Deezer trenutno raspolaže s 56 milijuna licenciranih snimki u svom katalogu, iz svih glazbenih žanrova. Na usluzi je dostupno i preko 30.000 radijskih postaja.",
   "ddg definitions":[
@@ -2079,6 +2202,10 @@
   "google images":[
    "Google Slike. Najpotpunije pretraživanja slika na webu.",
    "https://images.google.com"
+  ],
+  "google news":[
+   "Prije nego što nastavite",
+   "https://news.google.com"
   ],
   "google scholar":"Google znalac, usluga koju na svojoj tražilici nudi Google. To je internetski pretraživač znanstvene literature, razvijen u okvirima pretraživača Googlea. Danas je Googleov znalac prvi internetski pokazatelj citiranosti.Glavni tvorac Znalca računalni je znanstvenik indijskog podrijetla Anurag Acharya.",
   "google play apps":"Google Play Googleova je mrežna trgovina aplikacija, glazbe, filmova i ostalih digitalnih sadržaja. Predstavljen je u kolovozu 2008. godine, a njegovo korištenje počinje od listopada 2008. godine. Pojava prvih komercijalnih aplikacija započinje od strane britanskih i američkih programera od veljače 2009.",
@@ -2123,6 +2250,10 @@
    "Hírek nemzetközi, országos és helyi hírforrásokból, amelyek részletes információt nyújtanak Önnek a sporttal, szórakozással, üzleti élettel, politikával, időjárással és egyéb témákkal kapcsolatban.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "A Bing segít, hogy az információk tettekké válhassanak, használatával gyorsabban és egyszerűbben juthat a kereséstől a cselekvésig.",
+   "https://www.bing.com/videos"
+  ],
   "currency":"A DuckDuckGo egy internetes kereső, mely fontosnak tartja a felhasználók személyes adatainak a védelmét, illetve kerüli a személyre szabott keresési eredményeket. A DuckDuckGo abban különbözik a többi keresőeszköztől, hogy nem kategorizálja a felhasználóit, hanem ugyanarra a kifejezésre valamennyi felhasználójának ugyanazokat a találatokat jeleníti meg. A DuckDuckGo kihangsúlyozza, hogy az információkat a legjobb forrásokból szerzi, így a találatait a főbb közösségi fejlesztésű oldalakról, például a Wikipédiáról szerzi, illetve együttműködik más keresőeszközökkel, mint például a Yandex, Yahoo!, Bing és Yummly.",
   "deezer":"A Deezer egy 2007 óta létező francia zenei stream szolgáltató internetes vállalkozás. Netrádióként működik, de emellett előfizetési díj ellenében online musicboxként is. A díjat vállalók lejátszási listákat, vagy szóló darabokat tölthetnek le. Fájlok fel is tölthetők egy saját zenetárba. A Deezer mintegy 73 millió számot, köztük magyar felvételeket is tartalmaz.",
   "deviantart":"A deviantART (dA) egy nemzetközi, internetes művészeti publikációs helyként, ismeretségi hálózatként és webshopként egyszerre működő honlap, az egyik legnagyobb online alkotóközösség. 2000. augusztus 7-én indította útjára Scott Jarkoff, Angelo Sotira, Matthew Stepens és még sokan mások. Tulajdonosa a deviantART, Inc.",
@@ -2138,10 +2269,6 @@
   "duckduckgo images":[
    "currency:hu",
    "ref"
-  ],
-  "fdroid":[
-   "Az F-Droid szabad és nyílt forráskódú alkalmazások telepíthető katalógusa az Android platformhoz. A kliens egyszerűvé teszi a böngészést, a telepítést és a frissítések nyomon követését az eszközén.",
-   "https://f-droid.org/"
   ],
   "flickr":"A Flickr egy ingyenes fényképmegosztó weboldal, web 2.0-s web szolgáltatás és online közösségi platform.",
   "github":"A GitHub, Inc. egy egyesült államokbeli nemzetközi vállalat, amely a Git segítségével szoftverfejlesztési verziókövetés-szolgáltatást nyújt. 2018-ban a Microsoft leányvállalata lett 7,5 milliárd dollárért. Saját funkcióin felül a Git elosztott verziókövetését és forráskódkezelését (SCM) teszi elérhetővé. Hozzáférés-kezelést és számos együttműködési funkciót nyújt, mint például bugkövetés, szolgáltatáslekérés, feladatkezelés, valamint wikiket minden projekthez.",
@@ -2162,7 +2289,7 @@
   "library of congress":"A Kongresszusi Könyvtár az Amerikai Egyesült Államok nemzeti könyvtára, mely Washingtonban található négy épületben. Ez a világ legnagyobb könyvtára mind fizikai méretei, mind tárolt könyveinek, dokumentumainak száma szerint.",
   "mixcloud":"A Mixcloud egy freemium zenemegosztó streamingszolgáltató weboldal, ami rádióműsorok, zenei mixek és podcastok megosztását teszi lehetővé. Az oldal crowdsourcing alapján működik, a regisztrált felhasználók által feltöltött munkák biztosítják a tartalmat. A felhasználók korlátlanul tölthetnek fel az oldalra, de a feltöltött munkákat letölteni nem lehet, csak streamelni. A Mixcloud alkalmazása megjelent Androidra és iOS-re.",
   "openstreetmap":"Az OpenStreetMap (OSM) csoportmunkán alapuló térképfejlesztés, melynek célja egy szabadon szerkeszthető és felhasználható térkép készítése az egész világról.",
-  "piratebay":"A svéd The Pirate Bay (TPB) a világ egyik legnagyobb torrentoldala. Az Alexa Internet statisztikái szerint a TPB látogatottság alapján a 89. helyen áll. A portál nem tartalmaz illegális tartalmakat, csak a fájlcserét segítő információt (metaadatokat).",
+  "piratebay":"A svéd The Pirate Bay (TPB) a világ egyik legnagyobb torrentoldala. Az Alexa Internet statisztikái Archiválva 2011. december 13-i dátummal a Wayback Machine-ben szerint a TPB látogatottság alapján a 89. helyen áll. A portál nem tartalmaz illegális tartalmakat, csak a fájlcserét segítő információt (metaadatokat).",
   "reddit":"A Reddit egy közösségi weboldal, amelyen a felhasználók megoszthatják híreiket, képeiket és cikkeiket az ún. \"subredditeken\" (alredditeken). Kizárólag a regisztrált felhasználók adhatnak hozzá tartalmat, illetve értékelhetik a már meglévőket a \"fel\" és \"le\" nyilak segítségével. Több nyelven, köztük magyarul is elérhető.",
   "soundcloud":"A SoundCloud egy svéd alapítású, németországi székhelyű platform, ingyenes és fizetős zenei streaming szolgáltatásként, közösségi oldalként és online zeneáruházként működik. Eredetileg azért jött létre, hogy a zenészek számára kollaboratív tartalomszerkesztést biztosítson, azáltal, hogy megoszthatják felvételeiket és ezt értékelhetik, később azonban a hangsúly inkább a kész dalok közzétételére és véleményezésére helyeződött át, ezáltal az oldal egyfajta, jobbára amatőr és félprofi audio-művészeti közösségi oldallá fejlődött. Az ingyenes változat összességében korlátozott időtartamú audio felvétel feltöltését engedi - a hangmintáktól és hangszertesztektől komplett dalokon át egészen a több órás élő és bootleg felvételekig. A SoundCloud néhány hónap alatt a Myspace egyik legnagyobb riválisa lett. 2014 decemberi adatok szerint a platform 175 millió egyedi látogatót vonz és az alkotók percenként 12 órányi hangfelvételt töltenek fel rá.",
   "youtube":"A YouTube nyilvános videómegosztó webhely, ahol a felhasználók videókat tölthetnek fel és nézhetnek meg. A YouTube székhelye a kaliforniai San Brunóban található. A Time magazin a 2006-os év találmányának választotta a honlapot.",
@@ -2184,10 +2311,6 @@
  "ia":{
   "wikipedia":"Wikipedia [wikipeˈdia] es un projecto de Wikimedia sin scopo lucrative fundate le 15 de januario 2001 pro crear un encyclopedia in numerose linguas in le Internet per redaction collaborative utilisante un si appelate principio wiki. Secundo le demanda e le distribution public, Wikipedia es ora un del medias de massa.",
   "wikidata":"Wikidata es un base de cognoscentia modificate in collaboration e implementate per le Fundation Wikimedia. Illo es concipite pro fornir un fonte commun de typos de datos secur que pote esser usate per projectos Wikimedia como Wikipedia. Isto es simile al maniera que Wikimedia Commons forni un immagazinage central pro files multimedial pro accesso ab omne projectos Wikimedia. Wikidata es actionate per le software Wikibase.",
-  "openstreetmap":[
-   "OpenStreetMap is the free wiki world map.",
-   "https://www.openstreetmap.org/"
-  ],
   "youtube":"YouTube es un sito web, loco pro observar videos fundate in februario 2005 del cooperatores temporal del PayPal Chad Hurley, Steve Chen e Jawed Karim. Super iste sito web le usatores pote spectar parve filmes, como currente de datos transportate al computator del audiente, e supercargar proprie parve filmes. Le 9 de octobre 2006 Google annunciava su emption de YouTube.",
   "wiktionary":"Wiktionario es un dictionario multilingue in linea, liberemente modificabile e distribuibile sub un licentia Creative Commons. Con su projectos-fratres includente Wikipedia, Wiktionario es sub gerentia del Fundation MediaWiki."
  },
@@ -2205,11 +2328,15 @@
    "Berita dari sumber berita dunia, nasional, dan lokal, diatur untuk memberikan Anda liputan berita mendalam tentang olahraga, hiburan, bisnis, politik, cuaca, dan lainnya.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing membantu anda menukarkan maklumat kepada tindakan, menjadikan carian ke melaksanakannya lebih pantas dan mudah.",
+   "https://www.bing.com/videos"
+  ],
   "bitbucket":"Bitbucket adalah sebuah layanan hosting yang berbasis web untuk kode sumber dan pembangunan proyek yang menggunakan Mercurial ataupun sistem kendali versi Git yang dimiliki oleh Atlassian. Bitbucket menawarkan paket akun komersial dan gratis. Akun gratis tersebut menawarkan sebuah layanan repositori dengan jumlah yang tidak terbatas sejak bulan September 2010. Bitbucket terintegrasi dengan perangkat lunak Atlassian lain seperti Jira, HipChat, Confluence dan Bamboo.",
   "crossref":"Secara etimologis, CrossRef berasal dari kata \"cross\" dan “reference\". Oleh karena itu, Rujukan silang/CrossRef bisa didefinisikan sebagai pembanding dari dua atau lebih sumber informasi. CrossRefadalah lembaga pendaftaran Digital Object Identifier (DOI)resmi yang dikeluarkan pada tahun 2000 sebagai kerja sama antar penerbit untuk membuat sebuah linking referensi lintas penerbit pada jurnal ''online''. CrossRef merupakan implementasi paling kuat dari model DOI. Sekarang, CrossRef telah memiliki jutaan interlink dengan beragam item termasuk jurnal, buku, laporan, hingga data set. Ini adalah sistem yang dipakai secara universal di Eropa dalam industri penerbitan jurnal ilmiah. Tujuan dari CrossRef adalah untuk memfasilitasi kreasi jaringan dari referensi pada jurnal online ke artikel halaman.",
   "curlie":"Proyek Direktori Terbuka, dikenal dengan nama Dmoz adalah sebuah direktori konten terbuka multibahasa dari World Wide Web, direktori ini dimiliki oleh AOL, tetapi disusun dan dirawat oleh sekumpulan editor sukarela dari sebuah komunitas maya. Direktori ODP tidak mencari keuntungan dalam mendaftarkan situs-situs web yang dikirimkan. ODP menggunakan skema hierarkis ontologi untuk mengatur daftar situs-situs web dalam direktorinya. Daftar situs-situs web dalam direktori ODP yang memiliki topik serupa dikelompokkan ke dalam sebuah kategori, yang dapat mencakup kategori yang lebih kecil.",
   "currency":"DuckDuckGo adalah mesin pencari internet yang menggunakan informasi dari berbagai sumber, seperti website crowdsourced seperti Wikipedia dan dari kemitraan dengan mesin pencari lain seperti Yandex, Yahoo, Bing dan WolframAlpha untuk mendapatkan hasilnya. Kebijakan mesin pencari mengatakan bahwa itu melindungi privasi, dan tidak merekam informasi pengguna. Karena pengguna tidak diprofilkan, \"Filter gelembung\" dapat dihindari, dengan semua pengguna yang menunjukkan hasil pencarian yang sama untuk istilah pencarian tertentu.",
-  "deezer":"Deezer adalah Layanan Streaming Musik berbasis internet yang memungkinkan pengguna mendengarkan konten musik dari label rekaman termasuk Universal Music Group, Sony Music dan Warner Music Group serta podcast melalui berbagai perangakat online atau offline. Deezer dibuat di Paris, Prancis dan saat ini memiliki 56 juta lagu berlisensi di katalognya, 100 juta playlist, 16 juta pengguna aktif bulanan, serta 7 juta pelanggan berbayar pada Januari 2019. Layanan ini tersedia untuk Web, Android, iOs, Windows Mobile, BlackBerry OS, Windows dan MacOS.",
+  "deezer":"Deezer adalah Layanan streaming musik berbasis internet yang memungkinkan pengguna mendengarkan konten musik dari label rekaman termasuk Universal Music Group, Sony Music dan Warner Music Group serta podcast melalui berbagai perangakat online atau offline. Deezer dibuat di Paris, Prancis dan saat ini memiliki 56 juta lagu berlisensi di katalognya, 100 juta playlist, 16 juta pengguna aktif bulanan, serta 7 juta pelanggan berbayar pada Januari 2019. Layanan ini tersedia untuk Web, Android, iOs, Windows Mobile, BlackBerry OS, Windows dan MacOS.",
   "deviantart":"DeviantArt adalah sebuah komunitas maya untuk pembuat-pembuat seni yang telah diluncurkan pada 7 Agustus 2000. Tujuan DeviantArt adalah untuk menyediakan tempat bagi para seniman untuk memamerkan serta membicarakan karya-karya mereka.",
   "ddg definitions":[
    "currency:id",
@@ -2443,6 +2570,10 @@
    "世界、国内、地方のニュース ソースから、スポーツ、エンターテイメント、ビジネス、政治、お天気情報など、さまざまな分野の詳細なニュースを整理してお届けします。",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing は情報を行動に変え、検索から実行まで迅速かつ容易に移行するのに役立ちます。",
+   "https://www.bing.com/videos"
+  ],
   "bitbucket":"Bitbucket は、Mercurial(2020年6月1日までのリリース)またはGit(2011年10月以降)リビジョン管理システムを使用するソースコードおよび開発プロジェクト向けに、アトラシアンが運営するWeb ベースのバージョン管理リポジトリホスティングサービスである。商用プランと無料アカウントの両方を提供している。2019年2月現在、プライベートリポジトリを無制限に持てる無料アカウントを提供している。ユーザーがプライベートリポジトリしか持っていない場合でも、プライベートリポジトリはプロファイルページに表示されず、ウェブサイト上には\"このユーザーはリポジトリを持っていません\"と表示される。このサービスはDjangoフレームワークを用いてPythonで書かれている。",
   "currency":"DuckDuckGo（ダックダックゴー）は、インターネット検索エンジンである。利用者のプライバシーの保護と利用履歴等を記録保存しないことを運営方針としている。VivaldiやTor Browserの標準検索エンジンにも採用されている。また、DuckDuckGoは検索結果のパーソナライズを行わないため「フィルターバブル」に陥らない（DuckDuckGoはGoogleのフィルターバブル問題についてブログで指摘している）。",
   "deezer":"Deezer (ディーザー) は、フランスの音楽配信サービスである。",
@@ -2475,7 +2606,7 @@
    "google play apps:ja",
    "ref"
   ],
-  "imdb":"IMDb は、映画、テレビ番組、ホームビデオ、ビデオゲーム、オンラインのストリーミングコンテンツに関連する情報を集めたオンラインデータベースで、キャスト、制作スタッフ、個人の経歴、プロットの概要、トリビア、評価、ファンや批評家のレビューなどが含まれている。追加のファン機能であるメッセージボードは、2017年2月に廃止された。元々はファンが運営していたウェブサイトだったが、現在はAmazonの子会社であるIMDb.com, Inc.がデータベースを所有・運営している。",
+  "imdb":"IMDb は、映画、テレビ番組、ホームビデオ、ビデオゲーム、オンラインのストリーミングコンテンツに関連する情報を集めたオンラインデータベースで、キャスト、制作スタッフ、個人の経歴、作品の概要、トリビア、評価、ファンや批評家のレビューなどが含まれている。追加のファン機能であるメッセージボードは、2017年2月に廃止された。元々はファンが運営していたウェブサイトだったが、現在はAmazonの子会社であるIMDb.com, Inc.がデータベースを所有・運営している。",
   "ina":"フランス国立視聴覚研究所 は、フランスの全ラジオ・テレビの視聴覚アーカイヴの宝庫である。ラジオフランスが主催し、放送局本部の建物内にある。内部にフランス音楽研究グループ を有する。",
   "library genesis":"Library GenesisまたはLibGenは、様々なトピックスに関する論文や書籍のためのサーチエンジンであり、 有料で配布されていたり、どこにおいてもデジタル化されていなかったりするコンテンツを無料でアクセス可能にしている。 特に、エルゼビアのScienceDirectウェブポータルで配布されているPDFファイルを収録している。",
   "library of congress":"アメリカ議会図書館 は、アメリカ合衆国の事実上の国立図書館。蔵書数、予算額、職員数全ての点で世界最大規模の図書館である。",
@@ -2525,6 +2656,10 @@
    "전세계, 국내 및 현지 뉴스원에서 제공하는 뉴스, 스포츠, 엔터테인먼트, 비즈니스, 정치, 날씨 등 심층적인 뉴스 범위를 제공하도록 구성.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing을 사용하면 정보를 기반으로 작업을 수행할 수 있고 검색에서 작업 수행까지 더 빠르고 쉽게 진행할 수 있습니다.",
+   "https://www.bing.com/videos"
+  ],
   "bitbucket":"빗버킷(Bitbucket)은 아틀라시안 소유의 웹 기반 버전 관리 저장소 호스팅 서비스로서, 깃(2011년 10월 이후) 버전 관리 시스템을 사용하는 소스 코드 및 개발 프로젝트를 대상으로 한다. 빗버킷은 상용 플랜과 무료 계정을 동시에 제공한다. 2010년 9월 기준으로 무료 계정의 경우 무제한 수의 개인 저장소(무료 계정의 경우 최대 5명의 사용자 보유 가능)를 제공한다. 빗버킷은 지라, 힙챗, 컨플루언스, 밤부 등의 기타 아틀라시안 소프트웨어와 연동된다.",
   "crossref":[
    "국제 DOI 재단의 공식 디지털 객체 식별자 등록 기관 중 하나",
@@ -2547,10 +2682,7 @@
    "ref"
   ],
   "etymonline":"온라인 어원 사전(Online Etymology Dictionary)은 영어 단어의 어원을 설명해 주는 온라인 사전이다. 온라인 어원 사전의 약자는 OED인데, 옥스퍼드 영어 사전의 약자와 일치한다.",
-  "fdroid":[
-   "F-Droid는 Android 플랫폼을 위한 설치 가능한 FOSS (자유-오픈 소스 소프트웨어) 애플리케이션의 카탈로그입니다. 클라이언트는 여러분의 기기에서 찾아보고, 설치하고, 업데이트의 추적을 유지하는 것을 쉽게 합니다.",
-   "https://f-droid.org/"
-  ],
+  "fdroid":"F-Droid는 구글 플레이 스토어와 비슷한 기능을 담당하는 안드로이드용 앱 스토어이자 소프트웨어 저장소이다. 이 프로젝트가 호스팅하는 주요 저장소는 자유-오픈 소스 앱들만 포함한다. F-Droid 웹사이트나 클라이언트 앱을 통해 계정 등록 없이 애플리케이션의 검색, 다운로드, 설치가 가능하다. 광고, 사용자 추적, 비자유 소프트웨어의 의존성 등 \"Anti-Features\"가 앱 설명에 표기된다.",
   "flickr":"플리커(영어: Flickr)는 미국의 기업 야후의 온라인 사진 공유 커뮤니티 사이트로 2004년 2월부터 운영되고 있다. 웹 2.0의 대표적인 프로그램 중 하나로 거론되며, 캐나다 밴쿠버의 기업인 루디코프에서 개발했다.",
   "free software directory":"자유 소프트웨어 디렉터리(Free Software Directory, FSD)는 자유 소프트웨어 재단(FSF)의 프로젝트이다. 자유 운영 체제, 특히 GNU와 리눅스에서 구동되는 자유 소프트웨어를 분류한다. 분류된 프로젝트들은 대개 기타 여러 운영 체제에서 실행이 가능하다. 이 프로젝트는 한때 유네스코에 의해 공동 운영되었다.",
   "gitlab":"깃랩(GitLab)은 깃랩 사(GitLab Inc.)가 개발한 깃 저장소 및 CI/CD, 이슈 추적, 보안성 테스트 등의 기능을 갖춘 웹 기반의 데브옵스 플랫폼으로써, 오픈 소스 라이선스 및 사유 소프트웨어 라이선스를 사용한다. 2019년 기준으로, 깃 저장소와 이슈 추적 기능을 갖춘 유일한 단일 어플리케이션의 데브옵스 솔루션이다. 시중에 유통되고 있는 많은 데브옵스 솔루션들은 자신들의 특화된 영역 이외는 API를 이용한 연동 만을 제공하지만 깃랩은 단일 어플리케이션으로써 데브옵스의 전 영역의 기능들을 모두 제공하고 있다.",
@@ -2627,6 +2759,10 @@
    "Naujienos iš viso pasaulio, nacionalinių ir vietinių naujienų šaltinių parengtos taip, kad išsamiai atskleistų sporto, pramogų, verslo, politikos įvykius, orus ir dar daugiau.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Naudodami „Bing“ pateikiamą informaciją galėsite skirti mažiau laiko paieškoms ir greičiau imtis konkrečių darbų.",
+   "https://www.bing.com/videos"
+  ],
   "deviantart":"deviantArt, deviantART arba DeviantArt – 2000 m. sukurta internetinė svetainė, skirta naudotojų sukurtiems meno kūriniams saugoti ir platinti.",
   "flickr":"„Flickr“ – socialinis tinklas, priklausantis „SmugMug“ bendrovei.",
   "google":"Google Search (Google) – internetinės paieškos sistema plėtojama „Google“ bendrovės. Plačiausiai naudojamas paieškos variklis internete, užimantis daugiau nei 90 % rinkos dalį. Įvykdo daugiau nei 5 mlrd. užklausų per dieną. „Google“ paieškos sistemoje ieškoma interneto puslapių, naujienų, nuotraukų, vaizdo įrašų („YouTube“) bei kitų išteklių. „Google“ siūlo ir papildomų paslaugų.",
@@ -2635,7 +2771,7 @@
    "https://images.google.com"
   ],
   "google news":[
-   "Išsamios naujausios žinios, kurias iš viso pasaulio naujienų šaltinių surinko „Google“ naujienos.",
+   "Prieš tęsdami",
    "https://news.google.com"
   ],
   "google videos":"Google Video – nemokama Google paslauga, kuri leidžia kiekvienam įkelti video klipus į Google serverius, šitaip ją padarant nemokamai prienamą arba apmokestintą per Google Video parduotuvę. Naudotojai gali naršyti ir peržiūrėti filmus tiesiogiai Google Video svetainėje arba parsisiųti failus ir juos pateikti savo asmeninėje svetainėje.",
@@ -2669,13 +2805,21 @@
    "wikidata"
   ],
   "wikipedia":"Vikipēdija (Wikipedia) ir brīva, daudzvalodu enciklopēdija ar bezmaksas saturu, kuras ikdienas darbību nodrošina bezpeļņas organizācija Wikimedia Foundation. Kopš tās dibināšanas 2001. gadā, Vikipēdija ir kļuvusi par vienu no populārākajām uzziņu un ziņu vietnēm vispasaules tīmeklī, kā arī vienu no apmeklētākajām mājaslapām visā pasaulē.",
+  "bing":[
+   "Bing palīdz pārvērst informāciju darbībā, ļaujot ātrāk un vieglāk pāriet no meklēšanas pie darīšanas.",
+   "https://www.bing.com"
+  ],
   "bing images":[
-   "Ik dienu skatiet populārākos attēlus, fona attēlus, GIF attēlus un idejas pakalpojumā Bing.",
-   "https://www.bing.com/images"
+   "bing:lv",
+   "ref"
   ],
   "bing news":[
    "Ziņas, ko piedāvā pasaules, valsts un vietējie ziņu avoti, sniedz visaptverošu pārskatu par jaunumiem sportā, izklaides nozarē, uzņēmējdarbībā, politikā, laika prognozi un citām tēmām.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "bing:lv",
+   "ref"
   ],
   "currency":"DuckDuckGo ir interneta meklētājprogramma, kuru izveidoja Gabriels Veinbergs un laida klajā 2008. gada 25. septembrī. 2014. gada 21. maijā DuckDuckGo ieviesa jauno mājaslapas dizainu, kas fokusējās uz labāk formulētām atbildēm un labāku izskatu. Jaunajā dizainā tika iekļautas tādas pieprasītas funkcijas kā attēlu meklēšana.",
   "ddg definitions":[
@@ -2698,7 +2842,7 @@
    "https://images.google.com"
   ],
   "google news":[
-   "Visaptverošs jaunāko ziņu saturs, kas pakalpojumā Google ziņas vākts no ziņu avotiem visā pasaulē",
+   "Pirms turpināšanas",
    "https://news.google.com"
   ],
   "google scholar":[
@@ -3217,6 +3361,14 @@
   "petalsearch news":[
    "petalsearch:en",
    "ref"
+  ],
+  "lib.rs":[
+   "lib.rs:en",
+   "ref"
+  ],
+  "sourcehut":[
+   "sourcehut:en",
+   "ref"
   ]
  },
  "nl":{
@@ -3253,8 +3405,8 @@
    "https://www.bing.com/news"
   ],
   "bing videos":[
-   "bing videos:da",
-   "ref"
+   "Met Bing zet je informatie om in actie, zodat je sneller en gemakkelijker kunt overschakelen van zoeken naar doen.",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":[
    "bitbucket:nl-BE",
@@ -3492,15 +3644,27 @@
  "pa":{
   "arxiv":"arXiv ਜਿਸ ਨੂੰ ਆਰਕਾਇਵ ਉੱਚਾਰਿਆ ਕਰਦੇ ਹਨ ਹਿਸਾਬ, ਭੌਤਿਕੀ, ਰਸਾਇਣਕੀ, ਖਗੋਲਿਕੀ, ਸੰਗਣਿਕੀ, ਮਾਤਰਾਤਮਿਕ (ਕਵਾਂਟੀਟੇਟਿਵ​)ਜੀਵ ਵਿਗਿਆਨ, ਸੰਖਿਅਕੀ (ਸਟੈਟਿਸਟਿਕਸ​) ਅਤੇ ਮਾਤਰਾਤਮਿਕ ਵਿੱਤ (ਫਾਇਨੈਂਸ​) ਦੇ ਖੇਤਰਾਂ ਵਿੱਚ ਵਿਗਿਆਨਕ ਲੇਖਾਂ ਦਾ ਇੱਕ ਕੋਸ਼ ਹੈ ਜਿਸ ਨੂੰ ਇੰਟਰਨੇਟ ਉੱਤੇ ਖੋਜਿਆ ਅਤੇ ਪੜ੍ਹਿਆ ਜਾ ਸਕਦਾ ਹੈ। ਸੰਨ 1991 ਵਿੱਚ ਇਸ ਦੀ ਸਥਾਪਨਾ ਹੋਈ ਅਤੇ ਇਹ ਤੇਜੀ ਨਾਲ ਵਧਣ ਲਗਾ। ਵਰਤਮਾਨ ਵਿੱਚ ਬਹੁਤ ਸਾਰੇ ਵਿਦਵਾਨ ਕਿਸੇ ਨਵੀਂ ਖੋਜ ਜਾਂ ਸੋਚ ਉੱਤੇ ਲੇਖ ਲਿਖਣ ਦੇ ਬਾਅਦ ਆਪ ਹੀ ਉਸਨੂੰ ਆਰਕਾਇਵ-ਕੋਸ਼ ਉੱਤੇ ਪਾ ਦਿੰਦੇ ਹਨ। ਅਕਤੂਬਰ 3,2008 ਤੱਕ ਇਸ ਵਿੱਚ 5 ਲੱਖ ਤੋਂ ਜਿਆਦਾ ਲੇਖ ਸਨ। 2012 ਤੱਕ ਇਸ ਵਿੱਚ ਹਰ ਮਹੀਨੇ 7,000 ਤੋਂ ਜਿਆਦਾ ਨਵੇਂ ਲੇਖ ਜੋੜੇ ਜਾ ਰਹੇ ਸਨ।",
   "wikipedia":"ਵਿਕੀਪੀਡੀਆ ਇੱਕ ਬਹੁਭਾਸ਼ਾਈ ਆਨਲਾਈਨ ਵਿਸ਼ਵਕੋਸ਼ ਹੈ, ਜੋ ਇੱਕ ਖੁੱਲੇ ਸਹਿਯੋਗ ਪ੍ਰੋਜੈਕਟ ਵਜੋਂ ਬਣਾਇਆ ਗਿਆ ਹੈ ਅਤੇ ਵਾਲੰਟੀਅਰ ਸੰਪਾਦਕਾਂ ਦੇ ਸਮੂਹ ਦੁਆਰਾ ਵਿਕੀ-ਅਧਾਰਿਤ ਸੋਧ ਪ੍ਰਣਾਲੀ ਰਾਹੀਂ ਸਾਂਭਿਆ ਜਾਂਦਾ ਹੈ। ਇਹ ਵਰਲਡ ਵਾਈਡ ਵੈੱਬ 'ਤੇ ਸਭ ਤੋਂ ਵੱਡਾ ਅਤੇ ਸਭ ਤੋਂ ਮਸ਼ਹੂਰ, ਆਮ ਹਵਾਲਿਆਂ ਵਾਲਾ ਕੰਮ ਹੈ ਅਤੇ ਮਾਰਚ 2020 ਤੱਕ ਐਲੈਕਸਾ ਦੁਆਰਾ ਦਰਜਾ ਪ੍ਰਾਪਤ 20 ਸਭ ਤੋਂ ਪ੍ਰਸਿੱਧ ਵੈਬਸਾਈਟਾਂ ਵਿੱਚੋਂ ਇੱਕ ਹੈ। ਇਸ ਵਿੱਚ ਵਿਸ਼ੇਸ਼ ਤੌਰ 'ਤੇ ਮੁਫਤ ਸਮੱਗਰੀ ਹੁੰਦੀ ਹੈ ਅਤੇ ਕੋਈ ਵਪਾਰਕ ਵਿਗਿਆਪਨ ਨਹੀਂ ਹੁੰਦੇ ਹਨ, ਅਤੇ ਇਹ ਇੱਕ ਗੈਰ-ਮੁਨਾਫ਼ਾ ਅੰਤਰਰਾਸ਼ਟਰੀ ਸੰਸਥਾ ਵਿਕੀਮੀਡੀਆ ਫਾਊਂਡੇਸ਼ਨ ਦੁਆਰਾ ਚਲਾਇਆ ਜਾਂਦਾ ਹੈ। ਵਿਕੀਪੀਡੀਆ ਵਿੱਚ ਕੋਈ ਵੀ ਵਿਅਕਤੀ ਨਵੇਂ ਲੇਖ ਲਿਖ ਸਕਦਾ ਹੈ ਅਤੇ ਪਹਿਲਾਂ ਬਣੇ ਤਕਰੀਬਨ ਸਾਰੇ ਲੇਖਾਂ ਨੂੰ ਸੋਧ ਸਕਦਾ ਹੈ।",
+  "bing":[
+   "Bing ਤੁਹਾਨੂੰ ਜਾਣਕਾਰੀ ਨੂੰ ਕਾਰਜ ਵਿੱਚ ਬਦਲਣ ਲਈ ਮਦਦ ਕਰਦਾ ਹੈ, ਖੋਜ ਤੋਂ ਕੁਝ ਕਰਨ ਨੂੰ ਤੇਜ਼ ਤੇ ਸੌਖਾ ਬਣਾਉਂਦਾ ਹੈ।",
+   "https://www.bing.com"
+  ],
   "bing images":[
-   "ਹਰ ਰੋਜ਼ Bing 'ਤੇ ਪ੍ਰਚਲਿਤ ਪ੍ਰਤੀਬਿੰਬ, ਵਾਲਪੇਪਰ, GIF ਅਤੇ ਵਿਚਾਰ ਦੇਖੋ।",
-   "https://www.bing.com/images"
+   "bing:pa",
+   "ref"
+  ],
+  "bing videos":[
+   "bing:pa",
+   "ref"
   ],
   "wikidata":"ਵਿਕੀਡਾਟਾ, ਵਿਕੀਮੀਡੀਆ ਫ਼ਾਊਂਡੇਸ਼ਨ ਦੁਆਰਾ ਸੰਚਾਲਿਤ ਕੀਤੀ ਜਾਣ ਵਾਲੀ ਵਿਕੀ ਪਰਿਯੋਜਨਾ ਹੈ। ਵਿਕੀਪੀਡੀਆ ਵਾਂਗ ਹੀ ਇਹ ਵੀ ਇੱਕ ਵਿਕੀਪਰਿਯੋਜਨਾ ਹੈ, ਜੋ ਕਿ ਇੱਕ ਮੁਫ਼ਤ ਡਾਟਾਬੇਸ ਹੈ ਅਤੇ ਸਮੁੱਚੇ ਲੋਕਾਂ ਦੁਆਰਾ ਇਹ ਸੰਪਾਦਿਤ ਕੀਤਾ ਜਾਂਦਾ ਹੈ। ਇਹ ਡਾਟਾ ਦਾ ਇੱਕ ਆਮ ਸਰੋਤ ਹੈ, ਜੋ ਕਿ ਬਾਕੀ ਵਿਕੀਮੀਡੀਆ ਪਰਿਯੋਜਨਾਵਾਂ ਅਤੇ ਪਬਲਿਕ ਡੋਮੇਨ ਲਸੰਸ ਦੁਆਰਾ ਬਾਕੀ ਵੈੱਬਸਾਈਟਾਂ ਦੁਆਰਾ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ। ਇਹ ਵਿਕੀਮੀਡੀਆ ਕਾਮਨਜ਼ ਵਰਗੀ ਹੀ ਇੱਕ ਪਰਿਯੋਜਨਾ ਹੈ, ਭਾਵ ਕਿ ਜਿਵੇਂ ਕਾਮਨਜ਼ ਵਿੱਚ ਅਪਲੋਡ ਕੀਤੀਆਂ ਗਈਆਂ ਤਸਵੀਰਾਂ ਬਾਕੀ ਸਾਰੇ ਵਿਕੀਪ੍ਰੋਜੈਕਟਾਂ ਵਿੱਚ ਵਰਤੀਆਂ ਜਾਂਦੀਆਂ ਹਨ, ਉਵੇਂ ਹੀ ਵਿਕੀਡਾਟਾ ਵਿਚਲਾ ਡਾਟਾ ਵੀ ਬਾਕੀ ਵਿਕੀਪ੍ਰੋਜੈਕਟਾਂ ਦੁਆਰਾ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ। ਵਿਕੀਡਾਟਾ ਲਈ ਵਿਕੀਬੇਸ ਨਾਂ ਦਾ ਸਾਫ਼ਟਵੇਅਰ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ।",
   "google":"ਗੂਗਲ ਸਰਚ, ਜਿਸ ਨੂੰ ਆਮ ਤੌਰ ਤੇ ਗੂਗਲ ਵੈਬ ਸਰਚ ਜਾਂ ਬਸ ਗੂਗਲ ਕਿਹਾ ਜਾਂਦਾ ਹੈ, ਗੂਗਲ ਦੁਆਰਾ ਤਿਆਰ ਕੀਤਾ ਗਿਆ ਇੱਕ ਵੈਬ ਖੋਜ ਇੰਜਨ ਹੈ। ਇਹ ਵਰਲਡ ਵਾਈਡ ਵੈੱਬ ਤੇ ਸਭ ਤੋਂ ਵੱਧ ਵਰਤਿਆ ਖੋਜ ਇੰਜਨ ਹੈ, ਹਰ ਰੋਜ਼ ਤਿੰਨ ਅਰਬ ਤੋਂ ਵੱਧ ਖੋਜਾਂ ਦਾ ਪ੍ਰਬੰਧ ਕਰਦਾ ਹੈ। ਫਰਵਰੀ 2016 ਤੱਕ, ਇਹ 64.0% ਮਾਰਕੀਟ ਸ਼ੇਅਰ ਨਾਲ ਅਮਰੀਕਾ ਵਿੱਚ ਸਭ ਤੋਂ ਵੱਧ ਵਰਤਿਆ ਗਿਆ ਖੋਜ ਇੰਜਣ ਹੈ।",
   "google images":[
    "Google ਚਿੱਤਰ। ਵੈੱਬ 'ਤੇ ਸਭ ਤੋਂ ਵਿਆਪਕ ਚਿੱਤਰ ਖੋਜ।",
    "https://images.google.com"
+  ],
+  "google news":[
+   "ਤੁਹਾਡੇ ਵੱਲੋਂ ਜਾਰੀ ਰੱਖਣ ਤੋਂ ਪਹਿਲਾਂ",
+   "https://news.google.com"
   ],
   "google play apps":"ਗੂਗਲ ਪਲੇ ਇੱਕ ਡਿਜੀਟਲ ਵਿਤਰਣ ਸੇਵਾ ਹੈ ਜੋ ਗੂਗਲ ਦੁਆਰਾ ਚਲਾਇਆ ਅਤੇ ਵਿਕਸਤ ਕੀਤਾ ਗਿਆ ਹੈ। ਇਹ ਐਂਡਰੋਇਡ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਲਈ ਅਧਿਕਾਰਕ ਐਪ ਸਟੋਰ ਦੇ ਤੌਰ ਤੇ ਕੰਮ ਕਰਦਾ ਹੈ, ਜਿਸ ਨਾਲ ਯੂਜ਼ਰਸ ਐਂਡਰਾਇਡ ਸਾਫਟਵੇਅਰ ਡਿਵੈਲਪਮੈਂਟ ਕਿੱਟ (ਐਸ.ਡੀ.ਕੇ.) ਨਾਲ ਵਿਕਸਿਤ ਕੀਤੇ ਐਪਲੀਕੇਸ਼ਨਾਂ ਨੂੰ ਬ੍ਰਾਊਜ਼ ਅਤੇ ਡਾਊਨਲੋਡ ਕਰ ਸਕਦੇ ਹਨ ਅਤੇ ਗੂਗਲ ਰਾਹੀਂ ਪ੍ਰਕਾਸ਼ਿਤ ਹੋ ਸਕਦੇ ਹਨ। ਗੂਗਲ ਪਲੇ ਡਿਜ਼ੀਟਲ ਮੀਡੀਆ ਸਟੋਰ ਦੇ ਤੌਰ ਤੇ ਵੀ ਕੰਮ ਕਰਦਾ ਹੈ, ਸੰਗੀਤ, ਰਸਾਲੇ, ਕਿਤਾਬਾਂ, ਫਿਲਮਾਂ ਅਤੇ ਟੀਵੀ ਪ੍ਰੋਗਰਾਮਾਂ ਦੀ ਪੇਸ਼ਕਸ਼ ਕਰਦਾ ਹੈ। ਇਸ ਨੇ ਪਹਿਲਾਂ 11 ਮਾਰਚ, 2015 ਨੂੰ ਇੱਕ ਵੱਖਰੀ ਔਨਲਾਈਨ ਹਾਰਡਵੇਅਰ ਰਿਟੇਲਰ, ਗੂਗਲ ਸਟੋਰ ਦੀ ਸ਼ੁਰੂਆਤ ਤਕ ਖਰੀਦਣ ਲਈ ਗੂਗਲ ਹਾਰਡਵੇਅਰ ਡਵਇਸ ਨੂੰ ਖਰੀਦਿਆ ਸੀ।",
   "google play movies":[
@@ -3511,6 +3675,10 @@
   "imdb":"ਆਈਐਮਡੀਬੀ ਇੱਕ ਆਨਲਾਈਨ ਡੈਟਾਬੇਸ ਹੈ ਜੋ ਅਦਾਕਾਰਾਂ, ਫ਼ਿਲਮਾਂ, ਟੈਲੀਵੀਜ਼ਨ ਪ੍ਰੋਗਰਾਮਾਂ ਅਤੇ ਵੀਡੀਓ ਗੇਮਾਂ ਬਾਰੇ ਜਾਣਕਾਰੀ ਇਕੱਠੀ ਕਰ ਕੇ ਪਾਠਕਾਂ ਦੇ ਸਾਹਮਣੇ ਪੇਸ਼ ਕਰਦਾ ਹੈ। ਜਿਸ ਵਿੱਚ ਜਿਸ ਵਿੱਚ ਕਾਸਟ, ਪ੍ਰੋਡਕਸ਼ਨ ਕਰੂ ਅਤੇ ਨਿੱਜੀ ਜੀਵਨੀਆਂ, ਪਲਾਟ ਸੰਖੇਪ, ਟ੍ਰੀਵੀਆ, ਫੈਨ ਅਤੇ ਆਲੋਚਨਾਤਮਕ ਸਮੀਖਿਆਵਾਂ ਅਤੇ ਰੇਟਿੰਗ ਸ਼ਾਮਲ ਹਨ। ਆਈ.ਐਮ.ਡੀਬੀ. ਦੀ ਵੈੱਬਸਾਈਟ ਅਕਤੂਬਰ 1990 ਵਿੱਚ ਸ਼ੁਰੂ ਹੋਈ ਸੀ ਅਤੇ 1998 ਤੋਂ ਐਮਾਜ਼ਾਨ ਕੰਪਨੀ ਅਧੀਨ ਹੈ।",
   "kickass":"ਕਿੱਕਐਸ ਟੌਰੈਂਟ ਟੌਰੈਂਟ ਅਤੇ ਮੈਗਨੇਟ ਕੜੀਆਂ ਦਾ ਸੰਗ੍ਰਹਿ ਹੈ ਜੋ ਬਿਟ-ਟੌਰੈਂਟ ਸਿਧਾਂਤ ਉੱਤੇ ਕੰਮ ਕਰਦਾ ਹੈ।",
   "library of congress":"ਕਾਂਗਰਸ ਦੀ ਲਾਇਬ੍ਰੇਰੀ ਇੱਕ ਖੋਜ ਲਾਇਬਰੇਰੀ ਹੈ ਜੋ ਆਧਿਕਾਰਿਕ ਤੌਰ 'ਤੇ ਯੂਨਾਈਟਿਡ ਸਟੇਟ ਕਾਂਗਰਸ ਦੀ ਸੇਵਾ ਕਰਦੀ ਹੈ ਅਤੇ ਯੂਨਾਈਟਿਡ ਸਟੇਟ ਦੀ ਅਸਲ ਰਾਸ਼ਟਰੀ ਲਾਇਬਰੇਰੀ ਹੈ। ਇਹ ਸੰਯੁਕਤ ਰਾਜ ਅਮਰੀਕਾ ਵਿੱਚ ਸਭ ਤੋਂ ਪੁਰਾਣੀ ਫੈਡਰਲ ਸਭਿਆਚਾਰਕ ਸੰਸਥਾ ਹੈ ਲਾਇਬਰੇਰੀ ਨੂੰ ਵਾਸ਼ਿੰਗਟਨ, ਡੀ.ਸੀ. ਵਿੱਚ ਕੈਪੀਟਲ ਹਿੱਲ ਵਿੱਚ ਤਿੰਨ ਇਮਾਰਤਾਂ ਵਿੱਚ ਸਥਿਤ ਹੈ; ਇਹ ਵਰਜੀਨੀਆ ਦੇ ਕੌਲਪੀਪਰ, ਨੈਸ਼ਨਲ ਆਡਿਓ-ਵਿਜ਼ੁਅਲ ਕੰਜ਼ਰਵੇਸ਼ਨ ਸੈਂਟਰ ਦਾ ਵੀ ਪ੍ਰਬੰਧਨ ਕਰਦਾ ਹੈ।",
+  "openstreetmap":[
+   "openstreetmap:fil",
+   "ref"
+  ],
   "reddit":"ਰੈਡਿਟ ਇੱਕ ਅਮਰੀਕੀ ਸੋਸ਼ਲ ਮੀਡੀਆ ਵੈੱਬਸਾਈਟ ਹੈ, ਜਿਸ ਨੂੰ ਲੋਕ ਖ਼ਾਸ ਤੌਰ 'ਤੇ ਵਿਚਾਰ-ਵਟਾਂਦਰਾ ਕਰਨ ਲਈ ਵਰਤਦੇ ਹਨ। ਜਿਹਨਾਂ ਲੋਕਾਂ ਨੇ ਸਾਈਟ ਉੱਤੇ ਰੈਜਿਸਟਰ ਕੀਤਾ ਹੈ, ਉਹ ਸਾਈਟ ਉੱਤੇ ਕੜੀਆਂ (ਲਿੰਕਸ), ਲਿਖਤ ਪੋਸਟਾਂ, ਤਸਵੀਰਾਂ ਅਤੇ ਵੀਡੀਓਜ਼ ਚਾੜ੍ਹ ਸਕਦੇ ਹਨ, ਅਤੇ ਉਸਨੂੰ ਬਾਕੀ ਮੈਂਬਰ ਅੱਪ ਜਾਂ ਡਾਊਨ ਵੋਟ ਕਰਦੇ ਹਨ । ਪੋਸਟਾਂ ਨੂੰ ਉਪਯੋਗੀਆਂ ਵੱਲੋਂ ਬਣਾਏ \"ਸਬਰੈਡਿਟਸ\" 'ਤੇ ਰੱਖਿਆ ਜਾਂਦਾ ਹੈ। ਪੋਸਟਾਂ ਜਿਹਨਾਂ ਨੂੰ ਵੱਧ ਅੱਪ-ਵੋਟਾਂ ਮਿਲਦੀਆਂ ਹਨ ਉਹ ਸਬਰੈਡਿਟਸ ਦੇ ਉੱਤੇ ਵਿਖਾਈ ਦਿੰਦੀਆਂ ਹਨ ਅਤੇ, ਜੇਕਰ ਪੋਸਟ ਨੂੰ ਬਹੁਤੇਰੀਆਂ ਅੱਪ-ਵੋਟਾਂ ਮਿਲ਼ ਜਾਣ ਤਾਂ ਉਹ ਸਾਈਟ ਦੇ ਮੁੱਖ ਪੰਨੇ ਉੱਤੇ ਵਿਖਾਈ ਦਿੰਦੀਆਂ ਹਨ। ਰੈਡਿਟ ਪ੍ਰਬੰਧਕ ਸਬਰੈਡਿਟਸ ਨੂੰ ਕਾਬੂ ਕਰਦੇ ਹਨ।↑ \"Reddit.com ਸਾਈਟ ਦੀ ਜਾਣਕਾਰੀ\". ਅਲੈਕਸਾ ਇੰਟਰਨੈਟ. Archived from the original on ਜੂਨ 14, 2016. Retrieved September 18, 2017.",
   "youtube":"ਯੂਟਿਊਬ ਪੇਪਾਲ (PayPal) ਦੇ ਤਿੰਨ ਸਾਬਕਾ ਮੁਲਜਮਾਂ ਦੁਆਰਾ ਬਣਾਈ ਇੱਕ ਵੀਡੀਓ ਸਾਂਝੀ ਕਰਨ ਵਾਲੀ ਵੈੱਬਸਾਈਟ ਹੈ ਜਿਸ ’ਤੇ ਵਰਤੋਂਕਾਰ ਵੀਡੀਓ ਵੇਖ ਅਤੇ ਖ਼ੁਦ ਆਪਣੀ ਵੀਡੀਓ ਚੜ੍ਹਾ ਸਕਦੇ ਹਨ। ਨਵੰਬਰ 2006 ਵਿੱਚ ਗੂਗਲ ਨੇ ਇਸਨੂੰ 1.65 ਬਿਲੀਅਨ ਅਮਰੀਕੀ ਡਾਲਰਾਂ ਵਿੱਚ ਖਰੀਦ ਲਿਆ ਅਤੇ ਹੁਣ ਇਸਨੂੰ ਗੂਗਲ ਦੀ ਸਹਾਇਕ ਦੇ ਰੂਪ ਵਿੱਚ ਚਲਾਉਂਦੀ ਹੈ। ਆਨਲਾਈਨ ਵੀਡੀਓ ਦੇਖਣ ਲਈ ਦੁਨੀਆਂ ਭਰ 'ਚ ਯੂਟਿਊਬ ਦਾ ਇਸਤੇਮਾਲ ਸਭ ਤੋਂ ਜ਼ਿਆਦਾ ਹੁੰਦਾ ਹੈ। ਯੂਟਿਊਬ 'ਤੇ ਜਿਨ੍ਹਾਂ ਵੀਡੀਓਜ਼ ਨੂੰ ਤੁਸੀਂ ਸਭ ਤੋਂ ਜ਼ਿਆਦਾ ਵੇਖਦੇ ਹੋ ਉਨ੍ਹਾਂ ਨੂੰ ਤੁਸੀਂ ਆਫਲਾਈਨ ਸੇਵ ਕਰ ਲੈਂਦੇ ਹਨ ਜਿਸ ਨਾਲ ਅਸੀਂ ਇਸ ਨੂੰ ਦੁਆਰਾ ਵੀ ਵੇਖ ਸਕਦੇ ਹੋ। ਇੰਟਰਨੈੱਟ ਤੇ ਯੂ ਟਯੂਬ ਰਾਂਹੀ ਪਹਿਲੀ ਵੀਡੀਉ Me at the zoo ਚੜਾਉਣ ਦੀ ਸ਼ੁਰਆਤ 23 ਅਪਰੈਲ, 2005 ਨੂੰ ਹੋਈ।",
   "wikibooks":"ਵਿਕੀਬੁਕਸ ਆਜ਼ਾਦ ਸੋਰਸ ਵਿੱਚ ਲਿਖੀਆਂ ਗਈਆਂ ਕਿਤਾਬਾਂ ਦੀ ਲਾਇਬ੍ਰੇਰੀ ਹੈ ਅਤੇ ਇਸਨੂੰ ਵਿਕੀਮੀਡੀਆ ਫਾਊਂਡੇਸ਼ਨ ਦੁਆਰਾ ਸ਼ੁਰੂ ਕੀਤਾ ਗਿਆ ਸੀ। ਇਹ ਪ੍ਰੋਜੈਕਟ ਬਹੁ-ਭਾਸ਼ਾਈ ਹੈ।ਇੱਥੇ ਓਹੀ ਪੁਸਤਕਾਂ ਸ਼ਾਮਲ ਕੀਤੀਆਂ ਜਾਂਦੀਆਂ ਹਨ ਜੋ ਬਿਨਾਂ ਕਿਸੇ ਕਾਪੀਰਾਈਟ ਦੇ ਅਜ਼ਾਦ ਸਮੱਗਰੀ ਵਜੋਂ ਜਾਰੀ ਕੀਤੀਆਂ ਹੁੰਦੀਆਂ ਹਨ।",
@@ -3533,6 +3701,10 @@
   "bing news":[
    "Wiadomości ze świata, z kraju i z lokalnych źródeł, uporządkowane w celu zapewnienia pełnego zakresu informacji dotyczących sportu, rozrywki, biznesu, polityki, pogody i innych tematów.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Usługa Bing pomaga przekształcać informacje w czyny, przyspieszając i ułatwiając przejście od wyszukiwania do działania.",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":"Bitbucket – hostingowy serwis internetowy przeznaczony dla projektów programistycznych wykorzystujących system kontroli wersji Git oraz Mercurial, którego obecnym właścicielem jest firma Atlassian. Serwis umożliwia bezpłatne wykorzystanie usługi wraz z dodatkowymi płatnymi planami. Jest obecnie jednym z najpopularniejszych tego typu serwisów, z którego korzystają m.in. firmy Ford, PayPal, czy Starbucks. W kwietniu 2019 r. Atlassian ogłosił, że Bitbucket dotarł do 10 milionów zarejestrowanych użytkowników i ponad 28 milionów repozytoriów.",
   "crossref":"Crossref – organizacja non-profit promująca rozwój i kooperatywne wykorzystanie nowych i innowacyjnych technologii w celu przyśpieszenia i ułatwienia wyszukiwania prac naukowych. Crossref jest oficjalną agencją rejestrującą linki DOI dla publikacji profesjonalnych.",
@@ -3647,7 +3819,11 @@
   "bing news":"Bing Notícias faz parte do motor de busca Bing, da Microsoft. É um motor de busca e agregador especificamente para artigos de notícias por meio de várias fontes fiáveis da internet, incluindo New York Times, Washington Post e Reuters.",
   "bing videos":"Bing Vídeos é um serviço de pesquisa de vídeo e faz parte do mecanismo de busca Bing, da Microsoft. O serviço permite aos usuários pesquisar e visualizar vídeos através de várias websites. Bing Vídeos foi oficialmente lançado em 26 de setembro de 2007, batizado de Live Search Video e renomeado como Bing Vídeos em 1 de junho de 2009.",
   "bitbucket":"Bitbucket é um serviço de hospedagem de projetos controlados através do Mercurial, um sistema de controle de versões distribuído. É similar ao GitHub. Bitbucket têm um serviço grátis e um comercial. O serviço é escrito em Python. Num blog de 2008, de Bruce Eckel comparou Bitbucket favoravelmente ao sítio web Launchpad, que utiliza Bazaar.",
-  "btdigg":"O BTDigg é o primeiro mecanismo de pesquisa BitTorrent DHT. Ele participou da rede BitTorrent DHT, suportando a rede e fazendo correspondência entre links magnéticos e alguns atributos de torrent que são indexados e inseridos em um banco de dados. Para usuários finais, o BTDigg fornece uma pesquisa de banco de dados em texto completo via interface da Web. A Web Part de seu sistema de pesquisa recuperou informações adequadas por meio de uma consulta de texto do usuário. A pesquisa na Web suportava consultas nos idiomas europeu e asiático. O nome do projeto era um acrônimo de BitTorrent Digger. Ficou offline em junho de 2016, devido a um índice de spam. O site retornou no final de 2016 em um domínio pontocom, ficou offline novamente e agora está online. . O site btdig.com tem a fonte de origem do rastreador de torrents listada no Github, dhtcrawler2.",
+  "btdigg":"O BTDigg é o primeiro mecanismo de pesquisa BitTorrent DHT. Ele participou da rede BitTorrent DHT, suportando a rede e fazendo correspondência entre links magnéticos e alguns atributos de torrent que são indexados e inseridos em um banco de dados. Para usuários finais, o BTDigg fornece uma pesquisa de banco de dados em texto completo via interface da web. A web part de seu sistema de pesquisa recuperou informações adequadas por meio de uma consulta de texto do usuário. A pesquisa na Web suportava consultas nos idiomas europeu e asiático. O nome do projeto era um acrônimo de BitTorrent Digger. Ficou offline em junho de 2016, devido a um índice de spam. O site retornou no final de 2016 em um domínio pontocom, ficou offline novamente e agora está online. O site btdig.com tem a fonte de origem do rastreador de torrents listada no Github, dhtcrawler2.Referências",
+  "ccc-tv":[
+   "ccc-tv:de",
+   "ref"
+  ],
   "currency":"DuckDuckGo é um motor de pesquisa sediado em Paoli, Pensilvânia. Este motor de busca tem a particularidade de utilizar informações de origem Crowdsourcing para melhorar a relevância dos resultados. A filosofia deste motor de pesquisa enfatiza a privacidade e não registra as informações do usuário.",
   "deezer":"Deezer é um serviço de streaming de áudio lançado em 2007. Disponível para usuários de mais de 180 países, a plataforma possui atualmente mais de 90 milhões de músicas, mais de 100 milhões de playlists e mais de 4 milhões de programas de áudio, como podcasts, em seu acervo. É uma empresa de capital fechado, com sede em Paris, e escritórios em Londres, Berlim, Miami, São Paulo e em outros lugares do mundo. Criada em Paris, França, a Deezer possui 16 milhões de usuários ativos mensais, permitindo que os usuários ouçam conteúdo de música de gravadoras incluindo EMI, Sony, Universal Music Group e Warner Music Group.",
   "deviantart":"DeviantArt, Inc é uma empresa virtual estadunidense, formando uma rede social que permite aos artistas iniciantes ou mesmo consagrados exporem seus trabalhos artísticos, promovê-los, compartilhá-los, bem como interagir com seus pares ou interessados, através do envio das imagens digitalizadas. Fundada em 2000, tem sua sede na cidade de Hollywood, estado da Califórnia.",
@@ -3674,7 +3850,7 @@
   "gentoo":"Genkernel é uma ferramenta para construir o módulo central do Gentoo Linux. O Genkernel compila o núcleo com todos os drivers disponíveis compilados como módulos, copiando-os para a memória RAM sendo depois copiada para o núcleo no momendo da inicialização do sistema, fornecendo detecção automática de hardware. Esta ferramenta permite utilizadores com menos experiência configurar o núcleo Linux.",
   "gitlab":"O GitLab é um gerenciador de repositório de software baseado em git, com suporte a Wiki, gerenciamento de tarefas e CI/CD. GitLab é similar ao GitHub, mas o GitLab permite que os desenvolvedores armazenem o código em seus próprios servidores, ao invés de servidores de terceiros. Ele é software livre, distribuído pela Licença MIT. Está disponível como um pacote Omnibus, assim como um instalador simplificado provido pela Bitnami e pela Digital Ocean.",
   "github":"GitHub é uma plataforma de hospedagem de código-fonte e arquivos com controle de versão usando o Git. Ele permite que programadores, utilitários ou qualquer usuário cadastrado na plataforma contribuam em projetos privados e/ou Open Source de qualquer lugar do mundo. GitHub é amplamente utilizado por programadores para divulgação de seus trabalhos ou para que outros programadores contribuam com o projeto, além de promover fácil comunicação através de recursos que relatam problemas ou mesclam repositórios remotos.",
-  "google":"O Google Busca é um serviço da empresa Google onde é possível fazer pesquisas na internet sobre qualquer tipo de assunto ou conteúdo. É atualmente o serviço de busca mais usado e também o primeiro serviço lançado pela Google LLC.",
+  "google":"O Google Busca é um serviço da empresa Google, em que é possível fazer pesquisas na internet sobre qualquer tipo de assunto ou conteúdo. É atualmente o serviço de busca mais usado; e também o primeiro serviço lançado pela Google LLC.",
   "google images":"O Google Imagens é um serviço de pesquisa de propriedade do Google que permite aos usuários pesquisar por conteúdo de imagem na World Wide Web. Foi introduzido em 12 de julho de 2001 devido a uma demanda por fotos do vestido verde Versace de Jennifer Lopez que a pesquisa regular do Google não conseguiu lidar. Em 2011, foi adicionada a funcionalidade de pesquisa reversa de imagens.",
   "google news":"Google Notícias é um agregador de notícias e aplicativo desenvolvido pela Google. Ele apresenta um fluxo contínuo e personalizável de artigos organizados a partir de milhares de editores e revistas. O Google Notícias está disponível no Android, no iOS e na Web.",
   "google videos":"O Google Videos foi uma página web de vídeos que permitia encontrar quaisquer vídeos alojados, não somente no Google Video, mas também no YouTube e outros websites de vídeos, até de concorrentes, como o Yahoo! Vídeos.",
@@ -4050,6 +4226,10 @@
    "Știri din surse internaționale, naționale și locale, organizate pentru a vă oferi o acoperire detaliată a subiectelor din sport, divertisment, afaceri, politică, meteo și altele.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing vă ajută să transformați informațiile în acțiuni și să treceți mai rapid și mai ușor de la căutare la realizare.",
+   "https://www.bing.com/videos"
+  ],
   "bitbucket":"Bitbucket este un serviciu de găzduire a unui depozit de control al versiunilor web, deținut de Atlassian, pentru proiecte de cod sursă și dezvoltare care utilizează sisteme de control de revizuire Mercurial sau Git. Bitbucket oferă atât planuri comerciale, cât și conturi gratuite.",
   "currency":"DuckDuckGo este un motor de căutare pe internet care pune accentul pe protejarea confidențialității utilizatorilor. DuckDuckGo se distinge de alte motoare de căutare prin faptul că nu își profilează utilizatorii și arată tuturor utilizatorilor aceleași rezultate ale căutării pentru un anumit termen de căutare.",
   "deezer":"Deezer este o platformă de distribuire audio care permite utilizatorilor să asculte conținut muzical pe mai multe tipuri de dispozitive, atât online, cât și offline.",
@@ -4094,7 +4274,7 @@
   "wikinews":"Wikiștiri este o sursă liberă de știri. Ediția în limba română a fost lansată în 19 ianuarie 2005 și de atunci sunt aproape 1000 de articole scrise.",
   "wikiquote":"Wikicitat este o sursă liberă de citate. Ediția în limba română a fost lansată în 2004 și de atunci sunt peste 250 pagini de citate scrise.",
   "wikisource":"Wikisursa este un depozit de texte originale scrise în orice limbă și aflate fie în domeniul public, fie sub o licență liberă compatibilă cu licența GFDL. Acest sit este un proiect multilingv și face parte din Fundația Wikimedia alături de alte proiecte precum Wikipedia, ce își propune să realizeze o enciclopedie cu un conținut liber.",
-  "wiktionary":"Wiktionary sau Wikționar este un proiect-frate al Wikipediei ce își propune să creeze un dicționar wiki liber în fiecare limbă. Ideea aparține lui Daniel Alston. Versiunea în limba engleză și-a început dezvoltarea pe 12 decembrie 2002. Wikționarul este etimologic: \"wik\", de la Wikipedia, \"ționar\" de la Dicționar.",
+  "wiktionary":"Wiktionary sau Wikționar este un proiect-frate al Wikipediei ce își propune să creeze un dicționar wiki liber în fiecare limbă. Ideea aparține lui Daniel Alston. Versiunea în limba engleză și-a început dezvoltarea pe 12 decembrie 2002. Wikționarul este etimologic: „wik”, de la Wikipedia, „ționar” de la Dicționar.",
   "wikiversity":"Wikiversity este un proiect online al Wikimedia Foundation, care își propune să creeze o bază de date cu materiale necesare studiului.",
   "wikivoyage":"Wikivoyage este un wiki destinat creării de ghiduri turistice cu conținut liber. Este un proiect al Fundației Wikimedia. Până în prezent, există versiuni ale acestui proiect în limbile engleză, olandeză, franceză, germană, ebraică, italiană, poloneză, portugheză, română, rusă, spaniolă, suedeză, ucraineană.",
   "wolframalpha":"Wolfram Alpha este un motor de căutare computațional dezvoltat de Wolfram Research. Acest serviciu online oferă răspunsuri la întrebări factuale și nu o listă de link-uri așa cum oferă motoarele de căutare obișnuite."
@@ -4113,6 +4293,10 @@
   "bing news":[
    "Упорядочение каналов новостей мирового масштаба, вашей страны, а также местных каналов для получения детального обзора новостей спорта, шоу-бизнеса, деловых новостей, политики, погоды и много другого.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing помогает принимать обоснованные решения и действовать на основе большего объема информации.",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":"Bitbucket — веб-сервис для хостинга проектов и их совместной разработки, основанный на системе контроля версий Git. По назначению и основным предлагаемым функциям аналогичен GitHub, от которого отличается с одной стороны меньшей пользовательской базой, а с другой, имеет определённые преимущества в плане размещения непубличных репозиториев — возможностью их бесплатного хостинга с ограничением на размер команды не более пяти человек и меньшей арендной платой при большем размере команды, а также управление правами доступа на уровне отдельных ветвей проекта. Если основные преимущества GitHub лежат в области социализации программирования, Bitbucket больше ориентирован на небольшие закрытые команды разработчиков. Слоган сервиса — «Bitbucket is the Git solution for professional teams».",
   "crossref":"Crossref — официальное агентство регистрации Цифровых Идентификаторов Объекта (DOI) международного DOI фонда. Оно объединяет издателей академических публикаций и создано в 2000 для создания системы персистентных библиографических ссылок в статьях.",
@@ -4237,13 +4421,17 @@
    "Správy zo sveta, z vašej krajiny a miestne správy. Usporiadané sú tak, aby ste získali podrobný prehľad o správach z oblastí športu, zábavy, obchodu, politiky, počasia a ďalších.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing zhmotní vaše informácie, aby ste mohli menej vyhľadávať a viac robiť.",
+   "https://www.bing.com/videos"
+  ],
   "deviantart":"DeviantArt je celosvetová internetová komunita, v ktorej jej členovia prezentujú svoje umelecké diela rozličných smerov a štýlov.",
   "wikidata":"Wikiúdaje je projekt kolektívne upravovanej podpornej databázy pre Wikipédiu. S návrhom projektu prišla nemecká pobočka nadácie Wikimedia, Wikimedia Deutschland. Wikiúdaje majú vytvoriť spoločné úložisko databázových údajov, podobne ako je Wikimedia Commons spoločné úložisko pre fotografie alebo zvukové súbory, ktoré potom môžu byť používané inými projektmi. Je to prvý nový projekt nadácie od roku 2006, kedy bola spustená Wikiverzita.",
   "flickr":"Flickr je komunitná webová lokalita pre zdieľanie fotografií a videa vytvorená spoločnosťou Ludicorp, ktorú neskôr získala spoločnosť Yahoo!. Bol tiež jedným z prvých serverov Webu 2.0, ktorý umožňoval používať tagy. Používatelia môžu svoje fotografie a videá umiestniť do mapy. V septembri 2010 bolo oznámené, že Flickr zdieľa viac ako 5 miliárd obrázkov. V máji 2013 bolo oznámené, že Flickr zdieľa viac ako 8 miliárd obrázkov.",
   "github":"GitHub, Inc. je poskytovateľom internetového hostingu na vývoj softvéru a správu verzií s použitím verziovacieho nástroja Git. Ponúka distribuované verziovanie a správu zdrojového kódu systémom Git, ale aj ďalšie vlastné funkcie. Umožňuje regulovať prístup a má niekoľko funkcií zameraných na spoluprácu, ako napríklad sledovanie hlásených chýb, požiadavky na nové funkcie, správa úloh, priebežná integrácia a wiki stránka pre každý projekt.",
   "google images":"Google Image Search je vyhľadávacia služba, pomocou ktorej Google umožňuje užívateľom vyhľadávať na internete obrázky. Bola zverejnená v roku 2001 a existuje vo všetkých jazykových verziách, v ktorých je samotný vyhľadávač. Kľúčové slová pri hľadaní obrázkov sú založené na názve súboru, slovami, ktoré na daný obrázok odkazujú a textom, ktorý je na danej stránke pri obrázku. Pri vyhľadávaní sú zobrazené miniatúry obrázkov. Keď na niektorú kliknete, obrázok je zobrazený hore a nižšie je obsah stránky na ktorej sa obrázok nachádza. Je to jednoduchšie pretože takto môžete ľahšie zistiť z akej stránky daný obrázok pochádza.",
   "google news":[
-   "Vyčerpávajúce a aktuálne spravodajstvo zozbierané službou Google News zo zdrojov správ z celého sveta.",
+   "Skôr ako budete pokračovať",
    "https://news.google.com"
   ],
   "google scholar":"Google Scholar je voľne prístupný webový vyhľadávací nástroj, ktorý indexuje plné texty alebo metadáta vedeckej literatúry v celej škále publikačných formátov a disciplín.",
@@ -4282,13 +4470,21 @@
  "sl":{
   "arxiv":"arXiv [arhájv] je spletni arhiv elektronskih preprintov znanstvenih člankov s področja matematike, fizike, astronomije, astrofizike, fizikalne kozmologije, računalništva, kvantitativne biologije, statistike in kvantitativnega finančništva. Na mnogih področjih matematike in fizike je skoraj večina znanstvenih člankov arhiviranih v arhivu arXiv. 3. oktobra 2008 je število člankov na arXiv.org preseglo pol milijona. 14. avgusta 2011 je arhiv deloval že dvajset let. Do leta 2014 je stopnja predložitve člankov narasla na več kot 8000 na mesec.",
   "wikipedia":"Wikipedija [vikipedíja] ali Vikipedija je prosta spletna enciklopedija, ki nastaja s sodelovanjem stotisočev prostovoljcev z vsega sveta. Vsebuje geselske članke v več kot 300 različnih jezikih in njihovih različicah, sponzorira pa jo nepridobitna fundacija Wikimedia. Zajema tradicionalne enciklopedične teme, obenem pa služi tudi kot almanah in zbornik. Ustanovitelj Jimmy Wales jo opisuje kot »poskus, da bi ustvarili in ponudili prosto enciklopedijo najvišje mogoče kakovosti prav vsakemu posamezniku v njegovem lastnem jeziku.« Wikipedija je eno od največkrat navedenih spletišč in dnevno doživi okoli 50 milijonov obiskov.",
+  "bing":[
+   "Bing vam pomaga od besed preiti k dejanjem, saj omogoča hitrejši in enostaven prehod od iskanja do aktivnosti.",
+   "https://www.bing.com"
+  ],
   "bing images":[
-   "V Bingu si vsak dan oglejte priljubljene slike, slike za ozadje, GIF-e in zamisli.",
-   "https://www.bing.com/images"
+   "bing:sl",
+   "ref"
   ],
   "bing news":[
    "Svetovne novice ter nacionalni in lokalni viri novic, ki vam omogočajo pregled novic o športu, zabavi, poslovanju, politiki, vremenu in drugem.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "bing:sl",
+   "ref"
   ],
   "wikidata":"Wikipodatki so prosta in odprta spletna zbirka znanj, zgrajena z wiki tehnologijo, ki jo upravlja Fundacija Wikimedia. Predstavlja strukturirano zbirko določenih tipov podatkov, ki jih je možno urejati in brati tako ročno, kot strojno.",
   "flickr":"Flickr je spletno mesto, ki omogoča gostovanje za slike in videoposnetke. Namenjeno je urejanju fotografij in videa ter deljenju vsebine uporabnikov z drugimi uporabniki.",
@@ -4299,7 +4495,7 @@
    "https://images.google.com"
   ],
   "google news":[
-   "Temeljita in ažurna predstavitev novic, zbranih iz virov z vsega sveta s storitvijo Google News.",
+   "Preden nadaljujete",
    "https://news.google.com"
   ],
   "google scholar":[
@@ -4394,6 +4590,10 @@
    "Nyheter från globala, nationella och lokala nyhetskällor som ordnats så att du enkelt får detaljerade nyheter om sport, underhållning, affärer, politik, väder och mycket mer.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing ger dig en genväg från information till action så du kan lägga mindre tid på att söka och mer tid på att göra.",
+   "https://www.bing.com/videos"
+  ],
   "bitbucket":"Bitbucket är en webbaserad lagringstjänst för kodprojekt som använder Mercurial eller Git. Tjänsten startades 2008 av Jesper Nøhr och köptes upp av det australiensiska företaget Atlassian i september 2010.",
   "currency":"Duckduckgo är en söktjänst som fokuserar på användarnas personliga integritet och anonymitet. Potentiell personidentifierande information sägs varken lagras vid besök på webbplatsen eller associeras med söktermer, vilket även gäller IP-adresser. Inget skickas heller till någon tredje part.",
   "deezer":"Deezer är en webbaserad musiktjänst som även har mobilappar. Tjänsten lanserades 2007 i Frankrike av Jonathan Benassaya.",
@@ -4433,10 +4633,6 @@
   "gpodder":"gPodder är ett datorprogram för bland annat GNU/Linux, Windows och Mac OS och fungerar som en hanterare för poddradiokanaler. Programmet är GNU GPL-licensierat och är således fri programvara. Programmets senaste stabila utgåva är version 2.9 och utgavs i oktober 2010. gPodder är skrivet i Python, och utvecklas av the gPodder Team, som leds av Thomas Perl.",
   "hoogle":"Haskell är ett funktionellt programspråk. Utvecklingen av språket, som fick sitt namn efter den amerikanska logikern Haskell Curry, startades 1987 av en internationell kommitté. Femton år senare, år 2003, publicerade de sedan en stabil definition av språket. Haskell bygger till stor del, som många andra funktionella programspråk, på lambdauttryck och rekursion, men har också ett starkt typsystem och flera andra relativt ovanliga egenskaper som exempelvis lat evaluering. Språket är också konstruerat för att vara så kompakt och så likt matematik som möjligt, och lånar därför symboler ur både logiken och matematiken.",
   "imdb":"Internet Movie Database är den äldsta och största filmdatabasen på internet. Dess tyngdpunkt ligger på engelskspråkiga filmer, men innehåller även information om icke-engelska filmer, lågbudget- och TV-filmer, TV-serier, datorspel samt i viss utsträckning TV-program. Enligt IMDB besöks webbplatsen av över 100 miljoner personer per månad och databasen innehåller över 3,5 miljoner filmer, TV-serier och program. Sedan 1998 ägs IMDB av Amazon.com.",
-  "ina":[
-   "museum i Frankrike",
-   "wikidata"
-  ],
   "library genesis":"Library Genesis eller LibGen är en sökmotor för vetenskapliga artiklar och böcker, som ger fri tillgång till annars betalt innehåll. Bland annat innehåller den PDF-filer från en webbportal vid namn ScienceDirect, vilket ägs av bokförlaget Elsevier. I augusti 2019 innehöll databasen mer än 76 miljoner vetenskapliga artiklar, 2,3 miljoner facklitterära böcker, 2,1 miljoner skönlitterära böcker och 2 miljoner filer av tecknade serier.",
   "library of congress":[
    "de facto nationalbibliotek för Amerikas förenta stater.",
@@ -4470,6 +4666,10 @@
   "bing images":[
    "bing:ta",
    "ref"
+  ],
+  "bing videos":[
+   "Bing தகவலை செயலாக மாற்ற உங்களுக்கு உதவுகிறது, தேடலிலிருந்து அதை விரைவாகவும் எளிதாகவும் செய்கிறது.",
+   "https://www.bing.com/videos"
   ],
   "currency":"டக்டக்கோ என்பது இணையத்தில் உள்ள ஒரு தேடுபொறியாகும். இந்த தேடுபொறி ஆனது ஒருவர் இணையத்தில் என்ன தேடுகிறார் என்பதை பற்றி எந்த விதமான பின்குறிப்பும் எடுத்து வைக்காது ஒருவரது அந்தரங்க தகவல்களை குறித்த தடங்களை பின் தொடராது. மேலும் வினவுகளுக்கு மிக சிறந்த பதில்களை தரவல்லது. இந்த தேடுபொறியை கப்ரியல் வேயன்பெர்க் என்பவர் நிறுவினார், இவரே இதன் தலைமை நிர்வாக அதிகாரியும் ஆவார். இந்த தேடுபொறி நிறுவனம் 2008 ஆம் ஆண்டு பிப்ரவரி மாதம் அமெரிக்காவின், பென்சில்வேனியா மாகாணத்தில் உள்ள வேலிஃபோர்ஜில் (valleyforge) நிறுவப்பட்டது",
   "ddg definitions":[
@@ -4522,9 +4722,17 @@
  },
  "te":{
   "wikipedia":"వికీపీడియా, వివిధ భాషల్లో లభించే ఒక స్వేచ్ఛా విజ్ఞాన సర్వస్వం. దీన్ని లాభాపేక్ష రహిత సంస్థ వికీమీడియా ఫౌండేషన్ నిర్వహిస్తుంది. వికీ అనగా అనేక మంది సభ్యుల సమష్టి కృషితో సులభంగా వెబ్ సైటును సృష్టించగల ఒక సాంకేతిక పరిజ్ఞానం. ఎన్‌సైక్లోపీడియా అనగా సర్వ విజ్ఞాన సర్వస్వం. వికీపీడియా అనేపదం ఈ రెండు పదాల నుంచి ఉద్భవించింది. ఇది 2001లో జిమ్మీ వేల్స్, లారీ సాంగర్లచే ప్రారంభించబడింది. అప్పటి నుంచి అత్యంత వేగంగా ఎదుగుతూ, ఇంటర్నెట్లో అతి పెద్ద వెబ్ సైట్లలో ఒకటిగా ప్రాచుర్యం పొందింది.",
+  "bing":[
+   "సమాచారాన్ని చర్య రూపంలోకి తీసుకురావడంలో Bing మీకు సహాయపడుతుంది, శోధన నుండి కార్యరంగంలోకి దిగే దాకా మొత్తం పనిని వేగవంతం మరియు సులభం చేస్తుంది.",
+   "https://www.bing.com"
+  ],
   "bing images":[
-   "Bingలో ప్రతిరోజూ జనాదరణ పొందుతున్న చిత్రాలు, వాల్పేపర్లు, GIF, బహుమతులు, ఆలోచనలను చూడండి.",
-   "https://www.bing.com/images"
+   "bing:te",
+   "ref"
+  ],
+  "bing videos":[
+   "bing:te",
+   "ref"
   ],
   "wikidata":"వికీడేటా అనేది వికీమీడియా ఫౌండేషన్ అందచేస్తున్న సహకారంతో సవరించగల జ్ఞాన భాండారము. ఇది ఒక సాధారణ స్వేచ్ఛా డేటా మూలం. దీనిని వికీపీడియా లాంటి వికీమీడియా ప్రాజెక్టులలో వాడతారు, ఇది ప్రజోపయోగ పరిధి షరతులతో అందుబాటులో ఉంది. మీడియా ఫైళ్ళకు నిల్వ ప్రాజెక్టు వికీమీడియా కామన్స్లాగా, ఇది అన్ని వికీమీడియా ప్రాజెక్టుల కోసం జ్ఞాన భాండాగారం. వికీడేటా సాఫ్ట్‌వేర్ ను వికీబేస్(Wikibase) గా వ్యవహరిస్తారు.",
   "google":"గూగుల్ శోధన,ఇది గూగుల్ అందించిన సెర్చ్ ఇంజిన్.2021లో రోజుకు 2 ట్రిలియన్ల కంటే ఎక్కువ అంతర్జాల శోధనలు దీని ద్వారా జరుగుతాయి,ఇది ప్రపంచ శోధన ఇంజిన్ మార్కెట్లో 92% వాటాను కలిగి ఉంది. ఇది ప్రపంచంలో అత్యధికంగా సందర్శించే వెబ్ సైట్ కూడా. ఇందులో వెతికిన విషయానికి గూగుల్ ద్వారా తిరిగి ఇవ్వబడ్డ శోధన ఫలితాల క్రమం, పాక్షికంగా,\"పేజ్ ర్యాంక్\"అని పిలువబడే ప్రాధాన్యతా ర్యాంక్ వ్యవస్థపై ఆధారపడి ఉంటుంది, అంతర్జాలంలో బహిరంగంగా అందుబాటులో ఉన్న పత్రాలలో వచనం (టెక్స్ట్) మాత్రమే కాక అనేక ప్రత్యేక సేవలు అందిస్తుంది. వీటిలో పర్యాయపదాలు, వాతావరణ అంచనాలు, సమయ మండలాలు, స్టాక్ కోట్స్, మ్యాప్ లు, భూకంప డేటా, మూవీ షోటైమ్స్, విమానాశ్రయాలు, గృహ జాబితాలు, మరియు క్రీడా ఫలితాలు ఉన్నాయి. దీనిని మొదట 1997లో లారీ పేజ్, సెర్జీ బ్రిన్,మరియు స్కాట్ హసన్ అభివృద్ధి చేశారు. దీనిపేరు అసలు ప్రణాళికాబద్ధమైన పేరు గూగోల్ googol తప్పుగా వ్రాయడం నుండి తీసుకోబడింది. 1999 మధ్యనాటికి, గూగుల్ $25 మిలియన్ రౌండ్ వెంచర్ క్యాపిటల్ ఫండింగ్ అందుకున్నప్పుడు, ఇది రోజుకు 500,000 శోధనలను ప్రాసెస్ చేస్తోంది",
@@ -4533,7 +4741,7 @@
    "https://images.google.com"
   ],
   "google news":[
-   "Google News ద్వారా సమగ్ర తాజా వార్తల కవరేజ్, ప్రపంచవ్యాప్తంగా అన్ని వార్తల వనరుల నుండి సేకరించబడుతుంది.",
+   "మీరు కొనసాగబోయే ముందు",
    "https://news.google.com"
   ],
   "google play apps":"గూగుల్ ప్లే అనునది గూగుల్ చే అభివృద్ధి చేయబడి నిర్వహింపబడుతున్న ఒక సాఫ్ట్‌వేర్ వేదిక. ఇక్కడ ముఖ్యంగా ఆండ్రాయిడ్, గూగుల్ క్రోమ్ ఆధారిత సాఫ్ట్‌వేర్లు ఉచితముగానూ, వ్యాపారాత్మకంగానూ లభిస్తాయి. 2014 నాటికి గూగుల్ ప్లేలో దాదాపు 7 లక్షలకు పైగా సాఫ్ట్‌వేర్ ఆప్స్ లభిస్తున్నట్లు మాషబుల్ ప్రకటించింది.",
@@ -4543,6 +4751,10 @@
   ],
   "imdb":"ఇంటర్నెట్ మూవీ డేటాబేసు వీడియోలకి సంబంధించిన ఒక వెబ్ సైటు. ఇది సినిమాలు, TV షోలు, నటులు, సాంకేతిక నిపుణుల వివరాలతో కూడిన అతి పెద్ద ఆన్ లైన్ సమాచార నిధి (డేటాబేసు). ఇది ప్రస్తుతం Amazon.com సంస్థ ఆధ్వర్వంలో నడుస్తుంది. ఇది అందుబాటులో ఉన్న ఏకైక భాష ఆంగ్లం.",
   "library of congress":"ప్రపంచంలోని అతి పెద్ద గ్రంథాలయం యునైటెడ్ స్టేట్స్ లైబ్రరీ ఆఫ్ కాంగ్రెస్, వాషింగ్టన్, డి.సి. లోని కాపిటల్ హిల్ పైన స్థాపించారు. ఇది 1800వ సంవత్సరం ఏప్రిల్ 24న స్థాపితమైంది.",
+  "openstreetmap":[
+   "openstreetmap:fil",
+   "ref"
+  ],
   "youtube":"యూట్యూబ్ అనేది అంతర్జాలంలో వీడియోలను ఇతరులతో పంచుకోవడాని వీలుకల్పించే ఒక అంతర్జాతీయ సేవ. దీని ప్రధాన కార్యాలయం అమెరికాలోని, కాలిఫోర్నియా రాష్ట్రం, శాన్ బ్రూనో అనే నగరంలో ఉంది.",
   "wikibooks":"వికీబుక్స్ స్వేచ్ఛానకలుహక్కులతో సమష్టిగా తయారు చేయగల పుస్తకాల జాల స్థలి. ఇది 2004 ఆగస్టు 13న ప్రారంభమైంది. వికీ ప్రాజెక్టులన్నిటిలోఅతితక్కువ వ్యాసపేజీలు ఉన్నాయి. దీనిలో ఉబుంటు వాడుకరి మార్గదర్శిని పూర్తికాబడిన పుస్తకం. దీనిలో ఉబుంటుతో తెలుగులో టైపు చేయడం దగ్గరనుండి, ఉత్తరములు వ్రాయుట, ప్రదర్శన పత్రములు చేయుట, వివిధ రకాల ధ్వని, దృశ్య శ్రవణ మాధ్యమములను నడుపుట, వాడబడే విహరిణులు లాంటివన్నీ ఎలా చేయవచ్చో వివరించటమైనది. ఇంకా వంట పుస్తకం ప్రారంభించబడింది. వికీసోర్స్ లో ఉండవలసిన కొన్ని వ్యాసాలు పొరపాటున వికీబుక్స్ లో సృష్టించబడినవి. ఈ ప్రాజెక్టు ప్రధాన ఉద్దేశం పాఠ్యపుస్తకాలు సమష్టిగా వృద్ధిచేయటం. ఏప్రిల్ 2010 అలెక్సా లెక్కల ప్రకారం ప్రపంచంలోని జాలస్థలులన్నిటిలో 2,462వ స్థానములోఉన్నది.",
   "wikiquote":"వికీకోట్ అనగా వికీవ్యాఖ్య .వికీమీడియా ఫౌండేషను ఆధ్వర్యములో మీడియావికీ సాఫ్టువేరుతో నడిచే వికీ ఆధారిత ప్రాజెక్టు కుటుంబములో ఒక ప్రాజెక్టు. డేనియల్ ఆల్స్టన్ యొక్క ఆలోచనను బ్రయన్ విబ్బర్ కార్యాచరణలో పెట్టగా రూపొందిన ఈ ప్రాజెక్టు యొక్క లక్ష్యం సమిష్టి సమన్వయ కృషితో వివిధ ప్రముఖ వ్యక్తులు, పుస్తకాలు, సామెతలనుండి సేకరించిన వ్యాఖ్యల యొక్క విస్తృత వనరును తయారుచేసి వాటికి సంబంధించిన వివరాలు పొందుపరచడం. అనేక అన్లైన్ వ్యాఖ్యల సేకరణలు ఉన్నప్పటికీ సందర్శకులను సేకరణ ప్రక్రియలో పాలుపంచుకొనే అవకాశము ఇస్తున్న అతికొద్ది వాటిల్లో వికీవ్యాఖ్య ఒకటిగా విశిష్ఠత సంపాదించుకొన్నది.",
@@ -4561,6 +4773,10 @@
   "bing news":[
    "ข่าวสารจากแหล่งข่าวทั่วโลก ในประเทศและท้องถิ่น เพื่อนำข่าวเชิงลึกที่ครอบคลุมทั้งข่าวกีฬา บันเทิง ธุรกิจ การเมือง การพยากรณ์อากาศ และอื่นๆ อีกมากมายมาให้คุณ",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing ช่วยให้คุณนำข้อมูลไปสู่การปฏิบัติได้อย่างรวดเร็วและง่ายขึ้นตั้งแต่การค้นหาจนถึงการดำเนินการ",
+   "https://www.bing.com/videos"
   ],
   "currency":"ดักดักโก เป็นบริษัทที่ให้บริการเสิร์ชเอนจินที่มุ่งเน้นเรื่องความเป็นส่วนตัวและมีตัวกรองไม่ให้มีผลการค้นหาเฉพาะบุคคล โดยทางดักดักโกใช้ API ร่วมกับเว็บไซต์อื่น ๆ เพื่อแสดงผลการสืบค้นข้อมูลอย่างรวดเร็ว นอจากนั้น ดึงผลการสืบค้นจากแหล่งอื่น ๆ เพิ่มเติม และใช้โปรแกรมรวบรวมข้อมูลของตัวเอง นอกจากนั้น ดักดักโกถือเป็นหนึ่งในบริการที่ถูกรัฐบาลจีนปิดกั้นการใช้งานจากประเทศจีน",
   "deviantart":"ดีเวียนต์อาร์ต เป็นชุมชนออนไลน์สัญชาติอเมริกันที่นำเสนองานศิลปะ, ภาพเคลื่อนไหว และภาพถ่าย ได้รับการเปิดตัวในวันที่ 7 สิงหาคม ค.ศ. 2000 โดยแอนเจโล โซติรา, สก็อตต์ จาร์กออฟ, แมทธิว สตีเฟนส์ และคนอื่น ๆ ผลงานต่าง ๆ จะได้รับการจัดเรียงในหมวดหมู่ ได้แก่ การถ่ายภาพ, ศิลปะดิจิทัล, ศิลปะแบบดั้งเดิม, วรรณกรรม, แฟลช, การผลิตภาพยนตร์, สกินสำหรับแอปพลิเคชัน, โปรแกรมอรรถประโยชน์สำหรับปรับแต่งระบบปฏิบัติการ และอื่น ๆ พร้อมกับทรัพยากรที่สามารถดาวน์โหลดได้ เช่น บทเรียนและคลังภาพถ่าย คุณสมบัติเพิ่มเติมได้แก่ วารสาร, การหยั่งเสียง, กลุ่ม และแฟ้มสะสมผลงาน",
@@ -4583,10 +4799,6 @@
   "google images":[
    "Google Photos การค้นหารูปภาพที่ครอบคลุมที่สุดบนเว็บ",
    "https://images.google.com"
-  ],
-  "google news":[
-   "รายงานข่าวครอบคลุมทันเหตุการณ์ รวบรวมจากแหล่งข่าวทั่วโลกโดย Google News",
-   "https://news.google.com"
   ],
   "google scholar":[
    "Google Scholar ให้วิธีที่ง่ายต่อการค้นหาวรรณกรรมทางวิชาการอย่างครอบคลุม ค้นหาในสาขาและแหล่งข้อมูลที่หลากหลาย เช่น บทความ วิทยานิพนธ์ หนังสือ บทคัดย่อ และความเห็นของศาล",
@@ -4668,7 +4880,7 @@
   "hoogle":"Haskell, isim babası matematikçi Haskell Curry olan arı işlevsel programlama dilidir. Haskell'i birçok programlama dilinden ayıran özellikleri tembel değerlendirme, monadlar ve tür sınıflarıdır. Haskell, Miranda dilinin semantikleri üzerine kuruludur. Akademide yoğun olarak kullanılmasıyla birlikte endüstride de kullanılmaktadır.",
   "imdb":"IMDb, ; filmler, diziler, televizyon programları, video oyunları ve internet içerikleri hakkında bilgiler barındıran çevrimiçi bir bilgi bankasıdır. Sinema ve televizyon yapımları hakkında oyuncu kadrosu, yapım ekibi, biyografiler, özetler, ilginç bilgiler, puanlar ve eleştiriler gibi bilgileri içerir. İlk kurulduğunda amatör sinemaseverler tarafından yönetilen IMDb, günümüzde Amazon'un alt kuruluşu IMDb.com Inc. tarafından yönetilmektedir.",
   "kickass":"KickassTorrents bir dizin için torrent dosyaları ve magnet bağlantıları kullanarak kullanıcıdan kullanıcıya dosya paylaşımı yöntemini sunan ve BitTorrent protokolünü kullanan bir web sitesi idi. Site 2008'de kuruldu ve 20 Temmuz 2016'da Amerika Birleşik Devletleri Hükümeti tarafından alan adına el konularak kullanıma kapatıldı. Sitenin vekil sunucuları da çalışanlar tarafından yayından kaldırıldı.",
-  "library genesis":"Library Genesis (Libgen) bilimsel dergi makaleleri, akademik ve genel ilgi kitapları, resimler, çizgi romanlar ve dergiler için bir dosya paylaşım web sitesidir. Kısmen, site başka türlü ödeme duvarı olan veya başka bir yerde dijitalleştirilmeyen içeriğe ücretsiz erişim sağlar. Libgen kendisini \"kamuya açık internet kaynaklarından toplanan\" ve kullanıcılar tarafından yüklenen araştırılabilir makale, kitap ve resim veri tabanı sağlayan bir \"link toplayıcı\" olarak tanımlamaktadır.",
+  "library genesis":"Library Genesis (Libgen), bilimsel dergi makaleleri, akademik ve genel ilgi kitapları, resimler, çizgi romanlar ve dergiler için bir dosya paylaşım web sitesidir. Kısmen, site başka türlü ödeme duvarı olan veya başka bir yerde dijitalleştirilmeyen içeriğe ücretsiz erişim sağlar. Libgen kendisini \"kamuya açık internet kaynaklarından toplanan\" ve kullanıcılar tarafından yüklenen araştırılabilir makale, kitap ve resim veri tabanı sağlayan bir \"link toplayıcı\" olarak tanımlamaktadır.",
   "library of congress":"Amerika Birleşik Devletleri Kongre Kütüphanesi, ABD'nin ulusal kütüphanesidir. Dünyanın en büyük ve en önemli kütüphanelerinden olan kongre kütüphanesi Washington'da bulunmaktadır. Ayrıca ABD’de yer alan en eski federal kültür yapısıdır.",
   "npm":"npm javascript betik dili için geliştirilmiş olan ve Node.js'in standart olarak kabul ettiği bir paket yönetim sistemidir. npm komut satırından çalıştırılır ve uygulamalar için bağımlılık yönetimi sağlar. Ayrıca geliştiricilerin merkezi bir npm kaynağından var olan paketleri kurmasına imkân verir. npm tamamen javascript dili kullanılarak Isaac Z. Schuleter tarafından, PHP'nin PEAR ve Perl'in CPAN sistemlerinden esinlenilerek geliştirilmiştir.",
   "openstreetmap":"OpenStreetMap özgür yazılım şartları altında oluşturulan özgür ve açık kaynaklı bir dünya çapında harita oluşturma projesidir. GPS alıcılarıyla ve diğer kamu malı kaynaklardan toplanan bilgiler ile oluşturulur.",
@@ -4743,6 +4955,10 @@
   "bing news":[
    "Канали новин світового масштабу, національні, а також місцеві канали впорядковано, щоб забезпечити детальний огляд новин спорту, шоу-бізнесу, ділових новин, політики, погоди тощо.",
    "https://www.bing.com/news"
+  ],
+  "bing videos":[
+   "Bing допоможе вам перетворити інформацію на дію, завдяки чому можна швидше та легше перейти від пошуку до справ.",
+   "https://www.bing.com/videos"
   ],
   "bitbucket":"Bitbucket — вебсервіс для хостингу проєктів на базі систем керування версіями: Mercurial та Git. Bitbucket надає як безкоштовні так і платні послуги. Є аналогом GitHub, однак, на відміну від GitHub, який до січня 2019 року зберігав файли безкоштовних профілів лише у відкритому доступі, Bitbucket від самого початку дозволяв безкоштовно створювати приватні репозиторії з можливістю спільної роботи з файлами до 5-ти користувачів. Bitbucket інтегрований з іншими програмними продуктами Atlassian, такими як, JIRA, Confluence, Bamboo та HipChat.",
   "btdigg":"BTDigg (укр.:БТДиґ)— це перша BitTorrent DHT пошукова система. Ця DHT пошукова система бере участь в BitTorrent DHT мережі, підтримує мережі і робить відповідності між magnet-посиланнями і кількома торент-атрибутами, які проіндексовані і вставляються в базу даних. BTDigg забезпечує повнотекстовий пошук по базі даних через вебінтерфейс. Вебчастина пошукової системи отримує необхідну інформацію від тексту запиту користувача. Вебпошук підтримує запити європейських і азійських мов. Назва проекту є абревіатурою від BitTorrent Digger.",
@@ -4840,6 +5056,10 @@
    "Tin tức từ nguồn tin tức thế giới, quốc gia và địa phương, được tổ chức để cung cấp cho bạn tin tức chuyên sâu về thể thao, giải trí, kinh doanh, chính trị, thời tiết và nhiều nội dung khác.",
    "https://www.bing.com/news"
   ],
+  "bing videos":[
+   "Bing giúp bạn biến thông tin thành hành động, làm cho việc chuyển từ tìm kiếm sang hành động trở nên nhanh hơn và dễ dàng hơn.",
+   "https://www.bing.com/videos"
+  ],
   "currency":"DuckDuckGo là một công cụ truy vấn dữ liệu Internet đặt trọng tâm vào việc bảo vệ sự riêng tư người tìm kiếm và không cung cấp thông tin người dùng. DuckDuckGo cũng phân biệt nó với các công cụ tìm kiếm khác bằng cách không lập hồ sơ kết quả tìm kiếm. DuckDuckGo nhấn mạnh lấy thông tin từ các nguồn tốt nhất chứ không phải từ đa số các nguồn, tạo ra kết quả tìm kiếm của mình từ chính các trang web được quần chúng đóng góp như Wikipedia và từ quan hệ đối tác với các công cụ tìm kiếm khác như Yandex, Yahoo, Bing, và Yummly.",
   "deezer":"Deezer là một dịch vụ nghe nhạc trực tuyến trên Internet. Nó cho phép người dùng có thể nghe các bản nhạc từ các hãng thu như Sony, Universal Music, và Warner Music Group trên nhiều thiết bị kể cả khi đang trực tuyến hay ngoại tuyến. Deezer được sáng lập tại Paris, Pháp và hiện đang có 53 triệu bài hát được cấp phép trong kho nhạc, cùng với hơn 30.000 kênh radio, 14 triệu người dùng hằng tháng, và 6 triệu thuê bao trả phí tính đến ngày 3 tháng 4 năm 2018. Deezer khả dụng cho Web, Android, iOS, Windows Phone, BlackBerry và Windows.",
   "ddg definitions":[
@@ -4900,132 +5120,52 @@
   "peertube":"PeerTube là một nền tảng chia sẻ video liên hợp, tự do và nguồn mở hoạt động với hình thức tự lưu trữ (self-hosting). Nền tảng này sử dụng giao thức ActivityPub và WebTorrent, một công nghệ P2P tiết kiệm tài nguyên cho các máy chủ cá nhân."
  },
  "zh-Hans-CN":{
-  "archive is":"archive.today又称archive.is，是一個私人資助的网页存档網站，資料中心位於歐洲法國的北部-加来海峡。這個網站典藏檔案館使用Apache Hadoop與Apache Accumulo軟體。它可以一次取回一個類似於WebCite的小於50MB的頁面，並能收錄Google地圖與Twitter。",
-  "artic":"芝加哥藝術博物館（英語：），是一座位於美國伊利諾州芝加哥的美術館，於1879年成立，是世界上最古老、規模最大的藝術博物館之一。該博物館因其策展與展示大量藝術家的作品而受到歡迎，每年共有約150萬人參觀。該博物館的收藏由11個策展部門管理，並保存了喬治·秀拉的《大碗岛的星期天下午》、巴勃羅·畢卡索的《老吉他手》 、愛德華·霍普的《夜遊者》和格兰特·伍德的《美国哥特式》等名作，博物館永久收藏近300,000件藝術品，每年舉辦30多個特展。",
-  "arxiv":"arXiv 是一個收集物理學、數學、計算機科學、生物學與數理經濟學的論文預印本的網站，始于1991年8月14日。截至2008年10月，arXiv.org已收集超過50萬篇預印本；至2014年底，藏量達到1百萬篇。截至2016年10月，提交率已達每月超過10,000篇。",
-  "bandcamp":"Bandcamp是一家美国線上音乐公司， 由前Oddpost联合创始人Ethan Diamond与程序员Shawn Grunberger、Joe Holt和Neal Tucker于2008年创立，总部位于加利福尼亚。",
-  "wikipedia":"維基百科 是维基媒体基金会运营的一个多语言的線上百科全書，并以创建和维护作为开放式协同合作项目，特点是自由內容、自由编辑、自由版权。目前是全球網絡上最大且最受大眾歡迎的参考工具书，名列全球二十大最受歡迎的網站，其在搜尋引擎中排名亦較為靠前。維基百科目前由非營利組織維基媒體基金會負責營運。Wikipedia是混成詞，分别取自於網站核心技術「Wiki」以及英文中百科全書之意的「encyclopedia」。截至2021年初，所有語種的維基百科條目數量達5,500萬。",
-  "bing":"是一款由微软公司推出的網路搜尋引擎。Bing的历史可追溯至于1998年的第三个季度发布的MSN Search，它的由Looksmart和Inktomi等提供；2006年3月8日，微软发布了Windows Live Search的公测版，并于同年9月11日让其取代了MSN Search，该引擎开始使用搜尋選項卡；次年3月，微软将其与Windows Live分开并更名Live Search，在此期间，其子服务曾经多次重组、关闭。到了2009年6月3日，微软将Live Search改造成了今天的Bing并正式发布。微软认为一词简单明了、易于拼写，容易被人记住；它源自成语「有求必应」。微软声称，此款搜尋引擎将以全新的姿态面世並带来革命。Bing的内测代号为Kumo，其后才被命名为。2020年10月5日，Bing更名為Microsoft Bing。",
-  "bing images":[
-   "bing:zh-Hans-CN",
-   "ref"
-  ],
-  "crossref":"Crossref （曾用名CrossRef）是國際DOI基金會 旗下的一個DOI注册机构，它的成員來自2,000個不同的出版商。Crossref由Publishers International Linking Association Inc.負責运营。該機構于2000年初成立。",
-  "deezer":"Deezer是一家法国在线音乐流媒体服务提供商。它允许用户在各种设备上在线或离线收听来自包括环球音乐集团、索尼音乐和华纳音乐集团在內的各家唱片公司的音乐。2007年，Deezer创建于法国巴黎，截至2019年1月，Deezer拥有5600万首授权曲目，拥有超过3万个电台频道，月活跃用户達1400万，付费用户為700万。该服务适用于Web、Android、IOS、Windows Mobile、BlackBerry OS、Microsoft Windows和MacOS。",
-  "etymonline":"在线词源词典（英語：）是免费的在线词典，由道格拉斯·哈珀 编纂和撰写，用于描述英语单词的词源。",
-  "fdroid":"是一个Android应用程序的软件资源库（或应用商店）；其功能类似于Google Play商店，但只包含自由及开放源代码软件。应用可从F-Droid网站或直接从F-Droid客户端应用浏览及安装，F-Droid客户端应用会自动更新其应用。F-Droid不要求用户注册账号。如果应用包含广告、用户分析器，追踪器或倚赖非自由软件，会被标记存在「负功能」（antifeatures）。运行F-Droid的服务器也均使用自由及开放源代码软件，从而允许任何人创建自己的软件库。",
-  "flickr":[
-   "flickr:zh-HK",
-   "ref"
-  ],
-  "free software directory":"自由软件目录是一个自由软件基金会（FSF）和联合国教育、科学及文化组织（ UNESCO ）的项目。自由软件目录包含自由操作系统下运行的有用自由软件。",
-  "genius":"Genius 是一家北美数字媒体公司，於2009年8月由湯姆·雷曼、伊兰·泽科里和马胡德·莫哈代姆建立。該網站允許使用者對歌曲歌词、新闻故事、诗歌和文件等提供注釋和解释。",
-  "github":"GitHub是一个在线软件源代码托管服务平台，使用Git作为版本控制软件，由开发者Chris Wanstrath、P. J. Hyett和汤姆·普雷斯顿·沃纳使用Ruby on Rails编写而成。在2018年，GitHub被微软公司收购。",
-  "google images":"Google图片搜索是Google公司於2001年7月推出的图片搜索服務。Google Chrome及Firefox提供擴充功能搜索網絡圖像。",
-  "google news":"Google新闻是Google开发的一款Web新闻聚合器，由Google首席工程師克里希纳·巴拉特 創造與領導開發。",
-  "google videos":"Google影片 是由Google提供的一项視訊共享和搜索服务。与YouTube类似，「Google影片」向用户提供必要的HTML代码，允许用户将选定的視訊嵌入到其它的网站的页面中。这种方法可以使用户在网站中嵌入大量的視訊而无需考虑頻寬和儲存容量限制的问题。在2006年10月9日，Google收购了前競争对手YouTube，并在2007年6月13日发表声明，「Google影片」的搜索结果将包含由网络蜘蛛在其它托管服务、YouTube和用户上传中抓取的内容。",
-  "google scholar":[
-   "借助 Google 学术搜索，您可以轻松地大范围搜索学术文献。搜索范围囊括众多知识领域和来源：文章、论文、图书、摘要和法院判决意见书。",
-   "https://scholar.google.com"
-  ],
-  "google play apps":"又稱Play 商店，前身为Android Market。是由Google为Android作業系統所開發的流動應用程式數位發行平台，包括數位媒體商店。它作為Android作業系統的官方應用商店，允許用戶瀏覽和下載使用Android SDK開發並透過Google發布的應用程式。 Google Play也是數位媒體商店，提供音樂，雜誌，書籍，電影和電視節目。它之前提供了Google硬件裝置，直到2015年3月11日推出一個單獨的線上硬件零售商Google Store。",
-  "google play movies":[
-   "google play apps:zh-Hans-CN",
-   "ref"
-  ],
-  "hoogle":"Haskell 是一种标准化的，通用的纯函數式編程語言，有惰性求值和强静态类型。它的命名源自美国逻辑学家哈斯凱爾·加里，他在数理逻辑方面上的工作使得函数式编程语言有了广泛的基础。在Haskell中，“函数是頭等物件”。作为一门函數程式語言，主要控制结构是函数。Haskell语言是1990年在编程语言Miranda的基础上标准化的，并且以λ演算为基础发展而来。这也是为什么Haskell语言以希腊字母「λ」（Lambda）作为自己的标志。Haskell具有“证明即程序、命题为类型”的特征。",
-  "imdb":"網路電影資料庫 是一个关于电影演员、电影、电视节目、电视藝人、电子游戏和電影製作小組的在线数据库。IMDb開辦於1990年10月17日，從1998年開始成為亚马逊公司旗下的网站，在2020年10月17日時，IMDb慶祝了他們30週年的紀念。",
-  "library genesis":"創世紀圖書館 是一個影子圖書館，用戶可在此一網站上分享下載学术期刊文章、学术書籍、一般書籍、雜誌、漫畫。此一網站為用戶提供擋在付費牆背後，抑或官方沒釋出電子版本的資料。創世紀圖書館形容自身為「資訊整合連結」網站，為「互聯網上所收集及用戶上載的」資源提供可供查找的資料庫。",
-  "z-library":[
-   "z-library:zh-HK",
-   "ref"
-  ],
-  "npm":[
-   "npm:zh-HK",
-   "ref"
-  ],
-  "openstreetmap":[
-   "openstreetmap:zh-HK",
-   "ref"
-  ],
-  "piratebay":"海盜灣 是一個專門儲存、分類及搜尋Bittorrent种子文件及磁力連結的網站，由瑞典的民間反版權組織海盜署於2003年成立，支持35种语言。",
-  "pypi":"PyPI 是Python的正式第三方 軟體套件的軟件存儲庫，它类似于CPAN（Perl的存储库）。一些软件包管理器例如pip，就是默認從PyPI下載软件包。用戶通过PyPI可以下載超过235,000个Python软件包。",
-  "reddit":"（） 是一个娱乐、社交及新聞网站，注册用户可以将文字或連結在網站上發布，使它基本上成為了一個電子佈告欄系統。注册用户可以对这些帖子进行投票，结果将被用来进行排名和决定它在首页或子页的位置。網站上的內容分類被稱為「subreddit」。subreddit的內容包括新聞、電子遊戲、電影、音樂、書籍、健身、食物和圖片分享等。",
-  "stackoverflow":"Stack Exchange是一系列问答网站，每一个网站包含不同领域的问题。这些网站参考Stack Overflow，一个关于程序设计的问答网站，也是Stack Exchange的第一个成员。如同Stack Overflow，这些网站使用声望奖励系统，用户对问题和答案进行投票，并影响用户声望。声望系统使这些网站可以自我控制。",
-  "askubuntu":[
-   "stackoverflow:zh-Hans-CN",
-   "ref"
-  ],
-  "superuser":[
-   "stackoverflow:zh-Hans-CN",
-   "ref"
-  ],
-  "semantic scholar":"语义学者 是具有人工智能功能的学术出版网络搜索引擎，由艾伦AI研究所开发，并于2015年11月发布。它能利用自然语言处理技術为学术论文提供摘要。与Google学术搜索和PubMed相比，语义学者提供的結果盡量凸顯出论文中最重要和最有影响力的元素。",
-  "startpage":[
-   "startpage:zh-HK",
-   "ref"
-  ],
-  "unsplash":"Unsplash是一个免费的照片共享网站。攝影師可以将照片上传到Unsplash，照片编辑者们会对用户上传的照片进行整理。Unsplash使用了较为自由的著作權许可条款，这让Unsplash成为了互联网上最大的摄影照片供应商之一，其网站上的照片经常在文章配图中出现。截止至2020年4月，该网站拥有超过18万名摄影师，图库中储存了超过160万张照片。Unsplash被《福布斯》、《企业家杂志》、CNET和The Next Web评为全球领先的摄影网站之一。",
-  "youtube":[
-   "在 YouTube 上畅享您喜爱的视频和音乐，上传原创内容并与亲朋好友和全世界观众分享您的视频。",
-   "https://www.youtube.com/"
-  ],
-  "dailymotion":"Dailymotion 是一家視訊分享網站，總部位於法國巴黎十七區。它的域名在YouTube之後一個月注冊。Dailymotion最广为人知的特点之一就是其提供支援开放格式ogg的視訊。和同類型的其他Flash視訊分享網站相比，Dailymotion以其短片具有高清晰畫質而聞名。到2008年1月，每天上傳到該站的短片大約是16,000，網頁瀏覽次數平均一天超過2600萬次。2008年1月，Dailymotion的Alexa全球網站排名為38。母公司為威望迪。",
-  "wikibooks":"維基教科書（英語：）是維基媒體的一項計劃，於2003年7月10日開放。 此計劃收集自由的教科書，並讓用戶自己編輯教科書——任何人都可以進入“編輯”頁面修改任何一本教科書。",
-  "wikinews":[
-   "wikinews:zh-HK",
-   "ref"
-  ],
-  "wiktionary":"维基词典（英語：），粵文版作維基字典，是维基百科的姊妹工程，旨在创建基于所有语言的自由词典。该项目于2002年12月12日启动，发起人是维基人Daniel Alston。",
-  "wikivoyage":"维基导游（英語：）是基于Wiki系统，由志愿者撰写的免费互联网旅游指南。项目于2006年9月由德国的同名组织Wikivoyage e.V.发起，于2006年12月10日上线，2012年8月加入维基媒体基金会。项目内容使用知识共享-署名-相同方式共享协议授权，因此可供其他用户自由地用作商业用途。同时访客可以免费访问任何内容，并可以自由下载离线版本。对此类计划有害的商业性影响，例如来自旅游业的影响，被排斥于计划之外。",
-  "wolframalpha":"，是由 Wolfram Research 公司推出的一款在线自动问答系统。其特色是可以直接向用户返回答案，而不是像传统搜索引擎一样提供一系列可能含有用户所需答案的相关网页。",
-  "naver":"NAVER（韓語：）是Naver公司旗下韩国著名入口／搜索引擎网站，其Logo为一顶草帽，于1999年6月正式投入使用。它使用獨有的搜尋引擎，並且在韓文搜尋服務中獨佔鰲頭。除了搜尋之外也提供入口網站的許多服務，例如新聞、電子信箱、電子地圖服務（含街景地圖）等。在Alexa排名上是韓國國內第一大的入口網站。 据ComScore统计，Naver在2007年8月收到二十亿次搜索，占70％以上的韩国搜索查询，它是世界上排名第十五的网民最常用的搜索引擎，超过25万韩国人选择Naver作为浏览器起始页。",
-  "rubygems":"RubyGems是Ruby的一个包管理器，提供了分发Ruby程序和函式庫的标准格式“gem”，旨在方便地管理gem安装的工具，以及用于分发gem的服务器。这类似于Python的pip。RubyGems大约创建于2003年11月，从Ruby 1.9版起成为Ruby标准库的一部分。",
-  "rumble":"Rumble是加拿大的视频分享网站，讓使用者投稿、觀看、分享及評論视频，由科技企業家克里斯·帕夫洛夫斯基 於2013年創立。自2020年7月以來，Rumble的月度用戶數經歷了快速增長，從160萬月度用戶增加到2021年第一季度末的3190萬。"
- },
- "zh-Hant-TW":{
   "archive is":[
-   "archive is:zh-Hans-CN",
+   "archive is:zh-HK",
    "ref"
   ],
   "artic":[
-   "artic:zh-Hans-CN",
+   "artic:zh-HK",
    "ref"
   ],
   "arxiv":[
-   "arxiv:zh-Hans-CN",
+   "arxiv:zh-HK",
    "ref"
   ],
   "bandcamp":[
-   "bandcamp:zh-Hans-CN",
+   "bandcamp:zh-HK",
    "ref"
   ],
   "wikipedia":[
-   "wikipedia:zh-Hans-CN",
+   "wikipedia:zh-HK",
    "ref"
   ],
   "bing":[
-   "bing:zh-Hans-CN",
+   "bing:zh-HK",
    "ref"
   ],
   "bing images":[
-   "bing:zh-Hans-CN",
+   "bing:zh-HK",
    "ref"
   ],
+  "bing videos":[
+   "Bing 可協助您將資訊轉化為行動，從開始搜尋到採取行動更快、更輕鬆。",
+   "https://www.bing.com/videos"
+  ],
   "crossref":[
-   "crossref:zh-Hans-CN",
+   "crossref:zh-HK",
    "ref"
   ],
   "deezer":[
-   "deezer:zh-Hans-CN",
+   "deezer:zh-HK",
    "ref"
   ],
   "etymonline":[
-   "etymonline:zh-Hans-CN",
+   "etymonline:zh-HK",
    "ref"
   ],
   "fdroid":[
-   "fdroid:zh-Hans-CN",
+   "fdroid:zh-HK",
    "ref"
   ],
   "flickr":[
@@ -5033,47 +5173,51 @@
    "ref"
   ],
   "free software directory":[
-   "free software directory:zh-Hans-CN",
+   "free software directory:zh-HK",
    "ref"
   ],
   "genius":[
-   "genius:zh-Hans-CN",
+   "genius:zh-HK",
    "ref"
   ],
   "github":[
-   "github:zh-Hans-CN",
+   "github:zh-HK",
    "ref"
   ],
   "google images":[
-   "google images:zh-Hans-CN",
+   "google images:zh-HK",
    "ref"
   ],
   "google news":[
-   "google news:zh-Hans-CN",
+   "google news:zh-HK",
    "ref"
   ],
   "google videos":[
-   "google videos:zh-Hans-CN",
+   "google videos:zh-HK",
    "ref"
   ],
+  "google scholar":[
+   "借助 Google 学术搜索，您可以轻松地大范围搜索学术文献。搜索范围囊括众多知识领域和来源：文章、论文、图书、摘要和法院判决意见书。",
+   "https://scholar.google.com"
+  ],
   "google play apps":[
-   "google play apps:zh-Hans-CN",
+   "google play apps:zh-HK",
    "ref"
   ],
   "google play movies":[
-   "google play apps:zh-Hans-CN",
+   "google play apps:zh-HK",
    "ref"
   ],
   "hoogle":[
-   "hoogle:zh-Hans-CN",
+   "hoogle:zh-HK",
    "ref"
   ],
   "imdb":[
-   "imdb:zh-Hans-CN",
+   "imdb:zh-HK",
    "ref"
   ],
   "library genesis":[
-   "library genesis:zh-Hans-CN",
+   "library genesis:zh-HK",
    "ref"
   ],
   "z-library":[
@@ -5089,31 +5233,31 @@
    "ref"
   ],
   "piratebay":[
-   "piratebay:zh-Hans-CN",
+   "piratebay:zh-HK",
    "ref"
   ],
   "pypi":[
-   "pypi:zh-Hans-CN",
+   "pypi:zh-HK",
    "ref"
   ],
   "reddit":[
-   "reddit:zh-Hans-CN",
+   "reddit:zh-HK",
    "ref"
   ],
   "stackoverflow":[
-   "stackoverflow:zh-Hans-CN",
+   "stackoverflow:zh-HK",
    "ref"
   ],
   "askubuntu":[
-   "stackoverflow:zh-Hans-CN",
+   "stackoverflow:zh-HK",
    "ref"
   ],
   "superuser":[
-   "stackoverflow:zh-Hans-CN",
+   "stackoverflow:zh-HK",
    "ref"
   ],
   "semantic scholar":[
-   "semantic scholar:zh-Hans-CN",
+   "semantic scholar:zh-HK",
    "ref"
   ],
   "startpage":[
@@ -5121,15 +5265,19 @@
    "ref"
   ],
   "unsplash":[
-   "unsplash:zh-Hans-CN",
+   "unsplash:zh-HK",
    "ref"
   ],
+  "youtube":[
+   "YouTube 上盡享你喜愛的影片和音樂、上載原創內容，並與親友和世界各地的人分享。",
+   "https://www.youtube.com/"
+  ],
   "dailymotion":[
-   "dailymotion:zh-Hans-CN",
+   "dailymotion:zh-HK",
    "ref"
   ],
   "wikibooks":[
-   "wikibooks:zh-Hans-CN",
+   "wikibooks:zh-HK",
    "ref"
   ],
   "wikinews":[
@@ -5137,34 +5285,206 @@
    "ref"
   ],
   "wiktionary":[
-   "wiktionary:zh-Hans-CN",
+   "wiktionary:zh-HK",
    "ref"
   ],
   "wikivoyage":[
-   "wikivoyage:zh-Hans-CN",
+   "wikivoyage:zh-HK",
    "ref"
   ],
   "wolframalpha":[
-   "wolframalpha:zh-Hans-CN",
+   "wolframalpha:zh-HK",
    "ref"
   ],
   "naver":[
-   "naver:zh-Hans-CN",
+   "naver:zh-HK",
    "ref"
   ],
   "rubygems":[
-   "rubygems:zh-Hans-CN",
+   "rubygems:zh-HK",
    "ref"
   ],
   "rumble":[
-   "rumble:zh-Hans-CN",
+   "rumble:zh-HK",
    "ref"
   ]
  },
- "nb_NO":{
+ "zh-Hant-TW":{
+  "archive is":[
+   "archive is:zh-HK",
+   "ref"
+  ],
+  "artic":[
+   "artic:zh-HK",
+   "ref"
+  ],
+  "arxiv":[
+   "arxiv:zh-HK",
+   "ref"
+  ],
+  "bandcamp":[
+   "bandcamp:zh-HK",
+   "ref"
+  ],
+  "wikipedia":[
+   "wikipedia:zh-HK",
+   "ref"
+  ],
+  "bing":[
+   "bing:zh-HK",
+   "ref"
+  ],
+  "bing images":[
+   "bing:zh-HK",
+   "ref"
+  ],
+  "crossref":[
+   "crossref:zh-HK",
+   "ref"
+  ],
+  "deezer":[
+   "deezer:zh-HK",
+   "ref"
+  ],
+  "etymonline":[
+   "etymonline:zh-HK",
+   "ref"
+  ],
+  "fdroid":[
+   "fdroid:zh-HK",
+   "ref"
+  ],
+  "flickr":[
+   "flickr:zh-HK",
+   "ref"
+  ],
+  "free software directory":[
+   "free software directory:zh-HK",
+   "ref"
+  ],
+  "genius":[
+   "genius:zh-HK",
+   "ref"
+  ],
+  "github":[
+   "github:zh-HK",
+   "ref"
+  ],
+  "google images":[
+   "google images:zh-HK",
+   "ref"
+  ],
   "google news":[
-   "Omfattende og oppdatert nyhetsdekning, samlet inn av Google News fra nyhetskilder i hele verden.",
-   "https://news.google.com"
+   "google news:zh-HK",
+   "ref"
+  ],
+  "google videos":[
+   "google videos:zh-HK",
+   "ref"
+  ],
+  "google play apps":[
+   "google play apps:zh-HK",
+   "ref"
+  ],
+  "google play movies":[
+   "google play apps:zh-HK",
+   "ref"
+  ],
+  "hoogle":[
+   "hoogle:zh-HK",
+   "ref"
+  ],
+  "imdb":[
+   "imdb:zh-HK",
+   "ref"
+  ],
+  "library genesis":[
+   "library genesis:zh-HK",
+   "ref"
+  ],
+  "z-library":[
+   "z-library:zh-HK",
+   "ref"
+  ],
+  "npm":[
+   "npm:zh-HK",
+   "ref"
+  ],
+  "openstreetmap":[
+   "openstreetmap:zh-HK",
+   "ref"
+  ],
+  "piratebay":[
+   "piratebay:zh-HK",
+   "ref"
+  ],
+  "pypi":[
+   "pypi:zh-HK",
+   "ref"
+  ],
+  "reddit":[
+   "reddit:zh-HK",
+   "ref"
+  ],
+  "stackoverflow":[
+   "stackoverflow:zh-HK",
+   "ref"
+  ],
+  "askubuntu":[
+   "stackoverflow:zh-HK",
+   "ref"
+  ],
+  "superuser":[
+   "stackoverflow:zh-HK",
+   "ref"
+  ],
+  "semantic scholar":[
+   "semantic scholar:zh-HK",
+   "ref"
+  ],
+  "startpage":[
+   "startpage:zh-HK",
+   "ref"
+  ],
+  "unsplash":[
+   "unsplash:zh-HK",
+   "ref"
+  ],
+  "dailymotion":[
+   "dailymotion:zh-HK",
+   "ref"
+  ],
+  "wikibooks":[
+   "wikibooks:zh-HK",
+   "ref"
+  ],
+  "wikinews":[
+   "wikinews:zh-HK",
+   "ref"
+  ],
+  "wiktionary":[
+   "wiktionary:zh-HK",
+   "ref"
+  ],
+  "wikivoyage":[
+   "wikivoyage:zh-HK",
+   "ref"
+  ],
+  "wolframalpha":[
+   "wolframalpha:zh-HK",
+   "ref"
+  ],
+  "naver":[
+   "naver:zh-HK",
+   "ref"
+  ],
+  "rubygems":[
+   "rubygems:zh-HK",
+   "ref"
+  ],
+  "rumble":[
+   "rumble:zh-HK",
+   "ref"
   ]
  }
 }

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1863,6 +1863,26 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name: sourcehut
+    shortcut: srht
+    engine: xpath
+    paging: true
+    search_url: https://sr.ht/projects?page={pageno}&search={query}
+    results_xpath: (//div[@class="event-list"])[1]/div[@class="event"]
+    url_xpath: ./h4/a[2]/@href
+    title_xpath: ./h4/a[2]
+    content_xpath: ./p
+    first_page_num: 1
+    categories: [it, repos]
+    disabled: true
+    about:
+      website: https://sr.ht
+      wikidata_id: Q78514485
+      official_api_documentation: https://man.sr.ht/
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name: ubuntuwiki


### PR DESCRIPTION
## What does this PR do?

Adds the sourcehut engine (https://sr.ht) using xpath

## Why is this change important?

With some concerns raised about Github, more and more projects are moved to alternatives forges like sourcehut, so it can be a great addition to add them.

## How to test this PR locally?

search `!srht hello world`

## Author's checklist

## Related issues
