### PR TITLE
Add lib.rs engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1846,6 +1846,23 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name: lib.rs
+    shortcut: lrs
+    engine: xpath
+    search_url: https://lib.rs/search?q={query}
+    results_xpath: /html/body/main/div/ol/li/a
+    url_xpath: ./@href
+    title_xpath: ./div[@class="h"]/h4
+    content_xpath: ./div[@class="h"]/p
+    categories: [it, packages]
+    disabled: true
+    about:
+      website: https://lib.rs
+      wikidata_id: Q113486010
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name: ubuntuwiki


### PR DESCRIPTION
## What does this PR do?

Adds the lib.rs engine

## Why is this change important?

It would be convenient for Rust users to search for package directly.

## How to test this PR locally?

search `!lrs fuse`

## Author's checklist

## Related issues