### PR TITLE
[fix] improve OpenSearch description

### DIFF
--- a/searx/templates/simple/opensearch.xml
+++ b/searx/templates/simple/opensearch.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>{{ instance_name }}</ShortName>
-  <Description>a privacy-respecting, hackable metasearch engine</Description>
+  <LongName>SearXNG metasearch</LongName>
+  <Description>SearXNG is a metasearch engine that respects your privacy.</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Image>{{ url_for('static', filename='img/favicon.png', _external=True) }}</Image>
-  <LongName>searx metasearch</LongName>
-  {% if opensearch_method == 'get' %}
-    <Url rel="results" type="text/html" method="get" template="{{ url_for('search', _external=True) }}?q={searchTerms}"/>
+  <Image type="image/png">{{ url_for('static', filename='img/favicon.png', _external=True) }}</Image>
+  {% if opensearch_method == 'GET' %}
+  <Url rel="results" type="text/html" method="{{ opensearch_method }}" template="{{ url_for('search', _external=True) }}?q={searchTerms}"/>
   {% else %}
-    <Url rel="results" type="text/html" method="post" template="{{ url_for('search', _external=True) }}">
-        <Param name="q" value="{searchTerms}" />
-    </Url>
+  <Url rel="results" type="text/html" method="{{ opensearch_method }}" template="{{ url_for('search', _external=True) }}">
+    <Param name="q" value="{searchTerms}" />
+  </Url>
   {% endif %}
   {% if autocomplete %}
-    <Url rel="suggestions" type="application/x-suggestions+json" template="{{ url_for('autocompleter', _external=True) }}?q={searchTerms}"/>
+    <Url rel="suggestions" type="application/x-suggestions+json" method="{{ opensearch_method }}" template="{{ url_for('autocompleter', _external=True) }}?q={searchTerms}"/>
   {% endif %}
-
-  <Url type="application/opensearchdescription+xml"
-      rel="self"
-      template="{{ opensearch_url }}" />
+  <Url rel="self" type="application/opensearchdescription+xml"  method="{{ opensearch_method }}" template="{{ opensearch_url }}" />
+  <Query role="example" searchTerms="SearXNG" />
+  <moz:SearchForm>{{ url_for('search', _external=True) }}</moz:SearchForm>
 </OpenSearchDescription>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1282,19 +1282,17 @@ Disallow: /*?*q=*
 
 @app.route('/opensearch.xml', methods=['GET'])
 def opensearch():
-    method = 'post'
-
-    if request.preferences.get_value('method') == 'GET':
-        method = 'get'
+    method = request.preferences.get_value('method')
+    autocomplete = request.preferences.get_value('autocomplete')
 
     # chrome/chromium only supports HTTP GET....
     if request.headers.get('User-Agent', '').lower().find('webkit') >= 0:
-        method = 'get'
+        method = 'GET'
 
-    autocomplete = request.preferences.get_value('autocomplete')
+    if method not in ('POST', 'GET'):
+        method = 'POST'
 
     ret = render('opensearch.xml', opensearch_method=method, autocomplete=autocomplete)
-
     resp = Response(response=ret, status=200, mimetype="application/opensearchdescription+xml")
     return resp
 

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -244,7 +244,9 @@ class ViewsTestCase(SearxTestCase):
     def test_opensearch_xml(self):
         result = self.app.get('/opensearch.xml')
         self.assertEqual(result.status_code, 200)
-        self.assertIn(b'<Description>a privacy-respecting, hackable metasearch engine</Description>', result.data)
+        self.assertIn(
+            b'<Description>SearXNG is a metasearch engine that respects your privacy.</Description>', result.data
+        )
 
     def test_favicon(self):
         result = self.app.get('/favicon.ico')


### PR DESCRIPTION
## What does this PR do?

Inspired by the OpenSearch description from qwant and with informations from the
specification[4] the ``opensearch.xml`` has been *improved*.

- convert `<Url>` methods from lower case to upper case (`POST`|`GET`)
- add `<moz:SearchForm>` and `xmlns:moz="http://www.mozilla.org/2006/browser/search/"`
- add `<Query role="example" searchTerms="SearXNG" />`  [4]
  OpenSearch description documents should include at least one Query element of `role="example"` that is expected to return search results. Search clients may use this example query to validate that the search engine is working properly.

- modified `<LongName>` to SearXNG
- modified `<Description>` the word 'hackable' scares uninitiated users and was removed
- add the `type="image/png"` to `<Image>`

[1] https://app.element.io/#/room/#searxng:matrix.org/$xN_abdKhNqUlgXRBrb_9F3pqOxnSzGQ1TG0s0G9hQVw
[2] https://github.com/searxng/searxng/issues/431
[3] https://developer.mozilla.org/en-US/docs/Web/OpenSearch
[4] https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#the-query-element

## Why is this change important?

Some HTTP-Clients do have issues with the ``opensearch.xml`` from SearXNG
(related [1][2]) while other OpenSearch descriptions[3] (e.g. from qwant) work
flawles.

## How to test this PR locally?

   make run

Visit http://127.0.0.1:8888/ and add the search engine to your WEB-Browser / test with different WEB-Browser from desktop and Smartphones (are there any iOS user here, please test on Safari and Chrome).
