### PR TITLE
[fix] harden get_engine_locale: handle UnknownLocaleError exceptions

### DIFF
--- a/searx/locales.py
+++ b/searx/locales.py
@@ -213,7 +213,13 @@ def get_engine_locale(searxng_locale, engine_locales, default=None):
         # need to narrow language nor territory.
         return engine_locale
 
-    locale = babel.Locale.parse(searxng_locale, sep='-')
+    try:
+        locale = babel.Locale.parse(searxng_locale, sep='-')
+    except babel.core.UnknownLocaleError:
+        try:
+            locale = babel.Locale.parse(searxng_locale.split('-')[1])
+        except babel.core.UnknownLocaleError:
+            return default
 
     # SearXNG's selected locale is not supported by the engine ..
 


### PR DESCRIPTION
When a user selects an unknown or invalid locale by using the search syntax:

    !qw siemens :de-TW

Before this patch a UnknownLocaleError exception will be rasied:

```
Traceback (most recent call last):
  File "SearXNG/searx/search/processors/online.py", line 154, in search
    search_results = self._search_basic(query, params)
  File "SearXNG/searx/search/processors/online.py", line 128, in _search_basic
    self.engine.request(query, params)
  File "SearXNG/searx/engines/qwant.py", line 98, in request
    q_locale = get_engine_locale(params['language'], supported_languages, default='en_US')
  File "SearXNG/searx/locales.py", line 216, in get_engine_locale
    locale = babel.Locale.parse(searxng_locale, sep='-')
  File "SearXNG/local/py3/lib/python3.8/site-packages/babel/core.py", line 330, in parse
    raise UnknownLocaleError(input_id)
```

This patch implements a simple exception handling, since e.g. `de-TW` does not
exists `de` will be used to get engines locale.  On invalid terms like `xy-XY`
the default will be returned.


## Related issue

Fix https://github.com/searxng/searxng/pull/1652/commits/9ae409a05a0980ae70590303a83d983011831a80 from #1652 
