### PR TITLE
[fix] typo in get_engine_locale

### DIFF
--- a/searx/locales.py
+++ b/searx/locales.py
@@ -252,8 +252,12 @@ def get_engine_locale(searxng_locale, engine_locales, default=None):
             terr_lang_dict[territory] = langs.get(searxng_lang)
 
         # first: check fr-FR, de-DE .. is supported by the engine
+        # exception: 'en' --> 'en-US'
 
         territory = locale.language.upper()
+        if territory == 'EN':
+            territory = 'US'
+
         if terr_lang_dict.get(territory):
             searxng_locale = locale.language + '-' + territory
             engine_locale = engine_locales.get(searxng_locale)

--- a/searx/locales.py
+++ b/searx/locales.py
@@ -217,7 +217,7 @@ def get_engine_locale(searxng_locale, engine_locales, default=None):
         locale = babel.Locale.parse(searxng_locale, sep='-')
     except babel.core.UnknownLocaleError:
         try:
-            locale = babel.Locale.parse(searxng_locale.split('-')[1])
+            locale = babel.Locale.parse(searxng_locale.split('-')[0])
         except babel.core.UnknownLocaleError:
             return default
 


### PR DESCRIPTION
Due to a typo in get_engine_locale, a language selection like `!qw :de siemens` did not work (in qwant).

@tiekoetter sorry for the noise ..


## Related PR
_edit from Dalf_

Fix https://github.com/searxng/searxng/pull/1652/commits/9ae409a05a0980ae70590303a83d983011831a80 from #1652 
* First fix in ef81d14ccf6838d6ea58ab4d27cb1fc93c2c88c3 from #1664
* Second fix in this PR

Closes: https://github.com/searxng/searxng/issues/1684