### PR TITLE
[mod] do not consent to tracking when using google

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -26,6 +26,7 @@ The google WEB engine itself has a special setup option:
 """
 
 from urllib.parse import urlencode
+from random import random
 from lxml import html
 from searx.utils import match_language, extract_text, eval_xpath, eval_xpath_list, eval_xpath_getindex
 from searx.exceptions import SearxEngineCaptchaException
@@ -282,7 +283,7 @@ def request(query, params):
         query_url += '&' + urlencode({'safe': filter_mapping[params['safesearch']]})
     params['url'] = query_url
 
-    params['cookies']['CONSENT'] = "YES+"
+    params['cookies']['CONSENT'] = "PENDING+" + str(random() * 100)
     params['headers'].update(lang_info['headers'])
     if use_mobile_ui:
         params['headers']['Accept'] = '*/*'

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -17,6 +17,7 @@ import binascii
 import re
 from urllib.parse import urlencode
 from base64 import b64decode
+from random import random
 from lxml import html
 
 from searx.utils import (
@@ -102,7 +103,7 @@ def request(query, params):
     )  # ceid includes a ':' character which must not be urlencoded
     params['url'] = query_url
 
-    params['cookies']['CONSENT'] = "YES+"
+    params['cookies']['CONSENT'] = "PENDING+" + str(random() * 100)
     params['headers'].update(lang_info['headers'])
     params['headers']['Accept'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
 

--- a/searx/engines/google_scholar.py
+++ b/searx/engines/google_scholar.py
@@ -13,6 +13,7 @@ Definitions`_.
 
 from urllib.parse import urlencode
 from datetime import datetime
+from random import random
 from lxml import html
 
 from searx.utils import (
@@ -91,7 +92,7 @@ def request(query, params):
     query_url += time_range_url(params)
     params['url'] = query_url
 
-    params['cookies']['CONSENT'] = "YES+"
+    params['cookies']['CONSENT'] = "PENDING+" + str(random() * 100)
     params['headers'].update(lang_info['headers'])
     params['headers']['Accept'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
 

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -18,6 +18,7 @@
 
 import re
 from urllib.parse import urlencode
+from random import random
 from lxml import html
 
 from searx.utils import (
@@ -127,7 +128,7 @@ def request(query, params):
         query_url += '&' + urlencode({'safe': filter_mapping[params['safesearch']]})
     params['url'] = query_url
 
-    params['cookies']['CONSENT'] = "YES+"
+    params['cookies']['CONSENT'] = "PENDING+" + str(random() * 100)
     params['headers'].update(lang_info['headers'])
     params['headers']['Accept'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
     return params

--- a/searx/engines/youtube_noapi.py
+++ b/searx/engines/youtube_noapi.py
@@ -6,6 +6,7 @@
 from functools import reduce
 from json import loads, dumps
 from urllib.parse import quote_plus
+from random import random
 
 # about
 about = {
@@ -36,7 +37,7 @@ base_youtube_url = 'https://www.youtube.com/watch?v='
 
 # do search-request
 def request(query, params):
-    params['cookies']['CONSENT'] = "YES+"
+    params['cookies']['CONSENT'] = "PENDING+" + str(random() * 100)
     if not params['engine_data'].get('next_page_token'):
         params['url'] = search_url.format(query=quote_plus(query), page=params['pageno'])
         if params['time_range'] in time_range_dict:


### PR DESCRIPTION
## What does this PR do?

do not consent to tracking when using google

Cherry picked from https://github.com/searx/searx/commit/5b50d7

## How to test this PR locally?

Test various google engines an the youtube (noapi) engine / the patch is applied on my instance:

- [!go london](https://darmarit.org/searx/search?q=%21go+london)
- [!goi london](https://darmarit.org/searx/search?q=%21goi+london)
- [!gov london](https://darmarit.org/searx/search?q=%21gov+london)
- [!gos  heisenberg](https://darmarit.org/searx/search?q=%21gos+heisenberg)
- [!yt london](https://darmarit.org/searx/search?q=%21yt+london)

You might get a "too many request" on my instance / this issue is not related to this PR and discussed here https://github.com/searxng/searxng/issues/1642

## Related issues

- https://github.com/searxng/searxng/issues/1555
