### PR TITLE
[fix] engine woxikon.de - don't raise exception on empty result list

### DIFF
--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -22,6 +22,7 @@ from urllib.parse import urlencode
 
 from lxml import html
 from searx.utils import extract_text, extract_url, eval_xpath, eval_xpath_list
+from searx.network import raise_for_httperror
 
 search_url = None
 """
@@ -60,9 +61,14 @@ lang_all = 'en'
 '''Replacement ``{lang}`` in :py:obj:`search_url` if language ``all`` is
 selected.
 '''
-raise_for_httperror = True
-'''True by default: raise an exception if the HTTP code of response is ``>=
-300``'''
+
+no_result_for_http_status = []
+'''Return empty result for these HTTP status codes instead of throwing an error.
+
+.. code:: yaml
+
+    no_result_for_http_status: []
+'''
 
 soft_max_redirects = 0
 '''Maximum redirects, soft limit. Record an error but don't stop the engine'''
@@ -179,12 +185,19 @@ def request(query, params):
 
     params['url'] = search_url.format(**fargs)
     params['soft_max_redirects'] = soft_max_redirects
-    params['raise_for_httperror'] = raise_for_httperror
+
+    params['raise_for_httperror'] = False
+
     return params
 
 
-def response(resp):
+def response(resp):  # pylint: disable=too-many-branches
     '''Scrap *results* from the response (see :ref:`engine results`).'''
+    if no_result_for_http_status and resp.status_code in no_result_for_http_status:
+        return []
+
+    raise_for_httperror(resp)
+
     results = []
     dom = html.fromstring(resp.text)
     is_onion = 'onions' in categories

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -60,6 +60,9 @@ lang_all = 'en'
 '''Replacement ``{lang}`` in :py:obj:`search_url` if language ``all`` is
 selected.
 '''
+raise_for_httperror = True
+'''True by default: raise an exception if the HTTP code of response is ``>=
+300``'''
 
 soft_max_redirects = 0
 '''Maximum redirects, soft limit. Record an error but don't stop the engine'''
@@ -176,7 +179,7 @@ def request(query, params):
 
     params['url'] = search_url.format(**fargs)
     params['soft_max_redirects'] = soft_max_redirects
-
+    params['raise_for_httperror'] = raise_for_httperror
     return params
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1808,6 +1808,7 @@ engines:
     url_xpath: //div[@class="upper-synonyms"]/a/@href
     content_xpath: //div[@class="synonyms-list-group"]
     title_xpath: //div[@class="upper-synonyms"]/a
+    raise_for_httperror: false
     about:
       website: https://www.woxikon.de/
       wikidata_id:  # No Wikidata ID

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1808,7 +1808,7 @@ engines:
     url_xpath: //div[@class="upper-synonyms"]/a/@href
     content_xpath: //div[@class="synonyms-list-group"]
     title_xpath: //div[@class="upper-synonyms"]/a
-    raise_for_httperror: false
+    no_result_for_http_status: [404]
     about:
       website: https://www.woxikon.de/
       wikidata_id:  # No Wikidata ID


### PR DESCRIPTION
## What does this PR do?

[fix] engine woxikon.de - don't raise exception on empty result list

Suggested-by: @allendema [1]

[1] https://github.com/searxng/searxng/issues/1543#issuecomment-1193317054

## Why is this change important?

Woxikon expects a word in German, so with query "foo" the site finds nothing and respons a 404:

    httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://synonyme.woxikon.de/synonyme/foo.php'

## How to test this PR locally?

     !woxikon.de_synonyme foo

There should not be an 404 error any longer.

## Related issues

Closes: https://github.com/searxng/searxng/issues/1543
