### PR TITLE
[fix] engine duden - don't raise exception on empty result list

### DIFF
--- a/searx/engines/duden.py
+++ b/searx/engines/duden.py
@@ -7,6 +7,7 @@ import re
 from urllib.parse import quote, urljoin
 from lxml import html
 from searx.utils import extract_text, eval_xpath, eval_xpath_list, eval_xpath_getindex
+from searx.network import raise_for_httperror
 
 # about
 about = {
@@ -47,6 +48,7 @@ def request(query, params):
     # after the last page of results, spelling corrections are returned after a HTTP redirect
     # whatever the page number is
     params['soft_max_redirects'] = 1
+    params['raise_for_httperror'] = False
     return params
 
 
@@ -55,6 +57,11 @@ def response(resp):
     resp: requests response object
     '''
     results = []
+
+    if resp.status_code == 404:
+        return results
+
+    raise_for_httperror(resp)
 
     dom = html.fromstring(resp.text)
 


### PR DESCRIPTION
## What does this PR do?

Duden expects a word in German, so with query "amazing" the site finds nothing
and respons a 404:

    httpx.HTTPStatusError: Client error '404 Not Found' for url\
      'https://www.duden.de/suchen/dudenonline/amazing'

[1] https://github.com/searxng/searxng/issues/1543#issuecomment-1193317054

Suggested-by: @allendema [1]
