### PR TITLE
[mod] limiter plugin: Accept-Encoding handling

### DIFF
--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -67,7 +67,7 @@ def is_accepted_request() -> bool:
             return False
 
         accept_encoding_list = [l.strip() for l in request.headers.get('Accept-Encoding', '').split(',')]
-        if 'gzip' not in accept_encoding_list or 'deflate' not in accept_encoding_list:
+        if 'gzip' not in accept_encoding_list and 'deflate' not in accept_encoding_list:
             logger.debug("suspicious Accept-Encoding")  # pylint: disable=undefined-variable
             return False
 


### PR DESCRIPTION
## What does this PR do?
Only raise "suspicious Accept-Encoding" when both "gzip" and "deflate" are missing from Accept-Encoding.
Prevent Browsers which only implement one compression solution from being blocked by the limiter plugin.
Example Browser which is currently blocked: Lynx Browser (https://lynx.invisible-island.net)

## Why is this change important?

Prevent Browsers which only implement one compression solution from being blocked by the limiter plugin.

## How to test this PR locally?

1. `make run`
2. Modify your Client to not have "gzip" or "deflate" in Accept-Encoding or use the Lynx Browser.
3. Search `time`