### PR TITLE
External bang: bug fix: URL encode the query so "!!g 1+1" works as intended

### DIFF
--- a/searx/external_bang.py
+++ b/searx/external_bang.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from urllib.parse import quote_plus
 from searx.data import EXTERNAL_BANGS
 
 LEAF_KEY = chr(16)
@@ -39,7 +40,7 @@ def get_bang_definition_and_ac(external_bangs_db, bang):
 
 def resolve_bang_definition(bang_definition, query):
     url, rank = bang_definition.split(chr(1))
-    url = url.replace(chr(2), query)
+    url = url.replace(chr(2), quote_plus(query))
     if url.startswith('//'):
         url = 'https:' + url
     rank = int(rank) if len(rank) > 0 else 0


### PR DESCRIPTION
## What does this PR do?

Currently `!!g 1+1` is read as `1 1` by Google because the query is not URL encoded.

## Why is this change important?

Bug fix

## How to test this PR locally?

Some URL includes the user query:
* as a parameter: encoding is mandatory ( `!!g 1+1` )
* a part of the URL path.: some website can deal with it ( `!!1122 1+1`)
* a fragment ( `#...`) : I can't find a relevant example search for `#` in `searx/data/external_bangs.json`.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Partially related to #1695