### PR TITLE
settings.yml: set default values for result_proxy

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -121,6 +121,7 @@ ui:
 #
 # result_proxy:
 #   url: http://127.0.0.1:3000/
+#   # the key is a base64 encoded string, the YAML !!binary prefix is optional
 #   key: !!binary "your_morty_proxy_key"
 #   # [true|false] enable the "proxy" button next to each result
 #   proxify_results: true

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -9,6 +9,7 @@ import numbers
 import errno
 import os
 import logging
+from base64 import b64decode
 from os.path import dirname, abspath
 
 from searx.languages import language_codes as languages
@@ -117,6 +118,15 @@ class SettingsDirectoryValue(SettingsValue):
         return super().__call__(value)
 
 
+class SettingsBytesValue(SettingsValue):
+    """str are base64 decoded"""
+
+    def __call__(self, value: typing.Any) -> typing.Any:
+        if isinstance(value, str):
+            value = b64decode(value)
+        return super().__call__(value)
+
+
 def apply_schema(settings, schema, path_list):
     error = False
     for key, value in schema.items():
@@ -214,6 +224,11 @@ SCHEMA = {
         'using_tor_proxy': SettingsValue(bool, False),
         'extra_proxy_timeout': SettingsValue(int, 0),
         'networks': {},
+    },
+    'result_proxy': {
+        'url': SettingsValue((None, str), None),
+        'key': SettingsBytesValue((None, bytes), None),
+        'proxify_results': SettingsValue(bool, False),
     },
     'plugins': SettingsValue(list, []),
     'enabled_plugins': SettingsValue((None, list), None),

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -315,16 +315,16 @@ def custom_url_for(endpoint: str, **values):
     return url_for(endpoint, **values) + suffix
 
 
-def proxify(url: str):
+def morty_proxify(url: str):
     if url.startswith('//'):
         url = 'https:' + url
 
-    if not settings.get('result_proxy'):
+    if not settings['result_proxy']['url']:
         return url
 
     url_params = dict(mortyurl=url)
 
-    if settings['result_proxy'].get('key'):
+    if settings['result_proxy']['key']:
         url_params['mortyhash'] = hmac.new(settings['result_proxy']['key'], url.encode(), hashlib.sha256).hexdigest()
 
     return '{0}?{1}'.format(settings['result_proxy']['url'], urlencode(url_params))
@@ -349,8 +349,8 @@ def image_proxify(url: str):
             return url
         return None
 
-    if settings.get('result_proxy'):
-        return proxify(url)
+    if settings['result_proxy']['url']:
+        return morty_proxify(url)
 
     h = new_hmac(settings['server']['secret_key'], url.encode())
 
@@ -462,8 +462,8 @@ def render(template_name: str, **kwargs):
     # helpers to create links to other pages
     kwargs['url_for'] = custom_url_for  # override url_for function in templates
     kwargs['image_proxify'] = image_proxify
-    kwargs['proxify'] = proxify if settings.get('result_proxy', {}).get('url') else None
-    kwargs['proxify_results'] = settings.get('result_proxy', {}).get('proxify_results', True)
+    kwargs['proxify'] = morty_proxify if settings['result_proxy']['url'] is not None else None
+    kwargs['proxify_results'] = settings['result_proxy']['proxify_results']
     kwargs['get_result_template'] = get_result_template
     kwargs['opensearch_url'] = (
         url_for('opensearch')


### PR DESCRIPTION
## What does this PR do?

* initialize `settings["result_proxy"]` with searx/settings_defaults.py
* allow `result_proxy.key` to be a string (convert into bytes by searx/settings_defaults.py)

## Why is this change important?

Related to #1522 : the string is base64 decoded, since Morty read the key as a base64 encoded string. 

In #1522 , the string is utf-8 encoded. 

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

#1522