### PR TITLE
Fix: The environment variable SEARX_SETTINGS_PATH was ignored

### DIFF
--- a/tests/unit/test_settings_loader.py
+++ b/tests/unit/test_settings_loader.py
@@ -23,10 +23,10 @@ class TestLoad(SearxTestCase):
             settings_loader.load_yaml(join(test_dir, '/settings/empty_settings.yml'))
 
     def test_check_settings_yml(self):
-        self.assertIsNone(settings_loader.check_settings_yml('/dev/zero'))
+        self.assertIsNone(settings_loader.existing_filename_or_none('/dev/zero'))
 
         bad_settings_path = join(test_dir, 'settings/syntaxerror_settings.yml')
-        self.assertEqual(settings_loader.check_settings_yml(bad_settings_path), bad_settings_path)
+        self.assertEqual(settings_loader.existing_filename_or_none(bad_settings_path), bad_settings_path)
 
 
 class TestDefaultSettings(SearxTestCase):


### PR DESCRIPTION
## What does this PR do?

Refactor searx.settings_loader.py.get_user_settings_path
(SearxSettingsException is never raised)

SearXNG searches the user settings is these directories (by descending priority):
* `environ['SEARXNG_SETTINGS_PATH']`
* `'/etc/searxng/settings.yml'`
* `environ['SEARX_SETTINGS_PATH']`
* `'/etc/searx/settings.yml'`

## Why is this change important?

* Don't ignore SEARX_SETTINGS_PATH
* Simplify the code of searx.settings_loader (`SearxSettingsException` is never raised).

## How to test this PR locally?

Define two custom settings.yml in the various locations:
* SEARXNG_SETTINGS_PATH and SEARX_SETTINGS_PATH : The SearXNG must be chosen.
* SEARXNG_SETTINGS_PATH and /etc/searx/settings.yml : The SearXNG must be chosen.
* SEARX_SETTINGS_PATH and /etc/searx/settings.yml : SEARX_SETTINGS_PATH must be chosen.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close https://github.com/searxng/searxng/issues/1519
