### PR TITLE
Remove usage of SEARX environment variables

### DIFF
--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -41,16 +41,6 @@ STR_TO_BOOL = {
 }
 _UNDEFINED = object()
 
-# compatibility
-SEARX_ENVIRON_VARIABLES = {
-    'SEARX_DISABLE_ETC_SETTINGS': 'SEARXNG_DISABLE_ETC_SETTINGS',
-    'SEARX_SETTINGS_PATH': 'SEARXNG_SETTINGS_PATH',
-    'SEARX_DEBUG': 'SEARXNG_DEBUG',
-    'SEARX_PORT': 'SEARXNG_PORT',
-    'SEARX_BIND_ADDRESS': 'SEARXNG_BIND_ADDRESS',
-    'SEARX_SECRET': 'SEARXNG_SECRET',
-}
-
 
 class SettingsValue:
     """Check and update a setting value"""
@@ -227,11 +217,5 @@ SCHEMA = {
 
 
 def settings_set_defaults(settings):
-    # compatibility with searx variables
-    for searx, searxng in SEARX_ENVIRON_VARIABLES.items():
-        if searx in os.environ and searxng not in os.environ:
-            os.environ[searxng] = os.environ[searx]
-            logger.warning('%s uses value from %s', searxng, searx)
-
     apply_schema(settings, SCHEMA, [])
     return settings

--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from typing import Optional
 from os import environ
 from os.path import dirname, join, abspath, isfile
 from collections.abc import Mapping
@@ -13,7 +14,7 @@ from searx.exceptions import SearxSettingsException
 searx_dir = abspath(dirname(__file__))
 
 
-def check_settings_yml(file_name):
+def existing_filename_or_none(file_name: str) -> Optional[str]:
     if isfile(file_name):
         return file_name
     return None
@@ -30,29 +31,29 @@ def load_yaml(file_name):
 
 
 def get_default_settings_path():
-    return check_settings_yml(join(searx_dir, 'settings.yml'))
+    return existing_filename_or_none(join(searx_dir, 'settings.yml'))
 
 
-def get_user_settings_path():
-    # find location of settings.yml
+def get_user_settings_path() -> Optional[str]:
+    """Get an user settings file.
+    By descending priority:
+    1. ``environ['SEARXNG_SETTINGS_PATH']``
+    2. ``/etc/searxng/settings.yml`` except if ``SEARXNG_DISABLE_ETC_SETTINGS`` is ``true`` or ``1``
+    3. ``None``
+    """
+
+    # check the environment variable SEARXNG_SETTINGS_PATH
+    # if the environment variable is defined, this is the last check
     if 'SEARXNG_SETTINGS_PATH' in environ:
-        # if possible set path to settings using the
-        # enviroment variable SEARXNG_SETTINGS_PATH
-        return check_settings_yml(environ['SEARXNG_SETTINGS_PATH'])
+        return existing_filename_or_none(environ['SEARXNG_SETTINGS_PATH'])
 
+    # if SEARXNG_DISABLE_ETC_SETTINGS don't look any futher
     if environ.get('SEARXNG_DISABLE_ETC_SETTINGS', '').lower() in ('1', 'true'):
         return None
 
-    # if not, get it from searx code base or last solution from /etc/searxng
-    try:
-        return check_settings_yml('/etc/searxng/settings.yml')
-    except SearxSettingsException as e:
-        # fall back to searx settings
-        try:
-            return check_settings_yml('/etc/searx/settings.yml')
-        except SearxSettingsException:
-            # if none are found, raise the exception about SearXNG
-            raise e  # pylint: disable=raise-missing-from
+    # check /etc/searxng/settings.yml
+    # (continue with other locations if the file is not found)
+    return existing_filename_or_none('/etc/searxng/settings.yml')
 
 
 def update_dict(default_dict, user_dict):

--- a/tests/unit/test_settings_loader.py
+++ b/tests/unit/test_settings_loader.py
@@ -22,11 +22,11 @@ class TestLoad(SearxTestCase):
         with self.assertRaises(SearxSettingsException):
             settings_loader.load_yaml(join(test_dir, '/settings/empty_settings.yml'))
 
-    def test_check_settings_yml(self):
-        self.assertIsNone(settings_loader.check_settings_yml('/dev/zero'))
+    def test_existing_filename_or_none(self):
+        self.assertIsNone(settings_loader.existing_filename_or_none('/dev/zero'))
 
         bad_settings_path = join(test_dir, 'settings/syntaxerror_settings.yml')
-        self.assertEqual(settings_loader.check_settings_yml(bad_settings_path), bad_settings_path)
+        self.assertEqual(settings_loader.existing_filename_or_none(bad_settings_path), bad_settings_path)
 
 
 class TestDefaultSettings(SearxTestCase):


### PR DESCRIPTION
## What does this PR do?

Remove usage of SEARX environment variable.

## Why is this change important?

See comment on https://github.com/searxng/searxng/pull/1709

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

A public announcement would be good: some users may rely on existing packages that relies on this SEARX variables.

## Related issues

* Close #1519 as won't fix
* Related to #373