### PR TITLE
[mod] option 'server: archive_url:' to configure internet archive

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -240,6 +240,7 @@ Global Settings
      query_in_title: false
      infinite_scroll: false
      center_alignment: false
+     cache_url: https://web.archive.org/web/
      default_theme: simple
      theme_args:
        simple_style: auto
@@ -266,6 +267,15 @@ Global Settings
   When enabled, the results are centered instead of being in the left (or RTL)
   side of the screen.  This setting only affects the *desktop layout*
   (:origin:`min-width: @tablet <searx/static/themes/simple/src/less/definitions.less>`)
+
+.. cache_url:
+
+``cache_url`` : ``https://web.archive.org/web/``
+  URL prefix of the internet archive or cache, don't forgett trailing slash (if
+  needed).  The default is https://web.archive.org/web/ alternatives are:
+
+  - https://webcache.googleusercontent.com/search?q=cache:
+  - https://archive.today/
 
 ``default_theme`` :
   Name of the theme you want to use by default on your SearXNG instance.

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -95,6 +95,8 @@ ui:
   default_theme: simple
   # center the results ?
   center_alignment: false
+  # URL prefix of the internet archive, don't forgett trailing slash (if needed).
+  # cache_url: "https://webcache.googleusercontent.com/search?q=cache:"
   # Default interface locale - leave blank to detect from browser information or
   # use codes from the 'locales' config section
   default_locale: ""

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -190,6 +190,7 @@ SCHEMA = {
         'advanced_search': SettingsValue(bool, False),
         'query_in_title': SettingsValue(bool, False),
         'infinite_scroll': SettingsValue(bool, False),
+        'cache_url': SettingsValue(str, 'https://web.archive.org/web/'),
     },
     'preferences': {
         'lock': SettingsValue(list, []),

--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -42,7 +42,7 @@
 {%- macro result_sub_footer(result, proxify) -%}
 <div class="engines">
   {% for engine in result.engines %}<span>{{ engine }}</span>{% endfor %}
-  {{ result_link("https://web.archive.org/web/" + result.url, icon_small('ellipsis-vertical-outline') + _('cached'), "cache_link") }}&lrm; {% if proxify and proxify_results %} {{ result_link(proxify(result.url), icon('link') + _('proxied'), "proxyfied_link") }} {% endif %}
+  {{ result_link(cache_url + result.url, icon_small('ellipsis-vertical-outline') + _('cached'), "cache_link") }}&lrm; {% if proxify and proxify_results %} {{ result_link(proxify(result.url), icon('link') + _('proxied'), "proxyfied_link") }} {% endif %}
 </div>{{- '' -}}
 <div class="break"></div>{{- '' -}}
 {%- endmacro -%}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -464,6 +464,7 @@ def render(template_name: str, **kwargs):
     kwargs['image_proxify'] = image_proxify
     kwargs['proxify'] = morty_proxify if settings['result_proxy']['url'] is not None else None
     kwargs['proxify_results'] = settings['result_proxy']['proxify_results']
+    kwargs['cache_url'] = settings['ui']['cache_url']
     kwargs['get_result_template'] = get_result_template
     kwargs['opensearch_url'] = (
         url_for('opensearch')


### PR DESCRIPTION
## What does this PR do?

The URL of the internet archive is hard coded in the template: make it configurable.

## Why is this change important?

Allow to configure alternative web archives.

## How to test this PR locally?

Check documentation and test internet archive by setting `https://archive.today/`
