### PR TITLE
Disable brave by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1852,6 +1852,7 @@ engines:
       month: 'pm'
       year: 'py'
     categories: [general, web]
+    disabled: true
     about:
       website: https://brave.com/search/
       wikidata_id: Q107355971


### PR DESCRIPTION
Brave is too unstable and will often not work by default. As seen in many issues: https://github.com/searxng/searxng/issues?q=is%3Aissue++sort%3Aupdated-desc+brave+label%3Abug+