### PR TITLE
GitHub worfklow: add daily security check using trivy

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,28 @@
+name: "Security checks"
+on:
+  schedule:
+    - cron: "42 05 * * *"
+  workflow_dispatch:
+
+jobs:
+  dockers:
+    name: Trivy ${{ matrix.image }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'searxng/searxng:latest'
+          ignore-unfixed: false
+          vuln-type: 'os,library'
+          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## What does this PR do?

Since morty and filtron are not part of the stack, this GH workflow replaces https://github.com/searxng/searxng-docker/blob/master/.github/workflows/security.yml to only check searxng/searxng.

In addition, the results are pushed to the GitHub Security tab.

## Why is this change important?

* ensure there is no flow in the dependencies.
* check searxng/searxng docker image in searxng/searxng project, which makes more sense.

## How to test this PR locally?

N/A

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

* https://github.com/searxng/searxng-docker/pull/77
* https://github.com/searxng/searxng-docker/pull/10