### PR TITLE
[dev] Add EditorConfig support and fix duplicate key in simple theme ESLint configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -165,3 +165,4 @@ features or generally made searx better:
 - Paul Alcock @Guilvareux
 - Sam A. `<https://samsapti.dev>`_
 - @XavierHorwood
+- Marko Korhonen `@FunctionalHacker <https://github.com/FunctionalHacker>`_

--- a/searx/static/themes/simple/.eslintrc.json
+++ b/searx/static/themes/simple/.eslintrc.json
@@ -14,7 +14,6 @@
         "no-trailing-spaces": 2,
         "space-before-function-paren": ["error", "always"],
         "space-infix-ops": "error",
-        "comma-spacing": ["error", { "before": false, "after": true }],
         "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
         "curly": ["error", "multi-line"],
         "block-spacing": ["error", "always"],


### PR DESCRIPTION
## What does this PR do?
I was just starting to get familiar with the searxng source code and thought I would get my feet wet contributing some fixes for the development experience.

Main addition is the [EditorConfig](https://editorconfig.org/) configuration file. This allows people using different editors have some project wide settings applied, such as indent style, indent size, eol, charset etc.

For now, only configuration is eol and charset for all files and indent settings for JavaScript files. More can be added later.

At the same time, I noticed a duplicate key in the simple theme ESLint configuration so I included that fix here too.

## Why is this change important?

Improves developer experience and makes contributing for new developers easier

## How to test this PR locally?
Use an editor [with EditorConfig support built in](https://editorconfig.org/#pre-installed) or [install a plugin for your current editor](https://editorconfig.org/#download) and try if the settings work.