### PR TITLE
Update about the metrics

### DIFF
--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -62,9 +62,9 @@
   <footer>
     <p>
     {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searx_version }} — {{ _('a privacy-respecting, hackable metasearch engine') }}<br/>
-        <a href="{{ searx_git_url }}">{{ _('Source code') }}</a> |
-        <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a> |
-        <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a>
+        <a href="{{ searx_git_url }}">{{ _('Source code') }}</a>
+        | <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a>
+        {% if enable_metrics %}| <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a>{% endif %}
         {% if get_setting('brand.public_instances') %}
         | <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>
         {% endif %}

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -310,9 +310,9 @@
         <th>{{ _("Supports selected language") }}</th>{{- "" -}}
         <th>{{ _("SafeSearch") }}</th>{{- "" -}}
         <th>{{ _("Time range") }}</th>{{- "" -}}
-        <th>{{ _("Response time") }}</th>{{- "" -}}
+        {%- if enable_metrics %}<th>{{ _("Response time") }}</th>{% endif -%}
         <th>{{ _("Max time") }}</th>{{- "" -}}
-        <th>{{ _("Reliability") }}</th>{{- "" -}}
+        {%- if enable_metrics %}<th>{{ _("Reliability") }}</th>{% endif -%}
       </tr>
       {% for group, engines in engines_by_category[categ] | group_engines_in_tab %}
       {% if loop.length > 1 %}
@@ -336,9 +336,9 @@
         <td>{{ checkbox(None, supports[search_engine.name]['supports_selected_language'], true) }}</td>{{- "" -}}
         <td>{{ checkbox(None, supports[search_engine.name]['safesearch'], true) }}</td>{{- "" -}}
         <td>{{ checkbox(None, supports[search_engine.name]['time_range_support'], true) }}</td>{{- "" -}}
-        {{- engine_time(search_engine.name) -}}
+        {%- if enable_metrics %}{{- engine_time(search_engine.name) -}}{% endif -%}
         <td class="{{ 'danger' if stats[search_engine.name]['warn_timeout'] else '' }}">{{ search_engine.timeout }}</td>{{- "" -}}
-        {{ engine_reliability(search_engine.name) -}}
+        {%- if enable_metrics %}{{ engine_reliability(search_engine.name) -}}{% endif -%}
       </tr>
       {% endif %}
       {% endfor %}

--- a/searx/templates/simple/stats.html
+++ b/searx/templates/simple/stats.html
@@ -33,10 +33,7 @@
         <td class="engine-name"><a href="{{ url_for('stats', engine=engine_stat.name|e) }}">{{ engine_stat.name }}</a></td>
         <td class="engine-score">
             {% if engine_stat.score %}
-            <span aria-labelledby="{{engine_stat.name}}_score" >{{ engine_stat.score|round(1) }}</span>
-            <div class="engine-tooltip" role="tooltip" id="{{engine_stat.name}}_score">{{- "" -}}
-                <p>{{ _('Scores per result') }}: {{ engine_stat.score_per_result | round(3) }}</p>
-            </div>
+            <span>{{ engine_stat.score_per_result|round(1) }}</span>
             {% endif %}
         </td>
         <td class="engine-result-count">

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -450,6 +450,7 @@ def render(template_name: str, **kwargs):
     kwargs['instance_name'] = get_setting('general.instance_name')
     kwargs['searx_version'] = VERSION_STRING
     kwargs['searx_git_url'] = GIT_URL
+    kwargs['enable_metrics'] = get_setting('general.enable_metrics')
     kwargs['get_setting'] = get_setting
     kwargs['get_pretty_url'] = get_pretty_url
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -145,7 +145,7 @@ result_templates = get_result_templates(templates_path)
 
 STATS_SORT_PARAMETERS = {
     'name': (False, 'name', ''),
-    'score': (True, 'score', 0),
+    'score': (True, 'score_per_result', 0),
     'result_count': (True, 'result_count', 0),
     'time': (False, 'total', 0),
     'reliability': (False, 'reliability', 100),


### PR DESCRIPTION
## What does this PR do?

Two commits:
* the first one changes `/stats` to display on the score per result instead of the result.
* the second one hides to empty information when `general.enable_metrics: false`:
   * hide the link to `/stats` at the bottom of the pages
   * in /preferences, hide the columns "Response time" and "Reliability" 

## Why is this change important?

* first commit: more privacy
* second commit: hide useless information when metrics are disabled.

## How to test this PR locally?

With `general.enable_metrics: true`
* make some queries
* go the `/stats`, check the column score, compare to the master branch. The scores should be around 1.
* click on the "Score" column, check the scores are sorted in the right order

With `general.enable_metrics: false`:
* make some queries
* check there is no link to `/stats` at the bottom of the pages
* go the preferences: check the columns "Response time" and "Reliability" are missing

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
