### PR TITLE
Re-use morty's default config while Docker startup

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -81,15 +81,16 @@ patch_searxng_settings() {
     # Morty configuration
 
     if [ -n "${MORTY_KEY}" ] && [ -n "${MORTY_URL}" ]; then
-        sed -i -e "s/image_proxy: false/image_proxy: true/g" \
+        sed -i \
+            -e "s/image_proxy: false/image_proxy: true/g" \
+            -e "s|# result_proxy:|result_proxy:|g" \
+            -e "s|#   url: http://127.0.0.1:3000/|  url: ${MORTY_URL}|g" \
+            -e "s|#   # the key is a base64 encoded string|  # the key is a base64 encoded string|g" \
+            -e "s|#   key: \!\!binary|  key: \!\!binary|g" \
+            -e "s/your_morty_proxy_key/${MORTY_KEY}/g" \
+            -e "s|#   # \[true|  # \[true|g" \
+            -e "s|#   proxify_results: true|  proxify_results: true|g" \
             "${CONF}"
-        cat >> "${CONF}" <<-EOF
-
-# Morty configuration
-result_proxy:
-   url: ${MORTY_URL}
-   key: !!binary "${MORTY_KEY}"
-EOF
     fi
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR enables morty's default configuration `result_proxy:` in [settings.yml](https://github.com/searxng/searxng/blob/eb3d185e66dea1add88ef8d3a3c6bb74b8a3b166/searx/settings.yml#L124) instead of adding a duplication at the end of the file while docker starts-up and updating a configuration.
The default config is commented which will just be uncommented and the given parameter `${MORTY_URL}` and `${MORTY_KEY}` will be applied.

As an additional change the option `proxify_results` will be automatically enabled.

## Why is this change important?

This avoids a confusing configuration.

## How to test this PR locally?

1. Run SearXNG via Docker and force to update the settings
   * e.g. via renaming `settings.yml`
2. compare `settings.yml` with origin one.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
