### PR TITLE
[fix] and improve docs generated from source code.

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -81,6 +81,7 @@ engine_shortcuts = {}
 
     engine_shortcuts[engine.shortcut] = engine.name
 
+:meta hide-value:
 """
 
 

--- a/searx/locales.py
+++ b/searx/locales.py
@@ -25,7 +25,10 @@ _flask_babel_get_translations = flask_babel.get_translations
 
 LOCALE_NAMES = {}
 """Mapping of locales and their description.  Locales e.g. 'fr' or 'pt-BR' (see
-:py:obj:`locales_initialize`)."""
+:py:obj:`locales_initialize`).
+
+:meta hide-value:
+"""
 
 RTL_LOCALES: Set[str] = set()
 """List of *Right-To-Left* locales e.g. 'he' or 'fa-IR' (see
@@ -159,7 +162,7 @@ def get_engine_locale(searxng_locale, engine_locales, default=None):
     ``searxng_locale``.
 
     Argument ``engine_locales`` is a python dict that maps *SearXNG locales* to
-    corresponding *engine locales*:
+    corresponding *engine locales*::
 
       <engine>: {
           # SearXNG string : engine-string


### PR DESCRIPTION
Fix::

    searx/locales.py:docstring of searx.locales.get_engine_locale:17: \
      WARNING: Definition list ends without a blank line; unexpected unindent.

Improvement: don't show default values in the generated documentation whe it is more a mess than a usefull information (`:meta hide-value:`).

before:

![image](https://user-images.githubusercontent.com/554536/190898370-bd960634-7db0-4e7d-beb4-54e554bd989d.png)

after:

![image](https://user-images.githubusercontent.com/554536/190898397-32751feb-eefc-4b57-9f61-8c48c75520e7.png)


before:

![image](https://user-images.githubusercontent.com/554536/190898306-78c46c73-1bbc-4e3d-9c40-63c4530260ed.png)


after:

![image](https://user-images.githubusercontent.com/554536/190898334-5d3d2bbb-d17b-47b0-a920-c62a3e81a25e.png)


