### PR TITLE
Brave engine: fix BrotliDecoderDecompressStream error

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1865,6 +1865,8 @@ engines:
       year: 'py'
     categories: [general, web]
     disabled: true
+    headers:
+      Accept-Encoding: gzip, deflate
     about:
       website: https://brave.com/search/
       wikidata_id: Q107355971


### PR DESCRIPTION
## What does this PR do?

Brave engine doesn't work: the response can't be decompress:

```
Traceback (most recent call last):
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_decoders.py", line 119, in decode
    return self._decompress(data)
brotli.error: BrotliDecoderDecompressStream failed while processing the stream

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/alexandre/code/searxng/searx/search/processors/online.py", line 154, in search
    search_results = self._search_basic(query, params)
  File "/home/alexandre/code/searxng/searx/search/processors/online.py", line 138, in _search_basic
    response = self._send_http_request(params)
  File "/home/alexandre/code/searxng/searx/search/processors/online.py", line 107, in _send_http_request
    response = req(params['url'], **request_args)
  File "/home/alexandre/code/searxng/searx/network/__init__.py", line 165, in get
    return request('get', url, **kwargs)
  File "/home/alexandre/code/searxng/searx/network/__init__.py", line 96, in request
    return future.result(timeout)
  File "/home/alexandre/.pyenv/versions/3.10.2/lib/python3.10/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/home/alexandre/.pyenv/versions/3.10.2/lib/python3.10/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/home/alexandre/code/searxng/searx/network/network.py", line 291, in request
    return await self.call_client(False, method, url, **kwargs)
  File "/home/alexandre/code/searxng/searx/network/network.py", line 287, in call_client
    raise e
  File "/home/alexandre/code/searxng/searx/network/network.py", line 272, in call_client
    response = await client.request(method, url, **kwargs)
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_client.py", line 1527, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_client.py", line 1628, in send
    raise exc
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_client.py", line 1622, in send
    await response.aread()
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_models.py", line 896, in aread
    self._content = b"".join([part async for part in self.aiter_bytes()])
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_models.py", line 896, in <listcomp>
    self._content = b"".join([part async for part in self.aiter_bytes()])
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_models.py", line 915, in aiter_bytes
    decoded = decoder.decode(raw_bytes)
  File "/home/alexandre/code/searxng/local/py3/lib/python3.10/site-packages/httpx/_decoders.py", line 121, in decode
    raise DecodingError(str(exc)) from exc
httpx.DecodingError: BrotliDecoderDecompressStream failed while processing the stream
```

## Why is this change important?

Fix Brave engine

## How to test this PR locally?


## Author's checklist

`curl --compressed -vvv --output /dev/null "https://search.brave.com/search?q=time&offset=0&spellcheck=1"` successfully decompressed the Brotli content...

## Related issues

* https://github.com/searxng/searxng/issues/1786
* https://github.com/searxng/searxng/issues/1785
* https://github.com/searxng/searxng/issues/1779
* https://github.com/searxng/searxng/issues/1778

