### PR TITLE
Hong Kong is Hong Kong, not Hong Kong China

### DIFF
--- a/searx/languages.py
+++ b/searx/languages.py
@@ -68,6 +68,6 @@ language_codes = (
     ('vi-VN', 'Tiếng Việt', 'Việt Nam', 'Vietnamese', '\U0001f1fb\U0001f1f3'),
     ('zh', '中文', '', 'Chinese', '\U0001f310'),
     ('zh-CN', '中文', '中国', 'Chinese', '\U0001f1e8\U0001f1f3'),
-    ('zh-HK', '中文', '中國香港', 'Chinese', '\U0001f1ed\U0001f1f0'),
+    ('zh-HK', '中文', '香港', 'Chinese', '\U0001f1ed\U0001f1f0'),
     ('zh-TW', '中文', '台灣', 'Chinese', '\U0001f1f9\U0001f1fc'),
 )


### PR DESCRIPTION
## What does this PR do?

Changed "China Hong Kong" to "Hong Kong" in languages.py.

## Why is this change important?

Hong Kong should not be "Hong Kong China". This wording simply supports the totalitarian government in china. To be honest, I feel being offended by this word.

I am not saying Hong Kong is not China (this is illegal anyway, ~~in Hong Kong saying Hong Kong is not China is a crime and has a maximum penalty of a life sentence~~), but you don't call things like "New York, United States", or "Glasgow, United Kingdom".