### PR TITLE
[fix] typo in crossref settings: disable --> disabled

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -413,7 +413,7 @@ engines:
     engine: crossref
     shortcut: cr
     timeout: 30
-    disable: true
+    disabled: true
 
   - name: yep
     engine: json_engine


### PR DESCRIPTION
Fix small typo from https://github.com/searxng/searxng/pull/1705