### PR TITLE
core.ac.uk: use paper.html template 

### DIFF
--- a/searx/engines/core.py
+++ b/searx/engines/core.py
@@ -53,6 +53,9 @@ def response(resp):
     for result in json_data['data']:
 
         source = result['_source']
+        if not source['urls']:
+            continue
+
         time = source['publishedDate'] or source['depositedDate']
         if time:
             date = datetime.fromtimestamp(time / 1000)


### PR DESCRIPTION
## What does this PR do?

core.ac.uk: use paper.html template and fix bug:

    Traceback (most recent call last):
    File "searx/search/processors/online.py", line 154, in search
      search_results = self._search_basic(query, params)
    File "searx/search/processors/online.py", line 142, in _search_basic
      return self.engine.response(response)
    File "SearXNG/searx/engines/core.py", line 73, in response
      'url': source['urls'][0].replace('http://', 'https://', 1),

## How to test this PR locally?

Enable `core.ac.uk` in the settings by uncomment the entry / you need an API key

Search e.g. `!cor YBCO thin film`

