### PR TITLE
[mod] shared.storage: implement a backend to store in the redis DB

### DIFF
--- a/searx/shared/shared_abstract.py
+++ b/searx/shared/shared_abstract.py
@@ -5,6 +5,10 @@ from typing import Optional
 
 
 class SharedDict(ABC):
+
+    def __init__(self, *args, **kwarg):
+        pass
+
     @abstractmethod
     def get_int(self, key: str) -> Optional[int]:
         pass

--- a/searx/shared/shared_redis.py
+++ b/searx/shared/shared_redis.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+# pyright: strict
+"""Module implements a :py:class:`shared_abstract.SharedDict` to store data in a
+redis DB (:py:obj:`redisdb`)."""
+
+from typing import Optional
+from . import shared_abstract
+from . import redisdb
+
+class RedisCacheSharedDict(shared_abstract.SharedDict):
+    """Store key/value in the redis DB, the default prefix of the key in the DB is
+    ``SearXNG_SharedDict`` (see :py.obj:`searx.redislib.purge_by_prefix`)."""
+
+    def __init__(self, key_prefix='SearXNG_SharedDict'):
+        self.key_prefix = key_prefix
+
+    def get_int(self, key: str) -> Optional[int]:
+        return int(redisdb.client().get(self.key_prefix + key))
+
+    def set_int(self, key: str, value: int):
+        redisdb.client().set(self.key_prefix + key, str(value).encode())
+
+    def get_str(self, key: str) -> Optional[str]:
+        value = redisdb.client().get(self.key_prefix + key)
+        return None if value is None else value.decode()
+
+    def set_str(self, key: str, value: str):
+        redisdb.client().set(self.key_prefix + key, value.encode())


### PR DESCRIPTION
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>

## What does this PR do?

- implement shared_redis.RedisCacheSharedDict to store key/value pairs in the redis DB.  The default key_prefix is 'SearXNG_SharedDict'.

- simplify searx.shared and import RedisCacheSharedDict, set key_prefix to 'SearXNG_storage'

## Why is this change important?


## How to test this PR locally?

```diff
diff --git a/searx/settings.yml b/searx/settings.yml
index 4ca7e8946..5a6ecd65b 100644
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -206,7 +206,7 @@ outgoing:
 
 checker:
   # disable checker when in debug mode
-  off_when_debug: true
+  off_when_debug: false
 
   # use "scheduling: false" to disable scheduling
   # scheduling: interval or int
@@ -216,9 +216,9 @@ checker:
   # * add "cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1"
   #   to your uwsgi.ini
 
-  # scheduling:
-  #   start_after: [300, 1800]  # delay to start the first run of the checker
-  #   every: [86400, 90000]     # how often the checker runs
+  scheduling:
+    start_after: [3, 30]  # delay to start the first run of the checker
+    every: [86400, 90000]     # how often the checker runs
 
   # additional tests: only for the YAML anchors (see the engines section)
   #
```

## Author's checklist


## Related issues

<!--
Closes #234
-->
