### PR TITLE
Fix floating point format in DDG weather humidity

### DIFF
--- a/searx/engines/duckduckgo_weather.py
+++ b/searx/engines/duckduckgo_weather.py
@@ -39,12 +39,12 @@ def generate_condition_table(condition):
 
     res += (
         f"<tr><td>{gettext('Wind')}</td><td>{condition['windBearing']}° — "
-        f"{'%.2f' % (condition['windSpeed'] * 1.6093440006147)} km/h / {condition['windSpeed']} mph</td></tr>"
+        f"{(condition['windSpeed'] * 1.6093440006147):.2f} km/h / {condition['windSpeed']} mph</td></tr>"
     )
 
     res += f"<tr><td>{gettext('Visibility')}</td><td>{condition['visibility']} km</td>"
 
-    res += f"<tr><td>{gettext('Humidity')}</td><td>{condition['humidity'] * 100}%</td></tr>"
+    res += f"<tr><td>{gettext('Humidity')}</td><td>{(condition['humidity'] * 100):.1f}%</td></tr>"
 
     return res
 


### PR DESCRIPTION
## What does this PR do?

- Keeps 1 decimal digit in DDG weather humidity, to account for FP internal representation.
- Also changes `windSpeed` to use the f-string formatting, for consistency

## Why is this change important?

humidity displayed as `"56.99999999999999%"` is not user-friendly

## How to test this PR locally?

- serve up searxng
- find a location that has humidity with one of the "problematic" values (`[7, 14, 28, 29, 55, 56, 57, 58]`)
- check that it appears rounded in the output. 
 
Sample query `"!ddw 12345"`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes #1836

