### PR TITLE
[upd] linuxdoc from v20211220 to v20221025

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14
 sphinx-notfound-page==0.8.3
 myst-parser==0.18.1
-linuxdoc==20211220
+linuxdoc==20221025
 aiounittest==1.4.2
 yamllint==1.28.0
 wlc==1.13


### PR DESCRIPTION
## What does this PR do?

[upd] linuxdoc from v20211220 to v20221025

linuxdoc v20221025 fixes an issue with the flat-table directive and adds `:align:` & `:width:` options to flat-table directive.

[1] https://github.com/return42/linuxdoc/pull/18
