### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ WORKDIR /usr/local/searxng
 
 COPY requirements.txt ./requirements.txt
 
-RUN apk upgrade --no-cache \
- && apk add --no-cache -t build-dependencies \
+RUN apk add --no-cache -t build-dependencies \
     build-base \
     py3-setuptools \
     python3-dev \
@@ -47,8 +46,7 @@ RUN apk upgrade --no-cache \
     brotli \
  && pip3 install --no-cache -r requirements.txt \
  && apk del build-dependencies \
- && rm -rf /root/.cache \
- && find /usr/lib/python*/ -name '*.pyc' -delete
+ && rm -rf /root/.cache
 
 COPY --chown=searxng:searxng dockerfiles ./dockerfiles
 COPY --chown=searxng:searxng searx ./searx
@@ -57,7 +55,8 @@ ARG TIMESTAMP_SETTINGS=0
 ARG TIMESTAMP_UWSGI=0
 ARG VERSION_GITCOMMIT=unknown
 
-RUN touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml \
+RUN su searxng -c "/usr/bin/python3 -m compileall -q searx" \
+ && touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml \
  && touch -c --date=@${TIMESTAMP_UWSGI} dockerfiles/uwsgi.ini \
  && find /usr/local/searxng/searx/static -a \( -name '*.html' -o -name '*.css' -o -name '*.js' \
     -o -name '*.svg' -o -name '*.ttf' -o -name '*.eot' \) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,21 +45,21 @@ RUN apk upgrade --no-cache \
     uwsgi \
     uwsgi-python3 \
     brotli \
- && pip3 install --upgrade pip wheel setuptools \
  && pip3 install --no-cache -r requirements.txt \
  && apk del build-dependencies \
- && rm -rf /root/.cache
+ && rm -rf /root/.cache \
+ && find /usr/lib/python*/ -name '*.pyc' -delete
 
-COPY --chown=searxng:searxng . .
+COPY --chown=searxng:searxng dockerfiles ./dockerfiles
+COPY --chown=searxng:searxng searx ./searx
 
 ARG TIMESTAMP_SETTINGS=0
 ARG TIMESTAMP_UWSGI=0
 ARG VERSION_GITCOMMIT=unknown
 
-RUN su searxng -c "/usr/bin/python3 -m compileall -q searx"; \
-    touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml; \
-    touch -c --date=@${TIMESTAMP_UWSGI} dockerfiles/uwsgi.ini; \
-    find /usr/local/searxng/searx/static -a \( -name '*.html' -o -name '*.css' -o -name '*.js' \
+RUN touch -c --date=@${TIMESTAMP_SETTINGS} searx/settings.yml \
+ && touch -c --date=@${TIMESTAMP_UWSGI} dockerfiles/uwsgi.ini \
+ && find /usr/local/searxng/searx/static -a \( -name '*.html' -o -name '*.css' -o -name '*.js' \
     -o -name '*.svg' -o -name '*.ttf' -o -name '*.eot' \) \
     -type f -exec gzip -9 -k {} \+ -exec brotli --best {} \+
 


### PR DESCRIPTION
## What does this PR do?

* Copy only source code and Docker entrypoint
* Avoid updating packages. The base image is updated frecuently

## Why is this change important?

* Docker image size reduced by 3 MB (195 MB -> 192 MB uncompressed)

## How to test this PR locally?

Deploy and check everything is working as before.
