### PR TITLE
Remove unused volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.16
 ENTRYPOINT ["/sbin/tini","--","/usr/local/searxng/dockerfiles/docker-entrypoint.sh"]
 EXPOSE 8080
-VOLUME /etc/searx
 VOLUME /etc/searxng
 
 ARG SEARXNG_GID=977


### PR DESCRIPTION
Docker file used old project volume instruction which is not existent in current one. It used to create clutter in created volumes without names and purposes polluting the docker environment.

Volume doesn't point to existing directory inside container and has no actual use other then creating docker volume mess each time container is run recreated or potentially restarted.