### PR TITLE
GH workflow: various improvements

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,9 +28,12 @@ jobs:
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        path: ./local
+        path: |
+          ./local
+          ./.nvm
+          ./node_modules
         key: python-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements*.txt', 'setup.py') }}
     - name: Install Python dependencies
       if: steps.cache-python.outputs.cache-hit != 'true'
@@ -63,10 +66,13 @@ jobs:
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        path: ./local
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py') }}
+        path: |
+          ./local
+          ./.nvm
+          ./node_modules
+        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: Install node dependencies
       run: make V=1 node.env
     - name: Build themes
@@ -90,10 +96,13 @@ jobs:
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        path: ./local
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py') }}
+        path: |
+          ./local
+          ./.nvm
+          ./node_modules
+        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: Build documentation
       run: |
         make V=1 docs.clean docs.html
@@ -129,10 +138,13 @@ jobs:
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        path: ./local
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py') }}
+        path: |
+          ./local
+          ./.nvm
+          ./node_modules
+        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: weblate & git setup
       env:
         WEBLATE_CONFIG: ${{ secrets.WEBLATE_CONFIG }}
@@ -171,10 +183,13 @@ jobs:
           architecture: 'x64'
       - name: Cache Python dependencies
         id: cache-python
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ./local
-          key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py') }}
+          path: |
+            ./local
+            ./.nvm
+            ./node_modules
+          key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
       - name: Set up QEMU
         if: env.DOCKERHUB_USERNAME != null
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   python:
     name: Python ${{ matrix.python-version }}
@@ -81,6 +84,8 @@ jobs:
   documentation:
     name: Documentation
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -125,6 +130,8 @@ jobs:
       - python
       - themes
       - documentation
+    permissions:
+      contents: write  # for make V=1 weblate.push.translations
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
         sudo ./utils/searxng.sh install packages
         sudo apt install firefox
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
@@ -57,7 +57,7 @@ jobs:
     - name: Install Ubuntu packages
       run: sudo ./utils/searxng.sh install buildhost
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
         architecture: 'x64'
@@ -84,7 +84,7 @@ jobs:
     - name: Install Ubuntu packages
       run: sudo ./utils/searxng.sh install buildhost
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
         architecture: 'x64'
@@ -123,7 +123,7 @@ jobs:
         fetch-depth: '0'
         token: ${{ secrets.WEBLATE_GITHUB_TOKEN }}
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
         architecture: 'x64'
@@ -165,7 +165,7 @@ jobs:
           # make sure "make docker.push" can get the git history
           fetch-depth: '0'
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
           architecture: 'x64'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version:  ["3.7", "3.8", "3.9", "3.10"]
+        python-version:  ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/translations-update.yml
+++ b/.github/workflows/translations-update.yml
@@ -22,10 +22,13 @@ jobs:
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        path: ./local
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py') }}
+        path: |
+          ./local
+          ./.nvm
+          ./node_modules
+        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: weblate & git setup
       env:
         WEBLATE_CONFIG: ${{ secrets.WEBLATE_CONFIG }}

--- a/.github/workflows/translations-update.yml
+++ b/.github/workflows/translations-update.yml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: '0'
         token: ${{ secrets.WEBLATE_GITHUB_TOKEN }}
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
         architecture: 'x64'


### PR DESCRIPTION
## What does this PR do?

GitHub displays this warning with the actions/setup-python@2 :
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR : 
* avoid GH warnings:
  * use actions/setup-python@v4 (previously v3)
  * use actions/cache@v3 (previously v2)
* in addition to `./local`, now `./.nvm` and `./node_modules` are cached : faster build time.
* add Python 3.11
* set content permission to read by default.

## Why is this change important?

* see above

## How to test this PR locally?

N/A

## Author's checklist

### remaining warning

I'm not sure why, this warning remains
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
```

Setting the node version doesn't fix the issue.
```yaml
- uses: actions/setup-node@v3
  with:
    node-version: 16
```

Note: Ubuntu 20.04 has [node version 10](https://packages.ubuntu.com/focal/nodejs).

### Ubuntu-22.04

I've tried to use `ubuntu-22.04` instead of `ubuntu-20.04` : it does not work by default because Firefox is a snap in Ubuntu 22.04 --> geckodriver can't connect to it (also, the Ubuntu package `firefox-geckodriver` doesn't exist for the version 22.04 and later).

The [geckodriver version 0.32.0](https://github.com/mozilla/geckodriver/releases/tag/v0.32.0) should fix that but it requires additional changes. The alternative is to download the last Firefox version from mozilla.org.

### sudo ./utils/searxng.sh install packages

`./utils/searxng.sh install packages` provides the Ubuntu packages to build the Python & Node dependencies.
However, if the GH cache provides them ( actions/cache ), the Ubuntu packages are not required.
We can write
```yaml
    - name: Install Firefox
      run: sudo apt install firefox
    ...
    - name: Install Ubuntu packages
      if: steps.cache-python.outputs.cache-hit != 'true'
      run: |
        sudo ./utils/searxng.sh install packages
```

This should speed up the build time by ~ 30 seconds (tested in my fork).

I haven't do the change in this PR, I'm afraid it breaks something.

## Related issues

<!--
Closes #234
-->
