### PR TITLE
Disabling zlibrary due to z-lib.org domain seizure

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -890,16 +890,19 @@ engines:
       require_api_key: false
       results: HTML
 
-  - name: z-library
-    engine: zlibrary
-    shortcut: zlib
-    categories: files
-    timeout: 3.0
-    # choose base_url, otherwise engine will do it at initialization time
-    # base_url: https://b-ok.cc
-    # base_url: https://de1lib.org
-    # base_url: https://booksc.eu   # does not have cover preview
-    # base_url: https://booksc.org  # does not have cover preview
+  # Disabling zlibrary due to z-lib.org domain seizure
+  # https://github.com/searxng/searxng/pull/1937
+  #
+  # - name: z-library
+  #   engine: zlibrary
+  #   shortcut: zlib
+  #   categories: files
+  #   timeout: 3.0
+  #   # choose base_url, otherwise engine will do it at initialization time
+  #   # base_url: https://b-ok.cc
+  #   # base_url: https://de1lib.org
+  #   # base_url: https://booksc.eu   # does not have cover preview
+  #   # base_url: https://booksc.org  # does not have cover preview
 
   - name: library of congress
     engine: loc


### PR DESCRIPTION
## What does this PR do?

Disables ZLibrary by default

## Why is this change important?

the z-lib.org domain was seized by the FBI. Leaving ZLibrary enabled causes searxng to crash on startup as a result.

## Related issues

<!--
Closes #1936
-->
