### PR TITLE
Switch back to protobuf for raw HTML

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -254,7 +254,7 @@ def request(query, params):
     if use_mobile_ui:
         additional_parameters = {
             'asearch': 'arc',
-            'async': 'use_ac:true,_fmt:html',
+            'async': 'use_ac:true,_fmt:prog',
         }
 
     # https://www.google.de/search?q=corona&hl=de&lr=lang_de&start=0&tbs=qdr%3Ad&safe=medium


### PR DESCRIPTION
## What does this PR do?

In https://github.com/searxng/searxng/pull/1648 I switched the output of the google mobile response to HTML in order to ease on the HTML parser but it seems like:
- This doesn't work anymore with searches for personalities, see https://github.com/searxng/searxng/issues/1935#issuecomment-1304943744
- This seems to be more rate limited, see https://github.com/searxng/searxng/issues/1904

That's why I propose to switch back to the old cryptic protobuf data that did work with our HTML parser but isn't a straight HTML page.

By the way `fmt=prog` seems to be the new protobuf parameter (Idk?), it returns the same info as `fmt=pc`. But it's the new parameter used on the google search website.

## Why is this change important?

See above

## How to test this PR locally?

1. Install SearX
2. Do `!go keyword`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Closes https://github.com/searxng/searxng/issues/1935
Closes https://github.com/searxng/searxng/issues/1904
