### PR TITLE
[fix] follow up of PR-1856

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -294,7 +294,7 @@ Global Settings
 
 .. _Redis.from_url(url): https://redis-py.readthedocs.io/en/stable/connections.html#redis.client.Redis.from_url
 
-A redis DB can be connected by an URL, in :py:obj:`searx.shared.redisdb` you
+A redis DB can be connected by an URL, in :py:obj:`searx.redisdb` you
 will find a description to test your redis connection in SerXNG.  When using
 sockets, don't forget to check the access rights on the socket::
 

--- a/docs/admin/installation-uwsgi.rst
+++ b/docs/admin/installation-uwsgi.rst
@@ -239,8 +239,8 @@ For example on Fedora (RHEL): If you try to install a redis DB with socket
 communication and you want to connect to it from the SearXNG uWSGI, you will see a
 *Permission denied* in the log of your instance::
 
-  ERROR:searx.shared.redis: [searxng (993)] can't connect redis DB ...
-  ERROR:searx.shared.redis:   Error 13 connecting to unix socket: /usr/local/searxng-redis/run/redis.sock. Permission denied.
+  ERROR:searx.redisdb: [searxng (993)] can't connect redis DB ...
+  ERROR:searx.redisdb:   Error 13 connecting to unix socket: /usr/local/searxng-redis/run/redis.sock. Permission denied.
   ERROR:searx.plugins.limiter: init limiter DB failed!!!
 
 Even if your *searxng* user of the uWSGI process is added to additional groups

--- a/docs/admin/update-searxng.rst
+++ b/docs/admin/update-searxng.rst
@@ -132,5 +132,4 @@ to see if there are some left overs.  In this example there exists a *old*
    INFO:  [OK] (old) account 'filtron' does not exists
    INFO:  [OK] (old) account 'morty' does not exists
    ...
-   INFO    searx.shared                  : Use shared_simple implementation
-   INFO    searx.shared.redis            : connected redis DB --> default
+   INFO    searx.redisdb            : connected redis DB --> default

--- a/docs/admin/update-searxng.rst
+++ b/docs/admin/update-searxng.rst
@@ -132,4 +132,5 @@ to see if there are some left overs.  In this example there exists a *old*
    INFO:  [OK] (old) account 'filtron' does not exists
    INFO:  [OK] (old) account 'morty' does not exists
    ...
-   INFO    searx.redisdb            : connected redis DB --> default
+   INFO    searx.redisdb                 : connecting to Redis db=0 path='/usr/local/searxng-redis/run/redis.sock'
+   INFO    searx.redisdb                 : connected to Redis

--- a/docs/src/searx.redisdb.rst
+++ b/docs/src/searx.redisdb.rst
@@ -4,5 +4,5 @@
 Redis DB
 ========
 
-.. automodule:: searx.shared.redisdb
+.. automodule:: searx.redisdb
   :members:

--- a/manage
+++ b/manage
@@ -32,6 +32,12 @@ export NODE_MINIMUM_VERSION="16.13.0"
 BLACK_OPTIONS=("--target-version" "py37" "--line-length" "120" "--skip-string-normalization")
 BLACK_TARGETS=("--exclude" "searx/static,searx/languages.py" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")
 
+_dev_redis_sock="/usr/local/searxng-redis/run/redis.sock"
+# set SEARXNG_REDIS_URL if it is not defined and "{_dev_redis_sock}" exists.
+if [ -S "${_dev_redis_sock}" ] && [ -z "${SEARXNG_REDIS_URL}" ]; then
+    export SEARXNG_REDIS_URL="unix://${_dev_redis_sock}?db=0"
+fi
+
 pylint.FILES() {
 
     # List files tagged by comment:
@@ -65,6 +71,8 @@ help() {
     cat <<EOF
 buildenv:
   rebuild ./utils/brand.env
+webapp.:
+  run       : run developer instance
 weblate.:
   push.translations: push translation changes from SearXNG to Weblate's counterpart
   to.translations: Update 'translations' branch with last additions from Weblate.
@@ -121,6 +129,10 @@ pygments.:
 EOF
     go.help
     static_help
+    cat <<EOF
+environment ...
+  SEARXNG_REDIS_URL : ${SEARXNG_REDIS_URL}
+EOF
 }
 
 

--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -16,7 +16,7 @@ Enable the plugin in ``settings.yml``:
 import re
 from flask import request
 
-from searx.shared import redisdb
+from searx import redisdb
 from searx.redislib import incr_sliding_window
 
 name = "Request limiter"

--- a/searx/redisdb.py
+++ b/searx/redisdb.py
@@ -7,8 +7,8 @@
 This implementation uses the :ref:`settings redis` setup from ``settings.yml``.
 A redis DB connect can be tested by::
 
-  >>> from searx.shared import redisdb
-  >>> redisdb.init()
+  >>> from searx import redisdb
+  >>> redisdb.initialize()
   True
   >>> db = redisdb.client()
   >>> db.set("foo", "bar")
@@ -30,7 +30,7 @@ OLD_REDIS_URL_DEFAULT_URL = 'unix:///usr/local/searxng-redis/run/redis.sock?db=0
 """This was the default Redis URL in settings.yml."""
 
 _CLIENT = None
-logger = logging.getLogger('searx.shared.redisdb')
+logger = logging.getLogger(__name__)
 
 
 def client() -> redis.Redis:

--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -14,7 +14,7 @@ from typing_extensions import TypedDict, Literal
 import redis.exceptions
 
 from searx import logger, settings, searx_debug
-from searx.shared.redisdb import client as get_redis_client
+from searx.redisdb import client as get_redis_client
 from searx.exceptions import SearxSettingsException
 from searx.search.processors import PROCESSORS
 from searx.search.checker import Checker

--- a/searx/search/checker/scheduler.py
+++ b/searx/search/checker/scheduler.py
@@ -17,7 +17,7 @@ import time
 import importlib
 from typing import Callable
 
-from searx.shared.redisdb import client as get_redis_client
+from searx.redisdb import client as get_redis_client
 from searx.redislib import lua_script_storage
 
 

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -174,7 +174,7 @@ SCHEMA = {
         'default_http_headers': SettingsValue(dict, {}),
     },
     'redis': {
-        'url': SettingsValue((None, False, str), False),
+        'url': SettingsValue((None, False, str), False, 'SEARXNG_REDIS_URL'),
     },
     'ui': {
         'static_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'static')),

--- a/searx/shared/__init__.py
+++ b/searx/shared/__init__.py
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: AGPL-3.0-or-later
-# lint: pylint
-"""Initialization of a *shared* storage.
-"""
-
-from . import redisdb

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -120,7 +120,7 @@ from searx.locales import (
 # renaming names from searx imports ...
 from searx.autocomplete import search_autocomplete, backends as autocomplete_backends
 from searx.languages import language_codes as languages
-from searx.shared.redisdb import initialize as redis_initialize
+from searx.redisdb import initialize as redis_initialize
 from searx.search import SearchWithPlugins, initialize as search_initialize
 from searx.network import stream as http_stream, set_context_network_name
 from searx.search.checker import get_result as checker_get_result

--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -295,7 +295,7 @@ In your instance, redis DB connector is configured at:
 
     ${redis_url}
 "
-    if searxng.instance.exec python -c "from searx.shared import redisdb; redisdb.initialize() or exit(42)"; then
+    if searxng.instance.exec python -c "from searx import redisdb; redisdb.initialize() or exit(42)"; then
         info_msg "SearXNG instance is able to connect redis DB."
         return
     fi
@@ -317,8 +317,8 @@ In your instance, redis DB connector is configured at:
             # fedora35 there is v2.0.20 installed --> no way to get additional
             # groups on fedora's tyrant mode.
             #
-            # ERROR:searx.shared.redis: [searxng (993)] can't connect redis DB ...
-            # ERROR:searx.shared.redis:   Error 13 connecting to unix socket: /usr/local/searxng-redis/run/redis.sock. Permission denied.
+            # ERROR:searx.redisdb: [searxng (993)] can't connect redis DB ...
+            # ERROR:searx.redisdb:   Error 13 connecting to unix socket: /usr/local/searxng-redis/run/redis.sock. Permission denied.
             # ERROR:searx.plugins.limiter: init limiter DB failed!!!
             #
             # $ ps -aef | grep '/usr/sbin/uwsgi --ini searxng.ini'

--- a/utils/searxng_check.py
+++ b/utils/searxng_check.py
@@ -26,8 +26,7 @@ if os.path.isfile(OLD_SETTING):
         ))
     warnings.warn(msg, DeprecationWarning)
 
-from searx.shared import redisdb
-from searx import get_setting
+from searx import redisdb, get_setting
 
 if not redisdb.initialize():
     warnings.warn("can't connect to redis DB at: %s" % get_setting('redis.url'), RuntimeWarning, stacklevel=2)


### PR DESCRIPTION
## What does this PR do?

* This first commit is the patch in this comment: https://github.com/searxng/searxng/pull/1945#issuecomment-1312001620
* The second commit moves `searx.shared.redisdb` to `searx.redisdb`.

## Why is this change important?

Clean up

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

In https://github.com/searxng/searxng/pull/1945#issuecomment-1312001620 one idea is stop SearXNG is the Redis connection can't be established. Reading the code, I'm meh :

```python
    except redis.exceptions.RedisError as e:
        _CLIENT = None
        _pw = pwd.getpwuid(os.getuid())
        msg = "[%s (%s)] can't connect redis DB ..."
        if redis_url == OLD_REDIS_URL_DEFAULT_URL and isinstance(e, redis.exceptions.ConnectionError):
            logger.exception(msg, _pw.pw_name, _pw.pw_uid)
            logger.info(
                "You can safely ignore the above Redis error if you don't use Redis. "
                "You can remove this error by setting redis.url to false in your settings.yml."
            )
        else:
            logger.fatal(msg, _pw.pw_name, _pw.pw_uid)
            sys.exit(1)
```

In webapp, the change from `redis_initialize()` to `redisdb.init()` can be done in another PR.

## Related issues

Related to:
* #1856
* #1945
