### PR TITLE
[fix] Deserialize preferences which are explicitly blank strings

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -441,7 +441,7 @@ class Preferences:
         """parse (base64) preferences from request (``flask.request.form['preferences']``)"""
         bin_data = decompress(urlsafe_b64decode(input_data))
         dict_data = {}
-        for x, y in parse_qs(bin_data.decode('ascii')).items():
+        for x, y in parse_qs(bin_data.decode('ascii'), keep_blank_values=True).items():
             dict_data[x] = y[0]
         self.parse_dict(dict_data)
 


### PR DESCRIPTION
Default behavior of urllib.parse_qs() is to treat a blank string as an undefined value. parse_qs() is used when preferences are read in from a URL, causing a failure to set user preference when the user's preference is a blank string.

## What does this PR do?

Change parse_qs in preference URL de-serialization to respect blank values.
Does not change behavior of undefined values (when preference has not changed by user.)

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

A blank string is a valid choice for some preferences (autocomplete and private engine token)

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

1. Set a preference which gets stored as a blank string (disable autocomplete or have no private engine token) and save.
2. Go to cookies and copy down a preferences URL.
3. Go back to preferences and change the earlier setting to something different and save.
4. Use the URL and see the old preference restored.
5. Repeat above without PR and see the old preference not restored.

## Related issues

Closes #1568
