### PR TITLE
Copy client connection kwargs before mutating

### DIFF
--- a/searx/shared/redisdb.py
+++ b/searx/shared/redisdb.py
@@ -47,7 +47,7 @@ def initialize():
         _CLIENT = redis.Redis.from_url(redis_url)
 
         # log the parameters as seen by the redis lib, without the password
-        kwargs = _CLIENT.get_connection_kwargs()
+        kwargs = _CLIENT.get_connection_kwargs().copy()
         kwargs.pop('password', None)
         kwargs = ' '.join([f'{k}={v!r}' for k, v in kwargs.items()])
         logger.info("connecting to Redis %s", kwargs)


### PR DESCRIPTION
## What does this PR do?

It copies the redis connection kwargs before mutating them.

## Why is this change important?

If Redis authentication is required, a password won't be used because it's been removed from the connection dict so it isn't logged.

## How to test this PR locally?

Set up redis with a password and check that the client still connects.

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
