### PR TITLE
Fix: don't crash when engine or name is missing in settings.yml

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -106,8 +106,12 @@ def load_engine(engine_data: dict) -> Optional[Engine]:
     - required attribute is not set :py:func:`is_missing_required_attributes`
 
     """
+    # pylint: disable=too-many-return-statements
 
-    engine_name = engine_data['name']
+    engine_name = engine_data.get('name')
+    if engine_name is None:
+        logger.error('An engine does not have a "name" field')
+        return None
     if '_' in engine_name:
         logger.error('Engine name contains underscore: "{}"'.format(engine_name))
         return None
@@ -118,7 +122,10 @@ def load_engine(engine_data: dict) -> Optional[Engine]:
         engine_data['name'] = engine_name
 
     # load_module
-    engine_module = engine_data['engine']
+    engine_module = engine_data.get('engine')
+    if engine_module is None:
+        logger.error('The "engine" field is missing for the engine named "{}"'.format(engine_name))
+        return None
     try:
         engine = load_module(engine_module + '.py', ENGINE_DIR)
     except (SyntaxError, KeyboardInterrupt, SystemExit, SystemError, ImportError, RuntimeError):

--- a/tests/unit/test_engines_init.py
+++ b/tests/unit/test_engines_init.py
@@ -53,3 +53,25 @@ class TestEnginesInit(SearxTestCase):
         self.assertIn('onions', engines.categories)
         self.assertIn('http://engine1.onion', engines.engines['engine1'].search_url)
         self.assertEqual(engines.engines['engine1'].timeout, 120.0)
+
+    def test_missing_name_field(self):
+        settings['outgoing']['using_tor_proxy'] = False
+        engine_list = [
+            {'engine': 'dummy', 'shortcut': 'e1', 'categories': 'general'},
+        ]
+        with self.assertLogs('searx.engines', level='ERROR') as cm:
+            engines.load_engines(engine_list)
+            self.assertEqual(len(engines.engines), 0)
+            self.assertEqual(cm.output, ['ERROR:searx.engines:An engine does not have a "name" field'])
+
+    def test_missing_engine_field(self):
+        settings['outgoing']['using_tor_proxy'] = False
+        engine_list = [
+            {'name': 'engine2', 'shortcut': 'e2', 'categories': 'onions'},
+        ]
+        with self.assertLogs('searx.engines', level='ERROR') as cm:
+            engines.load_engines(engine_list)
+            self.assertEqual(len(engines.engines), 0)
+            self.assertEqual(
+                cm.output, ['ERROR:searx.engines:The "engine" field is missing for the engine named "engine2"']
+            )


### PR DESCRIPTION
## What does this PR do?

SearXNG crashes if the engine or name fields are missing. With this commit, the app displays an error in the log and keeps loading.

## Why is this change important?

Without this PR, the error message is about a bug in the app rather a configuration error.

## How to test this PR locally?

See test scenario in https://github.com/searxng/searxng/issues/1951#issuecomment-1324741072

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #1951
