### PR TITLE
Fix: add trailing slash to duckduckgo url

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -18,7 +18,7 @@ from searx.network import get
 
 # about
 about = {
-    "website": 'https://lite.duckduckgo.com/lite',
+    "website": 'https://lite.duckduckgo.com/lite/',
     "wikidata_id": 'Q12805',
     "official_api_documentation": 'https://duckduckgo.com/api',
     "use_official_api": False,
@@ -46,7 +46,7 @@ language_aliases = {
 time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
 
 # search-url
-url = 'https://lite.duckduckgo.com/lite'
+url = 'https://lite.duckduckgo.com/lite/'
 url_ping = 'https://duckduckgo.com/t/sl_l'
 
 # match query's language to a region code that duckduckgo will accept


### PR DESCRIPTION
## What does this PR do?

Minor change to the duckduckgo url, adding a trailing slash.

## Why is this change important?

duckduckgo started blocking requests from SearXNG, possibly using the missing slash as the indicator that they are not coming from a real browser.

## How to test this PR locally?

Enable the duckduckgo engine and do a web search. You should not see a "access denied" error message anymore and duckduckgo results should show up. You should also be able to navigate between pages of results without the error.

## Author's checklist

N/A

## Related issues

Closes #1854
