### PR TITLE
Use fasttext-predict instead of fasttext(-wheel)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN apk add --no-cache -t build-dependencies \
     su-exec \
     python3 \
     py3-pip \
-    py3-numpy \
     libxml2 \
     libxslt \
     openssl \
@@ -44,8 +43,6 @@ RUN apk add --no-cache -t build-dependencies \
     uwsgi \
     uwsgi-python3 \
     brotli \
- && pip3 install --no-cache setuptools wheel \
- && sed -i s/fasttext-wheel/fasttext/ requirements.txt \
  && pip3 install --no-cache -r requirements.txt \
  && apk del build-dependencies \
  && rm -rf /root/.cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ setproctitle==1.3.2
 redis==4.4.0
 markdown-it-py==2.1.0
 typing_extensions==4.4.0
-fasttext-wheel==0.9.2
+fasttext-predict==0.9.2.1

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -15,7 +15,6 @@ from os.path import splitext, join
 from random import choice
 from html.parser import HTMLParser
 from urllib.parse import urljoin, urlparse
-import fasttext
 
 from lxml import html
 from lxml.etree import ElementBase, XPath, XPathError, XPathSyntaxError, _ElementStringResult, _ElementUnicodeResult
@@ -51,11 +50,8 @@ _STORAGE_UNIT_VALUE: Dict[str, int] = {
 _XPATH_CACHE: Dict[str, XPath] = {}
 _LANG_TO_LC_CACHE: Dict[str, Dict[str, str]] = {}
 
-_FASTTEXT_MODEL: Optional[fasttext.FastText._FastText] = None
+_FASTTEXT_MODEL: Optional["fasttext.FastText._FastText"] = None
 """fasttext model to predict laguage of a search term"""
-
-# Monkey patch: prevent fasttext from showing a (useless) warning when loading a model.
-fasttext.FastText.eprint = lambda x: None
 
 
 class _NotSetClass:  # pylint: disable=too-few-public-methods
@@ -630,9 +626,13 @@ def eval_xpath_getindex(elements: ElementBase, xpath_spec: XPathSpecType, index:
     return default
 
 
-def _get_fasttext_model() -> fasttext.FastText._FastText:
+def _get_fasttext_model() -> "fasttext.FastText._FastText":
     global _FASTTEXT_MODEL  # pylint: disable=global-statement
     if _FASTTEXT_MODEL is None:
+        import fasttext  # pylint: disable=import-outside-toplevel
+
+        # Monkey patch: prevent fasttext from showing a (useless) warning when loading a model.
+        fasttext.FastText.eprint = lambda x: None
         _FASTTEXT_MODEL = fasttext.load_model(str(data_dir / 'lid.176.ftz'))
     return _FASTTEXT_MODEL
 


### PR DESCRIPTION
## What does this PR do?

* use [fasttext-predict](https://github.com/searxng/fasttext-predict) :
  * fork of fasttext with only the predict method, drop everything else
  * less than 1MB on the disk (there is no external dependency)
  * the package has wheels and source (see #2028 )
* lazy load fasttext-predict: 
  * zero memory impact
  * load fasttext-predict for the checker or the language autodetection plugin
  * once loaded, it takes 5.5MB of RAM per worker (including the model).

## Why is this change important?

* Drop numpy dependency
* Fix installation issue

## How to test this PR locally?

* check the language autodetection works
* check the docker image size

## Author's checklist

* fasttext(-predict) is more than 200 time faster than langdetect. On a fast CPU:
    * fasttext(-predict): 0.02ms per call or even lower
    * langdetect: 3ms. It would surprise me if it raises to 30ms on a SBC like RaspberryPI. This won't be usable to check the languages of the results for example.
* langdetect uses about 2MB of RAM : with 4 workers, the fasttext-predict overhead is 14MB. I think it is reasonable since it is lazy loaded.
* I'm not sure how these issues / PR affect the SearXNG usage: 
  * https://github.com/Mimino666/langdetect/pull/33
  * https://github.com/Mimino666/langdetect/pull/40

* on the down side
    * fasttext-predict has to be compiled, fasttext-predict for various architecture (exceptions: arm/v7 and Apple Arm).
    * fasttext(-predict) has issue with CJK languages. Hopefully, there is a second model to deal with that: https://github.com/currentslab/fastlangid 

<details>
<summary>usage of fastlangid model</summary>

The fastlangid model is 1MB in RAM. So with 4 workers, the overhead is 18MB compare to langdetect (2 models + the fasttext package).

```python
from typing import Optional
import fasttext

UNCERTAIN_SETS = frozenset(('zh', 'ko', 'ja'))
CHINESE_FAMILY_CODES = frozenset(('zh-hant', 'zh-hans', 'zh-yue'))
MODEL_S_THRESHOLD = 0.93

def load_models(fasttext_model_path: str, fastlangid_model_path: Optional[str]) -> None:
    global FASTTEXT_MODEL, FASTLANGID_MODEL
    FASTTEXT_MODEL = fasttext.load_model(fasttext_model_path)
    if fastlangid_model_path:
        FASTLANGID_MODEL = fasttext.load_model(fastlangid_model_path)
    else:
        FASTLANGID_MODEL = None

def _label_to_lang(label):
    return label.split('__label__')[1]


def predict(text: str, min_probability: float = 0.3) -> Optional[str]:
    """
    * https://fasttext.cc/docs/en/language-identification.html
    * https://github.com/currentslab/fastlangid
    """
    if not isinstance(text, str):
        raise ValueError('text must a str')

    text = text.replace('\n', ' ')
    labels, probs = FASTTEXT_MODEL.predict(text, k=1)
    lang = _label_to_lang(labels[0]) if len(labels) > 0 else None

    if FASTLANGID_MODEL is not None:
        if lang in UNCERTAIN_SETS and probs[0] < MODEL_S_THRESHOLD:
            # lid.176.ftz models usually confuse chinese, korean, japanese words
            # if the model is not so sure we pass to our model to reduce down the uncertainty
            labels2, probs2 = FASTLANGID_MODEL.predict(text, k=1)
            return _label_to_lang(labels2[0]) if len(labels2) > 0 and probs2[0] > min_probability else None

        if lang == 'zh' and probs[0] >= MODEL_S_THRESHOLD:
            # predict chinese: now we want to know which chinese family it belongs
            labels2, probs2 = FASTLANGID_MODEL.predict(text, k=10)
            for label, prob in zip(labels2, probs2):
                lang = _label_to_lang(label)
                if lang in CHINESE_FAMILY_CODES and prob > min_probability :
                    return lang
            return 'zh' if probs[0] > min_probability else None

    return lang if probs[0] > min_probability else None

if __name__ == '__main__':
    load_models('lid.176.ftz', 'model_s.ftz')
    assert 'fr' == predict('L\'oiseau bleu est tombé du nid')    
    assert 'en' == predict('To Kill a Mockingbird')
    assert 'ja' == predict('2022年4月6日 (水) よりYahoo! JAPANは欧州経済領域（EEA)')
    assert 'zh-hant' == predict('2K 也決定從 NVIDIA GeForce Now 平台撤出')
    assert 'zh-hans' == predict('沈义人:OPPO Find X2系列缎黑等配色会逐渐补货,开售当日会加货')
```
</details>

Some articles about language detection:
* https://github.com/pemistahl/lingua-py#42-word-pair-detection but requires 800MB of memory.
* https://towardsdatascience.com/benchmarking-language-detection-for-nlp-8250ea8b67c
* https://medium.com/besedo-engineering/language-identification-for-very-short-texts-a-review-c9f2756773ad

## Related issues

Related to:
* https://github.com/searxng/searxng/issues/2033
* https://github.com/searxng/searxng/issues/2028
