### PR TITLE
Fix checksum virtualenv checks.

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -600,7 +600,7 @@ pyenv.OK() {
     fi
 
     if [ ! -f "${PY_ENV}/requirements.sha256" ] \
-        || ! sha256sum --check --status <"${PY_ENV}/requirements.sha256" 2>/dev/null; then
+        || ! sha256sum -c "${PY_ENV}/requirements.sha256" > /dev/null 2>&1; then
         build_msg PYENV "[virtualenv] requirements.sha256 failed"
         sed 's/^/          [virtualenv] - /' <"${PY_ENV}/requirements.sha256"
         return 1


### PR DESCRIPTION
There's already precedence for not using GNUism sha256sum longopts as seen in searxng/utils/lib_go.sh so update lib.sh to not use them either. A nice side effect is now the sha256sum usage doesn't care if you're using BSD sha256sum or GNU sha256sum which makes this work under FreeBSD.

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Removes a dependency on GNUism longopts when using sha256sum keeping the intended action as before but allowing for the use of sha256sum to work on platforms that do not use a GNU sha256sum. The intent we got from the usage was that it was wanted that the program's output be ignored and exit code read only.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

It is wanted that the build tooling work on FreeBSD (by myself, possibly others) such that we may contribute to the project. This change set renders SearXNG agnostic to the kind of sha256sum program being used so long as it supports the common shortopts and is functionally equivalent making it such that one not need install a GNU sha256sum into their `$PATH` just to be able to do `make run`.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

The way I tested it was with the following steps (under FreeBSD):
1. Ensure /sbin/sha256sum is the in use sha256sum.
2. `make clean; make run` and see that there is no failure related to sha256sum (or in one case that I now forget, an infinite loop of build env).
3. `make run` and ensure that environment build is in essence skipped.
4. remove one line from requirements.txt
5. `make clean; make run` and ensure that the environment is being rebuilt.
6. add back removed line in requirements.txt
7. symlink gsha256sum (GNU's sha256sum under FreeBSD) into a directory in `$PATH` with precedence as sha256sum ensuring that it becomes the utilized sha256sum (check with `which sha256sum`)
8. repeat steps 2 through 6

## Author's checklist

<!-- additional notes for reviewiers -->

Can't think of anything otherwise needing checking here but let me know and I'll check.

## Related issues

Part of the motivation for this PR is to aid in #1418, #2069, #2067.
<!--
Closes #234
-->
