### PR TITLE
Add HTTP Referer header to DuckDuckGo requests

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -73,6 +73,7 @@ def request(query, params):
     # link again and again ..
 
     params['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
+    params['headers']['Referer'] = 'https://lite.duckduckgo.com/'
 
     # initial page does not have an offset
     if params['pageno'] == 2:


### PR DESCRIPTION
## What does this PR do?

Adds an HTTP Referer header to DuckDuckGo requests

## Why is this change important?

DuckDuckGo started rejecting requests without this header.

## How to test this PR locally?

Enable DuckDuckGo and do a search, you should see no "access denied" error message, DDG result should be showing up, and you should be able to page through results.

## Author's checklist

N/A

## Related issues

Closes #2080 