### PR TITLE
[simple theme] set tab index for search page input field #1891

### DIFF
--- a/searx/templates/simple/search.html
+++ b/searx/templates/simple/search.html
@@ -6,7 +6,7 @@
     </a>
     <div id="search_view">
       <div class="search_box">
-        <input id="q" name="q" type="text" placeholder="{{ _('Search for...') }}" autocomplete="off" autocapitalize="none" spellcheck="false" autocorrect="off" dir="auto" value="{{ q or '' }}">
+        <input id="q" name="q" type="text" placeholder="{{ _('Search for...') }}" tabindex="1" autocomplete="off" autocapitalize="none" spellcheck="false" autocorrect="off" dir="auto" value="{{ q or '' }}">
         <button id="clear_search" type="reset" aria-label="{{ _('clear') }}" class="hide_if_nojs"><span>{{ icon_big('close') }}</span><span class="show_if_nojs">{{ _('clear') }}</span></button>
         <button id="send_search" type="submit" aria-label="{{ _('search') }}"><span class="hide_if_nojs">{{ icon_big('search-outline') }}</span><span class="show_if_nojs">{{ _('search') }}</span></button>
       </div>


### PR DESCRIPTION
## What does this PR do?

Improve UX by focusing search input element on search results page with one TAB key press.

## Why is this change important?

Currently it takes 5 TAB keypresses to reach search input on search results page, which is rather tedious.

## How to test this PR locally?

## Author's checklist

## Related issues

Closes #1891