### PR TITLE
Added a check to see if the element contains links

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -9,7 +9,7 @@
 import re
 from urllib.parse import urlencode, urlparse, parse_qs
 from lxml import html
-from searx.utils import eval_xpath, extract_text, eval_xpath_list, match_language
+from searx.utils import eval_xpath, extract_text, eval_xpath_list, match_language, eval_xpath_getindex
 from searx.network import multi_requests, Request
 
 about = {
@@ -84,9 +84,12 @@ def response(resp):
 
     url_to_resolve = []
     url_to_resolve_index = []
-    for i, result in enumerate(eval_xpath_list(dom, '//li[contains(@class, "b_algo")]')):
+    i = 0
+    for result in eval_xpath_list(dom, '//ol[@id="b_results"]/li[contains(@class, "b_algo")]'):
 
-        link = eval_xpath(result, './/h2/a')[0]
+        link = eval_xpath_getindex(result, './/h2/a', 0, None)
+        if link is None:
+            continue
         url = link.attrib.get('href')
         title = extract_text(link)
 
@@ -119,6 +122,8 @@ def response(resp):
 
         # append result
         results.append({'url': url, 'title': title, 'content': content})
+        # increment result pointer for the next iteration in this loop
+        i += 1
 
     # resolve all Bing redirections in parallel
     request_list = [


### PR DESCRIPTION
## What does this PR do?

Add a simple conditional `if` to check first if each search elements contain a link before proceeding to process that element. This fixes the `IndexError` caused by some elements in Bing search results not containing any links.

## Why is this change important?

Following [this fix](https://github.com/searxng/searxng/commit/9ee99423fe22550ef566245ef23e2a9e8ee76c27), specifically this line: 

https://github.com/searxng/searxng/blob/4e735b289b2a71583664e214e45aafccd0b85bfc/searx/engines/bing.py#L87

An Issue (#2087) was raised wherein Bing search results would include some elements that do not contain any link. This would cause the follow-up processes to crash, specifically on this line: 

https://github.com/searxng/searxng/blob/4e735b289b2a71583664e214e45aafccd0b85bfc/searx/engines/bing.py#L89

because it would expect a link element from the list but instead, it encountered an empty list. To prevent this, a simple conditional is thus added to check if the list is empty or not.

## How to test this PR locally?

Pull the branch with the latest commit of this PR locally, then run `make run`.

Alternatively, build a docker image locally and run it:

```docker
docker build -t $IMGNAME -f Dockerfile .
docker run -p $PORT:$PORT $IMGNAME:latest
```

Then do some searches using !bi flag, especially these two queries from which the Issue was raised:

`!bi certbot`
`!bi current events`

## Author's checklist

## Related issues

Closes #2087 