### PR TITLE
Bugfix/mojeek parsing

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1706,12 +1706,12 @@ engines:
     engine: xpath
     paging: true
     categories: [general, web]
-    search_url: https://www.mojeek.com/search?q={query}&s={pageno}
-    results_xpath: //a[@class="ob"]
+    search_url: https://www.mojeek.com/search?q={query}&s={pageno}&lang={lang}&lb={lang}
+    results_xpath: //ul[@class="results-standard"]/li/a[@class="ob"]
     url_xpath: ./@href
-    title_xpath: ./h2
-    content_xpath: ../p[@class="s"]
-    suggestion_xpath: /html/body//div[@class="top-info"]/p[@class="top-info spell"]/a
+    title_xpath: ../h2/a
+    content_xpath: ..//p[@class="s"]
+    suggestion_xpath: //div[@class="top-info"]/p[@class="top-info spell"]/em/a
     first_page_num: 0
     page_size: 10
     disabled: true


### PR DESCRIPTION
## What does this PR do?
This PR fix an issue with mojeek not showing results when using `!mjk` and shows the suggestions incase the user type it in correctly

## Why is this change important?
This change is important as the issue #2046  has been open and users cannot use mojeek.

## How to test this PR locally?
`!mjk how to cook `
and for suggestion type in  `!mjk faceeboook`

The search results are identical.

## Author's checklist
I'm slighty confused by the categories section in the settings.yml 1708. Look at docs and mojeek but I didn't understand what it is for. It returns a 403
<!-- additional notes for reviewiers -->
`172.17.0.1 - - [09/Jan/2023 06:46:03] "GET /search?q=!mjk%20how%20to%20cook%20&categories=none&pageno=1&time_range=None&language=en-US&safesearch=2&format=rss HTTP/1.1" 403 -`
## Related issues
Closes #2046 
