### PR TITLE
Adjust uWSGI workers and threads from env

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -61,6 +61,12 @@ echo "SearXNG version ${SEARXNG_VERSION}"
 # helpers to update the configuration files
 patch_uwsgi_settings() {
     CONF="$1"
+
+    # update uwsg.ini
+    sed -i \
+        -e "s|workers = .*|workers = ${UWSGI_WORKERS:-%k}|g" \
+        -e "s|threads = .*|threads = ${UWSGI_THREADS:-4}|g" \
+        "${CONF}"
 }
 
 patch_searxng_settings() {


### PR DESCRIPTION
## What does this PR do?

Makes the uWSGI worker count (and thread count) configurable from an env variable. According to https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#environment-variables even more variables could be added to this later on if needed.

## Why is this change important?

The [current worker count setting is %k](https://github.com/searxng/searxng/blob/master/dockerfiles/uwsgi.ini), which is the amount of cores detected, but since uWSGI workers consume about 150-200M of RAM, a system with lots of cores can explode in RAM consumption.

## How to test this PR locally?

Rebuild the Docker image and set any of the `UWSGI_WORKERS` or `UWSGI_THREADS` env variables. See the replacement result at `/etc/searxng/uwsgi.ini`. 

Or you can run the sed manually from the container's shell. No matter if you define 0, 1 or both variables, the sed always work, it keeps the defaults when no values are assigned to the env vars.

## Author's checklist

I tested the sed in a running container.

## Related issues

Closes https://github.com/searxng/searxng/issues/2096
Closes https://github.com/searxng/searxng/issues/447
