### PR TITLE
Add goo engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1967,6 +1967,26 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name: goo
+    shortcut: goo
+    engine: xpath
+    paging: true
+    search_url: https://search.goo.ne.jp/web.jsp?MT={query}&FR={pageno}0
+    url_xpath: //div[@class="result"]/p[@class='title fsL1']/a/@href
+    title_xpath: //div[@class="result"]/p[@class='title fsL1']/a
+    content_xpath: //p[contains(@class,'url fsM')]/following-sibling::p
+    first_page_num: 0
+    categories: [general, web]
+    disabled: true
+    timeout: 4.0
+    about:
+      website: https://search.goo.ne.jp
+      wikidata_id: Q249044
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+      language: ja
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name: ubuntuwiki


### PR DESCRIPTION
## What does this PR do?
Add a goo engine to SearXNG.
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
goo is a Japanese search engine and uses Google results.<br>
 This is useful for those who want to use Google results when SeaerXNG receives a reCAPTCHA from other search engines such as Google or Startpage.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
1. Build SearXNG
2. Enable goo engine from the settings
3. Do some search and make sure the engine has been added.


## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues
Closes #1374

