### PR TITLE
Standalone words highlighting for query result in non-CJK characters

### DIFF
--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -124,13 +124,14 @@ def contains_cjko(s: str) -> bool:
     Returns:
         bool: True if the input s contains the characters and False otherwise.
     """
-    unicode_ranges = ('\u4e00-\u9fff' # Chinese characters
-                      '\u3040-\u309f' # Japanese hiragana
-                      '\u30a0-\u30ff' # Japanese katakana
-                      '\u4e00-\u9faf' # Japanese kanji
-                      '\uac00-\ud7af' # Korean hangul syllables
-                      '\u1100-\u11ff' # Korean hangul jamo
-                      )
+    unicode_ranges = (
+        '\u4e00-\u9fff'  # Chinese characters
+        '\u3040-\u309f'  # Japanese hiragana
+        '\u30a0-\u30ff'  # Japanese katakana
+        '\u4e00-\u9faf'  # Japanese kanji
+        '\uac00-\ud7af'  # Korean hangul syllables
+        '\u1100-\u11ff'  # Korean hangul jamo
+    )
     return bool(re.search(fr'[{unicode_ranges}]', s))
 
 
@@ -168,7 +169,9 @@ def highlight_content(content, query):
     querysplit = query.split()
     queries = []
     for qs in querysplit:
-        queries.extend(re.findall(regex_highlight_cjk(qs), content, flags=re.I | re.U))
+        qs = qs.replace("'", "").replace('"', '').replace(" ", "")
+        if len(qs) > 0:
+            queries.extend(re.findall(regex_highlight_cjk(qs), content, flags=re.I | re.U))
     if len(queries) > 0:
         for q in set(queries):
             content = re.sub(regex_highlight_cjk(q), f'<span class="highlight">{q}</span>', content)

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -113,31 +113,65 @@ def prettify_url(url, max_length=74):
         return url
 
 
+def contains_cjko(s: str) -> bool:
+    """This function check whether or not a string contains Chinese, Japanese,
+    or Korean characters. It employs regex and uses the u escape sequence to
+    match any character in a set of Unicode ranges.
+
+    Args:
+        s (str): string to be checked.
+
+    Returns:
+        bool: True if the input s contains the characters and False otherwise.
+    """
+    unicode_ranges = ('\u4e00-\u9fff' # Chinese characters
+                      '\u3040-\u309f' # Japanese hiragana
+                      '\u30a0-\u30ff' # Japanese katakana
+                      '\u4e00-\u9faf' # Japanese kanji
+                      '\uac00-\ud7af' # Korean hangul syllables
+                      '\u1100-\u11ff' # Korean hangul jamo
+                      )
+    return bool(re.search(fr'[{unicode_ranges}]', s))
+
+
+def regex_highlight_cjk(word: str) -> str:
+    """Generate the regex pattern to match for a given word according
+    to whether or not the word contains CJK characters or not.
+    If the word is and/or contains CJK character, the regex pattern
+    will match standalone word by taking into account the presence
+    of whitespace before and after it; if not, it will match any presence
+    of the word throughout the text, ignoring the whitespace.
+
+    Args:
+        word (str): the word to be matched with regex pattern.
+
+    Returns:
+        str: the regex pattern for the word.
+    """
+    rword = re.escape(word)
+    if contains_cjko(rword):
+        return fr'({rword})'
+    else:
+        return fr'\b({rword})(?!\w)'
+
+
 def highlight_content(content, query):
 
     if not content:
         return None
+
     # ignoring html contents
     # TODO better html content detection
     if content.find('<') != -1:
         return content
 
-    if content.lower().find(query.lower()) > -1:
-        query_regex = '({0})'.format(re.escape(query))
-        content = re.sub(query_regex, '<span class="highlight">\\1</span>', content, flags=re.I | re.U)
-    else:
-        regex_parts = []
-        for chunk in query.split():
-            chunk = chunk.replace('"', '')
-            if len(chunk) == 0:
-                continue
-            elif len(chunk) == 1:
-                regex_parts.append('\\W+{0}\\W+'.format(re.escape(chunk)))
-            else:
-                regex_parts.append('{0}'.format(re.escape(chunk)))
-        query_regex = '({0})'.format('|'.join(regex_parts))
-        content = re.sub(query_regex, '<span class="highlight">\\1</span>', content, flags=re.I | re.U)
-
+    querysplit = query.split()
+    queries = []
+    for qs in querysplit:
+        queries.extend(re.findall(regex_highlight_cjk(qs), content, flags=re.I | re.U))
+    if len(queries) > 0:
+        for q in set(queries):
+            content = re.sub(regex_highlight_cjk(q), f'<span class="highlight">{q}</span>', content)
     return content
 
 

--- a/tests/unit/test_webutils.py
+++ b/tests/unit/test_webutils.py
@@ -28,32 +28,33 @@ class TestWebUtils(SearxTestCase):
 
         content = 'a'
         query = 'test'
-        self.assertEqual(webutils.highlight_content(content, query), content)
+        self.assertEqual(webutils.highlight_content(content, query), 'a')
         query = 'a test'
-        self.assertEqual(webutils.highlight_content(content, query), content)
+        self.assertEqual(webutils.highlight_content(content, query), '<span class="highlight">a</span>')
 
         data = (
             ('" test "', 'a test string', 'a <span class="highlight">test</span> string'),
-            ('"a"', 'this is a test string', 'this is<span class="highlight"> a </span>test string'),
+            ('"a"', 'this is a test string', 'this is <span class="highlight">a</span> test string'),
             (
                 'a test',
                 'this is a test string that matches entire query',
-                'this is <span class="highlight">a test</span> string that matches entire query',
+                'this is <span class="highlight">a</span> <span class="highlight">test</span> string that matches entire query',
             ),
             (
                 'this a test',
                 'this is a string to test.',
                 (
-                    '<span class="highlight">this</span> is<span class="highlight"> a </span>'
-                    'string to <span class="highlight">test</span>.'
+                    '<span class="highlight">this</span> is <span class="highlight">a</span> string to <span class="highlight">test</span>.'
                 ),
             ),
             (
                 'match this "exact phrase"',
                 'this string contains the exact phrase we want to match',
-                (
-                    '<span class="highlight">this</span> string contains the <span class="highlight">exact</span>'
-                    ' <span class="highlight">phrase</span> we want to <span class="highlight">match</span>'
+                ''.join(
+                    [
+                        '<span class="highlight">this</span> string contains the <span class="highlight">exact</span> ',
+                        '<span class="highlight">phrase</span> we want to <span class="highlight">match</span>',
+                    ]
                 ),
             ),
         )


### PR DESCRIPTION
## What does this PR do?

Modifying the content highlight to become only full or standalone words for query results in non-CJK (Chinese, Japanese, and Korean) characters. 

## Why is this change important?

During searches using non-CJK languages/characters, such as English, query letters got emphasized even in the middle of another unrelated word on the search page. Examples can be found when doing some searches using alphabetic, English words with all language flag, such as `the :all`, `java :all`, `master :all`. The expected result should be that only standalone words are highlighted.

For example, `master` in `master of science` should be highlighted, while  `master` in `grandmaster` shouldn't.

By modifying the `highlight_content()` function in `webutils.py`, and adding a function that will recognize if the query contains CJK characters or not, the query highlight will still work for words enclosed by other characters for the CJK letters, whereas for the other languages, it will only be highlighted if the words aren't enclosed by other characters.

Some screenshots of the results:

| ![screenshot-127 0 0 1_8888-2023 01 15-21_19_06](https://user-images.githubusercontent.com/22837764/212565726-f26c85fd-5996-4355-bb03-b0ce616b0b9a.png) |
| --- |
| query: `the :all`. Notice that the `the` in `otherwise` is no longer highlighted |

| ![screenshot-127 0 0 1_8888-2023 01 15-21_21_40](https://user-images.githubusercontent.com/22837764/212565793-1b869b36-4b3c-489c-82b0-5e5ad6d96849.png) |
| --- |
| query: `master :all`. Notice the `master` instances in the `MasterPlus+` content aren't highlighted because they're not standalone words |

| ![screenshot-127 0 0 1_8888-2023 01 15-21_24_50](https://user-images.githubusercontent.com/22837764/212565880-06d82544-5021-414b-a674-9cc5c934ce41.png) |
| --- |
| query: `村上春樹 books`. Notice the query word in kanji characters are highlighted even when they are enclosed by other letters, while the `books` is not. |

## How to test this PR locally?

Pull the branch with the latest commit of this PR locally, then run `make run`.

Alternatively, build a docker image locally and run it:

```shell
docker build -t $IMGNAME -f Dockerfile .
docker run -p $PORT:$PORT $IMGNAME:latest
```

Then, do some searches using queries such as `the :all`, `java :all`, and `master :all`.

## Author's checklist

+ Because of the change of the `highlight_content()` function, the test codes for the `test_highlight_content` (done during `make test`) were also modified

## Related issues

Closes #2095 