### PR TITLE
fix: typo in suggestions

### DIFF
--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -65,7 +65,7 @@
 
         {% if suggestions %}
         <div id="suggestions" role="complementary" aria-labelledby="suggestions-title">
-	  <h4 class="title" id="suggestions-title">{{ _('Suggestions') }} : </h4>
+	  <h4 class="title" id="suggestions-title">{{ _('Suggestions') }}: </h4>
 	  <div class="wrapper">
             {% for suggestion in suggestions %}
             <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">


### PR DESCRIPTION
## What does this PR do?

Removes the extra space in the simple theme's suggestions box
![image](https://user-images.githubusercontent.com/26145882/212861983-eaa94d52-4ccb-4812-b82d-507ae6cd7219.png)

## Why is this change important?

It's driving me insane

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
