### PR TITLE
Version number follows PEP440 : replace - by +

### DIFF
--- a/searx/version.py
+++ b/searx/version.py
@@ -59,7 +59,7 @@ def get_git_url_and_branch():
 
 
 def get_git_version():
-    git_commit_date_hash = subprocess_run(r"git show -s --date='format:%Y.%m.%d' --format='%cd-%h'")
+    git_commit_date_hash = subprocess_run(r"git show -s --date='format:%Y.%m.%d' --format='%cd+%h'")
     tag_version = git_version = git_commit_date_hash
 
     # add "-dirty" suffix if there are uncommited changes except searx/settings.yml
@@ -67,7 +67,7 @@ def get_git_version():
         subprocess_run("git diff --quiet -- . ':!searx/settings.yml' ':!utils/brand.env'")
     except subprocess.CalledProcessError as e:
         if e.returncode == 1:
-            git_version += "-dirty"
+            git_version += "+dirty"
         else:
             logger.warning('"%s" returns an unexpected return code %i', e.returncode, e.cmd)
     return git_version, tag_version


### PR DESCRIPTION
## What does this PR do?

Version like `2023-01-16-a432ab65` is invalid, `2023-01-16+a432ab65` is valid.

See https://peps.python.org/pep-0440/#local-version-identifiers

## Why is this change important?

Allow to install SearXNG

## How to test this PR locally?

* `make install`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Close #2111