### PR TITLE
SearXNG version: fix make docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ gh-pages/
 /node_modules/
 
 .idea/
+
+searx/version_frozen.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN su searxng -c "/usr/bin/python3 -m compileall -q searx" \
 ARG LABEL_DATE=
 ARG GIT_URL=unknown
 ARG SEARXNG_GIT_VERSION=unknown
+ARG SEARXNG_DOCKER_TAG=unknown
 ARG LABEL_VCS_REF=
 ARG LABEL_VCS_URL=
 LABEL maintainer="searxng <${GIT_URL}>" \
@@ -79,7 +80,7 @@ LABEL maintainer="searxng <${GIT_URL}>" \
       org.label-schema.build-date="${LABEL_DATE}" \
       org.label-schema.usage="https://github.com/searxng/searxng-docker" \
       org.opencontainers.image.title="searxng" \
-      org.opencontainers.image.version="${SEARXNG_GIT_VERSION}" \
+      org.opencontainers.image.version="${SEARXNG_DOCKER_TAG}" \
       org.opencontainers.image.url="${LABEL_VCS_URL}" \
       org.opencontainers.image.revision=${LABEL_VCS_REF} \
       org.opencontainers.image.source=${LABEL_VCS_URL} \

--- a/manage
+++ b/manage
@@ -478,7 +478,7 @@ docker.build() {
         eval "$(python -m searx.version)"
 
         # Get the last git commit id
-        VERSION_GITCOMMIT=$(echo "$VERSION_STRING" | cut -d- -f3)
+        VERSION_GITCOMMIT=$(echo "$VERSION_TAG" | cut -d+ -f2)
         build_msg DOCKER "Last commit : $VERSION_GITCOMMIT"
 
         # define the docker image name
@@ -500,6 +500,7 @@ docker.build() {
         docker $BUILD \
          --build-arg BASE_IMAGE="${DEPENDENCIES_IMAGE_NAME}" \
          --build-arg GIT_URL="${GIT_URL}" \
+         --build-arg SEARXNG_DOCKER_TAG="${DOCKER_TAG}" \
          --build-arg SEARXNG_GIT_VERSION="${VERSION_STRING}" \
          --build-arg VERSION_GITCOMMIT="${VERSION_GITCOMMIT}" \
          --build-arg LABEL_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
@@ -507,11 +508,11 @@ docker.build() {
          --build-arg LABEL_VCS_URL="${GIT_URL}" \
          --build-arg TIMESTAMP_SETTINGS="$(git log -1 --format="%cd" --date=unix -- searx/settings.yml)" \
          --build-arg TIMESTAMP_UWSGI="$(git log -1 --format="%cd" --date=unix -- dockerfiles/uwsgi.ini)" \
-         -t "${SEARXNG_IMAGE_NAME}:latest" -t "${SEARXNG_IMAGE_NAME}:${VERSION_STRING}" .
+         -t "${SEARXNG_IMAGE_NAME}:latest" -t "${SEARXNG_IMAGE_NAME}:${DOCKER_TAG}" .
 
         if [ "$1" = "push" ]; then
 	        docker push "${SEARXNG_IMAGE_NAME}:latest"
-	        docker push "${SEARXNG_IMAGE_NAME}:${SEARXNG_GIT_VERSION}"
+	        docker push "${SEARXNG_IMAGE_NAME}:${DOCKER_TAG}"
 	    fi
     )
     dump_return $?

--- a/searx/version.py
+++ b/searx/version.py
@@ -62,7 +62,7 @@ def get_git_version():
     git_commit_date_hash = subprocess_run(r"git show -s --date='format:%Y.%m.%d' --format='%cd+%h'")
     tag_version = git_version = git_commit_date_hash
 
-    # add "-dirty" suffix if there are uncommited changes except searx/settings.yml
+    # add "+dirty" suffix if there are uncommited changes except searx/settings.yml
     try:
         subprocess_run("git diff --quiet -- . ':!searx/settings.yml' ':!utils/brand.env'")
     except subprocess.CalledProcessError as e:
@@ -70,16 +70,23 @@ def get_git_version():
             git_version += "+dirty"
         else:
             logger.warning('"%s" returns an unexpected return code %i', e.returncode, e.cmd)
-    return git_version, tag_version
+    docker_tag = git_version.replace("+", "-")
+    return git_version, tag_version, docker_tag
 
 
 try:
     vf = importlib.import_module('searx.version_frozen')
-    VERSION_STRING, VERSION_TAG, GIT_URL, GIT_BRANCH = vf.VERSION_STRING, vf.VERSION_TAG, vf.GIT_URL, vf.GIT_BRANCH
+    VERSION_STRING, VERSION_TAG, DOCKER_TAG, GIT_URL, GIT_BRANCH = (
+        vf.VERSION_STRING,
+        vf.VERSION_TAG,
+        vf.DOCKER_TAG,
+        vf.GIT_URL,
+        vf.GIT_BRANCH,
+    )
 except ImportError:
     try:
         try:
-            VERSION_STRING, VERSION_TAG = get_git_version()
+            VERSION_STRING, VERSION_TAG, DOCKER_TAG = get_git_version()
         except subprocess.CalledProcessError as ex:
             logger.error("Error while getting the version: %s", ex.stderr)
         try:
@@ -102,6 +109,7 @@ if __name__ == "__main__":
 
 VERSION_STRING = "{VERSION_STRING}"
 VERSION_TAG = "{VERSION_TAG}"
+DOCKER_TAG = "{DOCKER_TAG}"
 GIT_URL = "{GIT_URL}"
 GIT_BRANCH = "{GIT_BRANCH}"
 """
@@ -114,6 +122,7 @@ GIT_BRANCH = "{GIT_BRANCH}"
         shell_code = f"""
 VERSION_STRING="{VERSION_STRING}"
 VERSION_TAG="{VERSION_TAG}"
+DOCKER_TAG="{DOCKER_TAG}"
 GIT_URL="{GIT_URL}"
 GIT_BRANCH="{GIT_BRANCH}"
 """


### PR DESCRIPTION
## What does this PR do?

* Docker tags can't contains `+`.
* Python package version can't contains `-`.
* #2117 breaks `make docker`.
 
This PR:
* fixes the Docker tag using an additional variable `DOCKER_TAG`, see `searx/version.py`:
* fixes the Docker labels `org.label-schema.vcs-ref` and `org.opencontainers.image.revision`
* adds `searx/version_frozen` to `.gitignore`

Output example of `python -m searx.version` :

```
VERSION_STRING="2023.01.20+379768442"
VERSION_TAG="2023.01.20+379768442"
DOCKER_TAG="2023.01.20-379768442"
GIT_URL="https://github.com/dalf/searxng"
GIT_BRANCH="fix_version_continuation"
```

## Why is this change important?

Fix docker build

## How to test this PR locally?

1. `make docker`
2. Check:
   * `./local/py3/bin/python -m searx.version freeze`
   * `make run` 

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

continuation of #2117
related to #2111
