### PR TITLE
weblate: migration to https://translate.codeberg.org/

### DIFF
--- a/.weblate
+++ b/.weblate
@@ -1,3 +1,3 @@
 [weblate]
-url = https://weblate.bubu1.eu/api/
+url = https://translate.codeberg.org/api/
 translation = searxng/searxng

--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,8 @@ our homepage_.
 .. |commits| image:: https://img.shields.io/github/commit-activity/y/searxng/searxng?color=yellow&label=commits
    :target: https://github.com/searxng/searxng/commits/master
 
-.. |weblate| image:: https://weblate.bubu1.eu/widgets/searxng/-/searxng/svg-badge.svg
-   :target: https://weblate.bubu1.eu/projects/searxng/
+.. |weblate| image:: https://translate.codeberg.org/widgets/searxng/-/searxng/svg-badge.svg
+   :target: https://translate.codeberg.org/projects/searxng/
 
 
 Contact
@@ -134,7 +134,7 @@ Contributing is easier
 .. _Morty: https://github.com/asciimoo/morty
 .. _Filtron: https://github.com/searxng/filtron
 .. _limiter: https://docs.searxng.org/src/searx.plugins.limiter.html
-.. _Weblate: https://weblate.bubu1.eu/projects/searxng/searxng/
+.. _Weblate: https://translate.codeberg.org/projects/searxng/searxng/
 .. _Development Quickstart: https://docs.searxng.org/dev/quickstart.html
 
 
@@ -142,10 +142,10 @@ Translations
 ============
 
 We need translators, suggestions are welcome at
-https://weblate.bubu1.eu/projects/searxng/searxng/
+https://translate.codeberg.org/projects/searxng/searxng/
 
-.. figure:: https://weblate.bubu1.eu/widgets/searxng/-/multi-auto.svg
-   :target: https://weblate.bubu1.eu/projects/searxng/
+.. figure:: https://translate.codeberg.org/widgets/searxng/-/multi-auto.svg
+   :target: https://translate.codeberg.org/projects/searxng/
 
 
 Make a donation

--- a/docs/dev/translation.rst
+++ b/docs/dev/translation.rst
@@ -4,15 +4,15 @@
 Translation
 ===========
 
-.. _weblate.bubu1.eu: https://weblate.bubu1.eu/projects/searxng/
+.. _translate.codeberg.org: https://translate.codeberg.org/projects/searxng/
 .. _Weblate: https://docs.weblate.org
 .. _translations branch: https://github.com/searxng/searxng/tree/translations
 .. _orphan branch: https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt---orphanltnewbranchgt
-.. _Weblate repository: https://weblate.bubu1.eu/projects/searxng/searxng/#repository
+.. _Weblate repository: https://translate.codeberg.org/projects/searxng/searxng/#repository
 .. _wlc: https://docs.weblate.org/en/latest/wlc.html
 
-.. |translated| image:: https://weblate.bubu1.eu/widgets/searxng/-/searxng/svg-badge.svg
-   :target: https://weblate.bubu1.eu/projects/searxng/
+.. |translated| image:: https://translate.codeberg.org/widgets/searxng/-/searxng/svg-badge.svg
+   :target: https://translate.codeberg.org/projects/searxng/
 
 .. sidebar:: |translated|
 
@@ -24,11 +24,11 @@ Translation
    - Babel Command-Line: `pybabel <http://babel.pocoo.org/en/latest/cmdline.html>`_
    - `weblate workflow <https://docs.weblate.org/en/latest/workflows.html>`_
 
-Translation takes place on weblate.bubu1.eu_.
+Translation takes place on translate.codeberg.org_.
 
-Translations which has been added by translators on the weblate.bubu1.eu_ UI are
+Translations which has been added by translators on the translate.codeberg.org_ UI are
 committed to Weblate's counterpart of the SearXNG *origin* repository which is
-located at ``https://weblate.bubu1.eu/git/searxng/searxng``.
+located at ``https://translate.codeberg.org/git/searxng/searxng``.
 
 There is no need to clone this repository, :ref:`SearXNG Weblate workflow` take
 care of the synchronization with the *origin*.  To avoid merging commits from
@@ -68,7 +68,7 @@ wlc
 ===
 
 .. _wlc configuration: https://docs.weblate.org/en/latest/wlc.html#wlc-config
-.. _API key: https://weblate.bubu1.eu/accounts/profile/#api
+.. _API key: https://translate.codeberg.org/accounts/profile/#api
 
 All weblate integration is done by GitHub workflows, but if you want to use wlc_,
 copy this content into `wlc configuration`_ in your HOME ``~/.config/weblate``
@@ -76,6 +76,6 @@ copy this content into `wlc configuration`_ in your HOME ``~/.config/weblate``
 .. code-block:: ini
 
   [keys]
-  https://weblate.bubu1.eu/api/ = APIKEY
+  https://translate.codeberg.org/api/ = APIKEY
 
 Replace ``APIKEY`` by your `API key`_.

--- a/manage
+++ b/manage
@@ -190,11 +190,11 @@ weblate.translations.worktree() {
     # 'translations' from Weblate's counterpart (weblate) of the SearXNG
     # (origin).
     #
-    #     remote weblate https://weblate.bubu1.eu/git/searxng/searxng/
+    #     remote weblate https://translate.codeberg.org/git/searxng/searxng/
 
     (   set -e
         if ! git remote get-url weblate 2> /dev/null; then
-            git remote add weblate https://weblate.bubu1.eu/git/searxng/searxng/
+            git remote add weblate https://translate.codeberg.org/git/searxng/searxng/
         fi
         if [ -d "${TRANSLATIONS_WORKTREE}" ]; then
             pushd .

--- a/searx/infopage/de/about.md
+++ b/searx/infopage/de/about.md
@@ -79,7 +79,7 @@ machen.  Je dezentraler das Internet ist, desto mehr Freiheit haben wir!
 [SearXNG Dokumentation]: {{get_setting('brand.docs_url')}}
 [searx]: https://github.com/searx/searx
 [Metasuchmaschine]: https://de.wikipedia.org/wiki/Metasuchmaschine
-[Weblate]: https://weblate.bubu1.eu/projects/searxng/
+[Weblate]: https://translate.codeberg.org/projects/searxng/
 [Seeks-Projekt]: https://beniz.github.io/seeks/
 [OpenSearch]: https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md
 [Firefox]: https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox

--- a/searx/infopage/en/about.md
+++ b/searx/infopage/en/about.md
@@ -71,7 +71,7 @@ internet is, the more freedom we have!
 [SearXNG docs]: {{get_setting('brand.docs_url')}}
 [searx]: https://github.com/searx/searx
 [metasearch engine]: https://en.wikipedia.org/wiki/Metasearch_engine
-[Weblate]: https://weblate.bubu1.eu/projects/searxng/
+[Weblate]: https://translate.codeberg.org/projects/searxng/
 [Seeks project]: https://beniz.github.io/seeks/
 [OpenSearch]: https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md
 [Firefox]: https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox

--- a/searx/infopage/id/about.md
+++ b/searx/infopage/id/about.md
@@ -74,7 +74,7 @@ terdesentralisasinya internet, lebih banyak kebebasan yang kita punya!
 [dokumentasi SearXNG]: {{get_setting('brand.docs_url')}}
 [searx]: https://github.com/searx/searx
 [mesin pencari meta]: https://id.wikipedia.org/wiki/Mesin_pencari_web#Mesin_Pencari_dan_Mesin_Pencari-meta
-[Weblate]: https://weblate.bubu1.eu/projects/searxng/
+[Weblate]: https://translate.codeberg.org/projects/searxng/
 [proyek Seeks]: https://beniz.github.io/seeks/
 [OpenSearch]: https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md
 [Firefox]: https://support.mozilla.org/id/kb/add-or-remove-search-engine-firefox


### PR DESCRIPTION
## What does this PR do?

See notice on https://weblate.bubu1.eu/ :
![image](https://user-images.githubusercontent.com/1594191/213872297-27a4b696-026b-481f-8c72-82a9a2fe815b.png)

## Why is this change important?

Migrate before shutdown down of weblate.bubu1.eu

## How to test this PR locally?

N/A

## Author's checklist

See https://translate.codeberg.org/projects/searxng/searxng/

⚠️ important notes
* this is not backup & restore, this is a new project : all comments are forgotten
* I've tried to restore the backup, but there is an error

## Related issues

<!--
Closes #234
-->
