### PR TITLE
SearXNG version: YYYY.MM.DD without leading zero

### DIFF
--- a/searx/version.py
+++ b/searx/version.py
@@ -59,7 +59,7 @@ def get_git_url_and_branch():
 
 
 def get_git_version():
-    git_commit_date_hash = subprocess_run(r"git show -s --date='format:%Y.%m.%d' --format='%cd+%h'")
+    git_commit_date_hash = subprocess_run(r"git show -s --date='format:%-Y.%-m.%-d' --format='%cd+%h'")
     tag_version = git_version = git_commit_date_hash
 
     # add "+dirty" suffix if there are uncommited changes except searx/settings.yml


### PR DESCRIPTION
## What does this PR do?

See https://github.com/searxng/searxng/discussions/2120 : leading zero in the version number doesn't comply with PEP440.

## Why is this change important?

Avoid bugs in the update procedure.

## How to test this PR locally?

* `make install`

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to https://github.com/searxng/searxng/discussions/2120