### PR TITLE
Fix update languages

### DIFF
--- a/searx/engines/peertube.py
+++ b/searx/engines/peertube.py
@@ -22,9 +22,7 @@ about = {
 categories = ["videos"]
 paging = True
 base_url = "https://peer.tube"
-supported_languages_url = (
-    'https://framagit.org/framasoft/peertube/search-index/-/raw/master/client/src/views/Search.vue'
-)
+supported_languages_url = 'https://peer.tube/api/v1/videos/languages'
 
 
 # do search-request
@@ -84,9 +82,6 @@ def response(resp):
 
 
 def _fetch_supported_languages(resp):
-    import re
-
-    # https://docs.python.org/3/howto/regex.html#greedy-versus-non-greedy
-    videolanguages = re.search(r"videoLanguages \(\)[^\n]+(.*?)\]", resp.text, re.DOTALL)
-    peertube_languages = [m.group(1) for m in re.finditer(r"\{ id: '([a-z]+)', label:", videolanguages.group(1))]
+    videolanguages = resp.json()
+    peertube_languages = list(videolanguages.keys())
     return peertube_languages

--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -106,9 +106,9 @@ def _fetch_supported_languages(resp):
         for tr in trs:
             td = tr.xpath('./td')
             code = td[3].xpath('./a')[0].text
-            name = td[2].xpath('./a')[0].text
+            name = td[1].xpath('./a')[0].text
             english_name = td[1].xpath('./a')[0].text
-            articles = int(td[4].xpath('./a/b')[0].text.replace(',', ''))
+            articles = int(td[4].xpath('./a')[0].text.replace(',', ''))
             # exclude languages with too few articles
             if articles >= 100:
                 supported_languages[code] = {"name": name, "english_name": english_name}


### PR DESCRIPTION
## What does this PR do?

Update the `_fetch_supported_languages` functions, so `./searxng_extra/update/update_languages.py` can update the languages.

## Why is this change important?

Follow the engine updates (wikipedia & peertube).


## How to test this PR locally?

    ./manage pyenv.cmd python ./searxng_extra/update/update_languages.py

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

Related to https://github.com/searxng/searxng/actions/runs/4034463258

```
fetched 46 languages from engine google news
fetched 46 languages from engine google scholar
fetched 46 languages from engine google videos
    _engines_languages = fetch_supported_languages()
  File "/home/runner/work/searxng/searxng/./searxng_extra/update/update_languages.py", line 42, in fetch_supported_languages
    engines_languages[engine_name] = engines[engine_name].fetch_supported_languages()
  File "/home/runner/work/searxng/searxng/searx/engines/__init__.py", line 243, in <lambda>
    lambda: engine._fetch_supported_languages(get(engine.supported_languages_url, headers=headers))
  File "/home/runner/work/searxng/searxng/searx/engines/peertube.py", line 91, in _fetch_supported_languages
    peertube_languages = [m.group(1) for m in re.finditer(r"\{ id: '([a-z]+)', label:", videolanguages.group(1))]
AttributeError: 'NoneType' object has no attribute 'group'
Error: Process completed with exit code 1.
```