### PR TITLE
[LXC] ubuntu 21.10 upgrade to ubuntu 22.04 LTS 

### DIFF
--- a/utils/lxc-searxng.env
+++ b/utils/lxc-searxng.env
@@ -16,8 +16,8 @@ lxc_set_suite_env() {
     export LXC_SUITE=(
 
         # end of standard support see https://wiki.ubuntu.com/Releases
-        "$LINUXCONTAINERS_ORG_NAME:ubuntu/20.04"  "ubu2004" # April 2025
-        "$LINUXCONTAINERS_ORG_NAME:ubuntu/21.10"  "ubu2110" # July 2027
+        "$LINUXCONTAINERS_ORG_NAME:ubuntu/20.04"  "ubu2004" # LTS EOSS April 2025
+        "$LINUXCONTAINERS_ORG_NAME:ubuntu/22.04"  "ubu2204" # LTS EOSS April 2027
 
         # EOL see https://fedoraproject.org/wiki/Releases
         "$LINUXCONTAINERS_ORG_NAME:fedora/35"     "fedora35"

--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -25,22 +25,17 @@ LXC_HOST_PREFIX="${LXC_HOST_PREFIX:-test}"
 LXC_SHARE_FOLDER="/share"
 LXC_REPO_ROOT="${LXC_SHARE_FOLDER}/$(basename "${REPO_ROOT}")"
 
-ubu1804_boilerplate="
+# shellcheck disable=SC2034
+ubu2004_boilerplate="
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get upgrade -y
 apt-get install -y git curl wget
-"
-ubu1904_boilerplate="$ubu1804_boilerplate"
-
-# shellcheck disable=SC2034
-ubu2004_boilerplate="
-$ubu1904_boilerplate
 echo 'Set disable_coredump false' >> /etc/sudo.conf
 "
 
 # shellcheck disable=SC2034
-ubu2110_boilerplate="$ubu1904_boilerplate"
+ubu2204_boilerplate="$ubu2004_boilerplate"
 
 # shellcheck disable=SC2034
 archlinux_boilerplate="


### PR DESCRIPTION
[LXC] ubuntu 21.10 upgrade to ubuntu 22.04 LTS / https://wiki.ubuntu.com/Releases

Tested by::

    # build the container ..
    $ sudo -H ./utils/lxc.sh build searxng-ubu2204

    # install a complete SearXNG suite ..
    $ sudo -H ./utils/lxc.sh cmd searxng-ubu2204 FORCE_TIMEOUT=0 ./utils/searxng.sh install all

    # install nginx to export the SearXNG instance by HTTP
    $ sudo -H ./utils/lxc.sh cmd searxng-ubu2204 FORCE_TIMEOUT=0 ./utils/searxng.sh install nginx

    # check instance
    $  sudo -H ./utils/lxc.sh cmd searxng-ubu2204 FORCE_TIMEOUT=0 ./utils/searxng.sh instance check
    INFO:  [searxng-ubu2204] FORCE_TIMEOUT=0 ./utils/searxng.sh instance check
    INFO:  wrapper:  utils/searxng.sh instance _call searxng.check

    SearXNG checks
    --------------
    ...
    INFO    searx                         : merge the default settings ( /usr/local/searxng/searxng-src/searx/settings.yml ) and the user settings ( /etc/searxng/settings.yml )
    INFO    searx                         : max_request_timeout=None
    INFO    searx.redisdb                 : connecting to Redis db=0 path='/usr/local/searxng-redis/run/redis.sock'
    INFO    searx.redisdb                 : connected to Redis



Related: https://github.com/searxng/searxng/discussions/2147#discussioncomment-4836753