### PR TITLE
[fix-2146] set different HTTP Referer header to DuckDuckGo requests

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -73,7 +73,7 @@ def request(query, params):
     # link again and again ..
 
     params['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
-    params['headers']['Referer'] = 'https://lite.duckduckgo.com/'
+    params['headers']['Referer'] = 'https://google.com/'
 
     # initial page does not have an offset
     if params['pageno'] == 2:


### PR DESCRIPTION
For what ever reasons, ddg-lite don't like the Referer

    https://lite.duckduckgo.com/

In an interactive session in the WEB browser  the Referer has exactly this value, but ddg-lite don't like this value when the request is build up by SearXNG.  The new value is:

    https://google.com/

What fakes a user comes from a google link.

Related: https://github.com/searxng/searxng/pull/2081

Closes: https://github.com/searxng/searxng/issues/2146
