### PR TITLE
[fix] time_range in HTML form should not be a string 'None'

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -815,7 +815,7 @@ def search():
         q=request.form['q'],
         selected_categories = search_query.categories,
         pageno = search_query.pageno,
-        time_range = search_query.time_range,
+        time_range = search_query.time_range or '',
         number_of_results = format_decimal(number_of_results),
         suggestions = suggestion_urls,
         answers = result_container.answers,


### PR DESCRIPTION
Before this patch SearXNG returns 'time_range': 'None'::

    <form method="GET" action="/searx/search">
      ...
      <input type="hidden" name="time_range" value="None">
      ...
    </form>

