### PR TITLE
[fix] remove engine neeva from settings.yml

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1002,38 +1002,6 @@ engines:
   #   collection: 'reviews'  # name of the db collection
   #   key: 'name'  # key in the collection to search for
 
-  - name: neeva
-    engine: xpath
-    shortcut: nv
-    time_range_support: true
-    time_range_url: '&alf%5Bfreshness%5D={time_range_val}'
-    time_range_map:
-      day: 'Day'
-      week: 'Week'
-      month: 'Month'
-      year: 'Year'
-    search_url: https://neeva.com/search?q={query}&c=All&src=Pagination&page={pageno}{time_range}
-    results_xpath: //div[@class="web-index__component-2rKiM"] | //li[@class="web-rich-deep-links__deepLink-SIbD4"]
-    url_xpath: .//a[@class="lib-doc-title__link-1b9rC"]/@href | ./h2/a/@href
-    title_xpath: .//a[@class="lib-doc-title__link-1b9rC"] | ./h2/a
-    content_xpath: >
-      .//div[@class="lib-doc-snippet__component-3ewW6"]/text() |
-      .//div[@class="lib-doc-snippet__component-3ewW6"]/*[not(self::a)] |
-      ./p
-    content_html_to_text: true
-    suggestion_xpath: //span[@class="result-related-searches__link-2ho_u"]
-    paging: true
-    disabled: true
-    categories: [general, web]
-    timeout: 5.0
-    soft_max_redirects: 2
-    about:
-      website: https://neeva.com
-      official_api_documentation:
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-
   - name: npm
     engine: json_engine
     paging: true


### PR DESCRIPTION
Engine is broken and can't by used any longer as a simple XPath engine. @allendema tested a `engines/neeva.py` version using JSON from the DOM, but without luck: There was some kind of captcha for pagination .. https://github.com/searxng/searxng/issues/2007#issuecomment-1426061698

Closes: https://github.com/searxng/searxng/issues/2007
