### PR TITLE
[fix] engine brave: fix XPath of title element

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1849,7 +1849,7 @@ engines:
     time_range_url: "&tf={time_range_val}"
     search_url: https://search.brave.com/search?q={query}&offset={pageno}&spellcheck=1{time_range}
     url_xpath: //a[@class="result-header"]/@href
-    title_xpath: //span[@class="snippet-title"]
+    title_xpath: //*[contains(@class,"snippet fdb")]/*[@class="result-header"]/*[@class="snippet-title"]
     content_xpath: //p[1][@class="snippet-description"]
     suggestion_xpath: //div[@class="text-gray h6"]/a
     time_range_map:


### PR DESCRIPTION
Brave has mismatch between links and descriptions due to advertisement:

Suggested by: @allendema & @AlyoshaVasilieva
Closes: https://github.com/searxng/searxng/issues/2020 
