### PR TITLE
[fix] make nvm.env exit with error when VERBOSE is unset

### DIFF
--- a/utils/lib_nvm.sh
+++ b/utils/lib_nvm.sh
@@ -27,6 +27,7 @@ nvm.env() {
     source "${NVM_DIR}/nvm.sh"
     source "${NVM_DIR}/bash_completion"
     [ "$VERBOSE" = "1" ] && info_msg "sourced NVM environment from ${NVM_DIR}"
+    return 0
 }
 
 nvm.is_installed() {
@@ -102,11 +103,15 @@ EOF
 nvm.install() {
     local NVM_VERSION_TAG
     info_msg "install (update) NVM at ${NVM_DIR}"
-    if [[ -d "${NVM_DIR}" ]] ; then
+    if nvm.is_installed; then
         info_msg "already cloned at: ${NVM_DIR}"
         pushd "${NVM_DIR}" &> /dev/null
         git fetch --all | prefix_stdout "  ${_Yellow}||${_creset} "
     else
+        # delete any leftovers from previos installations
+        if nvm.is_local; then
+            rm -rf "${NVM_DIR}"
+        fi
         info_msg "clone: ${NVM_GIT_URL}"
         git clone "${NVM_GIT_URL}" "${NVM_DIR}" 2>&1 | prefix_stdout "  ${_Yellow}||${_creset} "
         pushd "${NVM_DIR}" &> /dev/null


### PR DESCRIPTION
Fix `make nvm.env` exit with error when VERBOSE is unset

    $ make nvm.install
    INFO:  install (update) NVM at /800GBPCIex4/share/SearXNG/.nvm
    INFO:  already cloned at: /800GBPCIex4/share/SearXNG/.nvm
      || Fetching origin
    INFO:  checkout v0.39.1
      || HEAD is now at 9600617 v0.39.1
    make: *** [Makefile:96: nvm.install] Error 1

Without this fix we need to set VERBOSE environment to avoid the `Error 1`:

    $ VERBOSE=0 make nvm.install
