### PR TITLE
[doc] add example for enabling an engine disabled by default

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -168,3 +168,4 @@ features or generally made searx better:
 - Ahmad Alkadri `<https://github.com/ahmad-alkadri>`_
 - Milad Laly @Milad-Laly
 - @llmII
+- @blob42 `<https://blob42.xyz>`_

--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -657,8 +657,9 @@ and can relied on the default configuration :origin:`searx/settings.yml` using:
 ``engines:``
   With ``use_default_settings: true``, each settings can be override in a
   similar way, the ``engines`` section is merged according to the engine
-  ``name``.  In this example, SearXNG will load all the engine and the arch linux
-  wiki engine has a :ref:`token <private engines>`:
+  ``name``.  In this example, SearXNG will load all the default engines, will 
+  enable the ``bing`` engine and define a :ref:`token <private engines>` for
+  the arch linux engine:
 
   .. code-block:: yaml
 
@@ -668,6 +669,9 @@ and can relied on the default configuration :origin:`searx/settings.yml` using:
     engines:
       - name: arch linux wiki
         tokens: ['$ecretValue']
+      - name: bing
+        disabled: false
+
 
 ``engines:`` / ``remove:``
   It is possible to remove some engines from the default settings. The following


### PR DESCRIPTION
## What does this PR do?

Update the doc examples to show how to enable an engine that is disabled by default.

## Why is this change important?

No example is provided for this scenario and it can be tricky to guess the usage of `disabled`

## How to test this PR locally?

doc correctly displayed

## Author's checklist


## Related issues

