### PR TITLE
Fix the petalsearch engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1873,13 +1873,15 @@ engines:
     engine: xpath
     paging: true
     search_url: https://petalsearch.com/search?query={query}&pn={pageno}
-    results_xpath: //div[@class="webpage-content"]/div[@class="title-cont"]/a
-    url_xpath: ./@href
-    title_xpath: .
-    content_xpath: ../../div[@class="webpage-text"]
-    suggestion_xpath: //div[@class="related-search-items"]/a
+    url_xpath: //div[@class='card-source']
+    title_xpath: //div[@class='title-name']
+    content_xpath: //div[@class='webpage-text']
     first_page_num: 1
     disabled: true
+    headers:
+      User-Agent: Mozilla/5.0 (Linux; Android 7.0;) \
+        AppleWebKit/537.36 (KHTML, like Gecko) \
+        Mobile Safari/537.36 (compatible; PetalBot;+https://webmaster.petalsearch.com/site/petalbot)
     about:
       website: https://petalsearch.com/
       wikidata_id: Q104399280
@@ -1892,26 +1894,6 @@ engines:
     shortcut: ptsi
     disabled: true
     timeout: 3.0
-
-  - name: petalsearch news
-    shortcut: ptsn
-    categories: news
-    engine: xpath
-    paging: true
-    search_url: https://petalsearch.com/search?channel=news&query={query}&pn={pageno}
-    results_xpath: //div[@class="news-container"]/div/div/div/a
-    url_xpath: ./@href
-    title_xpath: ./div
-    content_xpath: ../div[@class="news-text"]
-    thumbnail_xpath: ../../../../img/@src
-    first_page_num: 1
-    disabled: true
-    about:
-      website: https://petalsearch.com/
-      wikidata_id: Q104399280
-      use_official_api: false
-      require_api_key: false
-      results: HTML
 
   - name: lib.rs
     shortcut: lrs


### PR DESCRIPTION
## What does this PR do?

Fix the petalsearch engine by updating its Xpaths with the correct values and removed the petalsearch news because of the absence of its content description.

## Why is this change important?

Petalsearch is a new websearch that seemingly has its own engine and indexes. It's been in SearxNG for quite a while, but the website seems to have changed and this fix will make the engine working again.

## How to test this PR locally?

Pull the branch with the latest commit of this PR locally, then run `make run`  .

Alternatively, build a docker image locally and run it:

```
docker build -t $IMGNAME -f Dockerfile .
docker run -p $PORT:$PORT $IMGNAME:latest
```

Then, do some searches using queries such as john doe !petalsearch, John Wick !petalsearch, etc.

Some test results done on my local machine:

![screenshot-127 0 0 1_8888-2023 02 12-23_25_46](https://user-images.githubusercontent.com/22837764/218342524-1be74fb9-84db-435c-b174-8583b65d73d5.png)

![screenshot-127 0 0 1_8888-2023 02 12-23_27_34](https://user-images.githubusercontent.com/22837764/218342534-355bf66f-1636-4573-a4e3-56ee3ffed42c.png)

## Author's checklist

I added a specific user-agent, which is basically the petalsearch's bot's user-agent, as the header for this engine's call. Basically all other user-agents apparently will be blocked by petalsearch except their own user-agent. I don't know precisely how they do it but I guess it involves some device and browser fingerprinting, to prevent scraper to get their search results.

Source info of the user-agent is [here](https://aspiegel.com/petalbot).

## Related issues

Could potentially close #2128 -- to be discussed first if this approach is preferable or not, because it heavily relies on the specific user-agent.