### PR TITLE
[mod] disbale engine tineye by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -583,6 +583,7 @@ engines:
     engine: tineye
     shortcut: tin
     timeout: 9.0
+    disabled: true
 
   - name: etymonline
     engine: xpath


### PR DESCRIPTION
Tineye becomes active as soon as a https:// signature is found in the search term, but most of the time a reverse image search is not requested when a URL is specified, often the URL is just from a C&P.

The frequent requests to tineye lead in the end to the SearXNG instance being blocked by tineye and the user seeing unexpected error messages.

BTW: many maintainers have disabled this engine in their local SearXNG settings.
