### PR TITLE
[mod] info page: Privacy Policy

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -13,3 +13,4 @@ User information
    search-syntax
    configured_engines
    about
+   privacy-policy

--- a/docs/user/privacy-policy.rst
+++ b/docs/user/privacy-policy.rst
@@ -1,0 +1,5 @@
+.. _privacy-policy:
+
+.. include:: privacy-policy.md
+   :parser: myst_parser.sphinx_
+

--- a/searx/infopage/__init__.py
+++ b/searx/infopage/__init__.py
@@ -134,6 +134,7 @@ class InfoPageSet:  # pylint: disable=too-few-public-methods
         self.toc: typing.List[str] = [
             'search-syntax',
             'about',
+            'privacy-policy',
             'donate',
         ]
         """list of articles in the online documentation"""

--- a/searx/infopage/en/privacy-policy.md
+++ b/searx/infopage/en/privacy-policy.md
@@ -1,0 +1,217 @@
+# Privacy Policy
+
+We provide this information for SearXNG's instances installed on servers in the
+Economic European Area (EEA) or outside the EEA for those who consult the
+{{link('SearXNG website', 'search')}} or submit queries.  So that you know, this
+information applies only to this SearXNG instance **and not to other websites
+the user may consult through links**.
+
+When data subjects or SearXNG providers are in the EEA, the [EU Regulation
+2016/679 (GDPR)](https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32016R0679&from=EN)
+applies.
+
+Indeed, according to Article 3(2) of the GDPR, we underline whether SearXNG's
+instances are installed on servers, not in the EEA, but the service is offered
+to users in the EEA, Regulation 2016/679 applies.
+
+> Article 3
+> Territorial scope
+>
+> 1. This Regulation applies to the processing of personal data in the context
+>    of the activities of an establishment of a controller or a processor in the
+>    Union, regardless of whether the processing takes place in the Union or
+>    not.
+>
+> 2. This Regulation applies to the processing of personal data of data subjects
+>    who are in the Union by a controller or processor not established in the
+>    Union, where the processing activities are related to:
+>
+>    (a) the offering of goods or services, irrespective of whether a payment of
+>        the data subject is required, to such data subjects in the Union; or
+>
+>    (b) the monitoring of their behaviour as far as their behaviour takes place
+>        within the Union.
+>
+> 3. This Regulation applies to the processing of personal data by a controller
+>    not established in the Union, but in a place where Member State law applies
+>    by virtue of public international law.
+
+## Data controller
+
+The data controller is `{name of the instance maintaner}` - (`{maintainer's
+email}`).
+
+## How does SearXNG protect privacy?
+
+SearXNG protects the privacy of its users in multiple ways regardless of the
+type of instance (private or public). Removal of private data from search
+requests comes in three forms:
+
+1. Removal of private data from requests going to search services.
+
+2. Not forwarding anything from third-party services through search services
+   (e.g., advertisement).
+
+3. Removal of private data from requests going to the result pages.  Removing
+   private data means not sending cookies to external search engines and
+   generating a random browser profile for every request. Thus, it does not
+   matter if a public or private instance handles the request because it is
+   anonymized in both cases. IP addresses will be the IP of the
+   instance. However, the SearXNG admin can configure it to use a proxy or Tor.
+   [Result proxy](https://github.com/asciimoo/morty) is supported, too. SearXNG
+   does not serve ads or tracking content, unlike most search services. So
+   private data is not forwarded to third parties who might monetize it. Besides
+   protecting users from search services, referring pages and search queries are
+   hidden from visited result pages.
+
+## What's happened when you send a query through a SearXNG instance?
+
+We reproduce the steps below:
+
+1. You send your query from a SearXNG instance;
+
+2. The SearXNG instance sends your query to the search engines set by default on
+   every specific SearXNG instance (All the SearXNG instances (private and
+   public) might differ because it depends on the settings chosen by the admin.
+   However, you can view and modify what the engines set by default via
+   {{link('Preferences => Engines', 'preferences')}}).
+
+3. The search engines (for instance, DDG or Qwant) that receive your query
+   elaborate on it and send the response to the SearXNG instance.
+
+## Is your data or personal data transmitted to search engines?
+
+**The answer is NO, and precisely:**
+
+1. **None of your data nor personal data is transmitted** from the SearXNG instance except:
+
+  - Your query;
+  - The language you selected on the SearXNG instance;
+  - The technical parameters are needed to form the same query.
+
+2. **No metadata is transmitted**.
+
+**In the end, only**:
+
+- your query,
+- the language you selected on the SearXNG instance and
+- the technical parameters needed to form the same query
+
+are transmitted to search engines.
+
+## Can the search engines see your data or install cookies or other stuff on your browser?
+
+**The answer is: No, they cannot.**
+
+Indeed, the search engines (for example, DDG or qwant) that receive your query
+through the SearXNG instance:
+
+1. Do not know from where (IP or location) your query comes and see your IP
+   since they are talking only with the SearXNG instance;
+
+2. Acquire only the IP of the SearXNG instance you used for your query.
+
+3. Cannot send your browser cookies or other data to track you since the search
+   engines that receive your query are only connected to the SearXNG instance
+   and not your web browser.
+
+## What data is collected
+
+This SearXNG instance receives only your IP but does not collect it.
+
+**Each user is responsible for the content they intend to submit as a query**.
+
+### Who can access the data, and for what activities?
+
+None neither the server administrator (instance) can access Personally
+Identifiable Information (PII) nor data of the queries but only - for technical
+needs - system logs without the possibility of retrieving any personal data
+anyway.
+
+## The purposes of the processing
+
+When data subjects or SearXNG providers are in the EEA, the GDPR applies.
+Still, the purpose is to provide all access to the SearXNG instance by allowing
+users to submit queries and read and consult the search results.
+
+Furthermore, the purposes are also related to server maintenance and system and
+application upgrades.
+
+The optional, explicit, and voluntary sending of electronic mail to the
+addresses indicated on the footer of this site involves the acquisition of the
+sender's address necessary for the replies and any other personal data contained
+in the message.  These data are processed to respond to messages sent and handle
+related requests. Failure to provide personal data for communications with us or
+send requests will prevent evading them. We store data for the time strictly
+necessary for the purposes related to data processing.
+
+## Legal basis for the processing
+
+When data subjects or SearXNG providers are in the EEA, the GDPR applies.
+Still, the processing of personal data is based on consent - according to
+Article 6, par. 1, letter a) of EU Regulation 2016/679 - expressed by the user
+by browsing this website, choosing the preferences, and submitting queries, thus
+accepting this information.
+
+Consent is optional, and the user can withdraw at any time by request sent by
+email to `{maintainer's email}`¡, specifying that, in this case, whether the
+user does not consent, they cannot consult this website.
+
+Regarding server maintenance and system and application upgrades, the legal
+basis is the legitimate interest according to Article 6, letter f) of the EU
+Regulation 2016/679.
+
+The processing of personal data is necessary to pursue the data controller's
+legitimate interest in providing information about studies and research,
+according to article 6, par. 1, letter f) of EU Regulation 2016/679, in
+compliance with the provisions of the same Regulation.
+
+## Cookies
+
+The only cookies are only **functional ones** and, therefore, no profiling or
+tracking activities.
+
+**Thus, this site does not use cookies other than functional cookies solely for
+the functional purposes described above, and their installation does not require
+the user's consent**.
+
+## Data recipients
+
+We don't communicate personal data collected from this website following its
+consultation to recipients or categories of recipients.
+
+## Period for storing personal data
+
+This website does not collect nor store user data.
+
+## Transferring personal data to a third country or international organization
+
+When data subjects or SearXNG providers are in the EEA, the GDPR applies.
+Still, the data controller, the administrator of SearXNG's instance, does not
+transfer any personal data outside the European Economic Area (EEA) if SearXNG
+is installed on the server located within the European Economic Area.
+
+## Security measures
+
+The SearXNG instance maintainer adopts appropriate security measures to prevent
+unauthorized access, disclosure, modification, or unauthorized destruction of
+data.  Your data in the communication session with this website are protected by
+a Secure Sockets Layer (SSL) certificate that uses a cryptographic presentation
+protocol, encrypting the information.
+
+## Data subjects' rights
+
+When data subjects or SearXNG providers are in the EEA, the GDPR applies.
+Still, users (data subjects) who access the service provided by this instance
+may exercise the rights according to Articles 15 to 22 of EU Regulation
+2016/679.  You can lodge all requests to exercise these rights by writing to
+`{maintainer's email}`.
+
+## Right to lodge a complaint
+
+When data subjects or SearXNG providers are in the EEA, the GDPR applies.
+Still, whether a data subject considers that the processing of personal data
+relating to them as performed via this SearXNG instance infringes the
+Regulation, they have the right to lodge a complaint with the competent
+Supervisory Authority (Data Protection Authority) according to Article 77 of the
+EU Regulation 2016/679.

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -189,6 +189,10 @@ class ViewsTestCase(SearxTestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn(b'<h1>Search syntax</h1>', result.data)
 
+        result = self.app.get('/info/en/privacy-policy')
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(b'<h1>Privacy Policy</h1>', result.data)
+
     def test_health(self):
         result = self.app.get('/healthz')
         self.assertEqual(result.status_code, 200)


### PR DESCRIPTION

## What does this PR do?

Initial creation of an info page on the topic "Privacy Policy".

[1] https://github.com/searxng/searxng/issues/1285#issuecomment-1431497644

Suggested-by: @nicfab [1]

## Why is this change important?

- https://github.com/searxng/searxng/issues/1285

## How to test this PR locally?

The "Privacy Policy" is assembled two places:

1. the info pages of the SearXNG instance --> `make run` --> open *About* page, klick on tab "Privacy Policy"

2. in the online documentation --> `make docs.clean docs.live`  --> jump to section "User information // Privacy Policy" 

## Related issues

Closes #1285
