### PR TITLE
fix: storage unit value

### DIFF
--- a/searx/utils.py
+++ b/searx/utils.py
@@ -39,12 +39,14 @@ _ECMA_UNESCAPE4_RE = re.compile(r'%u([0-9a-fA-F]{4})', re.UNICODE)
 _ECMA_UNESCAPE2_RE = re.compile(r'%([0-9a-fA-F]{2})', re.UNICODE)
 
 _STORAGE_UNIT_VALUE: Dict[str, int] = {
-    'TB': 1024 * 1024 * 1024 * 1024,
-    'GB': 1024 * 1024 * 1024,
-    'MB': 1024 * 1024,
-    'TiB': 1000 * 1000 * 1000 * 1000,
-    'MiB': 1000 * 1000,
-    'KiB': 1000,
+    'TB': 1000 * 1000 * 1000 * 1000,
+    'GB': 1000 * 1000 * 1000,
+    'MB': 1000 * 1000,
+    'kB': 1000,
+    'TiB': 1024 * 1024 * 1024 * 1024,
+    'GiB': 1024 * 1024 * 1024,
+    'MiB': 1024 * 1024,
+    'KiB': 1024,
 }
 
 _XPATH_CACHE: Dict[str, XPath] = {}


### PR DESCRIPTION
## What does this PR do?

- add missing storage unit value
- Gibibyte and Gigabyte were confused

## Why is this change important?

- fix nyaa engine filesize

### searxng
![searxng](https://user-images.githubusercontent.com/94218744/221310785-6243671c-479d-4bf9-8c92-8414e308cdef.png)

### nyaa
![nyaa](https://user-images.githubusercontent.com/94218744/221310658-d2978531-a80f-4938-a94b-dff8578ea8ce.png)