### PR TITLE
Increase timeout for gentoo wiki engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -681,6 +681,7 @@ engines:
   - name: gentoo
     engine: gentoo
     shortcut: ge
+    timeout: 10.0
 
   - name: gitlab
     engine: json_engine


### PR DESCRIPTION
## What does this PR do?

This PR increases the timeout for the gentoo engine

## Why is this change important?

See issue #2216 
This PR fixes the bug.

## How to test this PR locally?

Run SearXNG.
Search for one of the terms that cause the issue (i.e "funtoo" did it for me)
Go to the "IT" tab
Check if the gentoo engine returns a timeout error.

## Author's checklist


## Related issues
#2216

