### PR TITLE
[fix] make docs: NameError: name 'DOC' is not defined

### DIFF
--- a/searxng_extra/docs_prebuild
+++ b/searxng_extra/docs_prebuild
@@ -78,7 +78,6 @@ def _instance_infosetset_ctx(base_url):
     # found ..
 
     time.sleep(3)
-    return DOC
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
To reproduce the issue set base_url::

```diff
diff --git a/searx/settings.yml b/searx/settings.yml
index 841457b5e..4e282cb61 100644
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -72,7 +72,7 @@ server:
   bind_address: "127.0.0.1"
   # public URL of the instance, to ensure correct inbound links. Is overwritten
   # by ${SEARXNG_URL}.
-  base_url: false  # "http://example.com/location"
+  base_url: "http://example.com/location"
   limiter: false  # rate limit the number of request on the instance, block some bots
```
and build the docs::
```
$ make docs
SPHINX    HTML ./docs --> file:///800GBPCIex4/share/SearXNG/dist/docs
DOCS      build build/docs/includes
Traceback (most recent call last):
  File "searxng_extra/docs_prebuild", line 85, in <module>
    sys.exit(main())
  File "searxng_extra/docs_prebuild", line 31, in main
    f.write(page.content)
  File "/usr/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "searxng_extra/docs_prebuild", line 81, in _instance_infosetset_ctx
    return DOC
NameError: name 'DOC' is not defined
```
