### PR TITLE
[fix] Remove unexpected language restriction in Bing

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -55,12 +55,10 @@ def request(query, params):
     if offset == 1:
         search_string = inital_query
 
-    if params['language'] == 'all':
-        lang = 'EN'
-    else:
+    # Add language filter in query if specific language was given
+    if params['language'] != 'all':
         lang = match_language(params['language'], supported_languages, language_aliases)
-
-    query = 'language:{} {}'.format(lang.split('-')[0].upper(), query)
+        query = 'language:{} {}'.format(lang.split('-')[0].upper(), query)
 
     search_path = search_string.format(query=urlencode({'q': query}), offset=offset)
 


### PR DESCRIPTION
## What does this PR do?
Fixed unusable Bing result for user who using language "Default language (all)" with non English search keywords.
> The origin code add `language: EN` to keywords if language was set to `all`

## Why is this change important?
The origin code:
- Make search without language restriction not possible
- No result, or add no sense result when keywords was not English and `default_lang` set to `all`

## Screenshot
**Origin:**
<img width="542" alt="bing_origin" src="https://user-images.githubusercontent.com/38161479/222934621-e72fb571-ef7a-4c0f-a518-023fbd07e5ef.png">

**With this PR:**
<img width="540" alt="bing_fix" src="https://user-images.githubusercontent.com/38161479/222934630-d5298faa-2ce4-4705-aedf-745d2ef8d527.png">

## How to test this PR locally?
1. Use origin code from master branch
2. Enable Bing only
3. Set `default_lang` to `all` or manually switch to "Default language" in result page
4. Search by using any language other than English, CJK was preferred
3. Take a screenshot
6. Checkout code to this PR
7. Search again, compare result quality with screenshot

>Example keyword: 人と、地球の、明日のために, copied from Toshiba website

## Author's checklist
- [x] Tested with(out) `default_lang`
- [x] Tested with different language in dropdown

## Related issues

#941 (Only related to title)
