### PR TITLE
Fix DDG engine - changing user-agent

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -74,6 +74,7 @@ def request(query, params):
 
     params['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
     params['headers']['Referer'] = 'https://google.com/'
+    params['headers']['User-Agent'] = 'curl/7.81.0'
 
     # initial page does not have an offset
     if params['pageno'] == 2:


### PR DESCRIPTION
## What does this PR do?

Fix the DDG engine by putting CURL's user-agent as its headers' parameter.

## Why is this change important?

DDG is a popular, privacy-conscious websearch. It's been in SearxNG for quite a while, but from time to time it keeps returning errors, thought to be rate limit, though it can be other things. This fix address the latest issue, which comes in the form of Error 403, whenever SearxNG tries using its DDG engine.

## How to test this PR locally?

Pull the branch with the latest commit of this PR locally, then run `make run`  .

Alternatively, build a docker image locally and run it:

```
docker build -t $IMGNAME -f Dockerfile .
docker run -p $PORT:$PORT $IMGNAME:latest
```

Then, do some searches using queries such as !duckduckgo your-query.

Some test results done on my local machine:

![screenshot-localhost_8080-2023 03 13-07_25_04](https://user-images.githubusercontent.com/22837764/224624779-dadae626-0ad9-4ec2-bd0f-5957020f90b9.png)

![screenshot-localhost_8080-2023 03 13-07_24_26](https://user-images.githubusercontent.com/22837764/224624798-be92e425-2caf-4197-8dbd-1d100dd616e6.png)

![screenshot-localhost_8080-2023 03 13-07_24_03](https://user-images.githubusercontent.com/22837764/224624819-346adfee-d1ee-4967-8c91-81ced0f53d83.png)

## Author's checklist

I added a specific user-agent, which is the CURL's user-agent, as the header for this engine's call. Basically so many (not all, but many) standard user-agents apparently will be blocked by DDG if we call it through SearxNG engine, but CURL is not.

Source info of the user-agent of CURL is [here](https://everything.curl.dev/http/requests/user-agent).

## Related issues

Could potentially close #2246