### PR TITLE
re.escape() the query in highlight_content to prevent a server side error.

### DIFF
--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -174,7 +174,9 @@ def highlight_content(content, query):
             queries.extend(re.findall(regex_highlight_cjk(qs), content, flags=re.I | re.U))
     if len(queries) > 0:
         for q in set(queries):
-            content = re.sub(regex_highlight_cjk(q), f'<span class="highlight">{q}</span>', content)
+            content = re.sub(
+                regex_highlight_cjk(q), f'<span class="highlight">{q}</span>'.replace('\\', r'\\'), content
+            )
     return content
 
 


### PR DESCRIPTION
## What does this PR do?

This PR replaces
`content = re.sub(regex_highlight_cjk(q), f'<span class="highlight">{q}</span>', content)`  
by
`content = re.sub(regex_highlight_cjk(q), f'<span class="highlight">{re.escape(q)}</span>', content)`  
in the highlight_content method to prevent a bad escape error.

## Why is this change important?
When searching for something containing what can look like an escape code (i.e Laminas\XmlRpc\Client) sre_parse can misinterpret it as a bad escape and throw a fatal error preventing the search.

## How to test this PR locally?
make run
Search for "Laminas\XmlRpc\Client"
No error should be thrown and the search should go on normally.


## Author's checklist

N/A

## Related issues
Closes both
#2250 
and
#2256 
