### PR TITLE
[enh] add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.py]
+max_line_length = 119
+
+[*.html]
+indent_size = 4
+
+[*.json]
+indent_size = 4
+insert_final_newline = ignore
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab
+
+[docs/**.rst]
+max_line_length = 79
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
EditorConfig [1] helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs.

The EditorConfig specification [2] support is pre installed in common IDEs [3] and plugins for many others are available [4].

[1] https://editorconfig.org
[2] https://editorconfig-specification.readthedocs.io/
[3] https://editorconfig.org/#pre-installed
[4] https://editorconfig.org/#download

Related issues:

- https://github.com/searxng/searxng/pull/133
- https://github.com/searxng/searxng/pull/1736
