### PR TITLE
wikidata: Add description for results

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -260,7 +260,7 @@ def get_results(attribute_result, attributes, language):
                     infobox_urls.append({'title': attribute.get_label(language), 'url': url, **attribute.kwargs})
                     # "normal" results (not infobox) include official website and Wikipedia links.
                     if attribute.kwargs.get('official') or attribute_type == WDArticle:
-                        results.append({'title': infobox_title, 'url': url})
+                        results.append({'title': infobox_title, 'url': url, "content":infobox_content})
                     # update the infobox_id with the wikipedia URL
                     # first the local wikipedia URL, and as fallback the english wikipedia URL
                     if attribute_type == WDArticle and (

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -260,7 +260,7 @@ def get_results(attribute_result, attributes, language):
                     infobox_urls.append({'title': attribute.get_label(language), 'url': url, **attribute.kwargs})
                     # "normal" results (not infobox) include official website and Wikipedia links.
                     if attribute.kwargs.get('official') or attribute_type == WDArticle:
-                        results.append({'title': infobox_title, 'url': url, "content":infobox_content})
+                        results.append({'title': infobox_title, 'url': url, "content": infobox_content})
                     # update the infobox_id with the wikipedia URL
                     # first the local wikipedia URL, and as fallback the english wikipedia URL
                     if attribute_type == WDArticle and (


### PR DESCRIPTION
## What does this PR do?

This PR simply sets the result content for wikidata results as the entry's description instead of nothing.

## Why is this change important?

It may be helpful when looking at the result to know what the page is actually about.
It also makes the results less barren and gives a very quick one sentence overview of what the thing being searched for is.
It's overall better than having nothing.

## How to test this PR locally?

1. make run
2. (OPTIONAL) Set wikidata as the only engine
3. Search for anything
4. Look at the wikidata results


## Author's checklist
N/A

## Related issues

Closes #2254 

## Screenshot
![image](https://user-images.githubusercontent.com/88553777/226488185-0c235d6e-d854-4d31-ba13-cfe69ad0c1a1.png)

