### PR TITLE
Add GitHub Codespaces configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+RUN apt-get update && \
+    apt-get -y install python3 python3-venv redis firefox-esr graphviz imagemagick librsvg2-bin fonts-dejavu shellcheck

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-azuretools.vscode-docker"
+      ],
+      "remote.otherPortsAttributes": {
+        "protocol": "https"
+      },
+      "settings": {
+        "files.autoSave": "off",
+        "python.defaultInterpreterPath": "/workspaces/searxng/local/py3/bin/python3",
+        "python.formatting.blackPath": "/workspaces/searxng/local/py3/bin/black",
+        "python.linting.pylintPath": "/workspaces/searxng/local/py3/bin/pylint"
+      }
+    }
+  },
+  "forwardPorts": [8000, 8888],
+  "portsAttributes": {
+    "8000": {"label": "Sphinx documentation"},
+    "8888": {"label": "SearXNG"}
+  },
+  "postCreateCommand": "git pull && make install"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // See https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "SearXNG",
+            "type": "python",
+            "request": "launch",
+            "module": "searx.webapp",
+            "env": {
+                "FLASK_APP": "webapp",
+                "FLASK_DEBUG": "1",
+                "SEARXNG_DEBUG": "1",
+            },
+            "args": [
+                "run"
+            ],
+            "jinja": true,
+            "justMyCode": true,
+            "python": "${workspaceFolder}/local/py3/bin/python",
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true,
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "make run",
+            "type": "shell",
+            "command": "make run",
+            "problemMatcher": [],
+            "isBackground": true,
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "make docs.live",
+            "type": "shell",
+            "command": "make docs.live",
+            "problemMatcher": [],
+            "isBackground": true,
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "group": {
+                "kind": "build"
+            }
+        }
+    ]
+}

--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,25 @@ Help translate SearXNG at `Weblate`_
    :target: https://translate.codeberg.org/projects/searxng/
 
 
+Codespaces
+==========
+
+You can contribute from your browser using `GitHub Codespaces`_:
+
+- Fork the repository
+- Click on the ``<> Code`` green button
+- Click on the ``Codespaces`` tab instead of ``Local``
+- Click on ``Create codespace on master``
+- VSCode is going to start in the browser
+- Wait for ``git pull && make install`` to appears and then to disapear
+- You have `120 hours per month`_ (see also your `list of existing Codespaces`_)
+- You can start SearXNG using ``make run`` in the terminal or by pressing ``Ctrl+Shift+B``.
+
+.. _GitHub Codespaces: https://docs.github.com/en/codespaces/overview
+.. _120 hours per month: https://github.com/settings/billing
+.. _list of existing Codespaces: https://github.com/codespaces
+
+
 Donations
 =========
 


### PR DESCRIPTION
## What does this PR do?

[GitHub Codespaces](https://docs.github.com/en/codespaces/overview) starts a VM and connect VSCode to it. This allows to contribute from a browser.

This PR adds the Codespaces configuration, so the user just have to start SearXNG (in the VM) and start coding.

## Why is this change important?

This may help some contributors to start, or in some other cases.

## How to test this PR locally?

Remote test: 
* go to https://github.com/searxng/searxng/tree/codespaces
* ![image](https://user-images.githubusercontent.com/1594191/226736318-9be6dcd4-34e5-490f-ac08-9fcc40368707.png)
* the setup is going to take a long time, once merge, it is possible to configure a cache, so the environment starts in about 2 minutes.

## Author's checklist

The cache has to be configured once merged into the master branch.

## Related issues

<!--
Closes #234
-->
