### PR TITLE
Add setting to change  favicon and logo

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -14,6 +14,7 @@ general:
   enable_metrics: true
 
 brand:
+  # Both favicon and logo are relative to SearXNG's root path unless they are absolute paths
   favicon: static/themes/simple/img/favicon.png
   logo: static/themes/simple/img/searxng.png
   new_issue_url: https://github.com/searxng/searxng/issues/new

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -14,6 +14,8 @@ general:
   enable_metrics: true
 
 brand:
+  favicon: static/favicon.ico
+  #logo: searx/static/themes/simple/img/searxng.png
   new_issue_url: https://github.com/searxng/searxng/issues/new
   docs_url: https://docs.searxng.org/
   public_instances: https://searx.space

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -14,8 +14,8 @@ general:
   enable_metrics: true
 
 brand:
-  favicon: static/favicon.ico
-  #logo: searx/static/themes/simple/img/searxng.png
+  favicon: static/themes/simple/img/favicon.png
+  logo: static/themes/simple/img/searxng.png
   new_issue_url: https://github.com/searxng/searxng/issues/new
   docs_url: https://docs.searxng.org/
   public_instances: https://searx.space

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -146,6 +146,8 @@ SCHEMA = {
         'enable_metrics': SettingsValue(bool, True),
     },
     'brand': {
+        'favicon': SettingsValue(str, "static/themes/simple/img/favicon.png"),
+        'logo': SettingsValue(str, "static/themes/simple/img/searxg.png"),
         'issue_url': SettingsValue(str, 'https://github.com/searxng/searxng/issues'),
         'new_issue_url': SettingsValue(str, 'https://github.com/searxng/searxng/issues/new'),
         'docs_url': SettingsValue(str, 'https://docs.searxng.org'),

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -24,8 +24,8 @@
   {% block head %}
   <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ opensearch_url }}"/>
   {% endblock %}
-  <link rel="icon" href="{{ url_for('static', filename='img/favicon.png') }}" sizes="any">
-  <link rel="icon" href="{{ url_for('static', filename='img/favicon.svg') }}" type="image/svg+xml">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" href="/favicon.ico" type="image/svg+xml">
 </head>
 <body class="{{ endpoint }}_endpoint" >
   <main id="main_{{  self._TemplateReference__context.name|replace("simple/", "")|replace(".html", "") }}" class="{{body_class}}">

--- a/searx/templates/simple/page_with_header.html
+++ b/searx/templates/simple/page_with_header.html
@@ -1,5 +1,5 @@
 {% set body_class = "page_with_header" %}
 {% extends "simple/base.html" %}
 {% block header %}
-<a href="{{ url_for('index') }}"><img class="logo" src="{{ url_for('static', filename='img/searxng.png') }}" alt="SearXNG"></a>
+<a href="{{ url_for('index') }}"><img class="logo" src="/logo" alt="SearXNG"></a>
 {% endblock %}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -298,6 +298,7 @@ def get_result_template(theme_name: str, template_name: str):
         return themed_path
     return 'result_templates/' + template_name
 
+
 def get_favicon_or_logo(imgtype: str, request):
 	# This method returns a favicon or regular image depending on the imgtype parameter
 	# It is used to not repeat code for /favicon.ico and /logo
@@ -316,12 +317,10 @@ def get_favicon_or_logo(imgtype: str, request):
 		)	
 	else:		
 		# Otherwise we're good to go, send whatever is specified.
-		filename = os.path.basename(path)
-		path = os.path.dirname(path)
 		# Works with both relative and absolute. 
 		return send_from_directory(
-			path,
-			filename,
+			os.path.dirname(path),
+			os.path.basename(path),
 			mimetype=mimetype
 		)
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -332,8 +332,7 @@ def get_favicon_or_logo(imgtype: str):
             resp, stream = http_stream(method='GET', url=path, headers=request_headers, allow_redirects=True)
             if resp.status_code != 200:
                 logger.debug(f"{imgtype}: Bad status code %i", resp.status_code)
-                if resp.status_code >= 400:
-                    return fallback
+                return fallback
             resp_ok = True
         except httpx.HTTPError:
             logger.debug(f"{imgtype}: HTTP error")

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -307,14 +307,64 @@ def get_favicon_or_logo(imgtype: str, request):
 	path = os.path.expanduser(settings.get("brand").get(imgtype))
 	relpath = os.path.join(app.root_path, path)
 	mimetype = 'image/vnd.microsoft.icon' if imgtype == "favicon" else None
-	
-	if not os.path.isfile(path) and not os.path.isfile(relpath):
-		# If path doesn't exist neither relatively nor absolutely, fallback  to whatever is in the theme
-		return send_from_directory(
+	fallback = ( send_from_directory(
 			os.path.join(app.root_path, settings['ui']['static_path'], 'themes', theme, 'img'),  # pyright: ignore
 			'favicon.png' if imgtype == "favicon" else "searxng.png",
-			mimetype=mimetype,
-		)	
+			mimetype=mimetype
+			)	)
+	
+	# If path is a URL
+	if "://" in path:
+		resp_ok = False
+		resp = None
+		# TODO: Make a a function for this used by both this function and the image proxy
+		try:
+			# Pull image from it
+			request_headers = {
+				'User-Agent': gen_useragent(),
+				'Accept': 'image/webp,*/*',
+				'Accept-Encoding': 'gzip, deflate',
+				'Sec-GPC': '1',
+				'DNT': '1',
+			}
+			resp, stream = http_stream(method='GET', url=path, headers=request_headers, allow_redirects=True)
+			if resp.status_code != 200:
+				logger.debug(f"{imgtype}: Bad status code %i", resp.status_code)
+				if resp.status_code >= 400:
+					return fallback
+			resp_ok = True
+		except httpx.HTTPError:
+			logger.debug(f"{imgtype}: HTTP error")
+			return fallback	
+		finally:
+			if resp and not resp_ok:
+				try:
+					resp.close()
+				except httpx.HTTPError:
+					logger.exception(f'{imgtype}: HTTP error on closing')
+		def close_stream():
+			nonlocal resp, stream
+			try:
+				if resp:
+					resp.close()
+				del resp
+				del stream
+			except httpx.HTTPError as e:
+				logger.debug(f'{imgtype}Exception while closing response', e)
+		try:
+			headers = dict_subset(resp.headers, {'Content-Type', 'Content-Encoding', 'Content-Length', 'Length'})			
+			response = Response(stream, mimetype=resp.headers['Content-Type'], headers=headers, direct_passthrough=True)
+			response.call_on_close(close_stream)
+			return response
+		except httpx.HTTPError:
+			close_stream()
+			return fallback
+
+
+			
+	elif not os.path.isfile(path) and not os.path.isfile(relpath):
+		# If path doesn't exist neither relatively nor absolutely, fallback  to whatever is in the theme
+		return fallback
 	else:		
 		# Otherwise we're good to go, send whatever is specified.
 		# Works with both relative and absolute. 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -299,80 +299,79 @@ def get_result_template(theme_name: str, template_name: str):
     return 'result_templates/' + template_name
 
 
-def get_favicon_or_logo(imgtype: str, request):
-	# This method returns a favicon or regular image depending on the imgtype parameter
-	# It is used to not repeat code for /favicon.ico and /logo
-	# Called by logo() and favicon()
-	theme = request.preferences.get_value("theme")
-	path = os.path.expanduser(settings.get("brand").get(imgtype))
-	relpath = os.path.join(app.root_path, path)
-	mimetype = 'image/vnd.microsoft.icon' if imgtype == "favicon" else None
-	fallback = ( send_from_directory(
-			os.path.join(app.root_path, settings['ui']['static_path'], 'themes', theme, 'img'),  # pyright: ignore
-			'favicon.png' if imgtype == "favicon" else "searxng.png",
-			mimetype=mimetype
-			)	)
-	
-	# If path is a URL
-	if "://" in path:
-		resp_ok = False
-		resp = None
-		# TODO: Make a a function for this used by both this function and the image proxy
-		try:
-			# Pull image from it
-			request_headers = {
-				'User-Agent': gen_useragent(),
-				'Accept': 'image/webp,*/*',
-				'Accept-Encoding': 'gzip, deflate',
-				'Sec-GPC': '1',
-				'DNT': '1',
-			}
-			resp, stream = http_stream(method='GET', url=path, headers=request_headers, allow_redirects=True)
-			if resp.status_code != 200:
-				logger.debug(f"{imgtype}: Bad status code %i", resp.status_code)
-				if resp.status_code >= 400:
-					return fallback
-			resp_ok = True
-		except httpx.HTTPError:
-			logger.debug(f"{imgtype}: HTTP error")
-			return fallback	
-		finally:
-			if resp and not resp_ok:
-				try:
-					resp.close()
-				except httpx.HTTPError:
-					logger.exception(f'{imgtype}: HTTP error on closing')
-		def close_stream():
-			nonlocal resp, stream
-			try:
-				if resp:
-					resp.close()
-				del resp
-				del stream
-			except httpx.HTTPError as e:
-				logger.debug(f'{imgtype}Exception while closing response', e)
-		try:
-			headers = dict_subset(resp.headers, {'Content-Type', 'Content-Encoding', 'Content-Length', 'Length'})			
-			response = Response(stream, mimetype=resp.headers['Content-Type'], headers=headers, direct_passthrough=True)
-			response.call_on_close(close_stream)
-			return response
-		except httpx.HTTPError:
-			close_stream()
-			return fallback
+def get_favicon_or_logo(imgtype: str):
+    # This method returns a favicon or regular image depending on the imgtype parameter
+    # It is used to not repeat code for /favicon.ico and /logo
+    # Called by logo() and favicon()
+    theme = request.preferences.get_value("theme")
+    path = os.path.expanduser(settings.get("brand").get(imgtype))
+    relpath = os.path.join(app.root_path, path)
+    mimetype = 'image/vnd.microsoft.icon' if imgtype == "favicon" else None
+    fallback = send_from_directory(
+        os.path.join(app.root_path, settings['ui']['static_path'], 'themes', theme, 'img'),  # pyright: ignore
+        'favicon.png' if imgtype == "favicon" else "searxng.png",
+        mimetype=mimetype,
+    )
 
+    # If path is a URL
+    if "://" in path:
+        resp_ok = False
+        resp = None
+        # TODO: Make a a function for this used by both this function and the image proxy
+        # ASAP to avoid repeated code like this
+        # pylint: disable=fixme
+        try:
+            # Pull image from it
+            request_headers = {
+                'User-Agent': gen_useragent(),
+                'Accept': 'image/webp,*/*',
+                'Accept-Encoding': 'gzip, deflate',
+                'Sec-GPC': '1',
+                'DNT': '1',
+            }
+            resp, stream = http_stream(method='GET', url=path, headers=request_headers, allow_redirects=True)
+            if resp.status_code != 200:
+                logger.debug(f"{imgtype}: Bad status code %i", resp.status_code)
+                if resp.status_code >= 400:
+                    return fallback
+            resp_ok = True
+        except httpx.HTTPError:
+            logger.debug(f"{imgtype}: HTTP error")
+            return fallback
+        finally:
+            if resp and not resp_ok:
+                try:
+                    resp.close()
+                except httpx.HTTPError:
+                    logger.exception(f'{imgtype}: HTTP error on closing')
 
-			
-	elif not os.path.isfile(path) and not os.path.isfile(relpath):
-		# If path doesn't exist neither relatively nor absolutely, fallback  to whatever is in the theme
-		return fallback
-	else:		
-		# Otherwise we're good to go, send whatever is specified.
-		# Works with both relative and absolute. 
-		return send_from_directory(
-			os.path.dirname(path),
-			os.path.basename(path),
-			mimetype=mimetype
-		)
+        def close_stream():
+            nonlocal resp, stream
+            try:
+                if resp:
+                    resp.close()
+                del resp
+                del stream
+            except httpx.HTTPError as e:
+                logger.debug(f'{imgtype}Exception while closing response', e)
+
+        try:
+            headers = dict_subset(resp.headers, {'Content-Type', 'Content-Encoding', 'Content-Length', 'Length'})
+            response = Response(stream, mimetype=resp.headers['Content-Type'], headers=headers, direct_passthrough=True)
+            response.call_on_close(close_stream)
+            return response
+        except httpx.HTTPError:
+            close_stream()
+            return fallback
+
+    elif not os.path.isfile(path) and not os.path.isfile(relpath):
+        # If path doesn't exist neither relatively nor absolutely, fallback  to whatever is in the theme
+        return fallback
+    else:
+        # Otherwise we're good to go, send whatever is specified.
+        # Works with both relative and absolute.
+        return send_from_directory(os.path.dirname(path), os.path.basename(path), mimetype=mimetype)
+
 
 def custom_url_for(endpoint: str, **values):
     suffix = ""
@@ -1378,12 +1377,12 @@ def opensearch():
 
 @app.route('/favicon.ico')
 def favicon():
-	return get_favicon_or_logo("favicon", request)
-	
+    return get_favicon_or_logo("favicon", request)
+
+
 @app.route('/logo')
-def logo():		
-	return get_favicon_or_logo("logo", request)
-		
+def logo():
+    return get_favicon_or_logo("logo", request)
 
 
 @app.route('/clear_cookies')

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -301,6 +301,7 @@ def get_result_template(theme_name: str, template_name: str):
 def get_favicon_or_logo(imgtype: str, request):
 	# This method returns a favicon or regular image depending on the imgtype parameter
 	# It is used to not repeat code for /favicon.ico and /logo
+	# Called by logo() and favicon()
 	theme = request.preferences.get_value("theme")
 	path = os.path.expanduser(settings.get("brand").get(imgtype))
 	relpath = os.path.join(app.root_path, path)
@@ -317,7 +318,7 @@ def get_favicon_or_logo(imgtype: str, request):
 		# Otherwise we're good to go, send whatever is specified.
 		filename = os.path.basename(path)
 		path = os.path.dirname(path)
-		# Works wih both relative and absolute. 
+		# Works with both relative and absolute. 
 		return send_from_directory(
 			path,
 			filename,

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -317,9 +317,9 @@ def get_favicon_or_logo(imgtype: str):
     if "://" in path:
         resp_ok = False
         resp = None
-        # TODO: Make a a function for this used by both this function and the image proxy
+        # TODO: Make a a function for this used by both this function and the image proxy # pylint: disable=fixme
         # ASAP to avoid repeated code like this
-        # pylint: disable=fixme
+
         try:
             # Pull image from it
             request_headers = {
@@ -1377,12 +1377,12 @@ def opensearch():
 
 @app.route('/favicon.ico')
 def favicon():
-    return get_favicon_or_logo("favicon", request)
+    return get_favicon_or_logo("favicon")
 
 
 @app.route('/logo')
 def logo():
-    return get_favicon_or_logo("logo", request)
+    return get_favicon_or_logo("logo")
 
 
 @app.route('/clear_cookies')

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -352,7 +352,7 @@ def get_favicon_or_logo(imgtype: str):
                 del resp
                 del stream
             except httpx.HTTPError as e:
-                logger.debug(f'{imgtype}Exception while closing response', e)
+                logger.debug(f'{imgtype}: Exception while closing response', e)
 
         try:
             headers = dict_subset(resp.headers, {'Content-Type', 'Content-Encoding', 'Content-Length', 'Length'})


### PR DESCRIPTION
## What does this PR do?

This PR adds two settings in settings.yml, one to set SearXNG's logo (like the one that appears in page_with_header.html) and one to set its favicon. Those settings can either be a full path, a relative path (to the app root) or a URL to pull the image from.
It also adds a new endpoint (/logo) and rewrites /favicon.ico to respect those new settings.
Finally it rewires base.html and page_with_header.html to use those new endpoints.
It also adds a function in webapp.py used by both the new endpoints (get_favicon_or_logo).

## Why is this change important?

It has been requested several times in the past without anything coming out of it (see related issues).
I personally think it's a good feature to make SearXNG more hackable/customisable, especially for public instances. Since the current solution of changing the image files is a pain and is not practical at all.
It's one more nice feature IMO.

## How to test this PR locally?

1. Set logo and favicon in settings.yml to files of your choice
2. make run
3. Check /logo and /favicon.ico
4. Repeat with favicon and logo set to a URL to an image, a path relative to SearXNG's root, and an invalid path/url.
And check the behavior.

## Author's checklist

I am aware of the repeated code problem in  this PR and i know that the pulling image from a URL should be made a function shared by both get_favicon_or_logo and the image proxy. However i'm not sure whether this is in the scope of this PR because image_proxy would be modified.
Should i commit it here or make another pull request if this is merged to fix that?

## Related issues

- #2249 
- https://github.com/searxng/searxng/discussions/2032#discussioncomment-4467735
