### PR TITLE
Revert "Bump redis from 4.5.1 to 4.5.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Brotli==1.0.9
 uvloop==0.17.0
 httpx-socks[asyncio]==0.7.2
 setproctitle==1.3.2
-redis==4.5.3
+redis==4.5.1
 markdown-it-py==2.2.0
 typing_extensions==4.5.0
 fasttext-predict==0.9.2.1


### PR DESCRIPTION
Sorry, I hastily merged the PR 

- searxng/searxng#2279

further testing showed the error::

    AttributeError: 'UnixDomainSocketConnection' object has no attribute 'socket_timeout'

This PR reverts searxng/searxng#2279 / further read:

- https://github.com/redis/redis-py/issues/2629#issuecomment-1482425208