### PR TITLE
[fix] engine gigablast: add &userid=<User ID>&code=<Feed Code>

### DIFF
--- a/searx/engines/gigablast.py
+++ b/searx/engines/gigablast.py
@@ -39,6 +39,9 @@ extra_param_ts = 0
 # after how many seconds extra_param expire
 extra_param_expiration_delay = 3000
 
+gb_userid = ''
+gb_code = ''
+
 
 def fetch_extra_param(query_args, headers):
 
@@ -70,6 +73,10 @@ def fetch_extra_param(query_args, headers):
 # do search-request
 def request(query, params):  # pylint: disable=unused-argument
     query_args = dict(c='main', q=query, dr=1, showgoodimages=0)
+
+    if gb_userid and gb_code:
+        query_args['userid'] = gb_userid
+        query_args['code'] = gb_code
 
     if params['language'] and params['language'] != 'all':
         query_args['qlangcountry'] = params['language']

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -674,6 +674,9 @@ engines:
     engine: gigablast
     shortcut: gb
     timeout: 4.0
+    # API key required, see https://gigablast.com/searchfeed.html
+    # gb_userid: unset
+    # gb_code: unknown
     disabled: true
     additional_tests:
       rosebud: *test_rosebud


### PR DESCRIPTION
Gigablast's API does block unauthorized request[1].

[1] https://gigablast.com/searchfeed.html

Closes: https://github.com/searxng/searxng/issues/1454