### PR TITLE
[upd] httpx v0.21.2 --> v0.23.3 & httpx-socks v0.7.2 --> v0.7.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,10 @@ lxml==4.9.2
 pygments==2.14.0
 python-dateutil==2.8.2
 pyyaml==6.0
-httpx[http2]==0.21.2
+httpx[http2]==0.23.3
 Brotli==1.0.9
 uvloop==0.17.0
-httpx-socks[asyncio]==0.7.2
+httpx-socks[asyncio]==0.7.5
 setproctitle==1.3.2
 redis==4.5.4
 markdown-it-py==2.2.0


### PR DESCRIPTION
[Dependabot alerts](https://github.com/searxng/searxng/security/dependabot) but did not update the httpx dependencies.

@dalf what do you think, can upgrade httpx packages?

I test this PR on my instance https://darmarit.org/searx/ .. so far I could not detect any issues.

Related: https://github.com/searxng/searxng/security/dependabot/4
