### PR TITLE
[fix] categories can't be removed from UI (categories_as_tabs)

### DIFF
--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -74,6 +74,10 @@ def update_settings(default_settings, user_settings):
             else:
                 default_settings[k] = v
 
+    categories_as_tabs = user_settings.get('categories_as_tabs')
+    if categories_as_tabs:
+        default_settings['categories_as_tabs'] = categories_as_tabs
+
     # parse the engines
     remove_engines = None
     keep_only_engines = None


### PR DESCRIPTION
When using ``use_default_settings: true``, removing default categories from settings.yml will not remove them from the UI.

The value ``categories_as_tabs`` is a dictionary type (a4c2cfb) and dictionary types are merged additive by ``settings_loader.update_settings()``.

This patch replaces the default ``categories_as_tabs`` by the one from the ``user_settings``.

Related: 

- https://github.com/searxng/searxng/issues/1019#issuecomment-1193145654
- https://github.com/searxng/searxng/pull/1545

## How to test this PR locally?

create a `/etc/searxng/settings.yml` ...

```
use_default_settings: true

categories_as_tabs:
  general:
  images:
  videos:

```

![grafik](https://user-images.githubusercontent.com/554536/229581801-66c94eef-df22-46f5-b43b-5e0bc9d9a174.png)
