### PR TITLE
Provide template (files.html) for results in file category

### DIFF
--- a/searx/templates/simple/result_templates/files.html
+++ b/searx/templates/simple/result_templates/files.html
@@ -1,0 +1,56 @@
+{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer, result_link with context %}
+{% from 'simple/icons.html' import icon_small %}
+
+{{- result_header(result, favicons, image_proxify) -}}
+{{- result_sub_header(result) -}}
+
+{%- if result.embedded -%}
+    <small> &bull; <a class="text-info btn-collapse collapsed cursor-pointer media-loader disabled_if_nojs" data-toggle="collapse" data-target="#result-media-{{ index }}" data-btn-text-collapsed="{{ _('show media') }}" data-btn-text-not-collapsed="{{ _('hide media') }}">
+    {%- if result.mtype == 'audio' %}{{ icon_small('musical-notes-outline') -}}
+    {%- elif result.mtype == 'video' %} {{ icon_small('play-outline') -}}
+    {%- endif %} {{ _('show media') }}</a></small>
+{%- endif -%}
+
+{%- if result.embedded -%}
+<div id="result-media-{{ index }}" class="collapse">
+   {{- result.embedded|safe -}}
+</div>
+{%- endif -%}
+
+{%- if result.abstract %}<p class="result-content result-abstract">{{ result.abstract|safe }}</p>{% endif -%}
+
+{%- if result.img_src -%}
+<div class="container-fluid">
+    <div class="row">
+<img src="{{ image_proxify(result.img_src) }}" alt="{{ result.title|striptags }}" title="{{ result.title|striptags }}" style="width: auto; max-height: 60px; min-height: 60px;" class="col-xs-2 col-sm-4 col-md-4 result-content">
+{%- if result.content %}<p class="result-content col-xs-8 col-sm-8 col-md-8">{{ result.content|safe }}</p>{% endif -%}
+    </div>
+</div>
+{%- else -%}
+{%- if result.content %}<p class="result-content">{{ result.content|safe }}</p>{% endif -%}
+{%- endif -%}
+
+<table class="result-metadata result-content">
+{%- if result.author %}<tr><td>{{ _('Author') }}</td><td>{{ result.author|safe }}</td></tr>{% endif -%}
+
+{%- if result.filename %}<tr><td>{{ _('Filename') }}</td><td>{{ result.filename|safe }}</td></tr>{% endif -%}
+
+{%- if result.size %}<tr><td>{{ _('Filesize') }}</td><td>
+        {%- if result.size < 1024 %}{{ result.size }} {{ _('Bytes') -}}
+        {%- elif result.size < 1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024) }} {{ _('kiB') -}}
+        {%- elif result.size < 1024*1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024/1024) }} {{ _('MiB') -}}
+        {%- elif result.size < 1024*1024*1024*1024 %}{{ '{0:0.2f}'.format(result.size/1024/1024/1024) }} {{ _('GiB') -}}
+        {%- else %}{{ '{0:0.2f}'.format(result.size/1024/1024/1024/1024) }} {{ _('TiB') }}{% endif -%}
+    </td></tr>
+{%- endif -%}
+
+{%- if result.time %}<tr><td>{{ _('Date') }}</td><td>{{ result.time|safe }}</td></tr>{% endif -%}
+
+{%- if result.mtype %}<tr><td>{{ _('Type') }}</td><td>{{ result.mtype|safe }}/{{ result.subtype|safe }}</td></tr>{% endif -%}
+</table>
+
+{%- if rtl -%}
+{{ result_sub_footer(result) }}
+{%- else -%}
+{{ result_footer(result) }}
+{%- endif -%}

--- a/searx/templates/simple/result_templates/files.html
+++ b/searx/templates/simple/result_templates/files.html
@@ -12,7 +12,7 @@
 {%- endif -%}
 
 {%- if result.embedded -%}
-<div id="result-media-{{ index }}" class="collapse">
+<div id="result-media-{{ index }}" class="collapse invisible">
    {{- result.embedded|safe -}}
 </div>
 {%- endif -%}

--- a/searx/templates/simple/result_templates/files.html
+++ b/searx/templates/simple/result_templates/files.html
@@ -49,8 +49,4 @@
 {%- if result.mtype %}<tr><td>{{ _('Type') }}</td><td>{{ result.mtype|safe }}/{{ result.subtype|safe }}</td></tr>{% endif -%}
 </table>
 
-{%- if rtl -%}
-{{ result_sub_footer(result) }}
-{%- else -%}
 {{ result_footer(result) }}
-{%- endif -%}


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

It adds a template for file results (i.e. results from searching in the file category) in the simple theme. 

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

It is [a requirement](https://github.com/searxng/searxng/blob/64e221426a4c27caa030cfa89b099636851c400b/searx/engines/recoll.py#L71) for the [recoll engine](https://docs.searxng.org/admin/engines/recoll.html).

## How to test this PR locally?

Just drop `files.html` into `searx/templates/simple/result_templates/` and restart SearXNG.

## Author's checklist

<!-- additional notes for reviewiers -->

This was basically copied and adapted from the oscar theme without much thinking about how templates work in SearX or a complete understanding of the simple theme. Please, review carefully.