### PR TITLE
[fix] Bing-WEB: use <span class='algoSlug_icon'> for the description

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -198,12 +198,10 @@ def response(resp):
         url = link.attrib.get('href')
         title = extract_text(link)
 
-        # Make sure that the element is free of <a href> links and <span class='algoSlug_icon'>
         content = eval_xpath(result, '(.//p)[1]')
         for p in content:
+            # Make sure that the element is free of <a href> links
             for e in p.xpath('.//a'):
-                e.getparent().remove(e)
-            for e in p.xpath('.//span[@class="algoSlug_icon"]'):
                 e.getparent().remove(e)
         content = extract_text(content)
 


### PR DESCRIPTION
On some result items from Bing-WEB the `<span class='algoSlug_icon'>` tag is the only tag that contains a description.  The issue can be reproduced by [1]::

    !bi vmware

[1] https://github.com/searxng/searxng/issues/1764#issuecomment-1417990531

Reported-by: @AlyoshaVasilieva