### PR TITLE
[mod] enable autocomplete from duckduckgo by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -26,7 +26,7 @@ search:
   # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "yandex",
   # "seznam", "startpage", "swisscows", "qwant", "wikipedia" - leave blank to turn it off
   # by default.
-  autocomplete: ""
+  autocomplete: "duckduckgo"
   # minimun characters to type before autocompleter starts
   autocomplete_min: 4
   # Default search language - leave blank to detect from browser information or


### PR DESCRIPTION
## What does this PR do?

enable autocomplete from duckduckgo by default

## Why is this change important?

- https://github.com/searxng/searxng/issues/1889

## Related issues

Closes: https://github.com/searxng/searxng/issues/1889