### PR TITLE
[mod] limiter: block unmaintained Farside instances

### DIFF
--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -34,9 +34,9 @@ block_user_agent = re.compile(
     + r'|bingbot|Baiduspider|yacybot|YandexMobileBot|YandexBot|Yahoo! Slurp|MJ12bot|AhrefsBot|archive.org_bot|msnbot'
     + r'|MJ12bot|SeznamBot|linkdexbot|Netvibes|SMTBot|zgrab|James BOT|Sogou|Abonti|Pixray|Spinn3r|SemrushBot|Exabot'
     + r'|ZmEu|BLEXBot|bitlybot'
-    # when you block requests from Farside instances, your instance will
-    # disappear from https://farside.link/
-    # + r'|Farside'
+    # unmaintained Farside instances
+    + r'|'
+    + re.escape(r'Mozilla/5.0 (compatible; Farside/0.1.0; +https://farside.link)')
     + r')'
 )
 


### PR DESCRIPTION
Since [bb3a01f8] has been merged to the Farside project, Farside instances do no longer need to send requests to SearXNG instances [1].

There are some old unmaintained Farside instances on the web that continue to query SearXNG instances --> we can safely block their requests.

[1] https://github.com/benbusby/farside/issues/95
[bb3a01f8] https://github.com/benbusby/farside/commit/bb3a01f8
