### PR TITLE
If language recognition fails use the Accept-Language

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -8,9 +8,10 @@
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 from zlib import compress, decompress
 from urllib.parse import parse_qs, urlencode
-from typing import Iterable, Dict, List
+from typing import Iterable, Dict, List, Optional
 
 import flask
+import babel
 
 from searx import settings, autocomplete
 from searx.enginelib import Engine
@@ -287,10 +288,65 @@ class PluginsSetting(BooleanChoices):
         return [item[len('plugin_') :] for item in items]
 
 
+class ClientPref:
+    """Container to assemble client prefferences and settings."""
+
+    # hint: searx.webapp.get_client_settings should be moved into this class
+
+    locale: babel.Locale
+    """Locale prefered by the client."""
+
+    def __init__(self, locale: Optional[babel.Locale] = None):
+        self.locale = locale
+
+    @property
+    def locale_tag(self):
+        if self.locale is None:
+            return None
+        tag = self.locale.language
+        if self.locale.territory:
+            tag += '-' + self.locale.territory
+        return tag
+
+    @classmethod
+    def from_http_request(cls, http_request: flask.Request):
+        """Build ClientPref object from HTTP request.
+
+        - `Accept-Language used for locale setting
+          <https://www.w3.org/International/questions/qa-accept-lang-locales.en>`__
+
+        """
+        al_header = http_request.headers.get("Accept-Language")
+        if not al_header:
+            return cls(locale=None)
+
+        pairs = []
+        for l in al_header.split(','):
+            # fmt: off
+            lang, qvalue = [_.strip() for _ in (l.split(';') + ['q=1',])[:2]]
+            # fmt: on
+            try:
+                qvalue = float(qvalue.split('=')[-1])
+                locale = babel.Locale.parse(lang, sep='-')
+            except (ValueError, babel.core.UnknownLocaleError):
+                continue
+            pairs.append((locale, qvalue))
+        pairs.sort(reverse=True, key=lambda x: x[1])
+        return cls(locale=pairs[0][0])
+
+
 class Preferences:
     """Validates and saves preferences to cookies"""
 
-    def __init__(self, themes: List[str], categories: List[str], engines: Dict[str, Engine], plugins: Iterable[Plugin]):
+    def __init__(
+        self,
+        themes: List[str],
+        categories: List[str],
+        engines: Dict[str, Engine],
+        plugins: Iterable[Plugin],
+        client: Optional[ClientPref] = None,
+    ):
+
         super().__init__()
 
         self.key_value_settings: Dict[str, Setting] = {
@@ -414,6 +470,7 @@ class Preferences:
         self.engines = EnginesSetting('engines', engines=engines.values())
         self.plugins = PluginsSetting('plugins', plugins=plugins)
         self.tokens = SetSetting('tokens')
+        self.client = client or ClientPref()
         self.unknown_params: Dict[str, str] = {}
 
     def get_as_url_params(self):

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -31,7 +31,7 @@ search:
   autocomplete_min: 4
   # Default search language - leave blank to detect from browser information or
   # use codes from 'languages.py'
-  default_lang: ""
+  default_lang: "auto"
   # Available languages
   # languages:
   #   - all

--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -6,6 +6,7 @@ from searx.query import RawTextQuery
 from searx.engines import categories, engines
 from searx.search import SearchQuery, EngineRef
 from searx.preferences import Preferences, is_locked
+from searx.utils import detect_language
 
 
 # remove duplicate queries.
@@ -214,7 +215,27 @@ def parse_engine_data(form):
 
 def get_search_query_from_webapp(
     preferences: Preferences, form: Dict[str, str]
-) -> Tuple[SearchQuery, RawTextQuery, List[EngineRef], List[EngineRef]]:
+) -> Tuple[SearchQuery, RawTextQuery, List[EngineRef], List[EngineRef], str]:
+    """Assemble data from preferences and request.form (from the HTML form) needed
+    in a search query.
+
+    The returned tuple consits of:
+
+    1. instance of :py:obj:`searx.search.SearchQuery`
+    2. instance of :py:obj:`searx.query.RawTextQuery`
+    3. list of :py:obj:`searx.search.EngineRef` instances
+    4. string with the *selected locale* of the query
+
+    About language/locale: if the client selects the alias ``auto`` the
+    ``SearchQuery`` object is build up by the :py:obj:`detected language
+    <searx.utils.detect_language>`.  If language recognition does not have a
+    match the language preferred by the :py:obj:`Preferences.client` is used.
+    If client does not have a preference, the default ``all`` is used.
+
+    The *selected locale* in the tuple always represents the selected
+    language/locale and might differ from the language recognition.
+
+    """
     # no text for the query ?
     if not form.get('q'):
         raise SearxParameterException('q', '')
@@ -229,12 +250,18 @@ def get_search_query_from_webapp(
     # set query
     query = raw_text_query.getQuery()
     query_pageno = parse_pageno(form)
-    query_lang = parse_lang(preferences, form, raw_text_query)
     query_safesearch = parse_safesearch(preferences, form)
     query_time_range = parse_time_range(form)
     query_timeout = parse_timeout(form, raw_text_query)
     external_bang = raw_text_query.external_bang
     engine_data = parse_engine_data(form)
+
+    query_lang = parse_lang(preferences, form, raw_text_query)
+    selected_locale = query_lang
+
+    if query_lang == 'auto':
+        query_lang = detect_language(query, threshold=0.8, only_search_languages=True)
+        query_lang = query_lang or preferences.client.locale_tag or 'all'
 
     if not is_locked('categories') and raw_text_query.specific:
         # if engines are calculated from query,
@@ -265,4 +292,5 @@ def get_search_query_from_webapp(
         raw_text_query,
         query_engineref_list_unknown,
         query_engineref_list_notoken,
+        selected_locale,
     )

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -84,6 +84,7 @@ from searx.webutils import (
 from searx.webadapter import (
     get_search_query_from_webapp,
     get_selected_categories,
+    parse_lang,
 )
 from searx.utils import (
     html_to_text,
@@ -440,11 +441,7 @@ def render(template_name: str, **kwargs):
         kwargs['rtl'] = True
 
     if 'current_language' not in kwargs:
-        _locale = request.preferences.get_value('language')
-        if _locale in ('auto', 'all'):
-            kwargs['current_language'] = _locale
-        else:
-            kwargs['current_language'] = match_locale(_locale, settings['search']['languages'])
+        kwargs['current_language'] = parse_lang(request.preferences, {}, RawTextQuery('', []))
 
     # values from settings
     kwargs['search_formats'] = [x for x in settings['search']['formats'] if x != 'html']
@@ -678,7 +675,9 @@ def search():
     raw_text_query = None
     result_container = None
     try:
-        search_query, raw_text_query, _, _ = get_search_query_from_webapp(request.preferences, request.form)
+        search_query, raw_text_query, _, _, selected_locale = get_search_query_from_webapp(
+            request.preferences, request.form
+        )
         # search = Search(search_query) #  without plugins
         search = SearchWithPlugins(search_query, request.user_plugins, request)  # pylint: disable=redefined-outer-name
 
@@ -809,13 +808,6 @@ def search():
         )
     )
 
-    if search_query.lang in ('auto', 'all'):
-        current_language = search_query.lang
-    else:
-        current_language = match_locale(
-            search_query.lang, settings['search']['languages'], fallback=request.preferences.get_value("language")
-        )
-
     # search_query.lang contains the user choice (all, auto, en, ...)
     # when the user choice is "auto", search.search_query.lang contains the detected language
     # otherwise it is equals to search_query.lang
@@ -838,7 +830,7 @@ def search():
             result_container.unresponsive_engines
         ),
         current_locale = request.preferences.get_value("locale"),
-        current_language = current_language,
+        current_language = selected_locale,
         search_language = match_locale(
             search.search_query.lang,
             settings['search']['languages'],


### PR DESCRIPTION
## What does this PR do?

1.  the language recognition fails use the Accept-Language 

- https://github.com/searxng/searxng/issues/2232

2. settings.yml: enable language detection by default_lang (auto)

-----

You can test this patch on my instance: https://darmarit.org/searx/

-----

Closes: https://github.com/searxng/searxng/issues/2232