### PR TITLE
Fix Israeli flag emoji in locale dropdown

### DIFF
--- a/searx/sxng_locales.py
+++ b/searx/sxng_locales.py
@@ -48,7 +48,7 @@ sxng_locales = (
     ('fr-CA', 'Français', 'Canada', 'French', '\U0001f1e8\U0001f1e6'),
     ('fr-CH', 'Français', 'Suisse', 'French', '\U0001f1e8\U0001f1ed'),
     ('fr-FR', 'Français', 'France', 'French', '\U0001f1eb\U0001f1f7'),
-    ('he', 'עברית', '', 'Hebrew', '\U0001f1ee\U0001f1f7'),
+    ('he', 'עברית', '', 'Hebrew', '\U0001f1ee\U0001f1f1'),
     ('hi', 'हिन्दी', '', 'Hindi', '\U0001f310'),
     ('hr', 'Hrvatski', '', 'Croatian', '\U0001f310'),
     ('hu', 'Magyar', '', 'Hungarian', '\U0001f310'),

--- a/searxng_extra/update/update_engine_traits.py
+++ b/searxng_extra/update/update_engine_traits.py
@@ -71,7 +71,7 @@ lang2emoji = {
     'bs': '\U0001F1E7\U0001F1E6',  # Bosnian / Bosnia & Herzegovina
     'jp': '\U0001F1EF\U0001F1F5',  # Japanese
     'ua': '\U0001F1FA\U0001F1E6',  # Ukrainian
-    'he': '\U0001F1EE\U0001F1F7',  # Hebrew
+    'he': '\U0001F1EE\U0001F1F1',  # Hebrew
 }
 
 


### PR DESCRIPTION
## What does this PR do?

The locale dropdown shows the flag of Iran (🇮🇷) instead of the flag of Israel (🇮🇱) for the Hebrew language.

See: https://emojipedia.org/flag-israel/

## Why is this change important?

UI bug.

## How to test this PR locally?

1. Go to `/preferences`
1. Look at the `Search language` dropdown.
1. Hebrew option (עברית) should have the correct flag.