### PR TITLE
[fix] doc of locales.get_engine_locale() / zh-classical is missleading

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -166,8 +166,6 @@ def send_wikidata_query(query, method='GET'):
 
 def request(query, params):
 
-    # wikidata does not support zh-classical (zh_Hans) / zh-TW, zh-HK and zh-CN
-    # mapped to zh
     eng_tag, _wiki_netloc = get_wiki_params(params['searxng_locale'], traits)
     query, attributes = get_query(query, eng_tag)
     logger.debug("request --> language %s // len(attributes): %s", eng_tag, len(attributes))

--- a/searx/locales.py
+++ b/searx/locales.py
@@ -245,7 +245,7 @@ def get_engine_locale(searxng_locale, engine_locales, default=None):
           ..
           'zh'             : 'zh'
           'zh_Hans'        : 'zh'
-          'zh_Hant'        : 'zh-classical'
+          'zh_Hant'        : 'zh_TW'
       }
 
     .. hint::


### PR DESCRIPTION
Wikipedia's zh-classical is not zh_Hant (see doc-string of engines.wikipedia). Fixed the example in the doc-string of locales.get_engine_locale() to 'zh_TW'.

Reported by @MarcAbonce in https://github.com/searxng/searxng/issues/2330#issuecomment-1510526468