### PR TITLE
[CI] drop Python 3.7 from CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version:  ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version:  ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
## What does this PR do?

drop Python 3.7 from CI

## Why is this change important?

- Python 3.7 supports security fixes only, as needed, until 2023-06 [1]
- Some of SearXNG's dependencies do no longer support Python 3.7 [2]

[1] https://peps.python.org/pep-0537/#and-beyond-schedule
[2] https://github.com/searxng/searxng/pull/2102

----

Released a announcement -->  https://github.com/searxng/searxng/discussions

