### PR TITLE
Go to main instead of search page when external bang query is empty

### DIFF
--- a/searx/external_bang.py
+++ b/searx/external_bang.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlparse
 from searx.data import EXTERNAL_BANGS
 
 LEAF_KEY = chr(16)
@@ -40,9 +40,15 @@ def get_bang_definition_and_ac(external_bangs_db, bang):
 
 def resolve_bang_definition(bang_definition, query):
     url, rank = bang_definition.split(chr(1))
-    url = url.replace(chr(2), quote_plus(query))
     if url.startswith('//'):
         url = 'https:' + url
+    if query:
+        url = url.replace(chr(2), quote_plus(query))
+    else:
+        # go to main instead of search page
+        o = urlparse(url)
+        url = o.scheme + '://' + o.netloc
+
     rank = int(rank) if len(rank) > 0 else 0
     return (url, rank)
 


### PR DESCRIPTION
## What does this PR do?

Added the check if the query for the external bang is empty.
If yes, then the URL is stripped to base domain.

## Why is this change important?

DDG bangs are also convenient shortcuts to websites.  
With this change, the behaviour is consistent with the original.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->
1. Search `!!gh`
2. Verify it redirects to https://github.com instead of https://github.com/search?utf8=%E2%9C%93&q=

## Related issues

Closes #2368 
