### PR TITLE
[mod] limiter: block requests from PetalBot

### DIFF
--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -37,6 +37,7 @@ block_user_agent = re.compile(
     # unmaintained Farside instances
     + r'|'
     + re.escape(r'Mozilla/5.0 (compatible; Farside/0.1.0; +https://farside.link)')
+    + '|.*PetalBot.*'
     + r')'
 )
 


### PR DESCRIPTION
Block requests from PetalBlock.  Normally robots.txt is enough to stop PetalBlock from making requests [1].  However, if SearXNG is offered below a path (example.org/search), then the robots.txt is not available in the root path of the domain / subdomain.

[1] https://webmaster.petalsearch.com/site/petalbot
