### PR TITLE
Bump Alpine 3.18 (Python 3.11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 ENTRYPOINT ["/sbin/tini","--","/usr/local/searxng/dockerfiles/docker-entrypoint.sh"]
 EXPOSE 8080
 VOLUME /etc/searxng


### PR DESCRIPTION
## What does this PR do?
Updates Alpine to 3.18
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
The releasenotes of Alpine state it bumps Python 3.11
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
crosscompiled it for arm64, uploaded it to dockerhub (nberlee/searxng:python311) and used it in my k8s cluster
<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
