### PR TITLE
[fix] version format string generated by 'git show'

### DIFF
--- a/searx/version.py
+++ b/searx/version.py
@@ -59,7 +59,10 @@ def get_git_url_and_branch():
 
 
 def get_git_version():
-    git_commit_date_hash = subprocess_run(r"git show -s --date='format:%-Y.%-m.%-d' --format='%cd+%h'")
+    git_commit_date_hash = subprocess_run(r"git show -s --date='format:%Y.%m.%d' --format='%cd+%h'")
+    # Remove leading zero from minor and patch level / replacement of PR-2122
+    # which depended on the git version: '2023.05.06+..' --> '2023.5.6+..'
+    git_commit_date_hash = git_commit_date_hash.replace('.0', '.')
     tag_version = git_version = git_commit_date_hash
 
     # add "+dirty" suffix if there are uncommited changes except searx/settings.yml


### PR DESCRIPTION
Newer versions of git [1] do no longer support a format string that includes a minus to remove leading zeros [2].  The format string '%Y.%m.%d'  is more version rod.

[1] https://github.com/searxng/searxng/issues/2413#issuecomment-1542320387
[2] https://github.com/searxng/searxng/pull/2122/files

Closes: https://github.com/searxng/searxng/issues/2413