### PR TITLE
use logger.warning

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -95,7 +95,7 @@ def load_engine(engine_data: dict) -> Optional[Engine]:
         return None
 
     if engine_name.lower() != engine_name:
-        logger.warn('Engine name is not lowercase: "{}", converting to lowercase'.format(engine_name))
+        logger.warning('Engine name is not lowercase: "{}", converting to lowercase'.format(engine_name))
         engine_name = engine_name.lower()
         engine_data['name'] = engine_name
 

--- a/searx/locales.py
+++ b/searx/locales.py
@@ -460,7 +460,7 @@ def build_engine_locales(tag_list: List[str]):
     for tag in tag_list:
         locale = get_locale(tag)
         if locale is None:
-            logger.warn("build_engine_locales: skip locale tag %s / unknown by babel", tag)
+            logger.warning("build_engine_locales: skip locale tag %s / unknown by babel", tag)
             continue
         if locale.territory:
             engine_locales[region_tag(locale)] = tag

--- a/searx/search/processors/abstract.py
+++ b/searx/search/processors/abstract.py
@@ -74,7 +74,7 @@ class EngineProcessor(ABC):
         try:
             self.engine.init(get_engine_from_settings(self.engine_name))
         except SearxEngineResponseException as exc:
-            self.logger.warn('Fail to initialize // %s', exc)
+            self.logger.warning('Fail to initialize // %s', exc)
         except Exception:  # pylint: disable=broad-except
             self.logger.exception('Fail to initialize')
         else:


### PR DESCRIPTION
## What does this PR do?

`logger.warn()` is depricated, use `logger.warning()` which is already being used in some files.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

`logger.warn()` is depricated.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

Before using this patch depreciation warnings were being logged. 
```
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
with this patch, this warning is removed.
<!-- commands to run the tests or instructions to test the changes-->
