### PR TITLE
[fix] ClientPref - don't raise exception if Accept-Language is invalid

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -331,8 +331,12 @@ class ClientPref:
             except (ValueError, babel.core.UnknownLocaleError):
                 continue
             pairs.append((locale, qvalue))
-        pairs.sort(reverse=True, key=lambda x: x[1])
-        return cls(locale=pairs[0][0])
+
+        locale = None
+        if pairs:
+            pairs.sort(reverse=True, key=lambda x: x[1])
+            locale = pairs[0][0]
+        return cls(locale=locale)
 
 
 class Preferences:


### PR DESCRIPTION
If the Accept-Language header [1] is set but empty or holds a value that is unknown to babel, an excpetion is raised::

    $ curl --header 'Accept-Language: xyz' 'http://127.0.0.1:8888/search?q=foo'
    ...
    Traceback (most recent call last):
      File "searx/preferences.py", line 335, in from_http_request
        return cls(locale=pairs[0][0])
    IndexError: list index out of range

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language

Reported by: @Eolien55 in https://github.com/searxng/searxng/issues/2434#issuecomment-1556199789
Closes: https://github.com/searxng/searxng/issues/2434
Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>
