### PR TITLE
[fix] URL percent-encoding in translations fail in babel

### DIFF
--- a/searx/templates/simple/preferences/method.html
+++ b/searx/templates/simple/preferences/method.html
@@ -11,6 +11,6 @@
     </select>{{- '' -}}
   </div>{{- '' -}}
   <div class="description">
-    {{- _('Change how forms are submitted, <a href="http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods" rel="external">learn more about request methods</a>') -}}
+    {{- _('Change how forms are submitted') }} <a href="https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods" rel="external">🔗</a>
   </div>{{- '' -}}
 </fieldset>{{- '' -}}


### PR DESCRIPTION
Closes: https://github.com/searxng/searxng/issues/2482
