### PR TITLE
[POC] limiter: change PING of link_token method from CSS to <img>

### DIFF
--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -17,9 +17,6 @@
   {% else %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/searxng.min.css') }}" type="text/css" media="screen">
   {% endif %}
-  {% if get_setting('server.limiter') or get_setting('server.public_instance') %}
-  <link rel="stylesheet" href="{{ url_for('client_token', token=link_token) }}" type="text/css">
-  {% endif %}
   {% block styles %}{% endblock %}
   <!--[if gte IE 9]>-->
   <script src="{{ url_for('static', filename='js/searxng.head.min.js') }}" client_settings="{{ client_settings }}"></script>
@@ -86,5 +83,8 @@
   <!--[if gte IE 9]>-->
   <script src="{{ url_for('static', filename='js/searxng.min.js') }}"></script>
   <!--<![endif]-->
+  {%- if get_setting('server.limiter') -%}
+    <img class='invisible' src="{{ url_for('client_token', token=link_token) }}">
+  {%- endif -%}
 </body>
 </html>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -617,10 +617,12 @@ def health():
     return Response('OK', mimetype='text/plain')
 
 
-@app.route('/client<token>.css', methods=['GET', 'POST'])
+@app.route('/client<token>.svg', methods=['GET', 'POST'])
 def client_token(token=None):
     link_token.ping(request, token)
-    return Response('', mimetype='text/css')
+    resp = Response('<svg></svg>', mimetype='image/svg+xml')
+    resp.headers['Cache-Control'] = 'no-store'
+    return resp
 
 
 @app.route('/search', methods=['GET', 'POST'])


### PR DESCRIPTION
while PR #2357 [1] was being implemented the question came up:

    would be better to change the PING resource from CSS to an image so that
    some terminal based browser may still able to pass the test [1]

This patch implements a POC in where a ``<img src=token>`` tag is loaded instaed a CSS.

To test this patch activate limiter and link_token method [3] and start a developer instance::

    make run

In your terminal browser open http://127.0.0.1:8888/search?q=foo

If the browser is suitable for the link_token method, it loads the image and the following messages appear::

    DEBUG   searx.botdetection.limiter    : OK 127.0.0.1/32: /clientft61aak7fzyu6o6v.svg ...
    DEBUG   searx.botdetection.link_token : token is valid --> True
    DEBUG   searx.botdetection.link_token : store ping_key for (client) network 127.0.0.1/32 (IP 127.0.0.1) -> SearXNG_limiter.ping[...]

Browsers that do not load images will be blocked: If you try by example::

    lynx http://127.0.0.1:8888/search?q=foo

you will see a WARNING message like::

    WARNING searx.botdetection.link_token : missing ping (IP: 127.0.0.1/32) / request: SearXNG_limiter.ping[...]

----

[1] https://github.com/searxng/searxng/commit/80aaef6c95b572df1fa3a8c30b7fdc1538d7a306
[2] https://github.com/searxng/searxng/pull/2357#issuecomment-1574898834
[3] activate limiter and link_token method

```diff
diff --git a/searx/botdetection/limiter.toml b/searx/botdetection/limiter.toml
index 71a231e8f..7e1dba755 100644
--- a/searx/botdetection/limiter.toml
+++ b/searx/botdetection/limiter.toml
@@ -17,6 +17,6 @@ ipv6_prefix = 48
 filter_link_local = false

 # acrivate link_token method in the ip_limit method
-link_token = false
+link_token = true

diff --git a/searx/settings.yml b/searx/settings.yml
index a82a3432d..e7b983afc 100644
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -73,7 +73,7 @@ server:
   # public URL of the instance, to ensure correct inbound links. Is overwritten
   # by ${SEARXNG_URL}.
   base_url: false  # "http://example.com/location"
-  limiter: false  # rate limit the number of request on the instance, block some bots
+  limiter: true  # rate limit the number of request on the instance, block some bots

   # If your instance owns a /etc/searxng/settings.yml file, then set the following
   # values there.
```