### PR TITLE
[fix] engines: don't spam marginalia.nu with default settings

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1472,27 +1472,6 @@ engines:
     about:
       website: https://wiby.me/
 
-  - name: marginalia
-    engine: json_engine
-    shortcut: mar
-    categories: general
-    paging: false
-    # index: {"0": "popular", "1": "blogs", "2": "big_sites",
-    # "3": "default", "4": experimental"}
-    search_url: https://api.marginalia.nu/public/search/{query}?index=4&count=20
-    results_query: results
-    url_query: url
-    title_query: title
-    content_query: description
-    timeout: 1.5
-    disabled: true
-    about:
-      website: https://www.marginalia.nu/
-      official_api_documentation: https://api.marginalia.nu/
-      use_official_api: true
-      require_api_key: true
-      results: JSON
-
   - name: alexandria
     engine: json_engine
     shortcut: alx


### PR DESCRIPTION
The engine configuration of marginalia [2][3][4][5] spams marginalia.nu with requests from SearXNG instances [1].  It is not in the interest of SearXNG to disturb other FOSS projects, so the engine will be removed::

    - name: marginalia
      engine: json_engine
      shortcut: mar
      categories: general
      paging: false
      # Key and license: https://www.marginalia.nu/marginalia-search/api/
      # index: 0 popular, 1 blogs, 2 big_sites, 3 default, 4 experimental
      search_url: https://api.marginalia.nu/<insert your key here>/search/{query}?index=4&count=20
      results_query: results
      url_query: url
      title_query: title
      content_query: description
      timeout: 1.5
      disabled: true
      about:
        website: https://www.marginalia.nu/
        official_api_documentation: https://api.marginalia.nu/
        use_official_api: true
        require_api_key: true
        results: JSON

[1] https://github.com/searxng/searxng/issues/1673
[2] https://github.com/searxng/searxng/pull/1627
[3] https://github.com/searxng/searxng/issues/1620
[4] https://news.ycombinator.com/item?id=35874640
[5] https://github.com/MarginaliaSearch/MarginaliaSearch/blob/d82a8584915c9d416921cc9f1c0637efedea664f/code/services-satellite/api-service/src/main/java/nu/marginalia/api/svc/ResponseCache.java#L12-L20

