### PR TITLE
[doc] settings.yml: add missing $SEARXNG_REDIS_URL to the docs

### DIFF
--- a/docs/admin/engines/settings.rst
+++ b/docs/admin/engines/settings.rst
@@ -328,7 +328,7 @@ In this example read/write access is given to the *searxng-redis* group.  To get
 access rights to redis instance (the socket), your SearXNG (or even your
 developer) account needs to be added to the *searxng-redis* group.
 
-``url``
+``url`` : ``$SEARXNG_REDIS_URL``
   URL to connect redis database, see `Redis.from_url(url)`_ & :ref:`redis db`::
 
     redis://[[username]:[password]]@localhost:6379/0


### PR DESCRIPTION
- https://github.com/searxng/searxng/issues/2499

@robigan sorry, a little bit late I see we have already a environment variable for the redis DB .. but we missed to document the variable. This patch adds the missing documentation.

