### PR TITLE
[fix] Google API has been changed

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -172,7 +172,8 @@ def get_google_info(params, eng_traits):
     # The Interface Language:
     #   https://developers.google.com/custom-search/docs/xml_results_appendices#interfaceLanguages
 
-    ret_val['params']['hl'] = lang_code
+    # https://github.com/searxng/searxng/issues/2515#issuecomment-1607150817
+    ret_val['params']['hl'] = f'{lang_code}-{country}'
 
     # lr parameter:
     #   The lr (language restrict) parameter restricts search results to
@@ -212,7 +213,8 @@ def get_google_info(params, eng_traits):
     #   countries other than the United States.
     #   https://developers.google.com/custom-search/docs/xml_results#glsp
 
-    ret_val['params']['gl'] = country
+    # https://github.com/searxng/searxng/issues/2515#issuecomment-1606294635
+    # ret_val['params']['gl'] = country
 
     # ie parameter:
     #   The ie parameter sets the character encoding scheme that should be used


### PR DESCRIPTION
It seems that Google is rolling out a modified WEB API [1][2].

In the past there was only the UI language in the `hl` argument but nowadays it seems a combination of the UI language and the "search region" is mixed in this argument and the `gl` argument has been removed.  I'm very surprised that google is starting to mix the parameters of the UI with the parameters of the search index.

This patch modifies the get_google_info(..) function.  Beside Google-WEB this function is also used by other Google services, here are some examples to test region & language of ..

- Google-WEB:    `!go dragon boat :en-CA`
- Google-News:   `!gon dragon boat :en-CA`
- Google-Videos: `!gov bmw :en-CA`
- Goolge-Images  `!goi bmw :en-CA`

---

- [1] https://github.com/searxng/searxng/issues/2515#issuecomment-1606294635
- [2] https://github.com/searxng/searxng/issues/2515#issuecomment-1607150817