### PR TITLE
[mod] Upgrade Sphinx from 6.2.1 to 7.0.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,14 +7,14 @@ splinter==0.19.0
 selenium==4.10.0
 twine==4.0.2
 Pallets-Sphinx-Themes==2.1.1
-Sphinx==6.2.1
+Sphinx==7.0.1
 sphinx-issues==3.0.1
 sphinx-jinja==2.0.2
 sphinx-tabs==3.4.1
 sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14
 sphinx-notfound-page==0.8.3
-myst-parser==1.0.0
+myst-parser==2.0.0
 linuxdoc==20230506
 aiounittest==1.4.2
 yamllint==1.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ uvloop==0.17.0
 httpx-socks[asyncio]==0.7.2
 setproctitle==1.3.2
 redis==4.5.5
-markdown-it-py==2.2.0
+markdown-it-py==3.0.0
 typing_extensions==4.6.3
 fasttext-predict==0.9.2.1
 pytomlpp==1.0.13


### PR DESCRIPTION
To upgrade Sphinx, MyST-Parser and markdown-it-py must also be updated at the same time:

Closes: https://github.com/searxng/searxng/pull/2433
Closes: https://github.com/searxng/searxng/pull/2492
Closes: https://github.com/searxng/searxng/pull/2504
