### PR TITLE
[feat] engine: implementation of Piped

### DIFF
--- a/docs/dev/engines/online/piped.rst
+++ b/docs/dev/engines/online/piped.rst
@@ -1,0 +1,13 @@
+.. _piped engine:
+
+=====
+Piped
+=====
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.engines.piped
+  :members:

--- a/searx/engines/piped.py
+++ b/searx/engines/piped.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Piped (Videos)
+"""
+
+import time
+import random
+from urllib.parse import urlencode
+from dateutil import parser
+
+# about
+about = {
+    "website": 'https://github.com/TeamPiped/Piped/',
+    "wikidata_id": 'Q107565255',
+    "official_api_documentation": 'https://docs.piped.video/docs/api-documentation/',
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+# engine dependent config
+categories = ["videos", "music"]
+paging = False
+
+# search-url
+backend_url = "https://pipedapi.kavin.rocks"
+frontend_url = "https://piped.video"
+
+
+# do search-request
+def request(query, params):
+    if isinstance(backend_url, list):
+        base_url = random.choice(backend_url)
+    else:
+        base_url = backend_url
+
+    search_url = base_url + "/search?{query}&filter=videos"
+    params["url"] = search_url.format(query=urlencode({'q': query}))
+
+    return params
+
+
+# get response from search-request
+def response(resp):
+    results = []
+
+    search_results = resp.json()["items"]
+
+    for result in search_results:
+        publishedDate = parser.parse(time.ctime(result.get("uploaded", 0) / 1000))
+
+        results.append(
+            {
+                # the api url differs from the frontend, hence use piped.video as default
+                "url": frontend_url + result.get("url", ""),
+                "title": result.get("title", ""),
+                "content": result.get("shortDescription", ""),
+                "template": "videos.html",
+                "publishedDate": publishedDate,
+                "iframe_src": frontend_url + '/embed' + result.get("url", ""),
+                "thumbnail": result.get("thumbnail", ""),
+            }
+        )
+
+    return results

--- a/searx/engines/piped.py
+++ b/searx/engines/piped.py
@@ -9,6 +9,29 @@ design.  `Piped’s architecture`_ consists of 3 components:
 
 .. _Piped’s architecture: https://docs.piped.video/docs/architecture/
 
+Configuration
+=============
+
+The :py:obj:`backend_url` and :py:obj:`frontend_url` has to be set in the engine
+named `piped` and are used by all piped engines
+
+.. code:: yaml
+
+  - name: piped
+    engine: piped
+    piped_filter: videos
+    ...
+    frontend_url: https://..
+    backend_url:
+      - https://..
+      - https://..
+
+  - name: piped.music
+    engine: piped
+    network: piped
+    shortcut: ppdm
+    piped_filter: music_songs
+    ...
 """
 
 from __future__ import annotations
@@ -16,6 +39,7 @@ from __future__ import annotations
 import time
 import random
 from urllib.parse import urlencode
+import datetime
 from dateutil import parser
 
 # about
@@ -29,11 +53,11 @@ about = {
 }
 
 # engine dependent config
-categories = ["videos", "music"]
+categories = []
 paging = False
 
 # search-url
-backend_url: list|str = "https://pipedapi.kavin.rocks"
+backend_url: list | str = "https://pipedapi.kavin.rocks"
 """Piped-Backend_: The core component behind Piped.  The value is an URL or a
 list of URLs.  In the latter case instance will be selected randomly.  For a
 complete list of offical instances see Piped-Instances (`JSON
@@ -50,17 +74,29 @@ frontend_url: str = "https://piped.video"
 .. _Piped-Frontend: https://github.com/TeamPiped/Piped
 """
 
-content_filter = 'videos'
-"""Content filter ``music_albums`` or ``videos``"""
+piped_filter = 'all'
+"""Content filter ``music_songs`` or ``videos``"""
+
+
+def _backend_url() -> str:
+    from searx.engines import engines  # pylint: disable=import-outside-toplevel
+
+    url = engines['piped'].backend_url  # type: ignore
+    if isinstance(url, list):
+        url = random.choice(url)
+    return url
+
+
+def _frontend_url() -> str:
+    from searx.engines import engines  # pylint: disable=import-outside-toplevel
+
+    return engines['piped'].frontend_url  # type: ignore
+
 
 def request(query, params):
-    if isinstance(backend_url, list):
-        base_url = random.choice(backend_url)
-    else:
-        base_url = backend_url
 
     query = urlencode({'q': query})
-    params["url"] = base_url + f"/search?{query}&filter={content_filter}"
+    params["url"] = _backend_url() + f"/search?{query}&filter={piped_filter}"
 
     return params
 
@@ -73,17 +109,27 @@ def response(resp):
     for result in search_results:
         publishedDate = parser.parse(time.ctime(result.get("uploaded", 0) / 1000))
 
-        results.append(
-            {
-                # the api url differs from the frontend, hence use piped.video as default
-                "url": frontend_url + result.get("url", ""),
-                "title": result.get("title", ""),
-                "content": result.get("shortDescription", ""),
-                "template": "videos.html",
-                "publishedDate": publishedDate,
-                "iframe_src": frontend_url + '/embed' + result.get("url", ""),
-                "thumbnail": result.get("thumbnail", ""),
-            }
-        )
+        item = {
+            # the api url differs from the frontend, hence use piped.video as default
+            "url": _frontend_url() + result.get("url", ""),
+            "title": result.get("title", ""),
+            "publishedDate": publishedDate,
+            "iframe_src": _frontend_url() + '/embed' + result.get("url", ""),
+        }
+
+        if piped_filter == 'videos':
+            item["template"] = "videos.html"
+            item["content"] = result.get("shortDescription", "")
+            item["thumbnail"] = result.get("thumbnail", "")
+
+        elif piped_filter == 'music_songs':
+            item["template"] = "default.html"
+            item["img_src"] = result.get("thumbnail", "")
+            item["content"] = result.get("uploaderName", "")
+            length = result.get("duration")
+            if length:
+                item["length"] = datetime.timedelta(seconds=length)
+
+        results.append(item)
 
     return results

--- a/searx/engines/piped.py
+++ b/searx/engines/piped.py
@@ -142,13 +142,14 @@ def response(resp):
 
         if piped_filter == 'videos':
             item["template"] = "videos.html"
-            item["content"] = result.get("shortDescription", "")
+            # if the value of shortDescription set, but is None, return empty string
+            item["content"] = result.get("shortDescription", "") or ""
             item["thumbnail"] = result.get("thumbnail", "")
 
         elif piped_filter == 'music_songs':
             item["template"] = "default.html"
             item["img_src"] = result.get("thumbnail", "")
-            item["content"] = result.get("uploaderName", "")
+            item["content"] = result.get("uploaderName", "") or ""
             length = result.get("duration")
             if length:
                 item["length"] = datetime.timedelta(seconds=length)

--- a/searx/engines/piped.py
+++ b/searx/engines/piped.py
@@ -1,7 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # lint: pylint
-"""Piped (Videos)
+"""An alternative privacy-friendly YouTube frontend which is efficient by
+design.  `Piped’s architecture`_ consists of 3 components:
+
+- :py:obj:`backend <backend_url>`
+- :py:obj:`frontend <frontend_url>`
+- proxy
+
+.. _Piped’s architecture: https://docs.piped.video/docs/architecture/
+
 """
+
+from __future__ import annotations
 
 import time
 import random
@@ -23,24 +33,38 @@ categories = ["videos", "music"]
 paging = False
 
 # search-url
-backend_url = "https://pipedapi.kavin.rocks"
-frontend_url = "https://piped.video"
+backend_url: list|str = "https://pipedapi.kavin.rocks"
+"""Piped-Backend_: The core component behind Piped.  The value is an URL or a
+list of URLs.  In the latter case instance will be selected randomly.  For a
+complete list of offical instances see Piped-Instances (`JSON
+<https://piped-instances.kavin.rocks/>`__)
 
+.. _Piped-Instances: https://github.com/TeamPiped/Piped/wiki/Instances
+.. _Piped-Backend: https://github.com/TeamPiped/Piped-Backend
 
-# do search-request
+"""
+
+frontend_url: str = "https://piped.video"
+"""Piped-Frontend_: URL to use as link and for embeds.
+
+.. _Piped-Frontend: https://github.com/TeamPiped/Piped
+"""
+
+content_filter = 'videos'
+"""Content filter ``music_albums`` or ``videos``"""
+
 def request(query, params):
     if isinstance(backend_url, list):
         base_url = random.choice(backend_url)
     else:
         base_url = backend_url
 
-    search_url = base_url + "/search?{query}&filter=videos"
-    params["url"] = search_url.format(query=urlencode({'q': query}))
+    query = urlencode({'q': query})
+    params["url"] = base_url + f"/search?{query}&filter={content_filter}"
 
     return params
 
 
-# get response from search-request
 def response(resp):
     results = []
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1136,6 +1136,19 @@ engines:
     engine: photon
     shortcut: ph
 
+  - name: piped
+    engine: piped
+    # Instance will be selected randomly, for more see https://piped-instances.kavin.rocks/
+    backend_url:
+      - https://pipedapi.kavin.rocks
+      - https://pipedapi-libre.kavin.rocks
+      - https://pipedapi.adminforge.de
+    # Url to use as link, and for embeds
+    frontend_url: https://srv.piped.video
+    shortcut: ppd
+    timeout: 3.0
+    disabled: true
+
   - name: piratebay
     engine: piratebay
     shortcut: tpb

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1138,16 +1138,26 @@ engines:
 
   - name: piped
     engine: piped
+    shortcut: ppd
+    categories: videos
+    piped_filter: videos
+    timeout: 3.0
+
+    # URL to use as link and for embeds
+    frontend_url: https://srv.piped.video
     # Instance will be selected randomly, for more see https://piped-instances.kavin.rocks/
     backend_url:
       - https://pipedapi.kavin.rocks
       - https://pipedapi-libre.kavin.rocks
       - https://pipedapi.adminforge.de
-    # URL to use as link and for embeds
-    frontend_url: https://srv.piped.video
-    shortcut: ppd
+
+  - name: piped.music
+    engine: piped
+    network: piped
+    shortcut: ppdm
+    categories: music
+    piped_filter: music_songs
     timeout: 3.0
-    disabled: true
 
   - name: piratebay
     engine: piratebay

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1143,7 +1143,7 @@ engines:
       - https://pipedapi.kavin.rocks
       - https://pipedapi-libre.kavin.rocks
       - https://pipedapi.adminforge.de
-    # Url to use as link, and for embeds
+    # URL to use as link and for embeds
     frontend_url: https://srv.piped.video
     shortcut: ppd
     timeout: 3.0


### PR DESCRIPTION
## What does this PR do?
* Add support for the Piped API for searching videos

## Why is this change important?
* Works similar to Invidious and the tracking issue for adding Piped didn't seem to be rejected, so I thought it'd be worth adding

## How to test this PR locally?
1. Move to preferences -> engines -> video
2. Uncheck all engines and enable Piped
3. Search something in the video category

## Related issues

closes #952

cc @FireMasterK