### PR TITLE
Move Wolfram Alpha into General category and disable by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1602,7 +1602,8 @@ engines:
     # Or you can use the html non-stable engine, activated by default
     engine: wolframalpha_noapi
     timeout: 6.0
-    categories: []
+    disabled: true
+    categories: general
 
   - name: dictzone
     engine: dictzone


### PR DESCRIPTION
As suggested in https://github.com/searxng/searxng/pull/813#issuecomment-1574851572 as a good compromise between https://github.com/searxng/searxng/pull/813#issuecomment-1020581765 and https://github.com/searxng/searxng/issues/966#issue-1171107451.

This will help users that want Wolfram Alpha instant answers by default with every query and don't mind the slowness. It will be disabled by default so it's fast for all users, and those that need it can enable it as a user-configurable option without requiring setting up their own instance to change the Wolfram Alpha categorization.

## Would close:
https://github.com/searxng/searxng/issues/966