### PR TITLE
add bt4g engine and disable by default btdigg

### DIFF
--- a/docs/dev/engines/index.rst
+++ b/docs/dev/engines/index.rst
@@ -4,10 +4,14 @@
 Engine Implementations
 ======================
 
-Framework Components
-====================
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+
 
 .. toctree::
+   :caption: Framework Components
    :maxdepth: 2
 
    enginelib

--- a/docs/dev/engines/online/bt4g.rst
+++ b/docs/dev/engines/online/bt4g.rst
@@ -1,0 +1,14 @@
+.. _bt4g engine:
+
+====
+BT4G
+====
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.engines.bt4g
+  :members:
+

--- a/searx/engines/bt4g.py
+++ b/searx/engines/bt4g.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""
+ BT4G (Videos, Music, Files)
+"""
+
+import re
+from datetime import datetime
+from urllib.parse import quote
+
+from lxml import etree
+
+from searx.utils import get_torrent_size
+
+# about
+about = {
+    "website": 'https://bt4gprx.com',
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'XML',
+}
+
+# engine dependent config
+categories = ['files']
+paging = True
+time_range_support = True
+
+# search-url
+url = 'https://bt4gprx.com'
+search_url = url + '/search?q={search_term}&orderby={order_by}&category={category}&p={pageno}&page=rss'
+bt4g_order_by = 'relevance'  # relevance, size, seeders, time
+bt4g_category = 'all'  # all, audio, movie, doc, app, other
+
+
+def request(query, params):
+
+    order_by = bt4g_order_by
+    if params['time_range']:
+        order_by = 'time'
+
+    params['url'] = search_url.format(
+        search_term=quote(query),
+        order_by=order_by,
+        category=bt4g_category,
+        pageno=params['pageno'],
+    )
+    return params
+
+
+def response(resp):
+    results = []
+
+    search_results = etree.XML(resp.content)
+
+    # return empty array if nothing is found
+    if len(search_results) == 0:
+        return []
+
+    for entry in search_results.xpath('./channel/item'):
+        title = entry.find("title").text
+        link = entry.find("guid").text
+        fullDescription = entry.find("description").text.split('<br>')
+        filesize = fullDescription[1]
+        filesizeParsed = re.split(r"([A-Z]+)", filesize)
+        magnetlink = entry.find("link").text
+        pubDate = entry.find("pubDate").text
+        results.append(
+            {
+                'url': link,
+                'title': title,
+                'magnetlink': magnetlink,
+                'seed': 'N/A',
+                'leech': 'N/A',
+                'filesize': get_torrent_size(filesizeParsed[0], filesizeParsed[1]),
+                'publishedDate': datetime.strptime(pubDate, '%a,%d %b %Y %H:%M:%S %z'),
+                'template': 'torrent.html',
+            }
+        )
+
+    return results

--- a/searx/engines/bt4g.py
+++ b/searx/engines/bt4g.py
@@ -1,7 +1,40 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # lint: pylint
-"""
- BT4G (Videos, Music, Files)
+"""BT4G_ (bt4g.com) is not a tracker and doesn't store any content and only
+collects torrent metadata (such as file names and file sizes) and a magnet link
+(torrent identifier).
+
+This engine does not parse the HTML page because there is an API in XML (RSS).
+The RSS feed provides fewer data like amount of seeders/leechers and the files
+in the torrent file.  It's a tradeoff for a "stable" engine as the XML from RSS
+content will change way less than the HTML page.
+
+.. _BT4G: https://bt4g.com/
+
+Configuration
+=============
+
+The engine has the following additional settings:
+
+- :py:obj:`bt4g_order_by`
+- :py:obj:`bt4g_category`
+
+With this options a SearXNG maintainer is able to configure **additional**
+engines for specific torrent searches.  For example a engine to search only for
+Movies and sort the result list by the count of seeders.
+
+.. code:: yaml
+
+  - name: bt4g.movie
+    engine: bt4g
+    shortcut: bt4gv
+    categories: video
+    bt4g_order_by: seeders
+    bt4g_category: 'movie'
+
+Implementations
+===============
+
 """
 
 import re
@@ -28,8 +61,19 @@ time_range_support = True
 # search-url
 url = 'https://bt4gprx.com'
 search_url = url + '/search?q={search_term}&orderby={order_by}&category={category}&p={pageno}&page=rss'
-bt4g_order_by = 'relevance'  # relevance, size, seeders, time
-bt4g_category = 'all'  # all, audio, movie, doc, app, other
+bt4g_order_by = 'relevance'
+"""Result list can be ordered by ``relevance`` (default), ``size``, ``seeders``
+or ``time``.
+
+.. hint::
+
+  When *time_range* is activate, the results always orderd by ``time``.
+"""
+
+bt4g_category = 'all'
+"""BT$G offers categoies: ``all`` (default), ``audio``, ``movie``, ``doc``,
+``app`` and `` other``.
+"""
 
 
 def request(query, params):

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -415,6 +415,7 @@ engines:
   - name: btdigg
     engine: btdigg
     shortcut: bt
+    disabled: true
 
   - name: ccc-tv
     engine: xpath
@@ -1925,6 +1926,10 @@ engines:
       require_api_key: false
       results: HTML
       language: ja
+
+  - name: bt4g
+    engine: bt4g
+    shortcut: bt4g
 
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.


### PR DESCRIPTION
## What does this PR do?

This adds the bt4g engine.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Implement engine requested in https://github.com/searxng/searxng/issues/2553

I did not parse the HTML page because there is an API in XML, but it provides fewer data like amount of seeders/leechers and the files in the torrent file. It's a tradeoff for a "stable" engine as the XML content will change way less than the HTML page.

## Screenshot 

![image](https://github.com/searxng/searxng/assets/4016501/220440c1-9e5e-4ca5-9e0a-7bcaccfb0e00)

## Related issues

Closes https://github.com/searxng/searxng/issues/2553
