### PR TITLE
add option to change yacy search mode

### DIFF
--- a/docs/dev/engines/online/yacy.rst
+++ b/docs/dev/engines/online/yacy.rst
@@ -1,0 +1,13 @@
+.. _yacy engine:
+
+====
+Yacy
+====
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.engines.yacy
+  :members:

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -27,6 +27,7 @@ paging = True
 number_of_results = 5
 http_digest_auth_user = ""
 http_digest_auth_pass = ""
+search_mode = 'global'  # 'global', 'local'. By default, in yacy this is 'global'.
 
 # search-url
 base_url = 'http://localhost:8090'
@@ -35,7 +36,7 @@ search_url = (
     '&startRecord={offset}'
     '&maximumRecords={limit}'
     '&contentdom={search_type}'
-    '&resource=global'
+    '&resource={resource}'
 )
 
 # yacy specific type-definitions
@@ -48,7 +49,11 @@ def request(query, params):
     search_type = search_types.get(params.get('category'), '0')
 
     params['url'] = base_url + search_url.format(
-        query=urlencode({'query': query}), offset=offset, limit=number_of_results, search_type=search_type
+        query=urlencode({'query': query}),
+        offset=offset,
+        limit=number_of_results,
+        search_type=search_type,
+        resource=search_mode,
     )
 
     if http_digest_auth_user and http_digest_auth_pass:
@@ -79,7 +84,6 @@ def response(resp):
     for result in search_results[0].get('items', []):
         # parse image results
         if resp.search_params.get('category') == 'images':
-
             result_url = ''
             if 'url' in result:
                 result_url = result['url']

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -1,11 +1,44 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""YaCy_ is a free distributed search engine, built on the principles of
+peer-to-peer (P2P) networks.
+
+API: Dev:APIyacysearch_
+
+Releases:
+
+- https://github.com/yacy/yacy_search_server/tags
+- https://download.yacy.net/
+
+.. _Yacy: https://yacy.net/
+.. _Dev:APIyacysearch: https://wiki.yacy.net/index.php/Dev:APIyacysearch
+
+Configuration
+=============
+
+The engine has the following (additional) settings:
+
+.. code:: yaml
+
+   - name: yacy
+     engine: yacy
+     shortcut: ya
+     base_url: http://localhost:8090
+     # Yacy search mode. 'global' or 'local'.
+     search_mode: 'global'
+     number_of_results: 5
+     http_digest_auth_user: ""
+     http_digest_auth_pass: ""
+
+
+Implementations
+===============
 """
- Yacy (Web, Images, Videos, Music, Files)
-"""
+# pylint: disable=fixme
 
 from json import loads
-from dateutil import parser
 from urllib.parse import urlencode
+from dateutil import parser
 
 from httpx import DigestAuth
 
@@ -27,8 +60,16 @@ paging = True
 number_of_results = 5
 http_digest_auth_user = ""
 http_digest_auth_pass = ""
-search_mode = 'global'  # 'global', 'local'. By default, in yacy this is 'global'.
+search_mode = 'global'
+"""Yacy search mode ``global`` or ``local``.  By default, Yacy operates in ``global``
+mode.
 
+``global``
+  Peer-to-Peer search
+
+``local``
+  Privacy or Stealth mode, restricts the search to local yacy instance.
+"""
 # search-url
 base_url = 'http://localhost:8090'
 search_url = (
@@ -43,7 +84,6 @@ search_url = (
 search_types = {'general': 'text', 'images': 'image', 'files': 'app', 'music': 'audio', 'videos': 'video'}
 
 
-# do search-request
 def request(query, params):
     offset = (params['pageno'] - 1) * number_of_results
     search_type = search_types.get(params.get('category'), '0')
@@ -66,7 +106,6 @@ def request(query, params):
     return params
 
 
-# get response from search-request
 def response(resp):
     results = []
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1737,6 +1737,10 @@ engines:
   #   enable_http: true
   #   number_of_results: 5
   #   timeout: 3.0
+  #   Yacy search mode. 'global' or 'local'. by default, Yacy operates in 'global' mode.
+  #   'global' = Peer-to-Peer search
+  #   'local' = Privacy or Stealth mode, restricts the search to local yacy instance.
+  #   search_mode: 'global'
 
   - name: rumble
     engine: rumble

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1733,13 +1733,10 @@ engines:
   #   engine: yacy
   #   shortcut: ya
   #   base_url: http://localhost:8090
-  # required if you aren't using HTTPS for your local yacy instance'
+  #   # required if you aren't using HTTPS for your local yacy instance'
   #   enable_http: true
-  #   number_of_results: 5
   #   timeout: 3.0
-  #   Yacy search mode. 'global' or 'local'. by default, Yacy operates in 'global' mode.
-  #   'global' = Peer-to-Peer search
-  #   'local' = Privacy or Stealth mode, restricts the search to local yacy instance.
+  #   # Yacy search mode. 'global' or 'local'.
   #   search_mode: 'global'
 
   - name: rumble


### PR DESCRIPTION
## What does this PR do?

Removes hardcoded "global" mode from Yacy engine and gives user an option to change the scope of the search instead.

## Why is this change important?

Yacy has two search modes, peer-to-peer search and local peer search. This PR enables the mode to be changed in the configuration.

`search_mode='global'` Does the peer-to-peer network search. This is the default search mode in Yacy.
`search_mode='local'` Does local peer only search.

In Yacy's default UI, this option is basically the top left "peer-to-peer" and "privacy" toggle.
![image](https://github.com/searxng/searxng/assets/4032653/71879bbd-0eed-442c-9e1e-6567fdf4237c)
And sometimes it's called Stealth Mode, because why not :grin:.
![image](https://github.com/searxng/searxng/assets/4032653/1cb1a419-bca2-4b25-8341-b33c47e1648c)

Documentation for reference https://wiki.yacy.net/index.php/Dev:APIyacysearch