### PR TITLE
[feat] implementation of Wikimedia commons for images

### DIFF
--- a/searx/engines/wikicommons.py
+++ b/searx/engines/wikicommons.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Wikimedia Commons (images)
+
+"""
+
+from urllib.parse import urlencode
+
+# about
+about = {
+    "website": 'https://commons.wikimedia.org/',
+    "wikidata_id": 'Q565',
+    "official_api_documentation": 'https://commons.wikimedia.org/w/api.php',
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+base_url = "https://commons.wikimedia.org"
+search_prefix = (
+    '?action=query'
+    '&format=json'
+    '&generator=search'
+    '&gsrnamespace=6'
+    '&gsrprop=snippet'
+    '&prop=info|imageinfo'
+    '&iiprop=url|size|mime'
+    '&iiurlheight=180'  # needed for the thumb url
+)
+paging = True
+number_of_results = 10
+
+
+def request(query, params):
+    language = 'en'
+    if params['language'] != 'all':
+        language = params['language'].split('-')[0]
+
+    args = {
+        'uselang': language,
+        'gsrlimit': number_of_results,
+        'gsroffset': number_of_results * (params["pageno"] - 1),
+        'gsrsearch': "filetype:bitmap|drawing " + query,
+    }
+
+    params["url"] = f"{base_url}/w/api.php{search_prefix}&{urlencode(args)}"
+    return params
+
+
+def response(resp):
+    results = []
+    json = resp.json()
+
+    if not json.get("query", {}).get("pages"):
+        return results
+
+    for item in json["query"]["pages"].values():
+        imageinfo = item["imageinfo"][0]
+        title = item["title"].replace("File:", "").rsplit('.', 1)[0]
+        result = {
+            'url': imageinfo["descriptionurl"],
+            'title': title,
+            'content': item["snippet"],
+            'img_src': imageinfo["url"],
+            'img_format': f'{imageinfo["width"]} x {imageinfo["height"]}',
+            'thumbnail_src': imageinfo["thumburl"],
+            'template': 'images.html',
+        }
+        results.append(result)
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1599,6 +1599,12 @@ engines:
       website: https://www.wikivoyage.org/
       wikidata_id: Q373
 
+  - name: wikicommons.images
+    engine: wikicommons
+    shortcut: wc
+    categories: images
+    number_of_results: 10
+
   - name: wolframalpha
     shortcut: wa
     # You can use the engine using the official stable API, but you need an API


### PR DESCRIPTION
## What does this PR do?
* Add support for the Wikimedia Commons API for searching images

## Why is this change important?
* Wikimedia Commons provides a large amount of images, that are copyleft or free to use
* The API supports much more, such as videos, audio files, and general/text content, but it's most important category are images

## How to test this PR locally?
1. Move to preferences -> engines -> images
2. Uncheck all engines and enable `wikicommons.images`
3. Search something in the images category

## Related issues

addresses #1221

(example url as note to self: https://commons.wikimedia.org/w/api.php?action=query&generator=search&gsrsearch=filetype:bitmap|drawing%20cat&gsrlimit=20&gsrnamespace=6&format=json&gsrprop=snippet&prop=info|imageinfo&gsrnamespace=6&iiprop=url|size|mime&iiurlheight=180&inprop=url)