### PR TITLE
[feat] new engine: wikispecies

### DIFF
--- a/docs/dev/engines/index.rst
+++ b/docs/dev/engines/index.rst
@@ -40,6 +40,12 @@ Online Engines
 
    demo/demo_online
    xpath
+   mediawiki
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
    online/*
 
 .. _offline engines:

--- a/docs/dev/engines/mediawiki.rst
+++ b/docs/dev/engines/mediawiki.rst
@@ -1,0 +1,13 @@
+.. _mediawiki engine:
+
+================
+MediaWiki Engine
+================
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.engines.mediawiki
+  :members:

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -3,9 +3,10 @@
  General mediawiki-engine (Web)
 """
 
-from json import loads
 from string import Formatter
 from urllib.parse import urlencode, quote
+
+from searx.utils import html_to_text
 
 # about
 about = {
@@ -69,7 +70,7 @@ def request(query, params):
 def response(resp):
     results = []
 
-    search_results = loads(resp.text)
+    search_results = resp.json()
 
     # return empty array if there are no results
     if not search_results.get('query', {}).get('search'):
@@ -86,7 +87,7 @@ def response(resp):
         )
 
         # append result
-        results.append({'url': url, 'title': result['title'], 'content': ''})
+        results.append({'url': url, 'title': result['title'], 'content': html_to_text(result.get('snippet', ''))})
 
     # return results
     return results

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -1,18 +1,59 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
- General mediawiki-engine (Web)
-"""
+# lint: pylint
+"""The MediaWiki engine is a *generic* engine to **query** Wikimedia wikis by
+the `MediaWiki Action API`_.  For a `query action`_ all Wikimedia wikis have
+endpoints that follow this pattern::
 
-from string import Formatter
+    https://{base_url}/w/api.php?action=query&list=search&format=json
+
+.. note::
+
+   In its actual state, this engine is implemented to parse JSON result
+   (`format=json`_) from a search query (`list=search`_).  If you need other
+   ``action`` and ``list`` types ask SearXNG developers to extend the
+   implementation according to your needs.
+
+.. _MediaWiki Action API: https://www.mediawiki.org/wiki/API:Main_page
+.. _query action: https://www.mediawiki.org/w/api.php?action=help&modules=query
+.. _`list=search`: https://www.mediawiki.org/w/api.php?action=help&modules=query%2Bsearch
+.. _`format=json`: https://www.mediawiki.org/w/api.php?action=help&modules=json
+
+Configuration
+=============
+
+Request:
+
+- :py:obj:`base_url`
+- :py:obj:`search_type`
+- :py:obj:`srenablerewrites`
+- :py:obj:`srsort`
+- :py:obj:`srprop`
+
+Implementations
+===============
+
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from datetime import datetime
 from urllib.parse import urlencode, quote
 
 from searx.utils import html_to_text
+from searx.enginelib.traits import EngineTraits
+
+if TYPE_CHECKING:
+    import logging
+
+    logger: logging.Logger
+
+traits: EngineTraits
 
 # about
 about = {
     "website": None,
     "wikidata_id": None,
-    "official_api_documentation": 'http://www.mediawiki.org/wiki/API:Search',
+    "official_api_documentation": 'https://www.mediawiki.org/w/api.php?action=help&modules=query',
     "use_official_api": True,
     "require_api_key": False,
     "results": 'JSON',
@@ -21,73 +62,119 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
-number_of_results = 1
-search_type = 'nearmatch'  # possible values: title, text, nearmatch
+number_of_results = 5
 
-# search-url
-base_url = 'https://{language}.wikipedia.org/'
-search_postfix = (
-    'w/api.php?action=query'
-    '&list=search'
-    '&{query}'
-    '&format=json'
-    '&sroffset={offset}'
-    '&srlimit={limit}'
-    '&srwhat={searchtype}'
-)
+search_type: str = 'nearmatch'
+"""Which type of search to perform.  One of the following values: ``nearmatch``,
+``text`` or ``title``.
+
+See ``srwhat`` argument in `list=search`_ documentation.
+"""
+
+srenablerewrites: bool = True
+"""Enable internal query rewriting (Type: boolean).  Some search backends can
+rewrite the query into another which is thought to provide better results, for
+instance by correcting spelling errors.
+
+See ``srenablerewrites`` argument in `list=search`_ documentation.
+"""
+
+srsort: str = 'relevance'
+"""Set the sort order of returned results.  One of the following values:
+``create_timestamp_asc``, ``create_timestamp_desc``, ``incoming_links_asc``,
+``incoming_links_desc``, ``just_match``, ``last_edit_asc``, ``last_edit_desc``,
+``none``, ``random``, ``relevance``, ``user_random``.
+
+See ``srenablerewrites`` argument in `list=search`_ documentation.
+"""
+
+srprop: str = 'sectiontitle|snippet|timestamp|categorysnippet'
+"""Which properties to return.
+
+See ``srprop`` argument in `list=search`_ documentation.
+"""
+
+base_url: str = 'https://{language}.wikipedia.org/'
+"""Base URL of the Wikimedia wiki.
+
+``{language}``:
+  ISO 639-1 language code (en, de, fr ..) of the search language.
+"""
+
+timestamp_format = '%Y-%m-%dT%H:%M:%SZ'
+"""The longhand version of MediaWiki time strings."""
 
 
-# do search-request
 def request(query, params):
-    offset = (params['pageno'] - 1) * number_of_results
-
-    string_args = dict(
-        query=urlencode({'srsearch': query}), offset=offset, limit=number_of_results, searchtype=search_type
-    )
-
-    format_strings = list(Formatter().parse(base_url))
-
-    if params['language'] == 'all':
-        language = 'en'
-    else:
-        language = params['language'].split('-')[0]
-
-    # format_string [('https://', 'language', '', None), ('.wikipedia.org/', None, None, None)]
-    if any(x[1] == 'language' for x in format_strings):
-        string_args['language'] = language
 
     # write search-language back to params, required in response
-    params['language'] = language
 
-    search_url = base_url + search_postfix
+    if params['language'] == 'all':
+        params['language'] = 'en'
+    else:
+        params['language'] = params['language'].split('-')[0]
 
-    params['url'] = search_url.format(**string_args)
+    if base_url.endswith('/'):
+        api_url = base_url + 'w/api.php?'
+    else:
+        api_url = base_url + '/w/api.php?'
+    api_url = api_url.format(language=params['language'])
 
+    offset = (params['pageno'] - 1) * number_of_results
+
+    args = {
+        'action': 'query',
+        'list': 'search',
+        'format': 'json',
+        'srsearch': query,
+        'sroffset': offset,
+        'srlimit': number_of_results,
+        'srwhat': search_type,
+        'srprop': srprop,
+        'srsort': srsort,
+    }
+    if srenablerewrites:
+        args['srenablerewrites'] = '1'
+
+    params['url'] = api_url + urlencode(args)
     return params
 
 
 # get response from search-request
 def response(resp):
-    results = []
 
+    results = []
     search_results = resp.json()
 
     # return empty array if there are no results
     if not search_results.get('query', {}).get('search'):
         return []
 
-    # parse results
     for result in search_results['query']['search']:
+
         if result.get('snippet', '').startswith('#REDIRECT'):
             continue
-        url = (
-            base_url.format(language=resp.search_params['language'])
-            + 'wiki/'
-            + quote(result['title'].replace(' ', '_').encode())
-        )
 
-        # append result
-        results.append({'url': url, 'title': result['title'], 'content': html_to_text(result.get('snippet', ''))})
+        title = result['title']
+        sectiontitle = result.get('sectiontitle')
+        content = html_to_text(result.get('snippet', ''))
+        metadata = html_to_text(result.get('categorysnippet', ''))
+        timestamp = result.get('timestamp')
+
+        url = (
+            base_url.format(language=resp.search_params['language']) + 'wiki/' + quote(title.replace(' ', '_').encode())
+        )
+        if sectiontitle:
+            # in case of sectiontitle create a link to the section in the wiki page
+            url += '#' + quote(sectiontitle.replace(' ', '_').encode())
+            title += ' / ' + sectiontitle
+
+        item = {'url': url, 'title': title, 'content': content, 'metadata': metadata}
+
+        if timestamp:
+            item['publishedDate'] = datetime.strptime(timestamp, timestamp_format)
+
+        results.append(item)
 
     # return results
     return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -668,11 +668,6 @@ engines:
     shortcut: fsd
     categories: [it, software wikis]
     base_url: https://directory.fsf.org/
-    number_of_results: 5
-    # what part of a page matches the query string: title, text, nearmatch
-    # * title     - query matches title
-    # * text      - query matches the text of page
-    # * nearmatch - nearmatch in title
     search_type: title
     timeout: 5.0
     disabled: true
@@ -1433,13 +1428,6 @@ engines:
     engine: twitter
     disabled: true
 
-  # maybe in a fun category
-  #  - name: uncyclopedia
-  #    engine: mediawiki
-  #    shortcut: unc
-  #    base_url: https://uncyclopedia.wikia.com/
-  #    number_of_results: 5
-
   # tmp suspended - too slow, too many errors
   #  - name: urbandictionary
   #    engine      : xpath
@@ -1518,7 +1506,6 @@ engines:
     shortcut: wb
     categories: general
     base_url: "https://{language}.wikibooks.org/"
-    number_of_results: 5
     search_type: text
     disabled: true
     about:
@@ -1530,9 +1517,9 @@ engines:
     shortcut: wn
     categories: news
     base_url: "https://{language}.wikinews.org/"
-    number_of_results: 5
     search_type: text
     disabled: true
+    srsort: create_timestamp_desc
     about:
       website: https://www.wikinews.org/
       wikidata_id: Q964
@@ -1542,7 +1529,6 @@ engines:
     shortcut: wq
     categories: general
     base_url: "https://{language}.wikiquote.org/"
-    number_of_results: 5
     search_type: text
     disabled: true
     additional_tests:
@@ -1556,7 +1542,6 @@ engines:
     shortcut: ws
     categories: general
     base_url: "https://{language}.wikisource.org/"
-    number_of_results: 5
     search_type: text
     disabled: true
     about:
@@ -1568,7 +1553,6 @@ engines:
     shortcut: wsp
     categories: [general, science]
     base_url: "https://species.wikimedia.org/"
-    number_of_results: 5
     search_type: text
     disabled: true
     about:
@@ -1580,7 +1564,6 @@ engines:
     shortcut: wt
     categories: [dictionaries]
     base_url: "https://{language}.wiktionary.org/"
-    number_of_results: 5
     search_type: text
     disabled: false
     about:
@@ -1592,7 +1575,6 @@ engines:
     shortcut: wv
     categories: general
     base_url: "https://{language}.wikiversity.org/"
-    number_of_results: 5
     search_type: text
     disabled: true
     about:
@@ -1604,7 +1586,6 @@ engines:
     shortcut: wy
     categories: general
     base_url: "https://{language}.wikivoyage.org/"
-    number_of_results: 5
     search_type: text
     disabled: true
     about:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1563,6 +1563,18 @@ engines:
       website: https://www.wikisource.org/
       wikidata_id: Q263
 
+  - name: wikipecies
+    engine: mediawiki
+    shortcut: wsp
+    categories: [general, science]
+    base_url: "https://species.wikimedia.org/"
+    number_of_results: 5
+    search_type: text
+    disabled: true
+    about:
+      website: https://species.wikimedia.org/
+      wikidata_id: Q13679
+
   - name: wiktionary
     engine: mediawiki
     shortcut: wt

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1504,10 +1504,9 @@ engines:
   - name: wikibooks
     engine: mediawiki
     shortcut: wb
-    categories: general
+    categories: [general, wikimedia]
     base_url: "https://{language}.wikibooks.org/"
     search_type: text
-    disabled: true
     about:
       website: https://www.wikibooks.org/
       wikidata_id: Q367
@@ -1515,10 +1514,9 @@ engines:
   - name: wikinews
     engine: mediawiki
     shortcut: wn
-    categories: news
+    categories: [news, wikimedia]
     base_url: "https://{language}.wikinews.org/"
     search_type: text
-    disabled: true
     srsort: create_timestamp_desc
     about:
       website: https://www.wikinews.org/
@@ -1527,10 +1525,9 @@ engines:
   - name: wikiquote
     engine: mediawiki
     shortcut: wq
-    categories: general
+    categories: [general, wikimedia]
     base_url: "https://{language}.wikiquote.org/"
     search_type: text
-    disabled: true
     additional_tests:
       rosebud: *test_rosebud
     about:
@@ -1540,10 +1537,9 @@ engines:
   - name: wikisource
     engine: mediawiki
     shortcut: ws
-    categories: general
+    categories: [general, wikimedia]
     base_url: "https://{language}.wikisource.org/"
     search_type: text
-    disabled: true
     about:
       website: https://www.wikisource.org/
       wikidata_id: Q263
@@ -1551,10 +1547,9 @@ engines:
   - name: wikipecies
     engine: mediawiki
     shortcut: wsp
-    categories: [general, science]
+    categories: [general, science, wikimedia]
     base_url: "https://species.wikimedia.org/"
     search_type: text
-    disabled: true
     about:
       website: https://species.wikimedia.org/
       wikidata_id: Q13679
@@ -1562,10 +1557,9 @@ engines:
   - name: wiktionary
     engine: mediawiki
     shortcut: wt
-    categories: [dictionaries]
+    categories: [dictionaries, wikimedia]
     base_url: "https://{language}.wiktionary.org/"
     search_type: text
-    disabled: false
     about:
       website: https://www.wiktionary.org/
       wikidata_id: Q151
@@ -1573,10 +1567,9 @@ engines:
   - name: wikiversity
     engine: mediawiki
     shortcut: wv
-    categories: general
+    categories: [general, wikimedia]
     base_url: "https://{language}.wikiversity.org/"
     search_type: text
-    disabled: true
     about:
       website: https://www.wikiversity.org/
       wikidata_id: Q370
@@ -1584,10 +1577,9 @@ engines:
   - name: wikivoyage
     engine: mediawiki
     shortcut: wy
-    categories: general
+    categories: [general, wikimedia]
     base_url: "https://{language}.wikivoyage.org/"
     search_type: text
-    disabled: true
     about:
       website: https://www.wikivoyage.org/
       wikidata_id: Q373


### PR DESCRIPTION
## What does this PR do?
* adds wikispecies as an engine
* wikispecies is just a standard wikimedia api

## Why is this change important?
* it contains articles about different animals/species and other forms of life.

## How to test this PR locally?
* disable all engines except and enable wikispecies

## Related issues

closes  #1222
