### PR TITLE
[fix] settings.yml: typo in engine name wikipecies -> wikispecies

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1561,7 +1561,7 @@ engines:
       website: https://www.wikisource.org/
       wikidata_id: Q263
 
-  - name: wikipecies
+  - name: wikispecies
     engine: mediawiki
     shortcut: wsp
     categories: [general, science, wikimedia]


### PR DESCRIPTION
## What does this PR do?

fix typo in engine name wikipecies -> wikispecies
