### PR TITLE
[mod] settings: show weight of each instance

### DIFF
--- a/searx/templates/simple/preferences/engines.html
+++ b/searx/templates/simple/preferences/engines.html
@@ -20,6 +20,7 @@
         <th>{{- _("Supports selected language") -}}</th>{{- '' -}}
         <th>{{- _("SafeSearch") -}}</th>{{- '' -}}
         <th>{{- _("Time range") -}}</th>{{- '' -}}
+        <th>{{- _("Weight") }}</th>
         {%- if enable_metrics -%}
           <th>{{- _("Response time") -}}</th>
         {%- endif -%}
@@ -72,6 +73,7 @@
               <td>
                 {{- checkbox(None, supports[search_engine.name]['time_range_support'], true) -}}
               </td>{{- '' -}}
+              <td>{{- search_engine.weight or '1.0' -}}</td>{{- '' -}}
               {%- if enable_metrics -%}
                 {{- engine_time(search_engine.name) -}}
               {%- endif -%}


### PR DESCRIPTION
## What does this PR do?
* this PR adds a new "Weight" column to the engine details table in the settings

## Why is this change important?
* it increases the transparency about how results are being generated

## How to test this PR locally?
* go to settings -> engines -> look at the "weight" tab

## Related issues
closes #1701
