### PR TITLE
uwsgi.ini: remove unused cache2

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -44,6 +44,3 @@ static-map = /static=/usr/local/searxng/searx/static
 static-expires = /* 31557600
 static-gzip-all = True
 offload-threads = %k
-
-# Cache
-cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
@@ -82,6 +82,3 @@ static-map = /static=${SEARXNG_STATIC}
 static-expires = /* 31557600
 static-gzip-all = True
 offload-threads = %k
-
-# Cache
-cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
@@ -79,6 +79,3 @@ static-map = /static=${SEARXNG_STATIC}
 static-expires = /* 31557600
 static-gzip-all = True
 offload-threads = %k
-
-# Cache
-cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini
@@ -85,6 +85,3 @@ static-map = /static=${SEARXNG_STATIC}
 static-expires = /* 31557600
 static-gzip-all = True
 offload-threads = %k
-
-# Cache
-cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
@@ -82,6 +82,3 @@ static-map = /static=${SEARXNG_STATIC}
 static-expires = /* 31557600
 static-gzip-all = True
 offload-threads = %k
-
-# Cache
-cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1


### PR DESCRIPTION

## What does this PR do?

The cache2 directive was used before PR #1856

SearXNG does not use the uwsgi API anymore.

## Why is this change important?

Currently `uwsgi` allocate 8MB of RAM for nothing (8MB = 2000 * 4096).

## How to test this PR locally?

* `make docker`
* run the docker image

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
