### PR TITLE
Bump httpx 0.21.2 from to 0.24.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,10 @@ lxml==4.9.3
 pygments==2.16.1
 python-dateutil==2.8.2
 pyyaml==6.0.1
-httpx[http2]==0.21.2
+httpx[http2]==0.24.1
 Brotli==1.0.9
 uvloop==0.17.0
-httpx-socks[asyncio]==0.7.2
+httpx-socks[asyncio]==0.7.7
 setproctitle==1.3.2
 redis==4.6.0
 markdown-it-py==3.0.0

--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -180,7 +180,15 @@ def get_loop():
 
 def init():
     # log
-    for logger_name in ('hpack.hpack', 'hpack.table', 'httpx._client'):
+    for logger_name in (
+        'httpx',
+        'httpcore.proxy',
+        'httpcore.connection',
+        'httpcore.http11',
+        'httpcore.http2',
+        'hpack.hpack',
+        'hpack.table',
+    ):
         logging.getLogger(logger_name).setLevel(logging.WARNING)
 
     # loop

--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -409,7 +409,7 @@ def done():
     """Close all HTTP client
 
     Avoid a warning at exit
-    see https://github.com/encode/httpx/blob/1a6e254f72d9fd5694a1c10a28927e193ab4f76b/httpx/_client.py#L1785
+    See https://github.com/encode/httpx/pull/2026
 
     Note: since Network.aclose has to be async, it is not possible to call this method on Network.__del__
     So Network.aclose is called here using atexit.register


### PR DESCRIPTION
## What does this PR do?

Update httpx to 0.24.1

## Why is this change important?

Up to date httpx version, so dependabot can create PR.

## How to test this PR locally?

Check the proxy configuration: http, socks4, socks5, socks5h

All seems to work as expected.
No error after re-connection after a 10 minutes delay.

However, it would be good to run this PR on a public instance with proxies for a few days to check, and then merge.

## Author's checklist

See https://github.com/encode/httpx/blob/master/CHANGELOG.md

Changes that might require some care:

> * Fix optional percent-encoding behaviour. (`#2671`)
> * Use utf-8 as the default character set, instead of falling back to charset-normalizer for auto-detection. To enable automatic character set detection, see [the documentation](https://www.python-httpx.org/advanced/#character-set-encodings-and-auto-detection). (`#2165`)
> * Fix which gen-delims need to be escaped for path/query/fragment components in URL. (`#2701`)
> * Fix Headers.update(...) to correctly handle repeated headers (`#2038`)

Note: 
* httpx 0.24.1 supports socks5h proxy but not socks5 proxy, so with this PR, SearXNG continue to rely on httpx-socks for the SOCKS proxy.
* Also, httpx-socks continues to be useful for proxy with https URL (which requires TLS in TLS connection).

About logging:
* This PR basically disable httpx logging to rely on SearXNG logging.
* See https://www.python-httpx.org/logging/ (this does not exist in the version 0.21.2):

> * The logging behaviour has been changed to be more in-line with other standard Python logging usages. We no longer have a custom TRACE log level, and we no longer use the HTTPX_LOG_LEVEL environment variable to auto-configure logging. We now have a significant amount of DEBUG logging available at the network level. Full documentation is available at https://www.python-httpx.org/logging/ (`#2547`, https://github.com/encode/httpcore/pull/648)

## Related issues

Supersede #2302
