### PR TITLE
[drop] engine archive.is / blocked by CAPTCHA [1]

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -346,25 +346,6 @@ engines:
     engine: archlinux
     shortcut: al
 
-  - name: archive is
-    engine: xpath
-    search_url: https://archive.is/search/?q={query}
-    url_xpath: (//div[@class="TEXT-BLOCK"]/a)/@href
-    title_xpath: (//div[@class="TEXT-BLOCK"]/a)
-    content_xpath: //div[@class="TEXT-BLOCK"]/ul/li
-    categories: general
-    timeout: 7.0
-    disabled: true
-    shortcut: ai
-    soft_max_redirects: 1
-    about:
-      website: https://archive.is/
-      wikidata_id: Q13515725
-      official_api_documentation: https://mementoweb.org/depot/native/archiveis/
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-
   - name: artic
     engine: artic
     shortcut: arc


### PR DESCRIPTION
## What does this PR do?

engine archive.is

## Why is this change important?

Sadly archive.is is blocked by a CAPTCHA that can't be avoid (at least in a XPath engine).

[1] https://github.com/searxng/searxng/issues/2643