### PR TITLE
[fix] preferences: change engine table category colspan to 8

### DIFF
--- a/searx/templates/simple/preferences/engines.html
+++ b/searx/templates/simple/preferences/engines.html
@@ -35,7 +35,7 @@
         {%- if loop.length > 1 -%}
           <tr>{{- '' -}}
             <th class="engine-group" colspan="2">{{- _(group) -}}</th>{{- '' -}}
-            <th class="engine-group" colspan="7">
+            <th class="engine-group" colspan="8">
               {%- if group_bang -%}
                 <span class="bang">{{- group_bang -}}</span>
               {%- endif -%}</th>{{- '' -}}


### PR DESCRIPTION
## What does this PR do?

* this is a small fix to increase the colspan of the category in engine preferences from 7 to 8, since there was a column added
=> fixing a small fallout from 473129031710973e3c02e7178085b751b5e821ed

## Why is this change important?

Fixing small visual bug.

## How to test this PR locally?

`make run` and check out engines tab in preferences page

## Author's checklist

Before this PR:
![image](https://github.com/searxng/searxng/assets/38733246/34ef0f87-c386-48d8-88ae-9aa684713495)

After this PR:
![image](https://github.com/searxng/searxng/assets/38733246/79cdcd74-9e12-484a-831b-ffa56c6e00fa)


## Related issues

<!--
Closes #234
-->
