### PR TITLE
[feat] settings: replace boolean select preferences with checkboxes

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -383,7 +383,8 @@ class Preferences:
                     '0': False,
                     '1': True,
                     'True': True,
-                    'False': False
+                    'False': False,
+                    'on': True
                 }
             ),
             'method': EnumStringSetting(
@@ -412,7 +413,8 @@ class Preferences:
                     '0': False,
                     '1': True,
                     'False': False,
-                    'True': True
+                    'True': True,
+                    'on': True
                 }
             ),
             'doi_resolver': MultipleChoiceSetting(
@@ -432,7 +434,8 @@ class Preferences:
                     '0': False,
                     '1': True,
                     'False': False,
-                    'True': True
+                    'True': True,
+                    'on': True
                 }
             ),
             'advanced_search': MapSetting(
@@ -454,7 +457,8 @@ class Preferences:
                     '0': False,
                     '1': True,
                     'True': True,
-                    'False': False
+                    'False': False,
+                    'on': True
                 }
             ),
             'infinite_scroll': MapSetting(
@@ -465,7 +469,8 @@ class Preferences:
                     '0': False,
                     '1': True,
                     'True': True,
-                    'False': False
+                    'False': False,
+                    'on': True
                 }
             ),
             # fmt: on

--- a/searx/templates/simple/preferences/center_alignment.html
+++ b/searx/templates/simple/preferences/center_alignment.html
@@ -1,10 +1,14 @@
 <fieldset>{{- '' -}}
   <legend id="pref_center_alignment">{{ _('Center Alignment') }}</legend>{{- '' -}}
   <p class="value">{{- '' -}}
-    <select name="center_alignment" aria-labelledby="pref_center_alignment">{{- '' -}}
-      <option value="1" {% if preferences.get_value('center_alignment') %}selected="selected"{% endif %}>{{ _('On') }}</option>{{- '' -}}
-      <option value="0" {% if not preferences.get_value('center_alignment') %}selected="selected"{% endif %}>{{ _('Off')}}</option>{{- '' -}}
-    </select>{{- '' -}}
+    <input type="checkbox" {{- ' ' -}}
+           name="center_alignment" {{- ' ' -}}
+           aria-labelledby="pref_center_alignment" {{- ' ' -}}
+           class="checkbox-onoff" {{- ' ' -}}
+           {%- if preferences.get_value('center_alignment') -%}
+             checked
+           {%- endif -%}{{- ' ' -}}
+           />{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Displays results in the center of the page (Oscar layout).') -}}

--- a/searx/templates/simple/preferences/image_proxy.html
+++ b/searx/templates/simple/preferences/image_proxy.html
@@ -1,11 +1,15 @@
 <fieldset>{{- '' -}}
   <legend id="pref_image_proxy">{{ _('Image proxy') }}</legend>{{- '' -}}
   <p class="value">{{- '' -}}
-    <select name='image_proxy' aria-labelledby="pref_image_proxy">{{- '' -}}
-      <option value="1" {% if image_proxy %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>{{- '' -}}
-      <option value="0" {% if not image_proxy %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>{{- '' -}}
-    </select>{{- '' -}}
-  </p>
+    <input type="checkbox" {{- ' ' -}}
+           name="image_proxy" {{- ' ' -}}
+           aria-labelledby="pref_image_proxy" {{- ' ' -}}
+           class="checkbox-onoff" {{- ' ' -}}
+           {%- if preferences.get_value('image_proxy') -%}
+             checked
+           {%- endif -%}{{- ' ' -}}
+           />{{- '' -}}
+  </p>{{- '' -}}
   <div class="description">
     {{- _('Proxying image results through SearXNG') -}}
   </div>{{- '' -}}

--- a/searx/templates/simple/preferences/infinite_scroll.html
+++ b/searx/templates/simple/preferences/infinite_scroll.html
@@ -1,10 +1,14 @@
 <fieldset>{{- '' -}}
   <legend>{{ _('Infinite scroll') }}</legend>{{- '' -}}
   <p class="value">{{- '' -}}
-    <select name='infinite_scroll'>{{- '' -}}
-      <option value="1" {% if infinite_scroll %}selected="selected"{% endif %}>{{ _('On') }}</option>{{- '' -}}
-      <option value="0" {% if not infinite_scroll %}selected="selected"{% endif %}>{{ _('Off')}}</option>{{- '' -}}
-    </select>{{- '' -}}
+    <input type="checkbox" {{- ' ' -}}
+           name="infinite_scroll" {{- ' ' -}}
+           aria-labelledby="pref_infinite_scroll" {{- ' ' -}}
+           class="checkbox-onoff" {{- ' ' -}}
+           {%- if preferences.get_value('infinite_scroll') -%}
+             checked
+           {%- endif -%}{{- ' ' -}}
+           />{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Automatically load next page when scrolling to bottom of current page') -}}

--- a/searx/templates/simple/preferences/query_in_title.html
+++ b/searx/templates/simple/preferences/query_in_title.html
@@ -1,10 +1,14 @@
 <fieldset>{{- '' -}}
-  <legend id="pref_query_in_title">{{ _("Query in the page's title") }}</legend>
+  <legend id="pref_query_in_title">{{ _("Query in the page's title") }}</legend>{{- '' -}}
   <p class="value">{{- '' -}}
-    <select name='query_in_title' aria-labelledby="pref_query_in_title">{{- '' -}}
-      <option value="1" {% if query_in_title %}selected="selected"{% endif %}>{{ _('Enabled') }}</option>{{- '' -}}
-      <option value="0" {% if not query_in_title %}selected="selected"{% endif %}>{{ _('Disabled') }}</option>{{- '' -}}
-    </select>{{- '' -}}
+    <input type="checkbox" {{- ' ' -}}
+           name="query_in_title" {{- ' ' -}}
+           aria-labelledby="pref_query_in_title" {{- ' ' -}}
+           class="checkbox-onoff" {{- ' ' -}}
+           {%- if preferences.get_value('query_in_title') -%}
+             checked
+           {%- endif -%}{{- ' ' -}}
+           />{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _("When enabled, the result page's title contains your query. Your browser can record this title") -}}

--- a/searx/templates/simple/preferences/results_on_new_tab.html
+++ b/searx/templates/simple/preferences/results_on_new_tab.html
@@ -1,10 +1,14 @@
 <fieldset>{{- '' -}}
   <legend id="pref_results_on_new_tab">{{ _('Results on new tabs') }}</legend>{{- '' -}}
   <p class="value">{{- '' -}}
-    <select name='results_on_new_tab' aria-labelledby="pref_results_on_new_tab">{{- '' -}}
-      <option value="1" {% if results_on_new_tab %}selected="selected"{% endif %}>{{ _('On') }}</option>{{- '' -}}
-      <option value="0" {% if not results_on_new_tab %}selected="selected"{% endif %}>{{ _('Off')}}</option>{{- '' -}}
-    </select>{{- '' -}}
+    <input type="checkbox" {{- ' ' -}}
+           name="results_on_new_tab" {{- ' ' -}}
+           aria-labelledby="pref_results_on_new_tab" {{- ' ' -}}
+           class="checkbox-onoff" {{- ' ' -}}
+           {%- if preferences.get_value('results_on_new_tab') -%}
+             checked
+           {%- endif -%}{{- ' ' -}}
+           />{{- ' ' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Open result links on new browser tabs') -}}


### PR DESCRIPTION
## What does this PR do?
* replace boolean select preferences with checkboxes

## Why is this change important?
* currently, boolean preferences that are not about enabling or disabling plugins are visible to the user as a dropdown - however, that's quite inconvenient since checkbox/switches are more common for boolean preferences, and also used for enabling and disabling plugins

## How to test this PR locally?
* open the settings and navigate to user interface or privacy

## Related issues
closes #1440
