### PR TITLE
[mod] engine mwmbl: add auto completion and link to official api docs

### DIFF
--- a/docs/admin/settings/settings_search.rst
+++ b/docs/admin/settings/settings_search.rst
@@ -35,6 +35,7 @@
   - ``dbpedia``
   - ``duckduckgo``
   - ``google``
+  - ``mwmbl``
   - ``startpage``
   - ``swisscows``
   - ``qwant``

--- a/docs/dev/engines/online/mwmbl.rst
+++ b/docs/dev/engines/online/mwmbl.rst
@@ -1,0 +1,27 @@
+.. _Mwmbl engine:
+
+============
+Mwmbl Engine
+============
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+
+.. _mwmbl web engine:
+
+Mwmbl WEB
+=========
+
+.. automodule:: searx.engines.mwmbl
+  :members:
+
+
+.. _mwmbl autocomplete:
+
+Mwmbl Autocomplete
+==================
+
+.. autofunction:: searx.autocomplete.mwmbl

--- a/docs/dev/search_api.rst
+++ b/docs/dev/search_api.rst
@@ -68,8 +68,8 @@ Parameters
   Proxy image results through SearXNG.
 
 ``autocomplete`` : default from :ref:`settings search`
-  [ ``google``, ``dbpedia``, ``duckduckgo``, ``startpage``, ``wikipedia``,
-  ``swisscows``, ``qwant`` ]
+  [ ``google``, ``dbpedia``, ``duckduckgo``, ``mwmbl``, ``startpage``,
+  ``wikipedia``, ``swisscows``, ``qwant`` ]
 
   Service which completes words as you type.
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -110,6 +110,16 @@ def google_complete(query, sxng_locale):
     return results
 
 
+def mwmbl(query, _lang):
+    # mwmbl autocompleter
+    url = 'https://api.mwmbl.org/search/complete?{query}'
+
+    results = get(url.format(query=urlencode({'q': query}))).json()[1]
+
+    # results starting with `go:` are direct urls and not useful for auto completion
+    return [result for result in results if not result.startswith("go: ") and not result.startswith("search: ")]
+
+
 def seznam(query, _lang):
     # seznam search autocompleter
     url = 'https://suggest.seznam.cz/fulltext/cs?{query}'
@@ -208,6 +218,7 @@ backends = {
     'dbpedia': dbpedia,
     'duckduckgo': duckduckgo,
     'google': google_complete,
+    'mwmbl': mwmbl,
     'seznam': seznam,
     'startpage': startpage,
     'swisscows': swisscows,

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -111,6 +111,8 @@ def google_complete(query, sxng_locale):
 
 
 def mwmbl(query, _lang):
+    """Autocomplete from Mwmbl_."""
+
     # mwmbl autocompleter
     url = 'https://api.mwmbl.org/search/complete?{query}'
 

--- a/searx/engines/mwmbl.py
+++ b/searx/engines/mwmbl.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 
 about = {
     "website": 'https://github.com/mwmbl/mwmbl',
-    "official_api_documentation": None,
+    "official_api_documentation": 'https://api.mwmbl.org/docs',
     "use_official_api": True,
     "require_api_key": False,
     "results": 'JSON',

--- a/searx/engines/mwmbl.py
+++ b/searx/engines/mwmbl.py
@@ -1,6 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # lint: pylint
-"""mwmbl (general)
+"""Mwmbl_ is a non-profit, ad-free, free-libre and free-lunch search engine with
+a focus on useability and speed.
+
+.. hint::
+
+   At the moment it is little more than an idea together with a proof of concept
+   implementation of the web front-end and search technology on a small index.
+   Mwmbl_ does not support regions, languages, safe-search or time range.
+   search.
+
+.. _Mwmbl: https://github.com/mwmbl/mwmbl
+
 """
 
 from urllib.parse import urlencode

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -23,7 +23,7 @@ brand:
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
-  # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "yandex",
+  # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "yandex", "mwmbl",
   # "seznam", "startpage", "swisscows", "qwant", "wikipedia" - leave blank to turn it off
   # by default.
   autocomplete: ""


### PR DESCRIPTION
## What does this PR do?
* add link to official mwmbl api docs
* add auto completions using mwmbl

## How to test this PR locally?
* `make run`
* go to settings and set autocomplete to `mwmbl`
* start typing to search for something and observe the suggestions

see https://github.com/searxng/searxng/pull/2648#issuecomment-1689920490