### PR TITLE
[mod] random answerer: add random hex color generator

### DIFF
--- a/searx/answerers/random/answerer.py
+++ b/searx/answerers/random/answerer.py
@@ -38,12 +38,18 @@ def random_uuid():
     return str(uuid.uuid4())
 
 
+def random_color():
+    color = "%06x" % random.randint(0, 0xFFFFFF)
+    return f"#{color.upper()}"
+
+
 random_types = {
     'string': random_string,
     'int': random_int,
     'float': random_float,
     'sha256': random_sha256,
     'uuid': random_uuid,
+    'color': random_color,
 }
 
 


### PR DESCRIPTION
## What does this PR do?
* adds a  random hex color generator as answerer

## Why is this change important?
* I'd consider this useful for myself when working on CSS projects to quickly get a random color that could be used

## How to test this PR locally?
* `make run`
* search `random color`

