### PR TITLE
[fix] google engine: don't overspecify the search query to Google

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -198,9 +198,11 @@ def get_google_info(params, eng_traits):
     #   particular country.
     #   https://developers.google.com/custom-search/docs/xml_results#crsp
 
-    ret_val['params']['cr'] = 'country' + country
-    if sxng_locale == 'all':
-        ret_val['params']['cr'] = ''
+    # specify a region (country) only if a region is given in the selected
+    # locale --> https://github.com/searxng/searxng/issues/2672
+    ret_val['params']['cr'] = ''
+    if len(sxng_locale.split('-')) > 1:
+        ret_val['params']['cr'] = 'country' + country
 
     # gl parameter: (mandatory by Geeogle News)
     #   The gl parameter value is a two-letter country code. For WebSearch


### PR DESCRIPTION
The method EngineTraits.get_region(..) returns engine's region string that **best fits** to SearXNG's locale.  This means it returns a region (country) if only a language is set in the locale.  By example the method returns for a locale tag `es` a region `ES`.

Google's search parameter `cr` restricts search results to documents originating in a particular country / in case of a locale tag (language) as described above, this argument should be unset in the query send to Google.

Closes: https://github.com/searxng/searxng/issues/2672

@nameless326 would you like to test this PR / thanks :+1:

@Bnyro if you have time for would you also give it a try and compare search results for (e.g.) `:de` and `de-DE` or `de-CH` .. of this PR (and to compare on a existing instance)