### PR TITLE
[dev-env] upgrade Sphinx-doc 7.2.3 and unpin at v7.1.2 on py3.8

### DIFF
--- a/docs/_themes/searxng/theme.conf
+++ b/docs/_themes/searxng/theme.conf
@@ -4,3 +4,4 @@ stylesheet = searxng.css
 
 [options]
 touch_icon =
+globaltoc_maxdepth = 5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,15 +7,16 @@ splinter==0.19.0
 selenium==4.11.2
 twine==4.0.2
 Pallets-Sphinx-Themes==2.1.1
-Sphinx==7.1.2
+Sphinx==7.1.2; python_version == '3.8'
+Sphinx==7.2.3; python_version > '3.8'
 sphinx-issues==3.0.1
 sphinx-jinja==2.0.2
 sphinx-tabs==3.4.1
 sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14
-sphinx-notfound-page==0.8.3
+sphinx-notfound-page==1.0.0rc1
 myst-parser==2.0.0
-linuxdoc==20230629
+linuxdoc==20230827
 aiounittest==1.4.2
 yamllint==1.32.0
 wlc==1.13


### PR DESCRIPTION
upgrade Sphinx-doc 7.2.3 and unpin at v7.1.2 on py3.8

- Sphinx-doc 7.2.0 drops py3.8 support [1][2]
- last version with py3.8 support is 7.1.2

Many LTS distributions still have py3.8 which EOL is in 2024-10 [3].

To continue to support a development environment on py3.8 the rigid dependency
in the development environment is unpinned in py3.8 / environment markers [4].

To get 7.2.3. work, a fix in sphinx-notfound-page is needed.

[1] https://github.com/searxng/searxng/pull/2658#issuecomment-1684867270
[2] https://github.com/sphinx-doc/sphinx/issues/11621
[3] https://devguide.python.org/versions/#supported-versions
[4] https://peps.python.org/pep-0508/#environment-markers
[5] https://github.com/readthedocs/sphinx-notfound-page/issues/219

----

### notes for the reviewers ...

What do you think, is it OK to unpin Sphinx-doc (in the develop environment)? .. otherwise we have to drop py3.8 support .. or do you know a better solution for this conflict of interest?

----

Closes: https://github.com/searxng/searxng/pull/2680