### PR TITLE
Bump sphinx-notfound-page from 1.0.0rc1 to 1.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ sphinx-jinja==2.0.2
 sphinx-tabs==3.4.1
 sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14
-sphinx-notfound-page==1.0.0rc1
+sphinx-notfound-page==1.0.0
 myst-parser==2.0.0
 linuxdoc==20230827
 aiounittest==1.4.2


### PR DESCRIPTION
## What does this PR do?

Follow up of:

- https://github.com/searxng/searxng/pull/2683

Bump sphinx-notfound-page from 1.0.0rc1 to 1.0.0