### PR TITLE
[fix] engine: wikicommons - don't quoute ':|' in URL parameters

### DIFF
--- a/searx/engines/wikicommons.py
+++ b/searx/engines/wikicommons.py
@@ -43,7 +43,7 @@ def request(query, params):
         'gsrsearch': "filetype:bitmap|drawing " + query,
     }
 
-    params["url"] = f"{base_url}/w/api.php{search_prefix}&{urlencode(args)}"
+    params["url"] = f"{base_url}/w/api.php{search_prefix}&{urlencode(args, safe=':|')}"
     return params
 
 


### PR DESCRIPTION
From [1]: It seems to be because of [2] For some reason it gets url encoded twice, resulting in

- ``filetype%253Abitmap%257Cdrawing+birds`` instead of
- ``filetype:bitmap%7Cdrawing+birds``

## How to test this PR locally?

Start instance `make run` and and use search syntax `!wc bird` 

----

- [1] https://github.com/searxng/searxng/issues/2707
- [2] https://github.com/searxng/searxng/blob/master/searx/engines/wikicommons.py#L43

Closes: #2707