### PR TITLE
[feat] simple theme: image preview - arrow keys to navigate

### DIFF
--- a/searx/static/themes/simple/src/js/main/keyboard.js
+++ b/searx/static/themes/simple/src/js/main/keyboard.js
@@ -32,6 +32,10 @@ searxng.ready(function () {
     return resultElement && resultElement.classList.contains('result-images');
   }
 
+  function hasImageInDetail () {
+    return document.querySelector('#results.image-detail-open') !== null;
+  }
+
   searxng.on('.result', 'click', function (e) {
     if (!isElementInDetail(e.target)) {
       highlightResult(this)(true, true);
@@ -170,6 +174,18 @@ searxng.ready(function () {
       }
     });
   }
+
+  searxng.on(document, 'keydown', function (e) {
+    if (hasImageInDetail()) {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        searxng.selectPrevious(false);
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        searxng.selectNext(false);
+      }
+    }
+  });
 
   function highlightResult (which) {
     return function (noScroll, keepFocus) {


### PR DESCRIPTION
## What does this PR do?
Use the left and right arrow keys to switch between images when the image preview is open

## Why is this change important?
Better UX

## How to test this PR locally?
Search for images, preview one, use arrow keys to navigate

## Author's checklist
I'm not sure this is the most efficient way, feedback is welcome!
I'd have preferred to bind it directly when opening the image preview in `results.js`, but then I'm not sure how to properly unbind them when closing it without unbinding other possible keydown events (vimKeys)

## Related issues
Closes #2720 
