### PR TITLE
[feat] new engine: svgrepo

### DIFF
--- a/searx/engines/svgrepo.py
+++ b/searx/engines/svgrepo.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Svgrepo (images)
+"""
+
+from lxml import html
+from searx.utils import extract_text, eval_xpath, eval_xpath_list
+
+about = {
+    "website": 'https://www.svgrepo.com',
+    "official_api_documentation": 'https://svgapi.com',
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+
+paging = True
+categories = ['images']
+base_url = "https://www.svgrepo.com"
+
+results_xpath = "//div[@class='style_nodeListing__7Nmro']/div"
+url_xpath = ".//a/@href"
+title_xpath = ".//a/@title"
+img_src_xpath = ".//img/@src"
+
+
+def request(query, params):
+    params['url'] = f"{base_url}/vectors/{query}/{params['pageno']}/"
+    return params
+
+
+def response(resp):
+    results = []
+
+    dom = html.fromstring(resp.text)
+    for result in eval_xpath_list(dom, results_xpath):
+        results.append(
+            {
+                'template': 'images.html',
+                'url': base_url + extract_text(eval_xpath(result, url_xpath)),
+                'title': extract_text(eval_xpath(result, title_xpath)).replace(" SVG File", "").replace("Show ", ""),
+                'img_src': extract_text(eval_xpath(result, img_src_xpath)),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1869,6 +1869,12 @@ engines:
     timeout: 5.0
     disabled: true
 
+  - name: svgrepo
+    engine: svgrepo
+    shortcut: svg
+    timeout: 10.0
+    disabled: true
+
     # wikimini: online encyclopedia for children
     # The fulltext and title parameter is necessary for Wikimini because
     # sometimes it will not show the results and redirect instead


### PR DESCRIPTION
## What does this PR do?
* adds a new engine, svgrepo.com, which provides copyleft svg files
* they do have an official api in fact, which requires an API key
* they also have an unofficial api they use internally, but I didn't really figure out how it works and hence scrapping the HTML results seems simpler

## Why is this change important?
* the engine is very useful for designers to get inspiration or normal people like me to quickly find vectors to use for their own website

## How to test this PR locally?
* `!svg linux`

## Notes
* As described in #2753, this doesn't really fit the images category, since it provides SVG vectors/icons and no images. Not sure if it's better located under the `other` category.
