### PR TITLE
[fix] dependabot: ignore Sphinx<=7.1.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ splinter==0.19.0
 selenium==4.12.0
 twine==4.0.2
 Pallets-Sphinx-Themes==2.1.1
-Sphinx==7.1.2; python_version == '3.8'
+Sphinx<=7.1.2; python_version == '3.8'
 Sphinx==7.2.5; python_version > '3.8'
 sphinx-issues==3.0.1
 sphinx-jinja==2.0.2


### PR DESCRIPTION
[1] https://github.com/searxng/searxng/pull/2727#issuecomment-1711282706
