### PR TITLE
codespace : add libpython3.11-dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/base:debian
 
 RUN apt-get update && \
-    apt-get -y install python3 python3-venv redis firefox-esr graphviz imagemagick librsvg2-bin fonts-dejavu shellcheck
+    apt-get -y install python3 python3-venv libpython3.11-dev redis firefox-esr graphviz imagemagick librsvg2-bin fonts-dejavu shellcheck


### PR DESCRIPTION
## What does this PR do?

The PR  #2599 has added the new dependency chompjs. This dependency requires libpython3.11-dev.

## Why is this change important?

Currently, CodeSpace setup does not work : https://github.com/searxng/searxng/discussions/2735

## How to test this PR locally?

Start a CodeSpace.

## Author's checklist

I don't understand why this is required in CodeSpace but not in the installation scripts.

## Related issues

<!--
Closes #234
-->
