### PR TITLE
[feat] implementation of qwant lite for web search

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1280,6 +1280,18 @@ engines:
     categories: [videos, web]
     network: qwant
 
+  - name: qwantlite
+    engine: xpath
+    paging: true
+    search_url: https://lite.qwant.com/?q={query}&p={pageno}
+    results_xpath: //section/article
+    url_xpath: ./span/text()
+    title_xpath: ./h2/a/text()
+    content_xpath: ./p/text()
+    shortcut: qwl
+    categories: [general, web]
+    network: qwant
+
   # - name: library
   #   engine: recoll
   #   shortcut: lib


### PR DESCRIPTION
## What does this PR do?
* add qwant lite for general web search as an experiment
* this is a very basic implementation, if it's able to bypass rate limits it will be implemented as its own module if needed
* my goal is to let some public instances with much traffic use it, and thus enable it by default, to see if there's any benefit over using the Qwant API

## Why is this change important?
* see https://github.com/searxng/searxng/issues/2719

## How to test this PR locally?
* !qwl hello world

## Related issues
see https://github.com/searxng/searxng/issues/2719
