### PR TITLE
[feat] engine: implementation of google icons/material design icons

### DIFF
--- a/searx/engines/material_icons.py
+++ b/searx/engines/material_icons.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Material Icons (images)
+"""
+
+import re
+from json import loads
+
+about = {
+    "website": 'https://fonts.google.com/icons',
+    "wikidata_id": 'Q107315222',
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+search_url = "https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true"
+result_url = "https://fonts.google.com/icons?icon.query={query}&selected=Material+Symbols+Outlined:{icon_name}:FILL@0{fill};wght@400;GRAD@0;opsz@24"  # pylint: disable=line-too-long
+img_src_url = "https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/{icon_name}/{svg_type}/24px.svg"
+filled_regex = r"(fill)(ed)?"
+
+
+def request(query, params):
+    params['url'] = search_url
+    params['query'] = query
+    return params
+
+
+def response(resp):
+    results = []
+
+    query = resp.search_params["query"].lower()
+    json_results = loads(resp.text[5:])
+
+    outlined = not re.findall(filled_regex, query)
+    query = re.sub(filled_regex, "", query).strip()
+    svg_type = "fill1" if not outlined else "default"
+
+    query_parts = query.split(" ")
+
+    for result in json_results["icons"]:
+        for part in query_parts:
+            if part in result["name"] or part in result["tags"] or part in result["categories"]:
+                break
+        else:
+            continue
+
+        tags = [tag.title() for tag in result["tags"]]
+        categories = [category.title() for category in result["categories"]]
+
+        results.append(
+            {
+                'template': 'images.html',
+                'url': result_url.format(icon_name=result["name"], query=result["name"], fill=0 if outlined else 1),
+                'img_src': img_src_url.format(icon_name=result["name"], svg_type=svg_type),
+                'title': result["name"].replace("_", "").title(),
+                'content': ", ".join(tags) + " / " + ", ".join(categories),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -790,6 +790,12 @@ engines:
     play_categ: movies
     disabled: true
 
+  - name: material icons
+    engine: material_icons
+    categories: images
+    shortcut: mi
+    disabled: true
+
   - name: gpodder
     engine: json_engine
     shortcut: gpod


### PR DESCRIPTION
## What does this PR do?
* Unfortunately, it doesn't have a search api. However, we can fetch a list of all available icons (response time is really fast) and filter by name, tag and category ourselves, exactly as the search on <https://fonts.google.com/icons> does it
* I know this is sorta not how engines usually work, but I use it very frequently and hence it would be very handy for me to have it integrated into SearXNG

## Why is this change important?
* Quote from its website: `Material Symbols are our newest icons consolidating over 3,061 glyphs in a single font file with a wide range of design variants.`
* That's very useful for designers or people searching for icons to use for their website
* It doesn't really fit the images category, similar to `Svgrepo`, but rather the category `icons`. Would it be better to put it into the `others` category, create a new `icons` category, or keep it in the `images` category?

## How to test this PR locally?
* !mi account
* !mi account filled
* !mi bird tree