### PR TITLE
[fix] engine - openstreetmap currency matching

### DIFF
--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -450,7 +450,7 @@ def get_key_label(key_name, lang):
         # https://taginfo.openstreetmap.org/keys/currency#values
         currency = key_name.split(':')
         if len(currency) > 1:
-            o = CURRENCIES['iso4217'].get(currency)
+            o = CURRENCIES['iso4217'].get(currency[1])
             if o:
                 return get_label(o, lang).lower()
             return currency


### PR DESCRIPTION
## What does this PR do?

The currency tag was being incorrectly parsed, leading to a full on error whenever there was any currency returned in `extratags`.

## Why is this change important?

It should be obvious that the old code never worked :) But it is very hard to test for. I found it by dumb luck.

## How to test this PR locally?

I haven't looked hard but `!osm hello world` gives "currency:XBT". 
Previously you would receive `TypeError: unhashable type: 'list'`, but now it  works as intended.
