### PR TITLE
[fix] engine - pypi redirect

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1235,7 +1235,7 @@ engines:
     shortcut: pypi
     engine: xpath
     paging: true
-    search_url: https://pypi.org/search?q={query}&page={pageno}
+    search_url: https://pypi.org/search/?q={query}&page={pageno}
     results_xpath: /html/body/main/div/div/div/form/div/ul/li/a[@class="package-snippet"]
     url_xpath: ./@href
     title_xpath: ./h3/span[@class="package-snippet__name"]


### PR DESCRIPTION
## What does this PR do?

Fixes pypi redirecting `/search?q={query}` to `/search/?q={query}`.

## Why is this change important?

The redirect wastes time and produces a warning.

## How to test this PR locally?

`!pypi requests`
previously this caused a warning `ErrorContext('searx/search/processors/online.py', 127, 'count_error(', None, '1 redirects, maximum: 0', ('200', 'OK', 'pypi.org')) True` due to the redirect.