### PR TITLE
[fix] engine - invidious thumbnails

### DIFF
--- a/searx/engines/invidious.py
+++ b/searx/engines/invidious.py
@@ -5,7 +5,7 @@
 
 import time
 import random
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlparse
 from dateutil import parser
 
 # about
@@ -74,6 +74,11 @@ def response(resp):
                 thumbnail = thumb.get("url", "")
             else:
                 thumbnail = ""
+
+            # some instances return a partial thumbnail url
+            # we check if the url is partial, and prepend the base_url if it is
+            if thumbnail and not urlparse(thumbnail).netloc:
+                thumbnail = resp.search_params['base_url'] + thumbnail
 
             publishedDate = parser.parse(time.ctime(result.get("published", 0)))
             length = time.gmtime(result.get("lengthSeconds"))


### PR DESCRIPTION
## What does this PR do?

Some invidious instances give partial thumbnail url's in the form `/vi/abcdefghi/sddefault.jpg`, where most give full url. This leads to thumbnails not displaying.

## Why is this change important?

Lots of instances have this problem, regardless of the version. I'm not sure why...

## How to test this PR locally?

Put `https://invidious.io.lol` as your only invidious instance in settings.yml, then do `!iv rick astley`.
Previously all thumbnails failed and gave 404's, now they work.

## Related issues

I don't see an issue for it but dalf mentioned it [here](https://github.com/searxng/searxng/pull/867#issuecomment-1030572960)
