### PR TITLE
[fix] settings.yml - change default invidious instances

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -872,6 +872,7 @@ engines:
       - https://invidious.flokinet.to
       - https://vid.puffyan.us
       - https://invidious.privacydev.net
+      - https://inv.tux.pizza
     shortcut: iv
     timeout: 3.0
     disabled: true

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -865,11 +865,14 @@ engines:
     # Instanes will be selected randomly, see https://api.invidious.io/ for
     # instances that are stable (good uptime) and close to you.
     base_url:
-      - https://invidious.snopyta.org
+      - https://invidious.io.lol
+      - https://invidious.fdn.fr
+      - https://yt.artemislena.eu
+      - https://invidious.tiekoetter.com
+      - https://invidious.flokinet.to
       - https://vid.puffyan.us
-      # - https://invidious.kavin.rocks  # Error 1020 // Access denied by Cloudflare
-      - https://invidio.xamh.de
-      - https://inv.riverside.rocks
+      - https://invidious.privacydev.net
+      - https://invidious.snopyta.org
     shortcut: iv
     timeout: 3.0
     disabled: true

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -872,7 +872,6 @@ engines:
       - https://invidious.flokinet.to
       - https://vid.puffyan.us
       - https://invidious.privacydev.net
-      - https://invidious.snopyta.org
     shortcut: iv
     timeout: 3.0
     disabled: true


### PR DESCRIPTION
## What does this PR do?

Removes two dead instances that lead to half the requests on a default installation failing.
I have added some new instances from [https://api.invidious.io](https://api.invidious.io/?sort_by=health). My criteria were: 1K+ users, 99%+ health and to be running a recent version. I have tested all the instances. They are also sorted by health.

## Why is this change important?

**Why have 8 instances instead of 4, won't it be more maintenance burden if one goes down?**
- If an instance goes down, only 1/8 requests fail, not 1/4 or as would've been now, 3/4. Thus there is less need to update them and less maintenance burden.
- More geographical diversity.
- Some instance will surely be far from any admin, this encourages them to customize the instances.

## How to test this PR locally?

`!iv what is love`
with default settings.yml this will fail 50% of the time. Now is works every time.