### PR TITLE
[fix] engine - piped.music incorrect timestamps

### DIFF
--- a/searx/engines/piped.py
+++ b/searx/engines/piped.py
@@ -130,13 +130,14 @@ def response(resp):
     json = resp.json()
 
     for result in json["items"]:
-        publishedDate = parser.parse(time.ctime(result.get("uploaded", 0) / 1000))
+        # note: piped returns -1 for all upload times when filtering for music
+        uploaded = result.get("uploaded", -1)
 
         item = {
             # the api url differs from the frontend, hence use piped.video as default
             "url": _frontend_url() + result.get("url", ""),
             "title": result.get("title", ""),
-            "publishedDate": publishedDate,
+            "publishedDate": parser.parse(time.ctime(uploaded / 1000)) if uploaded != -1 else None,
             "iframe_src": _frontend_url() + '/embed' + result.get("url", ""),
         }
 


### PR DESCRIPTION
## What does this PR do?

Piped will return -1 for all upload date timestamps, but only when filtering for music. Thus all dates become 1969. This change will make all -1 timestamps be None instead, thus not rendering the wrong timestamp.

## Why is this change important?

This issue affects upstream, you can see it at [https://piped.video/results?search_query=test&filter=music_videos](https://piped.video/results?search_query=test&filter=music_videos), but they simply don't show a date. (Maybe it's some YouTube issue, doesn't matter for us)

## How to test this PR locally?

`!ppdm take on me` and every date is Dec 31, 1969. Now the dates are not rendered.

