### PR TITLE
[fix] engine - pub.dev

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1214,10 +1214,10 @@ engines:
     shortcut: pd
     search_url: https://pub.dev/packages?q={query}&page={pageno}
     paging: true
-    results_xpath: /html/body/main/div/div[@class="search-results"]/div[@class="packages"]/div
+    results_xpath: //div[contains(@class,"packages-item")]
     url_xpath: ./div/h3/a/@href
     title_xpath: ./div/h3/a
-    content_xpath: ./p[@class="packages-description"]
+    content_xpath: ./div/div/div[contains(@class,"packages-description")]/span
     categories: [packages, it]
     timeout: 3.0
     disabled: true


### PR DESCRIPTION
## What does this PR do?

pud.dev wasn't working, now it is.

## Why is this change important?

Yes I did use `//` in the XPath, but the performance impact is negligible (<0.2ms), and this should make it more robust to future changes.

## How to test this PR locally?

`!pd http`