### PR TITLE
[fix] engine - pubmed content being None

### DIFF
--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -99,7 +99,7 @@ def response(resp):
             'template': 'paper.html',
             'url': url,
             'title': title,
-            'content': content,
+            'content': content or "",
             'journal': journal,
             'issn': [issn],
             'authors': authors,


### PR DESCRIPTION
## What does this PR do?

When result content is None that triggers an error and the result isn't shown. Now we return an empty string instead.

## Why is this change important?

Lots of results from pubmed don't have an abstract, and would have been skipped.

## How to test this PR locally?

`!pub hello world` and now you should be able to see a paper on crocodile teeth, which would've been skipped before.
