### PR TITLE
Draft: pixiv engine

### DIFF
--- a/searx/engines/pixiv.py
+++ b/searx/engines/pixiv.py
@@ -1,0 +1,65 @@
+import httpx
+from urllib.parse import urlencode
+from datetime import datetime
+
+# Engine metadata
+about = {
+    "website": "https://www.pixiv.net/",
+    "wikidata_id": None,
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+# Engine configuration
+paging = True
+categories = ['images']
+
+# Search URL
+base_url = "https://www.pixiv.net/ajax/search/illustrations"
+
+
+def request(query, params):
+    page_number = params.get("pageno", 1)
+    query_params = {
+        "word": query,
+        "order": "date_d",
+        "mode": "all",
+        "p": page_number,
+        "s_mode": "s_tag_full",
+        "type": "illust_and_ugoira",
+        "lang": "en",
+    }
+
+    with httpx.Client() as client:
+        response = client.get(f"{base_url}/{query}?{urlencode(query_params)}")
+        params["url"] = response.url
+
+    return params
+
+
+def format_results(item):
+    title = item["title"]
+    url = item["url"]
+    user_id = item["userId"]
+    user_name = item["userName"]
+    image_url = item["url"]
+
+
+    return {
+        "title": title,
+        "url": image_url,
+        "author": f"{user_name} (ID: {user_id})",
+        "img_src": image_url,
+        "source": 'pixiv.net',
+        "template": "images.html",
+    }
+
+
+def response(resp):
+    data = resp.json()
+    illustrations = data["body"]["illust"]["data"]
+    results = [format_results(item) for item in illustrations]
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1199,6 +1199,11 @@ engines:
     # country
     url: https://thepiratebay.org/
     timeout: 3.0
+  
+  - name: pixiv
+    shortcut: pv
+    engine: pixiv
+    disabled: true
 
   # Required dependency: psychopg2
   #  - name: postgresql


### PR DESCRIPTION
## What does this PR do?

This is my work on adding a pixiv engine to searxng. pixiv is quite similar to deviantart.

## Why is this change important?

another sweet engine

## How to test this PR locally?

test !pv

## Author's checklist

The problem with this engine is that the images do not load, however the image URLs are correct. As you should see in the terminal, we get 403 forbidden- but use https://www.pixiv.net as the referer and the image URLs work perfectly (tested with wget). i just don't know how to get searxng to do this with each individual picture that it gets.

current state of this engine:

![test](https://github.com/searxng/searxng/assets/138650713/fcbe513a-0fbb-44a8-83e2-3d55f219dfc8)
