### PR TITLE
[feat] implementation of qwant lite for web search

### DIFF
--- a/docs/dev/engines/online/qwant.rst
+++ b/docs/dev/engines/online/qwant.rst
@@ -1,0 +1,13 @@
+.. _qwant engine:
+
+=====
+Qwant
+=====
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.engines.qwant
+   :members:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1256,7 +1256,7 @@ engines:
       results: HTML
 
   - name: qwant
-    qwant_categ: web
+    qwant_categ: web-lite
     engine: qwant
     shortcut: qw
     categories: [general, web]


### PR DESCRIPTION
## What does this PR do?

- Implements a scrapper for Qwant-Lite `web-lite` in the python module.
- Set `web-lite` as default in the `settings.yml`

## Why is this change important?

Already described in https://github.com/searxng/searxng/pull/2748

## How to test this PR locally?

Start instance `make run` and query (e.g.) for a trademark `!qw bmw` .. in different regions (languages) / about regions supported by Qwant see below.

## Related issues

Related: https://github.com/searxng/searxng/issues/2719
Replace: https://github.com/searxng/searxng/pull/2748


-------

https://github.com/searxng/searxng/blob/b56db4e04e0f229ba8d3dc7881382d0f1ebdeb7d/searx/data/engine_traits.json#L3595-L3639