### PR TITLE
[fix] brave.news

### DIFF
--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -219,8 +219,7 @@ def response(resp):
     json_resp = json_data[1]['data']['body']['response']
 
     if brave_category == 'news':
-        json_resp = json_resp['news']
-        return _parse_news(json_resp)
+        return _parse_news(json_resp['news'])
 
     if brave_category == 'images':
         return _parse_images(json_resp)
@@ -299,7 +298,7 @@ def _parse_news(json_resp):
             'title': result['title'],
             'content': result['description'],
         }
-        if result['thumbnail'] != "null":
+        if result['thumbnail'] is not None:
             item['img_src'] = result['thumbnail']['src']
         result_list.append(item)
 

--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -338,7 +338,7 @@ def _parse_videos(json_resp):
             'duration': result['video']['duration'],
         }
 
-        if result['thumbnail'] != "null":
+        if result['thumbnail'] is not None:
             item['thumbnail'] = result['thumbnail']['src']
 
         iframe_src = _get_iframe_src(url)

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -40,6 +40,7 @@ _ECMA_UNESCAPE2_RE = re.compile(r'%([0-9a-fA-F]{2})', re.UNICODE)
 
 _JS_QUOTE_KEYS_RE = re.compile(r'([\{\s,])(\w+)(:)')
 _JS_VOID_RE = re.compile(r'void\s+[0-9]+|void\s*\([0-9]+\)')
+_JS_DECIMAL_RE = re.compile(r":\s*\.")
 
 _STORAGE_UNIT_VALUE: Dict[str, int] = {
     'TB': 1024 * 1024 * 1024 * 1024,
@@ -699,7 +700,7 @@ def js_variable_to_python(js_variable):
             # replace simple quote by double quote
             parts[i] = '"'
             in_string = None
-        #
+
         if not in_string:
             # replace void 0 by null
             # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void
@@ -714,6 +715,7 @@ def js_variable_to_python(js_variable):
     # becomes
     # { "a": 12 }
     s = _JS_QUOTE_KEYS_RE.sub(r'\1"\2"\3', s)
+    s = _JS_DECIMAL_RE.sub(":0.", s)
     # replace the surogate character by colon
     s = s.replace(chr(1), ':')
     # load the JSON and return the result


### PR DESCRIPTION
## What does this PR do?

Fixes the brave news engine by fixing an edge-case of `js_variable_to_python`.

## Why is this change important?

This was not a hard fix, but I have some concerns about the recently added `js_variable_to_python` that replaces chompjs. I'm worried about performance, and that it's likely it will break again. In this case it broke because in js you can write the float `0.314` as `.314`, saving some bytes. Anyways, the `js_variable_to_python` discussion is off-topic so I will post about it in Discussions.

## How to test this PR locally?

`!brnews test`

## Related issues

Closes #2782 
