### PR TITLE
[fix] tagesschau videos

### DIFF
--- a/searx/engines/tagesschau.py
+++ b/searx/engines/tagesschau.py
@@ -83,7 +83,8 @@ def _story(item):
 
 
 def _video(item):
-    video_url = item['streams']['h264s']
+    streams = item['streams']
+    video_url = streams.get('h264s') or streams.get('h264m') or streams.get('h264l') or streams.get('h264xl')
     title = item['title']
 
     if "_vapp.mxf" in title:


### PR DESCRIPTION
## What does this PR do?

Fixes tagesschau crashing when a video result didn't have `h264s` as codec. Now we fall back on higher resolution, and fail the result instead of crashing otherwise.

## Why is this change important?

Should h264s be first priority tho? If not feel free to change.

## How to test this PR locally?

`!ts video` doesn't errror now.