### PR TITLE
Auto deploy preview on okteto and add docker-compose support

### DIFF
--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -1,0 +1,20 @@
+name: Delete preview environment
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  closed:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Context
+      uses: okteto/context@latest
+      with:
+        token: ${{ secrets.OKTETO_TOKEN }}
+
+    - name: Destroy preview environment
+      uses: okteto/destroy-preview@latest
+      with:
+        name: pr-${{ github.event.number }}-unixfox

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy preview environment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+    - name: Context
+      uses: okteto/context@latest
+      with:
+        token: ${{ secrets.OKTETO_TOKEN }}
+
+    - name: Deploy preview environment
+      uses: okteto/deploy-preview@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        name: pr-${{ github.event.number }}-unixfox
+        timeout: 15m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+services:
+  searxng:
+    build: .
+    ports:
+      - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,10 @@ version: "3"
 services:
   searxng:
     build: .
+    environment:
+    - SEARXNG_REDIS_URL=redis://redis:6379/0
     ports:
       - 8080:8080
+
+  redis:
+    image: redis:alpine


### PR DESCRIPTION
## What does this PR do?

This PR automatically deploy a searxng instance available for reviewing a pull request.

And it automatically deletes the instance when the PR is closed.

When new changes are pushed, it even updates the preview environment.

This PR also add a docker-compose.yml which in my opinion I don't why we haven't added one yet because it's so much easier for beginners to do git clone then `docker-compose.yml`. This is also needed by okteto to deploy the preview environment.

## Why is this change important?

In order to be more efficient into our workflow, sometimes it takes less time to just visit the URL for validating the change. Instead of having to git clone locally and run a whole searxng environment.

## How to test this PR locally?

Currently opened test PR: https://github.com/unixfox/searxngpreviewenv/pull/12

## Author's checklist

- [x] Requires to add OKTETO_TOKEN as a secret env in the project settings.

## Related issues

<!--
Closes #234
-->
