### PR TITLE
Update .gitignore to ignor `utils/brand.env`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 local/
 gh-pages/
 *.egg-info/
+utils/brand.env
 
 /package-lock.json
 /node_modules/


### PR DESCRIPTION
## What does this PR do?
`.gitignor` the `utils/brand.env` which is generated automatically.
`utils/brand.env` contains informations for the local test, and shouldn't be uploaded into `master`.

it really annoyed me because i have to remove it manually every time!

## Why is this change important?
Improve the `Developer-Experience`
