### PR TITLE
[fix] engine - qwant wrong error type

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -112,11 +112,11 @@ def request(query, params):
     args = {'q': query}
     params['raise_for_httperror'] = False
 
-    if qwant_categ == 'web-lite':
+    # all qwant engines (incl qwant-lite) delivers only 5 pages maximum
+    if params['pageno'] > 5:
+        return None
 
-        # qwant-lite delivers only 5 pages maximum
-        if params['pageno'] > 5:
-            return None
+    if qwant_categ == 'web-lite':
 
         url = web_lite_url + '?'
         args['locale'] = q_locale.lower()
@@ -130,21 +130,15 @@ def request(query, params):
 
         args['locale'] = q_locale
         args['safesearch'] = params['safesearch']
-
         args['count'] = 50
-        offset = (params['pageno'] - 1) * args['count']
-        # count + offset must be lower than 250
-        args['offset'] = min(offset, 199)
+        args['offset'] = (params['pageno'] - 1) * args['count']
 
     else:  # web, news, videos
 
         args['locale'] = q_locale
         args['safesearch'] = params['safesearch']
-
         args['count'] = 10
-        offset = (params['pageno'] - 1) * args['count']
-        # count + offset must be lower than 50
-        args['offset'] = min(offset, 39)
+        args['offset'] = (params['pageno'] - 1) * args['count']
 
     params['url'] = url + urlencode(args)
 


### PR DESCRIPTION
## What does this PR do?

Returns TooManyRequestsException from qwant when the [undocumented](https://github.com/NullDev/qwant-api/blob/master/DOCUMENTATION.md#error-codes) error code 24 is received.

## Why is this change important?

Now we return the proper error and can suspend the engine accordingly. I suspect we will never raise SearxEngineAPIException and that line could be removed in the future.

## How to test this PR locally?

Activate the qwant 'web' engine:

```diff
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1256,7 +1256,7 @@ engines:
       results: HTML
 
   - name: qwant
-    qwant_categ: web-lite
+    qwant_categ: web
     engine: qwant
     shortcut: qw
     categories: [general, web]
```

Spam qwant 10-20 times, then do `!qw test`

## Related issues

Related to #2719 