### PR TITLE
wikipedia wikidata infobox + disable wikisource

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
 
 traits: EngineTraits
 
-display_type = ["infobox"]
-
 # about
 about = {
     "website": 'https://wikidata.org/',
@@ -42,6 +40,12 @@ about = {
     "require_api_key": False,
     "results": 'JSON',
 }
+
+display_type = ["infobox"]
+"""A list of display types composed from ``infobox`` and ``list``.  The latter
+one will add a hit to the result list.  The first one will show a hit in the
+info box.  Both values can be set, or one of the two can be set."""
+
 
 # SPARQL
 SPARQL_ENDPOINT_URL = 'https://query.wikidata.org/sparql'
@@ -270,8 +274,9 @@ def get_results(attribute_result, attributes, language):
                 for url in value.split(', '):
                     infobox_urls.append({'title': attribute.get_label(language), 'url': url, **attribute.kwargs})
                     # "normal" results (not infobox) include official website and Wikipedia links.
-                    if "infobox" in display_type and (attribute.kwargs.get('official') or attribute_type == WDArticle):
+                    if "list" in display_type and (attribute.kwargs.get('official') or attribute_type == WDArticle):
                         results.append({'title': infobox_title, 'url': url, "content": infobox_content})
+
                     # update the infobox_id with the wikipedia URL
                     # first the local wikipedia URL, and as fallback the english wikipedia URL
                     if attribute_type == WDArticle and (
@@ -307,7 +312,13 @@ def get_results(attribute_result, attributes, language):
     # add the wikidata URL at the end
     infobox_urls.append({'title': 'Wikidata', 'url': attribute_result['item']})
 
-    if img_src is None and len(infobox_attributes) == 0 and len(infobox_urls) == 1 and len(infobox_content) == 0:
+    if (
+        "list" in display_type
+        and img_src is None
+        and len(infobox_attributes) == 0
+        and len(infobox_urls) == 1
+        and len(infobox_content) == 0
+    ):
         results.append({'url': infobox_urls[0]['url'], 'title': infobox_title, 'content': infobox_content})
     elif "infobox" in display_type:
         results.append(

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 traits: EngineTraits
 
-display_type = "list"
+display_type = ["infobox"]
 
 # about
 about = {
@@ -270,7 +270,7 @@ def get_results(attribute_result, attributes, language):
                 for url in value.split(', '):
                     infobox_urls.append({'title': attribute.get_label(language), 'url': url, **attribute.kwargs})
                     # "normal" results (not infobox) include official website and Wikipedia links.
-                    if display_type == "list" and (attribute.kwargs.get('official') or attribute_type == WDArticle):
+                    if "infobox" in display_type and (attribute.kwargs.get('official') or attribute_type == WDArticle):
                         results.append({'title': infobox_title, 'url': url, "content": infobox_content})
                     # update the infobox_id with the wikipedia URL
                     # first the local wikipedia URL, and as fallback the english wikipedia URL
@@ -309,7 +309,7 @@ def get_results(attribute_result, attributes, language):
 
     if img_src is None and len(infobox_attributes) == 0 and len(infobox_urls) == 1 and len(infobox_content) == 0:
         results.append({'url': infobox_urls[0]['url'], 'title': infobox_title, 'content': infobox_content})
-    elif display_type == "infobox":
+    elif "infobox" in display_type:
         results.append(
             {
                 'infobox': infobox_title,

--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 traits: EngineTraits
 
+display_type = "list"
+
 # about
 about = {
     "website": 'https://wikidata.org/',
@@ -268,7 +270,7 @@ def get_results(attribute_result, attributes, language):
                 for url in value.split(', '):
                     infobox_urls.append({'title': attribute.get_label(language), 'url': url, **attribute.kwargs})
                     # "normal" results (not infobox) include official website and Wikipedia links.
-                    if attribute.kwargs.get('official') or attribute_type == WDArticle:
+                    if display_type == "list" and (attribute.kwargs.get('official') or attribute_type == WDArticle):
                         results.append({'title': infobox_title, 'url': url, "content": infobox_content})
                     # update the infobox_id with the wikipedia URL
                     # first the local wikipedia URL, and as fallback the english wikipedia URL
@@ -307,7 +309,7 @@ def get_results(attribute_result, attributes, language):
 
     if img_src is None and len(infobox_attributes) == 0 and len(infobox_urls) == 1 and len(infobox_content) == 0:
         results.append({'url': infobox_urls[0]['url'], 'title': infobox_title, 'content': infobox_content})
-    else:
+    elif display_type == "infobox":
         results.append(
             {
                 'infobox': infobox_title,

--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -67,8 +67,6 @@ from searx.enginelib.traits import EngineTraits
 
 traits: EngineTraits
 
-display_type = ["infobox"]
-
 # about
 about = {
     "website": 'https://www.wikipedia.org/',
@@ -78,6 +76,11 @@ about = {
     "require_api_key": False,
     "results": 'JSON',
 }
+
+display_type = ["infobox"]
+"""A list of display types composed from ``infobox`` and ``list``.  The latter
+one will add a hit to the result list.  The first one will show a hit in the
+info box.  Both values can be set, or one of the two can be set."""
 
 send_accept_language_header = True
 """The HTTP ``Accept-Language`` header is needed for wikis where
@@ -188,7 +191,9 @@ def response(resp):
     title = utils.html_to_text(api_result.get('titles', {}).get('display') or api_result.get('title'))
     wikipedia_link = api_result['content_urls']['desktop']['page']
 
-    if "list" in display_type:
+    if "list" in display_type or api_result.get('type') != 'standard':
+        # show item in the result list if 'list' is in the display options or it
+        # is a item that can't be displayed in a infobox.
         results.append({'url': wikipedia_link, 'title': title, 'content': api_result.get('description', '')})
 
     if "infobox" in display_type:

--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -67,6 +67,8 @@ from searx.enginelib.traits import EngineTraits
 
 traits: EngineTraits
 
+display_type = "list"
+
 # about
 about = {
     "website": 'https://www.wikipedia.org/',
@@ -185,18 +187,21 @@ def response(resp):
     api_result = resp.json()
     title = utils.html_to_text(api_result.get('titles', {}).get('display') or api_result.get('title'))
     wikipedia_link = api_result['content_urls']['desktop']['page']
-    results.append({'url': wikipedia_link, 'title': title, 'content': api_result.get('description', '')})
 
-    if api_result.get('type') == 'standard':
-        results.append(
-            {
-                'infobox': title,
-                'id': wikipedia_link,
-                'content': api_result.get('extract', ''),
-                'img_src': api_result.get('thumbnail', {}).get('source'),
-                'urls': [{'title': 'Wikipedia', 'url': wikipedia_link}],
-            }
-        )
+    if display_type == "list":
+        results.append({'url': wikipedia_link, 'title': title, 'content': api_result.get('description', '')})
+
+    if display_type == "infobox":
+        if api_result.get('type') == 'standard':
+            results.append(
+                {
+                    'infobox': title,
+                    'id': wikipedia_link,
+                    'content': api_result.get('extract', ''),
+                    'img_src': api_result.get('thumbnail', {}).get('source'),
+                    'urls': [{'title': 'Wikipedia', 'url': wikipedia_link}],
+                }
+            )
 
     return results
 

--- a/searx/engines/wikipedia.py
+++ b/searx/engines/wikipedia.py
@@ -67,7 +67,7 @@ from searx.enginelib.traits import EngineTraits
 
 traits: EngineTraits
 
-display_type = "list"
+display_type = ["infobox"]
 
 # about
 about = {
@@ -188,10 +188,10 @@ def response(resp):
     title = utils.html_to_text(api_result.get('titles', {}).get('display') or api_result.get('title'))
     wikipedia_link = api_result['content_urls']['desktop']['page']
 
-    if display_type == "list":
+    if "list" in display_type:
         results.append({'url': wikipedia_link, 'title': title, 'content': api_result.get('description', '')})
 
-    if display_type == "infobox":
+    if "infobox" in display_type:
         if api_result.get('type') == 'standard':
             results.append(
                 {

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -369,15 +369,8 @@ engines:
   - name: wikipedia
     engine: wikipedia
     shortcut: wp
-    display_type: "list"
-    base_url: 'https://{language}.wikipedia.org/'
-    categories: [general]
-    disabled: true
-
-  - name: wikipedia.infobox
-    engine: wikipedia
-    shortcut: wpi
-    display_type: "infobox"
+    # add "list" to the array to get results in the results list
+    display_type: ["infobox"]
     base_url: 'https://{language}.wikipedia.org/'
     categories: [general]
 
@@ -592,17 +585,9 @@ engines:
     shortcut: wd
     timeout: 3.0
     weight: 2
-    display_type: "list"
+    # add "list" to the array to get results in the results list
+    display_type: ["infobox"]
     tests: *tests_infobox
-    disabled: true
-    categories: [general]
-
-  - name: wikidata.infobox
-    engine: wikidata
-    timeout: 3.0
-    shortcut: wdi
-    weight: 2
-    display_type: "infobox"
     categories: [general]
 
   - name: duckduckgo

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -369,7 +369,17 @@ engines:
   - name: wikipedia
     engine: wikipedia
     shortcut: wp
+    display_type: "list"
     base_url: 'https://{language}.wikipedia.org/'
+    categories: [general]
+    disabled: true
+
+  - name: wikipedia.infobox
+    engine: wikipedia
+    shortcut: wpi
+    display_type: "infobox"
+    base_url: 'https://{language}.wikipedia.org/'
+    categories: [general]
 
   - name: bilibili
     engine: bilibili
@@ -582,7 +592,18 @@ engines:
     shortcut: wd
     timeout: 3.0
     weight: 2
+    display_type: "list"
     tests: *tests_infobox
+    disabled: true
+    categories: [general]
+
+  - name: wikidata.infobox
+    engine: wikidata
+    timeout: 3.0
+    shortcut: wdi
+    weight: 2
+    display_type: "infobox"
+    categories: [general]
 
   - name: duckduckgo
     engine: duckduckgo
@@ -1615,6 +1636,7 @@ engines:
     categories: [general, wikimedia]
     base_url: "https://{language}.wikisource.org/"
     search_type: text
+    disabled: true
     about:
       website: https://www.wikisource.org/
       wikidata_id: Q263


### PR DESCRIPTION
## What does this PR do?

By default, wikipedia and wikidata will only display their results into the infobox.

And disable wikisource by default.

## Why is this change important?

This change comes from the discussion in https://github.com/searxng/searxng/discussions/2802.

Here are the reasons for this change:
- The API behind wikipedia, wikidata and wikisource do not have a smart algorithm like a real search engine (google, ddg and more). They are polluting the results by default, they are not aware of the full of context of the query sent by the user.
  We are not trying to build a whole new search engine, we are just a proxy. We shouldn't try to steal the job from search engines by trying to guess what to display from wiki pages.
  Moreover, the existing search engines already provide the results from wiki pages, for instance if you search for the world "ok" you get wikipedia results as the first result.
- By default and if all the default search engines are broken, the user doesn't get any big error message. He gets meaningless results and that's it.
   <img src="https://github.com/searxng/searxng/assets/4016501/f5360780-18ca-464e-b744-fa47e2acc864" width="400" />
- All the wiki engines enabled by default make it so all the public instances are working fine as searx.space see they are returning results but **the actual search engines do not work**:
   <img src="https://github.com/searxng/searxng/assets/4016501/d849b3b0-cf6f-49bb-bec1-d722e6f85ab5" width="400" />
- Top10 of the public instances from https://searx.space have already disabled all of them, or at least 2 wiki engines out of 3. This is a strong factor that the majority of people will never really use these engines, as top public instances have already disabled them because they do not want to have them by default.

In conclusion, the disadvantages in keeping these wiki engines into the results list are numerous against the advantages they offer.

## Possible improvements

I have been thinking to create a new category called "wiki" with the engines like wikipedia, wikidata, wikisource and so on.

I'm not entirely sure if it's a good idea to add again a new category on top of all the existing ones, but this would be a good tradeoff with the removal of these engines from the general tab.

## Description about the implementation of this PR

I'm not entirely sure if it is done correctly, I created two similar engines in the settings for the same engine in order to get either the infobox or just the results in the list.

Also, I'm not sure if it's implemented properly in the engine code.

@return42 any ideas how to improve that? What do you think?

## Related issues

https://github.com/searxng/searxng/discussions/2802