### PR TITLE
[fix] engine - duckduckgo vqd edge-case

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -57,13 +57,13 @@ url = 'https://lite.duckduckgo.com/lite/'
 # url_ping = 'https://duckduckgo.com/t/sl_l'
 
 time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
-form_data = {'v': 'l', 'api': 'd.js', 'o': 'json'}
 
 
 def cache_vqd(query, value):
-    """Caches a ``vqd`` value from a query.
+    """Caches a ``vqd`` token from a query, if token is None the cached value
+    is deleted.
 
-    The vqd value depends on the query string and is needed for the follow up
+    The vqd token depends on the query string and is needed for the follow up
     pages or the images loaded by a XMLHttpRequest:
 
     - DuckDuckGo Web: `https://links.duckduckgo.com/d.js?q=...&vqd=...`
@@ -72,18 +72,27 @@ def cache_vqd(query, value):
     """
     c = redisdb.client()
     if c:
-        logger.debug("cache vqd value: %s", value)
         key = 'SearXNG_ddg_vqd' + redislib.secret_hash(query)
-        c.set(key, value, ex=600)
+        if value is not None:
+            logger.debug("cache vqd value: %s", value)
+            c.set(key, value, ex=600)
+        else:
+            # remove from cache
+            c.delete(key)
+
+
+def _get_vqd_value(query):
+    res = get('https://lite.duckduckgo.com/lite/?' + urlencode({'q': query}))
+    doc = lxml.html.fromstring(res.text)
+    return eval_xpath_getindex(doc, "//input[@name='vqd']/@value", 0, None)
 
 
 def get_vqd(query):
     """Returns the ``vqd`` that fits to the *query*.  If there is no ``vqd`` cached
-    (:py:obj:`cache_vqd`) the query is sent to DDG to get a vqd value from the
+    (:py:obj:`cache_vqd`) the query is sent to DDG to get a vqd token from the
     response.
 
     """
-    value = None
     c = redisdb.client()
     if c:
         key = 'SearXNG_ddg_vqd' + redislib.secret_hash(query)
@@ -93,12 +102,20 @@ def get_vqd(query):
             logger.debug("re-use cached vqd value: %s", value)
             return value
 
-    query_url = 'https://lite.duckduckgo.com/lite/?{args}'.format(args=urlencode({'q': query}))
-    res = get(query_url)
-    doc = lxml.html.fromstring(res.text)
-    value = doc.xpath("//input[@name='vqd']/@value")[0]
-    logger.debug("new vqd value: %s", value)
-    cache_vqd(query, value)
+    value = _get_vqd_value(query)
+    if not value:
+        # seems we got a CAPTCHA for this query string, send a dummy request to
+        # release the captcha and then fetch the vqd value for the query string
+        # again.
+        logger.warning("vqd token will no longer work, trying to get a new one by sending another query")
+        _get_vqd_value(f'{query[:3]} duckduckgo')
+        value = _get_vqd_value(query)
+
+    if not value:
+        logger.error("was not able to fetch a valid vqd token from DDG")
+    else:
+        logger.debug("new vqd value: %s", value)
+        cache_vqd(query, value)
     return value
 
 
@@ -241,10 +258,10 @@ def request(query, params):
     # initial page does not have additional data in the input form
     if params['pageno'] > 1:
 
-        params['data']['o'] = form_data.get('o', 'json')
-        params['data']['api'] = form_data.get('api', 'd.js')
-        params['data']['nextParams'] = form_data.get('nextParams', '')
-        params['data']['v'] = form_data.get('v', 'l')
+        params['data']['o'] = 'json'
+        params['data']['api'] = 'd.js'
+        params['data']['nextParams'] = ''
+        params['data']['v'] = 'l'
 
     params['data']['kl'] = eng_region
     params['cookies']['kl'] = eng_region
@@ -274,23 +291,19 @@ def response(resp):
         # the layout of the HTML tables is different.
         result_table = result_table[1]
     elif not len(result_table) >= 3:
-        # no more results
+        # no more results / if we have the vqd token in cache, it's no longer
+        # valid and has to be deleted
+        cache_vqd(resp.search_params['data']['q'], None)
         return []
     else:
         result_table = result_table[2]
         # update form data from response
         form = eval_xpath(doc, '//html/body/form/div[@class="filters"]/table//input/..')
         if len(form):
-
-            form = form[0]
-            form_data['v'] = eval_xpath(form, '//input[@name="v"]/@value')[0]
-            form_data['api'] = eval_xpath(form, '//input[@name="api"]/@value')[0]
-            form_data['o'] = eval_xpath(form, '//input[@name="o"]/@value')[0]
-            logger.debug('form_data: %s', form_data)
-
-            value = eval_xpath(form, '//input[@name="vqd"]/@value')[0]
+            value = eval_xpath_getindex(form[0], "//input[@name='vqd']/@value", 0, None)
             query = resp.search_params['data']['q']
-            cache_vqd(query, value)
+            if value:
+                cache_vqd(query, value)
 
     tr_rows = eval_xpath(result_table, './/tr')
     # In the last <tr> is the form of the 'previous/next page' links


### PR DESCRIPTION
## What does this PR do?

Fixes a crash on non-Redis instances whenever an invalid vqd token is retried. On instances with Redis, this results in no exception, but  also no result returned on seemingly valid queries.

## Why is this change important?

Let me preface that this fix is dumb, and DuckDuckGo is annoying. If someone has a better solution, please suggest.

I wouldn't have bothered with this if it wasn't for the fact that most public instances report this exception, it's one of the most common exceptions right now, and it brings down the reliability and result count of DuckDuckGo. See [searx.space](https://searx.space) section under the engines tab, the error is IndexError. (This also means that a large part of public instances don't use Redis, as this error only occurs when you don't... Maybe we need to advertise Redis better to admins?)

#### Now to explain the issue... And I might've misunderstood it entirely

We fetch a `vqd` token from duckduckgo whenever we do a query. This token is needed to access results on later pages of DuckDuckGo. This token is then cached in Redis for the associated query, if Redis is enabled. 

We perform a search, and when the results run out, searxng will give the appropriate ***Sorry! we didn't find any results.***. But now, the vqd token is no longer valid because we made an invalid request with the token (on the DuckDuckGo UI there would not have been a next page to click on). If Redis is enabled, the token is still in cache, and when we try the same query with a different page and request it, we get no results because the token was invalid. If Redis is not enabled, we re-request the token on every search (but the token is always the same for the same query), now if we request it again, but we invalidated it, we get a captcha when requesting it. This is not handled correctly by get_vqd and we get an IndexError.

To avoid the captcha is very simple, we need to perform a different query, this will give us a new token. Now if we perform the original query, we get a new token and the captcha is gone.

## How to test this PR locally?

Make sure to test with and without Redis. Search for something uncommon like some random text `!ddg vrylongqrywthrndmtxth2b9IKK5mV9wWufzOdLSz9YPhg`. Get to the end of the results. Now simply press the search button again for the same query and you will get a crash without Redis. With Redis we cache results (right?), so just go to a page that isn't cached and it will fail too.
