### PR TITLE
[mod] better error message when no results found

### DIFF
--- a/searx/static/themes/simple/src/less/toolkit.less
+++ b/searx/static/themes/simple/src/less/toolkit.less
@@ -176,6 +176,15 @@ div.selectable_url {
   border-color: var(--color-error);
 }
 
+.dialog-error-block {
+  .dialog();
+
+  display: block;
+  color: var(--color-error);
+  background: var(--color-error-background);
+  border-color: var(--color-error);
+}
+
 .dialog-warning {
   .dialog();
 

--- a/searx/templates/simple/elements/engines_msg.html
+++ b/searx/templates/simple/elements/engines_msg.html
@@ -1,5 +1,9 @@
 <div id="engines_msg">
+  {% if not results and not answers %}
+  <details class="sidebar-collapsable" open>
+  {% else %}
   <details class="sidebar-collapsable">
+  {% endif %}
     <summary class="title" id="engines_msg-title">{{ _('Messages from the search engines') }}</summary>
     <div class="dialog-error" role="alert">
       {{ icon_big('warning') }}

--- a/searx/templates/simple/messages/no_results.html
+++ b/searx/templates/simple/messages/no_results.html
@@ -1,5 +1,11 @@
 {% from 'simple/icons.html' import icon_big %}
-<div class="dialog-error" role="alert">
+<div class="dialog-error-block" role="alert">
   <p><strong>{{ _('Sorry!') }}</strong></p>
-  <p>{{ _("we didn't find any results. Please use another query or search in more categories.") }}</p>
+  <p>{{ _("No results were found. You can try to:") }}</p>
+  <ul>
+    <li>{{ _("Refresh the page.") }}</li>
+    <li>{{ _("Search for another query or select another category (above).") }}</li>
+    <li>{{ _("Change the search engine used in the preferences:") }} <a href="/preferences">/preferences</a></li>
+    <li>{{ _("Switch to another instance:") }} <a href="https://searx.space">https://searx.space</a></li>
+  </ul>
 </div>

--- a/tests/robot/test_webapp.py
+++ b/tests/robot/test_webapp.py
@@ -75,4 +75,4 @@ def test_search(browser):
     browser.visit(url)
     browser.fill('q', 'test search query')
     browser.find_by_xpath('//button[@type="submit"]').first.click()
-    assert browser.is_text_present('didn\'t find any results')
+    assert browser.is_text_present('No results were found')


### PR DESCRIPTION
## What does this PR do?

Better wording when no results are found and give solutions to the user.

When there are no results, the section `Messages from the search engines` is displayed by default so that the user immediately see all the search engines that do not work.

## Why is this change important?

<!-- MANDATORY -->

This change comes from the discussion in https://github.com/searxng/searxng/discussions/2802.

This gives solutions to the user in case no results were found. Previously, the user was left with no solution if he is a beginner.

## How to test this PR locally?

Preview of the change:

![image](https://github.com/searxng/searxng/assets/4016501/eafde219-2fdd-431b-89f5-7a887cce112b)

## Author's checklist

@return42 I hope I rebuilt the themes correctly. Let me know if it's not how it works.

## Related issues

https://github.com/searxng/searxng/discussions/2802
