### PR TITLE
[mod] Switch back to qwant web normal API

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1264,7 +1264,7 @@ engines:
       results: HTML
 
   - name: qwant
-    qwant_categ: web-lite
+    qwant_categ: web
     engine: qwant
     shortcut: qw
     categories: [general, web]


### PR DESCRIPTION
## What does this PR do?

This switch back to the old qwant web normal API.

## Why is this change important?

The new qwant web lite break the links in the results: https://github.com/searxng/searxng/issues/2812

And we JSON API is much more reliable than parsing HTML.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

Avoiding the bug by default in #2812
