### PR TITLE
[fix] engine - google images error when no results

### DIFF
--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -95,7 +95,7 @@ def response(resp):
     json_start = resp.text.find('{"ischj":')
     json_data = loads(resp.text[json_start:])
 
-    for item in json_data["ischj"]["metadata"]:
+    for item in json_data["ischj"].get("metadata", []):
 
         result_item = {
             'url': item["result"]["referrer_url"],


### PR DESCRIPTION
## What does this PR do?

Fixes `KeyError` when there are no results from Google Images.

## Why is this change important?

One of the top currently reported errors on searx.space

## How to test this PR locally?

`!goi ~^`