### PR TITLE
[fix] engine - brave don't show ads

### DIFF
--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -246,7 +246,7 @@ def _parse_search(resp):
 
         url = eval_xpath_getindex(result, './/a[contains(@class, "h")]/@href', 0, default=None)
         title_tag = eval_xpath_getindex(result, './/div[contains(@class, "title")]', 0, default=None)
-        if url is None or title_tag is None:
+        if url is None or title_tag is None or not urlparse(url).netloc:  # partial url likely means it's an ad
             continue
 
         content_tag = eval_xpath_getindex(result, './/div[@class="snippet-description"]', 0, default='')


### PR DESCRIPTION
## What does this PR do?

Don't include ads or other partial urls in brave results.

## Why is this change important?

No more ads. Also hope you don't mind me including some automatic cleanup by black, otherwise I can keep it a separate commit.

## How to test this PR locally?

`!brave air curtains` shouldn't show a Wayfair ad anymore

## Related issues

Closes #2805 