### PR TITLE
[fix] update user agent

### DIFF
--- a/searx/data/useragents.json
+++ b/searx/data/useragents.json
@@ -7,5 +7,5 @@
         "Windows NT 10.0; Win64; x64",
         "X11; Linux x86_64"
     ],
-    "ua": "Mozilla/5.0 ({os}; rv:{version}) Gecko/20100101 Firefox/{version}"
+    "ua": "Mozilla/5.0 ({os}; rv:109.0) Gecko/20100101 Firefox/{version}"
 }

--- a/searxng_extra/update/update_firefox_version.py
+++ b/searxng_extra/update/update_firefox_version.py
@@ -32,7 +32,7 @@ useragents = {
     "versions": (),
     "os": ('Windows NT 10.0; Win64; x64',
            'X11; Linux x86_64'),
-    "ua": "Mozilla/5.0 ({os}; rv:{version}) Gecko/20100101 Firefox/{version}",
+    "ua": "Mozilla/5.0 ({os}; rv:109.0) Gecko/20100101 Firefox/{version}",
     # fmt: on
 }
 
@@ -64,6 +64,12 @@ def fetch_firefox_last_versions():
     major_last = versions[0].major
     major_list = (major_last, major_last - 1)
     for version in versions:
+        msg = (
+            "Please check if the rv segment of the user agent is still frozen at 109.0: "
+            "https://bugzilla.mozilla.org/show_bug.cgi?id=1805967"
+        )
+        assert version.major != 120, msg
+
         major_current = version.major
         minor_current = version.minor
         if major_current in major_list:


### PR DESCRIPTION
## What does this PR do?

Fixes the User-Agent to be a valid one. Currently the geckoversion rv value is frozen as 109.

## Why is this change important?

As dalf found, [firefox froze their rv value at 109](https://bugzilla.mozilla.org/show_bug.cgi?id=1805967). This made our User-Agent invalid and led to us being detected as a bot by Bing. This could also have negative effects for other engines.

## How to test this PR locally?

Try some searches, make sure no engine is broken by this. Shouldn't be the case tho.