### PR TITLE
[fix] harmonize default settings for caching of /static files

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -39,8 +39,8 @@ buffer-size = 8192
 add-header = Connection: close
 
 # uwsgi serves the static files
-# expires set to one year since there are hashes
 static-map = /static=/usr/local/searxng/searx/static
-static-expires = /* 31557600
+# expires set to one day
+static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
@@ -78,7 +78,7 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one year since there are hashes
-static-expires = /* 31557600
+# expires set to one day
+static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
@@ -75,7 +75,7 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one year since there are hashes
-static-expires = /* 31557600
+# expires set to one day
+static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini
@@ -81,7 +81,7 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one year since there are hashes
-static-expires = /* 31557600
+# expires set to one day
+static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
@@ -78,7 +78,7 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one year since there are hashes
-static-expires = /* 31557600
+# expires set to one day
+static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k


### PR DESCRIPTION
Caching files on the client side for more than a day can confuse the end user when updating static files[1].

Depending on the way of providing a SearXNG instance via HTTP, there are several ways to optimize the access to the /static files.  However, since we don't know what optimization an admin has provided for his static files, we should have moderate settings in the defaults that run robustly in a wide variety of installations.

In this sense, all caches on the client side should be cleared after one day at the latest.  So far the files were cached for one year on client side; as soon as changes are made to the static files (with the option `static_use_hash: true`) the old static files are kept for one year on the CLient side / which can also be evaluated as unnecessary caching.

[1] https://github.com/searxng/searxng/discussions/2821

----

Related:

- https://github.com/searxng/searxng/pull/932#issuecomment-1067039518