### PR TITLE
[fix] internet archive scholar: crash when there's no title

### DIFF
--- a/searx/engines/internet_archive_scholar.py
+++ b/searx/engines/internet_archive_scholar.py
@@ -56,7 +56,7 @@ def response(resp):
             {
                 'template': 'paper.html',
                 'url': result['fulltext']['access_url'],
-                'title': result['biblio']['title'],
+                'title': result['biblio'].get('title') or result['biblio'].get('container_name'),
                 'content': html_to_text(content),
                 'publisher': result['biblio'].get('publisher'),
                 'doi': doi,


### PR DESCRIPTION
## What does this PR do?
* we now shot the journal title if the paper itself doesn't have a title, so that there's no crash and the paper is still visible to the user

## How to test this PR locally?
* !ias foo bar

## Additional notes
* I noticed Internet archive scholar also provides a thumbnail for some papers, but `paper.html` does not yet support that. Might be something to consider adding in the future.

## Related issues
closes #2823
