### PR TITLE
[mod] activate limiter & link_token method by default

### DIFF
--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -15,6 +15,7 @@ Administrator documentation
    installation-apache
    update-searxng
    answer-captcha
+   searx.botdetection
    api
    architecture
    plugins

--- a/docs/admin/searx.botdetection.rst
+++ b/docs/admin/searx.botdetection.rst
@@ -19,6 +19,8 @@ Bot Detection
   :members:
 
 
+.. _botdetection rate limit:
+
 Rate limit
 ==========
 
@@ -28,6 +30,8 @@ Rate limit
 .. automodule:: searx.botdetection.link_token
   :members:
 
+
+.. _botdetection probe headers:
 
 Probe HTTP headers
 ==================

--- a/searx/botdetection/__init__.py
+++ b/searx/botdetection/__init__.py
@@ -2,6 +2,23 @@
 # lint: pylint
 """.. _botdetection src:
 
+The :ref:`limiter <limiter src>` implements several methods to block bots:
+
+a. Analysis of the HTTP header in the request / can be easily bypassed.
+
+b. Block and pass lists in which IPs are listed / difficult to maintain, since
+   the IPs of bots are not all known and change over the time.
+
+c. Detection of bots based on the behavior of the requests and blocking and, if
+   necessary, unblocking of the IPs via a dynamically changeable IP block list.
+
+For dynamically changeable IP lists a Redis database is needed and for any kind
+of IP list the determination of the IP of the client is essential.  The IP of
+the client is determined via the X-Forwarded-For_ HTTP header
+
+.. _X-Forwarded-For:
+   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+
 X-Forwarded-For
 ===============
 

--- a/utils/templates/etc/searxng/limiter.toml
+++ b/utils/templates/etc/searxng/limiter.toml
@@ -1,0 +1,13 @@
+# Limiter configuration / bot protection & IP rate limitation
+
+[real_ip]
+
+# number of values to trust for X-Forwarded-For
+# https://docs.searxng.org/admin/searx.botdetection.html#searx.botdetection.get_real_ip
+x_for = 1
+
+[botdetection.ip_limit]
+
+# activate link_token method in the ip_limit method
+# https://docs.searxng.org/admin/searx.botdetection.html#method-ip-limit
+link_token = true


### PR DESCRIPTION
## What does this PR do?

activate limiter & link_token method (aka CSS ping) by default

## Why is this change important?

The SearXNG instances suffer from the massive bot requests

## How to test this PR locally?

Install SearXNG into a LXC:

    $ sudo ./utils/lxc.sh build searxng-archlinux
    ...
    $ sudo ./utils/lxc.sh install suite archlinux
    ...
    environment /usr/local/searxng/searxng-src/utils/brand.env:
      ...
      SEARXNG_URL          : http://10.186.30.3/searxng
    ...
    $ sudo ./utils/lxc.sh cmd searxng-archlinux ./utils/searxng.sh install nginx
    
Limiter configuration should be installed:

    $ sudo ./utils/lxc.sh cmd searxng-archlinux ls -la /etc/searxng
    ...
    -rw-r--r--  1 searxng searxng  388 Sep 23 11:21 limiter.toml

Open http://10.186.30.3/searxng in your WEB browser and look a the CSS files:

![grafik](https://github.com/searxng/searxng/assets/554536/ec5bddca-dcdd-4993-95a2-5950344a013f)

----

Without Redis you will see an error message::

    ERROR   searx.plugins.limiter         : The limiter requires Redis

.. the instance will run, but the limiter can then not be used.

----

Related:

- https://github.com/searxng/searxng-docker/pull/182