### PR TITLE
[fix] magnifier button always search in the general category (#2839)

### DIFF
--- a/searx/templates/simple/search.html
+++ b/searx/templates/simple/search.html
@@ -8,7 +8,7 @@
       <div class="search_box">
         <input id="q" name="q" type="text" placeholder="{{ _('Search for...') }}" tabindex="1" autocomplete="off" autocapitalize="none" spellcheck="false" autocorrect="off" dir="auto" value="{{ q or '' }}">
         <button id="clear_search" type="reset" aria-label="{{ _('clear') }}" class="hide_if_nojs"><span>{{ icon_big('close') }}</span><span class="show_if_nojs">{{ _('clear') }}</span></button>
-        <button id="send_search" type="submit" aria-label="{{ _('search') }}"><span class="hide_if_nojs">{{ icon_big('search-outline') }}</span><span class="show_if_nojs">{{ _('search') }}</span></button>
+        <button id="send_search" type="submit" {%- if search_on_category_select -%}name="category_{{ selected_categories[0]|replace(' ', '_') }}"{%- endif -%} aria-label="{{ _('search') }}"><span class="hide_if_nojs">{{ icon_big('search-outline') }}</span><span class="show_if_nojs">{{ _('search') }}</span></button>
       </div>
     </div>
     {% set display_tooltip = true %}


### PR DESCRIPTION
## What does this PR do?
solve #2839 

by adding a `name` property to the magnifier so it can send the category data to the search `form`.
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->


## How to test this PR locally?

1. Search for something in the image category
2. Once the results are displayed, Press the magnifier again.

**this means failed**: SearXNG returns result in the `General` category
while **this means success**: SearXNG returns result in the `Image` category

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues
Closes #2839
<!--
Closes #234
-->
