### PR TITLE
[mod] add new parameter called server.public_instance

### DIFF
--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -104,3 +104,9 @@ if max_request_timeout is None:
     logger.info('max_request_timeout=%s', repr(max_request_timeout))
 else:
     logger.info('max_request_timeout=%i second(s)', max_request_timeout)
+
+if settings['server']['public_instance']:
+    logger.warning(
+        "Be aware you have activated features intended only for public instances. "
+        + "This force the usage of the bot limiter and link_token plugins."
+    )

--- a/searx/botdetection/ip_limit.py
+++ b/searx/botdetection/ip_limit.py
@@ -47,6 +47,7 @@ from ipaddress import (
 import flask
 import werkzeug
 from searx.tools import config
+from searx import settings
 
 from searx import redisdb
 from searx.redislib import incr_sliding_window, drop_counter
@@ -109,7 +110,7 @@ def filter_request(
         if c > API_MAX:
             return too_many_requests(network, "too many request in API_WINDOW")
 
-    if cfg['botdetection.ip_limit.link_token']:
+    if settings['server']['public_instance'] or cfg['botdetection.ip_limit.link_token']:
 
         suspicious = link_token.is_suspicious(network, request, True)
 

--- a/searx/plugins/limiter.py
+++ b/searx/plugins/limiter.py
@@ -3,6 +3,7 @@
 # pyright: basic
 """see :ref:`limiter src`"""
 
+import sys
 import flask
 
 from searx import redisdb
@@ -23,10 +24,15 @@ def pre_request():
 
 
 def init(app: flask.Flask, settings) -> bool:
-    if not settings['server']['limiter']:
+    if not settings['server']['limiter'] and not settings['server']['public_instance']:
         return False
     if not redisdb.client():
-        logger.error("The limiter requires Redis")
+        logger.error(
+            "The limiter requires Redis, please consult the documentation: "
+            + "https://docs.searxng.org/admin/searx.botdetection.html#limiter"
+        )
+        if settings['server']['public_instance']:
+            sys.exit(1)
         return False
     app.before_request(pre_request)
     return True

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -74,6 +74,7 @@ server:
   # by ${SEARXNG_URL}.
   base_url: false  # "http://example.com/location"
   limiter: false  # rate limit the number of request on the instance, block some bots
+  public_instance: false  # enable features designed only for public instances
 
   # If your instance owns a /etc/searxng/settings.yml file, then set the following
   # values there.
@@ -95,7 +96,7 @@ server:
 
 redis:
   # URL to connect redis database. Is overwritten by ${SEARXNG_REDIS_URL}.
-  # https://redis-py.readthedocs.io/en/stable/connections.html#redis.client.Redis.from_url
+  # https://docs.searxng.org/admin/settings/settings_redis.html#settings-redis
   url: false
 
 ui:

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -174,6 +174,7 @@ SCHEMA = {
         'port': SettingsValue((int, str), 8888, 'SEARXNG_PORT'),
         'bind_address': SettingsValue(str, '127.0.0.1', 'SEARXNG_BIND_ADDRESS'),
         'limiter': SettingsValue(bool, False),
+        'public_instance': SettingsValue(bool, False),
         'secret_key': SettingsValue(str, environ_name='SEARXNG_SECRET'),
         'base_url': SettingsValue((False, str), False, 'SEARXNG_BASE_URL'),
         'image_proxy': SettingsValue(bool, False),

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1286,6 +1286,7 @@ def config():
             },
             'doi_resolvers': list(settings['doi_resolvers'].keys()),
             'default_doi_resolver': settings['default_doi_resolver'],
+            'public_instance': settings['server']['public_instance'],
         }
     )
 


### PR DESCRIPTION
## What does this PR do?

new parameter:
```
server:
  public_instance: false
```

For enabling by default advanced limiter functions.
And in the future allow us to add features just for the public instances.

This also makes redis mandatory for public instances.

As discussed in https://github.com/searxng/searxng/discussions/2802

## Why is this change important?

This is an important setting that allows to not enable features not needed for local usage, it allows us to develop features specifically for public instances.

It's the best middle ground to have both parties "happy".

And it goes towards a "world" where we are going to make redis mandatory.

## How to test this PR locally?

- Check if the limiter and the link_token limiter is working.
- Check if you can't start searxng without redis.
- Check if you can see the parameter public_instance in /config
- Check if the limiter and the link_token limiter are still working if the parameter `public_instance` is used.

## Author's checklist

- Check if the limiter and the link_token limiter is working.

![image](https://github.com/searxng/searxng/assets/4016501/28a4ab16-5f69-4c27-9e46-a0007221ac8f)

- Check if you can't start searxng without redis.

![image](https://github.com/searxng/searxng/assets/4016501/2260fd82-ba33-48dc-b980-2833a43c7ba4)

- Check if you can see the parameter public_instance in /config

![image](https://github.com/searxng/searxng/assets/4016501/5b300486-d192-46b1-8390-6625b5b053f3)

## Related issues

https://github.com/searxng/searxng/discussions/2802