### PR TITLE
[fix] engine - kickass update url, fix parsing, use multiple mirrors

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -911,9 +911,14 @@ engines:
 
   - name: kickass
     engine: kickass
+    base_url:
+      - https://kickasstorrents.to
+      - https://kickasstorrents.cr
+      - https://kickasstorrent.cr
+      - https://kickass.sx
+      - https://kat.am
     shortcut: kc
     timeout: 4.0
-    disabled: true
 
   - name: lemmy communities
     engine: lemmy


### PR DESCRIPTION
## What does this PR do?

- Adds 5 working kickass mirrors
- Fixes the xpaths and makes them more robust
- Unfortunately, magnet, download links and file counts aren't shown in the result anymore. Code for that is removed.

## Why is this change important?

So kickass is dead:
https://reddit.utsav2.dev/r/kickasstorrents/comments/mue44z/kat_is_dead/
https://thehackernews.com/2016/12/kickass-torrents-site.html
It has gone down, new clones by same staff have appeared and gone down again. The current clone network mirrors are listed on https://thekickasstorrents.to/ .

### Suggestions:
- Kickass can probably be enabled by default now.
- Test and see if the 4 second timeout can be decreased. I'm getting 0.2s P95.
- Maybe the shortcut should be !kat, as is the official abbreviation.

## How to test this PR locally?

`!kc 12 angry men`

## Related issues

Closes #2842 