### PR TITLE
[mod] warn to info for failed ping limiter

### DIFF
--- a/searx/botdetection/link_token.py
+++ b/searx/botdetection/link_token.py
@@ -83,7 +83,7 @@ def is_suspicious(network: IPv4Network | IPv6Network, request: flask.Request, re
 
     ping_key = get_ping_key(network, request)
     if not redis_client.get(ping_key):
-        logger.warning("missing ping (IP: %s) / request: %s", network.compressed, ping_key)
+        logger.info("missing ping (IP: %s) / request: %s", network.compressed, ping_key)
         return True
 
     if renew:


### PR DESCRIPTION
## What does this PR do?

Change the log level from warning to info for `searx.botdetection.link_token: missing ping`

## Why is this change important?

This spam a lot in the public instances, and it shouldn't be a warning as it means the limiter is doing its job.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
