### PR TITLE
[mod] settings.yml: remove plugin settings for plugins that don't exist anymore

### DIFF
--- a/docs/admin/api.rst
+++ b/docs/admin/api.rst
@@ -69,10 +69,6 @@ Sample response
        {
          "enabled": true,
          "name": "HTTPS rewrite"
-       },
-       {
-         "enabled": false,
-         "name": "Vim-like hotkeys"
        }
      ],
      "safe_search": 0

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -209,7 +209,6 @@ outgoing:
 # enabled_plugins:
 #   # these plugins are enabled if nothing is configured ..
 #   - 'Hash plugin'
-#   - 'Search on category select'
 #   - 'Self Information'
 #   - 'Tracker URL remover'
 #   - 'Ahmia blacklist'  # activation depends on outgoing.using_tor_proxy

--- a/utils/templates/etc/searxng/settings.yml
+++ b/utils/templates/etc/searxng/settings.yml
@@ -33,14 +33,11 @@ ui:
 
 enabled_plugins:
   - 'Hash plugin'
-  - 'Search on category select'
   - 'Self Informations'
   - 'Tracker URL remover'
   - 'Ahmia blacklist'
   # - 'Hostname replace'  # see hostname_replace configuration below
-  # - 'Infinite scroll'
   # - 'Open Access DOI rewrite'
-  # - 'Vim-like hotkeys'
 
 # plugins:
 #   - only_show_green_results


### PR DESCRIPTION
We have been replacing these plugins by normal UI settings recently, but forgot to remove the existing plugin settings in settings.yml where they have been enabled.