### PR TITLE
[fix] categories.html: can't select social media category using search on category select

### DIFF
--- a/searx/templates/simple/categories.html
+++ b/searx/templates/simple/categories.html
@@ -26,7 +26,7 @@
             {%- if display_tooltip %}<div class="help">{{ _('Click on the magnifier to perform search') }}</div>{% endif -%}
         {%- else -%}
             {%- for category in categories_as_tabs -%}{{- '\n' -}}
-                <button type="submit" name="category_{{ category|replace(' ', '_') }}" class="category category_button {% if category in selected_categories %}selected{% endif %}">
+                <button type="submit" name="category_{{ category }}" class="category category_button {% if category in selected_categories %}selected{% endif %}">
                     {{- icon_big(category_icons[category]) if category in category_icons else icon_big('globe-outline') -}}
                     <div class="category_name">{{- _(category) -}}</div>{{- '' -}}
                 </button>{{- '' -}}


### PR DESCRIPTION
## What does this PR do?
* fixes a regression from #2740 that we've overseen

## How to test this PR locally?
* make run
* search anything and click on the "social media" category


