### PR TITLE
[feat] engine: implementation of tootfinder

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1926,6 +1926,23 @@ engines:
     timeout: 10.0
     disabled: true
 
+  - name: tootfinder
+    engine: json_engine
+    categories: ['social media']
+    paging: false
+    search_url: https://www.tootfinder.ch/rest/api/search/{query}
+    url_query: uri
+    title_query: card/title
+    content_query: content
+    thumbnail_query: card/image
+    shortcut: toot
+    about:
+      website: https://tootfinder.ch/
+      official_api_documentation: https://wiki.tootfinder.ch/index.php?name=the-tootfinder-rest-api
+      use_official_api: true
+      require_api_key: false
+      results: 'JSON'
+
   - name: wallhaven
     engine: wallhaven
     # api_key: abcdefghijklmnopqrstuvwxyz


### PR DESCRIPTION
## What does this PR do?
* add tootfinder as a json engine, which is an engine to search posts via mastodon

## Why is this change important?
* Mastodon doesn't allow us to search posts really well, see my other PR for Mastodon

## How to test this PR locally?
* !toot linux

## Related issues
see #792