### PR TITLE
[feat] engine: implementation of hacker news

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -870,6 +870,25 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name: hackernews
+    engine: json_engine
+    paging: true
+    search_url: https://hn.algolia.com/api/v1/search?query={query}&page={pageno}
+    results_query: hits
+    url_query: url
+    title_query: title
+    content_query: story_text
+    categories: it
+    first_page_num: 0
+    shortcut: hn
+    about:
+      website: https://news.ycombinator.com/
+      wikidata_id: Q686797
+      official_api_documentation: https://hn.algolia.com/api
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
   - name: imdb
     engine: imdb
     shortcut: imdb


### PR DESCRIPTION
## What does this PR do?
* It's implemented as a simple json engine. If we created a module for it, we would be able to parse the upload date additionally if we wanted to implement a python module for the engine, however (in my opinion) that's not worth it

## Why is this change important?
* hackernews allows you to search for news related to IT

## How to test this PR locally?
* !hn test

## Related issues
closes #1632
https://github.com/searx/searx/issues/1456#issuecomment-466778239
