### PR TITLE
[feat] engine: implementation of matrixrooms.info

### DIFF
--- a/searx/engines/matrixrooms.py
+++ b/searx/engines/matrixrooms.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Matrixrooms.info (social media)
+"""
+
+from urllib.parse import quote_plus
+
+about = {
+    "website": 'https://matrixrooms.info',
+    "wikidata_id": 'Q107565255',
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+paging = True
+categories = ['social media']
+
+base_url = "https://apicdn.matrixrooms.info"
+matrix_url = "https://matrix.to"
+page_size = 20
+
+
+def request(query, params):
+    params['url'] = f"{base_url}/search/{quote_plus(query)}/{page_size}/{params['pageno']-1}"
+    return params
+
+
+def response(resp):
+    results = []
+
+    for result in resp.json():
+        results.append(
+            {
+                'url': matrix_url + '/#/' + result['alias'],
+                'title': result['name'],
+                'content': result['topic']
+                + f" // {result['members']} members"
+                + f" // {result['alias']}"
+                + f" // {result['server']}",
+                'thumbnail': result['avatar_url'],
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1017,6 +1017,11 @@ engines:
       require_api_key: false
       results: HTML
 
+  - name: matrixrooms
+    engine: matrixrooms
+    shortcut: mtrx
+    disabled: true
+
   - name: metacpan
     engine: metacpan
     shortcut: cpan


### PR DESCRIPTION
## What does this PR do?
* implement a new engine: matrixrooms.info

## Why is this change important?
* the engine allows you to quickly search for public Matrix or IRC rooms 

## How to test this PR locally?
* !mtrx searxng

