### PR TITLE
[mod] tagesschau: add option to only use tagesschau urls

### DIFF
--- a/searx/engines/tagesschau.py
+++ b/searx/engines/tagesschau.py
@@ -42,6 +42,17 @@ paging = True
 results_per_page = 10
 base_url = "https://www.tagesschau.de"
 
+use_source_url = True
+"""When set to false, display URLs from Tagesschau, and not the actual source
+(e.g. NDR, WDR, SWR, HR, ...)
+
+.. note::
+
+   The actual source may contain additional content, such as commentary, that is
+   not displayed in the Tagesschau.
+
+"""
+
 
 def request(query, params):
     args = {
@@ -78,7 +89,7 @@ def _story(item):
         'thumbnail': item.get('teaserImage', {}).get('imageVariants', {}).get('16x9-256'),
         'publishedDate': datetime.strptime(item['date'][:19], '%Y-%m-%dT%H:%M:%S'),
         'content': item['firstSentence'],
-        'url': item['shareURL'],
+        'url': item['shareURL'] if use_source_url else item['detailsweb'],
     }
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1482,6 +1482,9 @@ engines:
 
   - name: tagesschau
     engine: tagesschau
+    # when set to false, display URLs from Tagesschau, and not the actual source
+    # (e.g. NDR, WDR, SWR, HR, ...)
+    use_source_url: true
     shortcut: ts
     disabled: true
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->
* add a configurable option to the "Tagesschau" engine to return the URL pointing to the URL at tagesschau.de, instead of the real source (e.g. NDR)
* I've built a small alternative frontend and want to redirect all Tagesschau links to it, however that only works when there's one common domain (since I don't want to configure a hostname_replace for each single official public German news media)

## How to test this PR locally?
* !ts test
* set `use_source_url` to false and search again
* compare the URLs of the results

