### PR TITLE
[fix] #2866 Bug: Yahoo results for simplified Chinese search sometimes have the first character cut off

### DIFF
--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -159,7 +159,7 @@ def fetch_traits(engine_traits: EngineTraits):
 
     resp = network.get('https://search.yahoo.com/preferences/languages')
     if not resp.ok:
-        print("ERROR: response from peertube is not OK.")
+        print("ERROR: response from yahoo is not OK.")
 
     dom = html.fromstring(resp.text)
     offset = len('lang_')

--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -133,12 +133,7 @@ def response(resp):
             continue
         url = parse_url(url)
 
-        title = eval_xpath_getindex(result, './/h3/a', 0, default=None)
-        if title is None:
-            continue
-        offset = len(extract_text(title.xpath('span')))
-        title = extract_text(title)[offset:]
-
+        title = extract_text(result.xpath('.//h3//a/@aria-label'))
         content = eval_xpath_getindex(result, './/div[contains(@class, "compText")]', 0, default='')
         content = extract_text(content, allow_none=True)
 


### PR DESCRIPTION
Co-authored-by: @bnoctis

## What does this PR do?
fix the bug:
yahoo for simplified chinese sometimes cut off the last character.

fixed by: setting a offset_right.

## How to test this PR locally?
```
make run
```
and search for keyword `!yahoo 繁体字`

### for detail information in test, add these test codes to 
```diff
AT /searx/engines/yahoo.py near L140

         if title is None:
             continue
         offset = len(extract_text(title.xpath('span[1]')))
         offset_right = -len(extract_text(title.xpath('span[2]'))) or None
+        print("LOG1", '\"'+extract_text(title.xpath('span'))+'\"')
+        print("LOG2", '\"'+extract_text(title.xpath('span[1]'))+'\"')
+        print("LOG3", '\"'+extract_text(title.xpath('span[2]'))+'\"')
+        print("LOG4", '\"'+extract_text(title)+'\"')
+        print()
         title = extract_text(title)[offset:offset_right]

```

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues
Closes #2866
<!--
Closes #234
-->
