### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version:  ["3.8", "3.9", "3.10", "3.11"]
+        python-version:  ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do?

Add support for Python 3.12 (release on October 2nd).

## Why is this change important?

Support the last version of Python

## How to test this PR locally?

* install Python 3.12 (I've used pyenv)
* `make test`, `make run`

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

Close https://github.com/searxng/searxng/issues/2745
