### PR TITLE
Convert plugin searx.plugin.limiter to normal code

### DIFF
--- a/searx/botdetection/__init__.py
+++ b/searx/botdetection/__init__.py
@@ -42,3 +42,6 @@ X-Forwarded-For
 from ._helpers import dump_request
 from ._helpers import get_real_ip
 from ._helpers import too_many_requests
+from .install import initialize, is_installed
+
+__all__ = ['dump_request', 'get_real_ip', 'too_many_requests', 'initialize', 'is_installed']

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -94,7 +94,11 @@ from searx.utils import (
 from searx.version import VERSION_STRING, GIT_URL, GIT_BRANCH
 from searx.query import RawTextQuery
 from searx.plugins import Plugin, plugins, initialize as plugin_initialize
-from searx.botdetection import link_token
+from searx.botdetection import (
+    link_token,
+    initialize as botdetection_initialize,
+    is_installed as botdetection_is_installed,
+)
 from searx.plugins.oa_doi_rewrite import get_doi_resolver
 from searx.preferences import (
     Preferences,
@@ -1288,7 +1292,7 @@ def config():
                 'DOCS_URL': get_setting('brand.docs_url'),
             },
             'limiter': {
-                'enabled': settings['server']['limiter'],
+                'enabled': botdetection_is_installed(),
                 'botdetection.ip_limit.link_token': _limiter_cfg.get('botdetection.ip_limit.link_token'),
                 'botdetection.ip_lists.pass_searxng_org': _limiter_cfg.get('botdetection.ip_lists.pass_searxng_org'),
             },
@@ -1322,6 +1326,7 @@ if not werkzeug_reloader or (werkzeug_reloader and os.environ.get("WERKZEUG_RUN_
     redis_initialize()
     plugin_initialize(app)
     search_initialize(enable_checker=True, check_network=True, enable_metrics=settings['general']['enable_metrics'])
+    botdetection_initialize(app, settings)
 
 
 def run():


### PR DESCRIPTION
## What does this PR do?

The limiter plugin is not a plugin:
* the user can't enable or disable the plugin and there is no point to allow that
* the limiter does not use any of the features provides by the plugin framework

This commit convert the limiter plugin into normal code

Additional change: in `/config`, `limiter.enabled` is `true` only if the limiter is really enabled (Redis is available).

## Why is this change important?

The limiter is shown as a plugin here and there and this is confusing.

## How to test this PR locally?

* check the app works without the limiter, check `/config`
* check the app works with the limiter and with the token, check `/config`

## Author's checklist

The initialization code is in `searx/botdetection/install.py`, it can be in `searx/botdetection/__init__.py` in the same way that `searx.search` and `searx.redisdb`.
Alternative : move the code from `install.py` to `limiter.py`, but this lead to the next topic: naming ambiguity .

There are two names to reference the same thing:
* limiter
* `searx.botdetection`

Is there a difference between the botdetection and the limiter ?

Since limiter is the known public name, I suggest:
* to rename `searx.botdetection` into `searx.limiter`
* to move the code from `searx/botdetection/limiter.py` and `searx/botdetection/install.py` to `searx/limiter/__init__.py`.


## Related issues

<!--
Closes #234
-->

[EDIT] sorry for the numerous edits.