### PR TITLE
[fix] matrixrooms.info: pagination not working properly

### DIFF
--- a/searx/engines/matrixrooms.py
+++ b/searx/engines/matrixrooms.py
@@ -22,7 +22,7 @@ page_size = 20
 
 
 def request(query, params):
-    params['url'] = f"{base_url}/search/{quote_plus(query)}/{page_size}/{params['pageno']-1}"
+    params['url'] = f"{base_url}/search/{quote_plus(query)}/{page_size}/{(params['pageno']-1)*page_size}"
     return params
 
 


### PR DESCRIPTION
## What does this PR do?
* matrixrooms.info requires an offset parameter, not a page number

## Related issues
see https://github.com/searxng/searxng/pull/2864#issuecomment-1741716364
