### PR TITLE
[feat] engine: implementation of podcastindex.org

### DIFF
--- a/searx/engines/podcastindex.py
+++ b/searx/engines/podcastindex.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Podcast Index
+"""
+
+from urllib.parse import quote_plus
+from datetime import datetime
+
+about = {
+    'website': 'https://podcastindex.org',
+    'official_api_documentation': None,  # requires an account
+    'use_official_api': False,
+    'require_api_key': False,
+    'results': 'JSON',
+}
+categories = []
+
+base_url = "https://podcastindex.org"
+
+
+def request(query, params):
+    params['url'] = f"{base_url}/api/search/byterm?q={quote_plus(query)}"
+    return params
+
+
+def response(resp):
+    results = []
+
+    json = resp.json()
+
+    for result in json['feeds']:
+        results.append(
+            {
+                'url': result['link'],
+                'title': result['title'],
+                'content': result['description'],
+                'thumbnail': result['image'],
+                'publishedDate': datetime.utcfromtimestamp(result['newestItemPubdate']),
+                'metadata': f"{result['author']}, {result['episodeCount']} episodes",
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1235,6 +1235,10 @@ engines:
     url: https://thepiratebay.org/
     timeout: 3.0
 
+  - name: podcastindex
+    engine: podcastindex
+    shortcut: podcast
+
   # Required dependency: psychopg2
   #  - name: postgresql
   #    engine: postgresql


### PR DESCRIPTION
## What does this PR do?
* add a new engine for searching podcasts

## Why is this change important?
* we currently only have gpodder to search for podcasts (afaik)

## How to test this PR locally?
* !podcast linux

## Notes
* not sure if we should add it to the music category or not, currently it's not part of any category
