### PR TITLE
[feat] engine: implementation of fyyd

### DIFF
--- a/searx/engines/fyyd.py
+++ b/searx/engines/fyyd.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Fyyd (podcasts)
+"""
+
+from datetime import datetime
+from urllib.parse import urlencode
+
+about = {
+    'website': 'https://fyyd.de',
+    'official_api_documentation': 'https://github.com/eazyliving/fyyd-api',
+    'use_official_api': True,
+    'require_api_key': False,
+    'results': 'JSON',
+}
+categories = []
+paging = True
+
+base_url = "https://api.fyyd.de"
+page_size = 10
+
+
+def request(query, params):
+    args = {
+        'term': query,
+        'count': page_size,
+        'page': params['pageno'] - 1,
+    }
+    params['url'] = f"{base_url}/0.2/search/podcast?{urlencode(args)}"
+    return params
+
+
+def response(resp):
+    results = []
+
+    json_results = resp.json()['data']
+
+    for result in json_results:
+        results.append(
+            {
+                'url': result['htmlURL'],
+                'title': result['title'],
+                'content': result['description'],
+                'thumbnail': result['smallImageURL'],
+                'publishedDate': datetime.strptime(result['status_since'], '%Y-%m-%d %H:%M:%S'),
+                'metadata': f"Rank: {result['rank']} || {result['episode_count']} episodes",
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -702,6 +702,12 @@ engines:
     shortcut: frk
     disabled: true
 
+  - name: fyyd
+    engine: fyyd
+    shortcut: fy
+    timeout: 8.0
+    disabled: true
+
   - name: genius
     engine: genius
     shortcut: gen


### PR DESCRIPTION
## What does this PR do?
* add a new engine: fyyd, which allows searching for podcasts

## Why is this change important?
* we currently lack podcast search engines, and fyyd provides very good results

## How to test this PR locally?
* !fyyd linux

