### PR TITLE
[fix] enable bing by default / was disabled in cea7b71d14

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -384,7 +384,6 @@ engines:
   - name: bing
     engine: bing
     shortcut: bi
-    disabled: true
 
   - name: bing images
     engine: bing_images


### PR DESCRIPTION
The engine was deactivated at that time (cea7b71d14 in #1235) because there were problems, but they are fixed now.

- https://github.com/searxng/searxng/pull/1235
