### PR TITLE
improve issue search

### DIFF
--- a/searx/templates/simple/new_issue.html
+++ b/searx/templates/simple/new_issue.html
@@ -63,7 +63,7 @@ or manually by executing the searx/webapp.py file? -->
     <input type="checkbox" id="step1">
     <label for="step1">{{ _('Start submiting a new issue on GitHub') }}</label>
     <div class="step1 step_content">
-        <p><a href="{{ get_setting('brand.issue_url') }}?q=is%3Aissue+Bug:%20{{ engine_name }}" target="_blank" rel="noreferrer noreferrer">{{ _('Please check for existing bugs about this engine on GitHub') }}</a></p>
+        <p><a href="{{ get_setting('brand.issue_url') }}?q=is%3Aissue+Bug:%20{{ engine_name }} {{ technical_report }}" target="_blank" rel="noreferrer noreferrer">{{ _('Please check for existing bugs about this engine on GitHub') }}</a></p>
     </div>
     <input class="step1 step1_delay" type="checkbox" id="step2">
     <label class="step1 step1_delay" for="step2" >{{ _('I confirm there is no existing bug about the issue I encounter') }}</label>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1161,6 +1161,21 @@ def stats():
                 reliability_order = 1 - reliability_order
         return (reliability_order, key, engine_stat['name'])
 
+    technical_report = []
+    for error in engine_reliabilities.get(selected_engine_name, {}).get('errors', []):
+        technical_report.append(
+            f"\
+            Error: {error['exception_classname'] or error['log_message']} \
+            Parameters: {error['log_parameters']} \
+            File name: {error['filename'] }:{ error['line_no'] } \
+            Error Function: {error['function']} \
+            Code: {error['code']} \
+            ".replace(
+                ' ' * 12, ''
+            ).strip()
+        )
+    technical_report = ' '.join(technical_report)
+
     engine_stats['time'] = sorted(engine_stats['time'], reverse=reverse, key=get_key)
     return render(
         # fmt: off
@@ -1170,6 +1185,7 @@ def stats():
         engine_reliabilities = engine_reliabilities,
         selected_engine_name = selected_engine_name,
         searx_git_branch = GIT_BRANCH,
+        technical_report = technical_report,
         # fmt: on
     )
 


### PR DESCRIPTION
## What does this PR do?
As we said in #2896 ,
> > Besides, since the search query is more clear, the `submit issue` button can be shown after **clicking** the `check existing issues` link, forcing the user to check existing issues.
(You know better than me, at present, the button is triggered after waiting a couple of seconds )
> 
> Yes, this is a weak point in the current process ..
> 
> _Originally posted by @return42 in https://github.com/searxng/searxng/discussions/2896#discussioncomment-7196808_

the `search existing issues` link can be improved.

I manually generated a `technical report` (100% the same as in the issue), and add it to the link.
So now, the link will search for issues that contain the same "technical report" and filter out irrelevant issues.

The problem is, i'm sure that this is NOT the most effective way, but it is a good idea.

## screenshots
after this PR, mountains of issues are filted 👇 (only 7 left! )
![image](https://github.com/searxng/searxng/assets/88757735/52cbcf6f-6788-4eba-9937-d4e723c9c559)

If we could do it cleaner, maybe there would be only 1 issue left, and that one happens to be the same!

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
