### PR TITLE
[fix] kickass: crash when no results

### DIFF
--- a/searx/engines/kickass.py
+++ b/searx/engines/kickass.py
@@ -43,7 +43,7 @@ def response(resp):
     results = []
     dom = html.fromstring(resp.text)
 
-    search_res = eval_xpath_list(dom, '//table[contains(@class, "data")]//tr', None)
+    search_res = eval_xpath_list(dom, '//table[contains(@class, "data")]//tr[descendant::a]', None)
     if search_res is None:
         return []
 


### PR DESCRIPTION
## What does this PR do?
* fix crashes when there are no results during kickass searches by making sure the table element actually has an anchor element/link to a torrent file

## How to test this PR locally?
* !kickass genre-ab
