### PR TITLE
Add hotkeys option to settings.yml

### DIFF
--- a/docs/admin/settings/settings_ui.rst
+++ b/docs/admin/settings/settings_ui.rst
@@ -20,6 +20,7 @@
      theme_args:
        simple_style: auto
      search_on_category_select: true
+     hotkeys: default
 
 .. _static_use_hash:
 
@@ -64,3 +65,6 @@
 
 ``search_on_category_select``:
   Perform search immediately if a category selected. Disable to select multiple categories.
+
+``hotkeys``:
+  Hotkeys to use in the search interface: ``default``, ``vim`` (Vim-like).

--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -466,7 +466,7 @@ class Preferences:
                 locked=is_locked('search_on_category_select')
             ),
             'hotkeys': EnumStringSetting(
-                'default',
+                settings['ui']['hotkeys'],
                 choices=['default', 'vim']
             ),
             # fmt: on

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -127,6 +127,8 @@ ui:
   # Perform search immediately if a category selected.
   # Disable to select multiple categories at once and start the search manually.
   search_on_category_select: true
+  # Hotkeys: default or vim
+  hotkeys: default
 
 # Lock arbitrary settings on the preferences page.  To find the ID of the user
 # setting you want to lock, check the ID of the form on the page "preferences".

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -201,6 +201,7 @@ SCHEMA = {
         'infinite_scroll': SettingsValue(bool, False),
         'cache_url': SettingsValue(str, 'https://web.archive.org/web/'),
         'search_on_category_select': SettingsValue(bool, True),
+        'hotkeys': SettingsValue(('default', 'vim'), 'default'),
     },
     'preferences': {
         'lock': SettingsValue(list, []),


### PR DESCRIPTION
## What does this PR do?

The change in the hotkey mechanism introduced in 317db5b04f6de919e996df943f7f0a845b8238a9 does not allow configuration via `settings.yml`. This commit adds that functionality. Addresses #2898.

## Why is this change important?

It makes the hotkeys setting admin-configurable.

## How to test this PR locally?

Add the following in `settings.yml`:

```yaml
ui:
  hotkeys: vim
```

Then, restart SearXNG, and observe that the hotkeys change according to that setting.

## Related issues

Closes #2898.
