### PR TITLE
[fix] imgur - incorrect wikidata id

### DIFF
--- a/searx/engines/imgur.py
+++ b/searx/engines/imgur.py
@@ -9,7 +9,7 @@ from searx.utils import extract_text, eval_xpath, eval_xpath_list
 
 about = {
     "website": 'https://imgur.com/',
-    "wikidata_id": 'Q107565255',
+    "wikidata_id": 'Q355022',
     "official_api_documentation": 'https://api.imgur.com/',
     "use_official_api": False,
     "require_api_key": False,


### PR DESCRIPTION
## What does this PR do?
corrects the wikidata id
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
imgur is using the wikidata id for piped.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
