### PR TITLE
[fix] black --exclude option is a regular expression

### DIFF
--- a/manage
+++ b/manage
@@ -44,7 +44,7 @@ PY_SETUP_EXTRAS='[test]'
 GECKODRIVER_VERSION="v0.33.0"
 # SPHINXOPTS=
 BLACK_OPTIONS=("--target-version" "py311" "--line-length" "120" "--skip-string-normalization")
-BLACK_TARGETS=("--exclude" "searx/static,searx/languages.py" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")
+BLACK_TARGETS=("--exclude" "(searx/static|searx/languages.py)" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")
 
 _dev_redis_sock="/usr/local/searxng-redis/run/redis.sock"
 # set SEARXNG_REDIS_URL if it is not defined and "{_dev_redis_sock}" exists.


### PR DESCRIPTION
When ``searx/static/themes/simple/node_modules`` are installed the test from black runs into this path / Error::

    $ make test
    TEST      [yamllint] $YAMLLINT_FILES
    TEST      [black] $BLACK_TARGETS
    --- searx/static/themes/simple/node_modules/flatted/python/test.py	2023-10-13 10:09:50.460026 +0000
    +++ searx/static/themes/simple/node_modules/flatted/python/test.py	2023-10-13 10:10:04.974335 +0000
    @@ -1,9 +1,11 @@
    from flatted import stringify as _stringify, parse
    ...

black --exclude option is not a comma separated list, its a regular expression / see:

    $ black --help
    ...
    --exclude TEXT   A regular expression that matches files and
                     directories that should be excluded on recursive
                     searches ...
