### PR TITLE
[fix] HTMLParser: undocumented not implemented method

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -41,6 +41,7 @@ class TestUtils(SearxTestCase):
         self.assertIsInstance(utils.html_to_text(html_str), str)
         self.assertIsNotNone(utils.html_to_text(html_str))
         self.assertEqual(utils.html_to_text(html_str), "Test text")
+        self.assertEqual(utils.html_to_text(r"regexp: (?<![a-zA-Z]"), "regexp: (?<![a-zA-Z]")
 
     def test_extract_text(self):
         html_str = """


### PR DESCRIPTION
## What does this PR do?

[fix] HTMLParser: undocumented not implemented method

To be compatible to higher versions (>=py3.10) an error method is implemented which throws an AssertionError exception like the higher Python versions do [3].

## Why is this change important?

In python versions <py3.10 there is an issue with an undocumented method HTMLParser.error() [1][2] that was deprecated in Python 3.4 and removed in Python 3.5.

## How to test this PR locally?

You need Python <py3.10 AND a result item that is not a HTML but includes a `<` / in #2943 we tested it by this search term:

    :en !go regex exclude

Alternatively in a python interpreter: `./manage pyenv.cmd python`

with the fix ...

```python
>>> from searx.utils import html_to_text
>>> html_to_text(r'regexp: (?<![a-zA-Z]')
'regexp: (?<![a-zA-Z]'
```

without the fix ...

```python
>>> from searx.utils import html_to_text
>>> html_to_text(r'regexp: (?<![a-zA-Z]')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "SearXNG/searx/utils.py", line 161, in html_to_text
    s.feed(html_str)
  File "/usr/lib/python3.8/html/parser.py", line 111, in feed
    self.goahead(0)
  File "/usr/lib/python3.8/html/parser.py", line 179, in goahead
    k = self.parse_html_declaration(i)
  File "/usr/lib/python3.8/html/parser.py", line 264, in parse_html_declaration
    return self.parse_marked_section(i)
  File "/usr/lib/python3.8/_markupbase.py", line 159, in parse_marked_section
    self.error('unknown status keyword %r in marked section' % rawdata[i+3:j])
  File "/usr/lib/python3.8/_markupbase.py", line 33, in error
    raise NotImplementedError(
NotImplementedError: subclasses of ParserBase must override error()
```


## Related issues

- [1] https://github.com/python/cpython/issues/76025
- [2] https://bugs.python.org/issue31844
- [3] https://github.com/python/cpython/pull/8562

Closes: https://github.com/searxng/searxng/issues/2943