### PR TITLE
add subdomain replacement to hostname_replace.py

### DIFF
--- a/searx/plugins/hostname_replace.py
+++ b/searx/plugins/hostname_replace.py
@@ -30,7 +30,9 @@ def on_result(request, search, result):
                 # (only) on the 'parsed_url'
                 if not replacement:
                     return False
-                result[parsed] = result[parsed]._replace(netloc=pattern.sub(replacement, result[parsed].netloc))
+                subdomain = pattern.search(result[parsed].netloc).group(1) or ''
+                new_netloc = replacement.replace('(*)', subdomain)
+                result[parsed] = result[parsed]._replace(netloc=pattern.sub(new_netloc, result[parsed].netloc))
                 result['url'] = urlunparse(result[parsed])
 
         for url_field in _url_fields:
@@ -40,7 +42,10 @@ def on_result(request, search, result):
                     if not replacement:
                         del result[url_field]
                     else:
-                        url_src = url_src._replace(netloc=pattern.sub(replacement, url_src.netloc))
+                        # Add subdomain to replacement
+                        subdomain = pattern.search(url_src.netloc).group(1) or ''
+                        new_netloc = replacement.replace('(*)', subdomain)
+                        url_src = url_src._replace(netloc=pattern.sub(new_netloc, url_src.netloc))
                         result[url_field] = urlunparse(url_src)
 
     return True


### PR DESCRIPTION
## What does this PR do?

you can now rewrite turtle.example.com to newsite.com/turtle
we can now move the subdomain.

## Why is this change important?

i use this and maybe other people would like to use it also.

## How to test this PR locally?

configure hostname replace like this:
`'(.*\.)?(?P<subdomain>[^.]+)\.fandom\.com$': 'breezewiki.com/\g<subdomain>'`

enable the hostname replace plugin, and search "patrick star"

and you can see, https://spongebob.fandom.com/wiki/Patrick_Star becomes https://breezewiki.com/spongebob/wiki/Patrick_Star

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

related to #1646
