### PR TITLE
[feat] engine: implementation of mdn

### DIFF
--- a/searx/engines/json_engine.py
+++ b/searx/engines/json_engine.py
@@ -8,6 +8,7 @@ from searx.utils import to_string, html_to_text
 
 search_url = None
 url_query = None
+url_prefix = ""
 content_query = None
 title_query = None
 content_html_to_text = False
@@ -129,7 +130,7 @@ def response(resp):
                 content = ""
             results.append(
                 {
-                    'url': to_string(url),
+                    'url': url_prefix + to_string(url),
                     'title': title_filter(to_string(title)),
                     'content': content_filter(to_string(content)),
                 }
@@ -138,7 +139,7 @@ def response(resp):
         for url, title, content in zip(query(json, url_query), query(json, title_query), query(json, content_query)):
             results.append(
                 {
-                    'url': to_string(url),
+                    'url': url_prefix + to_string(url),
                     'title': title_filter(to_string(title)),
                     'content': content_filter(to_string(content)),
                 }

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1057,6 +1057,25 @@ engines:
   #   shortcut: mtrx
   #   disabled: true
 
+  - name: mdn
+    shortcut: mdn
+    engine: json_engine
+    categories: [it]
+    paging: true
+    search_url: https://developer.mozilla.org/api/v1/search?q={query}&page={pageno}
+    results_query: documents
+    url_query: mdn_url
+    url_prefix: https://developer.mozilla.org
+    title_query: title
+    content_query: summary
+    about:
+      website: https://developer.mozilla.org
+      wikidata_id: Q3273508
+      official_api_documentation: null
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
   - name: metacpan
     engine: metacpan
     shortcut: cpan


### PR DESCRIPTION
## What does this PR do?
- this PR adds a new engine, the "Mozilla Developer Network" (MDN in short form)

## Why is this change important?
- MSN is well known for informative articles on any topics related to web development such as `HTML`, `CSS`, `JS` and `SVG` (and more), I don't think there's much need to explain it because everyone should be familiar with these docs

## How to test this PR locally?
* !mdn :has()
