### PR TITLE
[fix] limit maximum page number of a search query to page 50

### DIFF
--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -45,7 +45,7 @@ def validate_engineref_list(
 
 def parse_pageno(form: Dict[str, str]) -> int:
     pageno_param = form.get('pageno', '1')
-    if not pageno_param.isdigit() or int(pageno_param) < 1:
+    if not pageno_param.isdigit() or int(pageno_param) < 1 or int(pageno_param) > 50:
         raise SearxParameterException('pageno', pageno_param)
     return int(pageno_param)
 


### PR DESCRIPTION
To test this PR run a local instance and try to query page 51:

    http://127.0.0.1:8888/search?q=foo&pageno=51

A parameter exception will be raised:

    searx.exceptions.SearxParameterException: Invalid value "51" for parameter pageno

And the client will receive a HTTP 400 (Bad request).

- Closes https://github.com/searxng/searxng/issues/2972

----

FYI: since I merged this PR on my instance I got google back to work (~~and ddg?, qwant? seems to work better / I am not 100% sure but at first glance I have the impression that the limitation of the maximum number of pages also has a positive effect on other engines~~),