### PR TITLE
Check `public_instance` in simple theme

### DIFF
--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -17,7 +17,7 @@
   {% else %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/searxng.min.css') }}" type="text/css" media="screen" />
   {% endif %}
-  {% if get_setting('server.limiter') %}
+  {% if get_setting('server.limiter') or get_setting('server.public_instance') %}
   <link rel="stylesheet" href="{{ url_for('client_token', token=link_token) }}" type="text/css" />
   {% endif %}
   {% block styles %}{% endblock %}


### PR DESCRIPTION
## What does this PR do?

Adds `link_token` ping injection to simple theme if `server.public_instance` is enabled

## Why is this change important?

Users are blocked as suspicious if `server.limiter` is not explicitly enabled when `server.public_instance` has force-enabled the limiter and the `simple` theme is used

## How to test this PR locally?

1. Start a server on `master`—or test existing public servers—with `server.limiter` disabled and `server.public_instance` enabled
2. Ping stylesheet is not included in in the response body
3. Do a few searches, get blocked as suspicious
    Logs will show `searx.botdetection.link_token : missing ping` and eventually `BLOCK too many request`
5. Start a server on this PR
6. Ping stylesheet is included in the response body
7. You are longer blocked as suspicious 🎉
    Debug logs will show `token is valid --> True`

## Related issues

Closes #2975