### PR TITLE
Revert "[fix] limit maximum page number of a search query to page 50."

### DIFF
--- a/searx/webadapter.py
+++ b/searx/webadapter.py
@@ -45,7 +45,7 @@ def validate_engineref_list(
 
 def parse_pageno(form: Dict[str, str]) -> int:
     pageno_param = form.get('pageno', '1')
-    if not pageno_param.isdigit() or int(pageno_param) < 1 or int(pageno_param) > 50:
+    if not pageno_param.isdigit() or int(pageno_param) < 1:
         raise SearxParameterException('pageno', pageno_param)
     return int(pageno_param)
 


### PR DESCRIPTION
## What does this PR do?

This reverts commit 7e2e335dd1e06ea20496028abe58b3ad8b255662 from #2973 

## Why is this change important?

It was not loved .. see discussion in #2973 

## How to test this PR locally?

To see the issue (back) that was intended to be fixed in #2973, start a `make run` instance and try to open e.g. page-no 500 of a google request:

- http://127.0.0.1:8888/search?q=!go%20foo&pageno=500

## Author's checklist

Be warned .. when you request e.g. page-no 500, google will be suspended for 24 (or whatever suspend time is in your settings.yml file).

Personally I think this is a step backward .. but if it is wanted by the SearXNG community I'm open to rollback #2973 .. but then someone other than me from the maintainer team would have to take over the merge and be responsible for alternative solutions to the problem.

## Related issues

- re-opens: https://github.com/searxng/searxng/issues/2972
