### PR TITLE
[fix] brave engine: This site did not provide any description

### DIFF
--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -248,7 +248,10 @@ def _parse_search(resp):
         if url is None or title_tag is None or not urlparse(url).netloc:  # partial url likely means it's an ad
             continue
 
-        content_tag = eval_xpath_getindex(result, './/div[@class="snippet-description"]', 0, default='')
+        content_tag = eval_xpath_getindex(
+            result, './/div[@class="snippet-description text-small-regular"]', 0, default=''
+        )
+
         img_src = eval_xpath_getindex(result, './/img[contains(@class, "thumb")]/@src', 0, default='')
 
         item = {


### PR DESCRIPTION
## What does this PR do?

fixes brave "This site did not provide any description" currently this happens with every search result.

## Why is this change important?

now we can have descriptions again.

## How to test this PR locally?

make run

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
