### PR TITLE
Docker: add UWSGI_WORKERS and UWSGI_THREAD environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ ENV INSTANCE_NAME=searxng \
     MORTY_KEY= \
     MORTY_URL= \
     SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml \
-    UWSGI_SETTINGS_PATH=/etc/searxng/uwsgi.ini
+    UWSGI_SETTINGS_PATH=/etc/searxng/uwsgi.ini \
+    UWSGI_WORKERS=%k \
+    UWSGI_THREADS=4
 
 WORKDIR /usr/local/searxng
 

--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -4,8 +4,12 @@ uid = searxng
 gid = searxng
 
 # Number of workers (usually CPU count)
-workers = %k
-threads = 4
+# default value: %k (= number of CPU core, see Dockerfile)
+workers = $(UWSGI_WORKERS)
+
+# Number of threads per worker
+# default value: 4 (see Dockerfile)
+threads = $(UWSGI_THREADS)
 
 # The right granted on the created socket
 chmod-socket = 666

--- a/docs/admin/installation-docker.rst
+++ b/docs/admin/installation-docker.rst
@@ -92,6 +92,9 @@ instance using `docker run <https://docs.docker.com/engine/reference/run/>`_:
                 searxng/searxng
    2f998.... # container's ID
 
+The environment variables UWSGI_WORKERS and UWSGI_THREADS overwrite the default
+number of UWSGI processes and UWSGI threads specified in `/etc/searxng/uwsgi.ini`.
+
 Open your WEB browser and visit the URL:
 
 .. code:: sh

--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -177,6 +177,7 @@ main() {
 
     case $1 in
         --getenv)  var="$2"; echo "${!var}"; exit 0;;
+        --cmd)  shift; "$@";;
         -h|--help) usage; exit 0;;
         install)
             sudo_or_exit

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
@@ -47,6 +47,9 @@ plugin = python
 # default behaviour is for performance reasons.
 enable-threads = true
 
+# Number of workers (usually CPU count)
+workers = ${UWSGI_WORKERS:-%k}
+threads = ${UWSGI_THREADS:-4}
 
 # plugin: python
 # --------------

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
@@ -47,6 +47,9 @@ plugin = python
 # default behaviour is for performance reasons.
 enable-threads = true
 
+# Number of workers (usually CPU count)
+workers = ${UWSGI_WORKERS:-%k}
+threads = ${UWSGI_THREADS:-4}
 
 # plugin: python
 # --------------

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini
@@ -50,6 +50,9 @@ plugin = python3,http
 # default behaviour is for performance reasons.
 enable-threads = true
 
+# Number of workers (usually CPU count)
+workers = ${UWSGI_WORKERS:-%k}
+threads = ${UWSGI_THREADS:-4}
 
 # plugin: python
 # --------------

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
@@ -50,6 +50,9 @@ plugin = python3,http
 # default behaviour is for performance reasons.
 enable-threads = true
 
+# Number of workers (usually CPU count)
+workers = ${UWSGI_WORKERS:-%k}
+threads = ${UWSGI_THREADS:-4}
 
 # plugin: python
 # --------------


### PR DESCRIPTION
## What does this PR do?

* UWSGI_WORKERS specifies the number of process.
* UWSGI_THREADS specifies the number of threads.

The Docker convention is to specify the whole configuration through environment variables. While not done in SearXNG, these two additional variables allows admins to skip uwsgi.ini

In additional, https://github.com/searxng/preview-environments starts Docker without additional files through searxng-helm-chat. Each instance consumes 1Go of RAM which is a lot especially when there are a lot of instances / pull requests. With `UWSGI_WORKERS=1` each instance consume about 250Mo.

## Why is this change important?

* Easier docker configuration
* Make preview-environments more reliable

## How to test this PR locally?

* `make docker.build`
* `docker run --rm -ti -p 8080:8080 ${GITHUB_LOGIN}/searxng` should start as many workers as number of CPU cores (same as the current master branch).
* `docker run --rm -ti -p 8080:8080 -e UWSGI_WORKERS=1 ${GITHUB_LOGIN}/searxng` should start one worker.

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
