### PR TITLE
[mod] Capitalize theme names/styles in theme.html view file

### DIFF
--- a/searx/templates/simple/preferences/theme.html
+++ b/searx/templates/simple/preferences/theme.html
@@ -5,7 +5,7 @@
       {%- for name in themes -%}
         <option value="{{ name }}"
                 {%- if name == theme %} selected="selected"{%- endif -%}>
-                {{- name -}}
+                {{- name | capitalize -}}
         </option>
       {%- endfor -%}
     </select>{{- '' -}}
@@ -22,7 +22,7 @@
       {%- for name in ['auto', 'light', 'dark'] -%}
         <option value="{{ name }}"
                 {%- if name == preferences.get_value('simple_style') %} selected="selected" {%- endif -%}>
-                {{- _(name) -}}
+                {{- _(name) | capitalize -}}
         </option>
       {%- endfor -%}
     </select>{{- '' -}}


### PR DESCRIPTION
## What does this PR do?

This changes the text within the `preferences/theme.html` view file to capitalize both theme names/styles. The original issue stated engines should also be capitalized however I disagree as I think it's much more logical to leave them as-is due to many engines having capitalized letters across the entire name. Maybe it would be a good idea to link the engines to a 'text-kind' name using a dictionary?

## Why is this change important?

It's not an incredibly important PR by any means, but it also something I have noticed personally and is a little bit of an eyesore.

## How to test this PR locally?

Goto `Preferences > User Interface` and you will see the capitalized names within the two related selectors/dropdowns.

## Related issues

Closes #3014 
