### PR TITLE
[mod] Change no results error message based on page number

### DIFF
--- a/searx/templates/simple/messages/no_results.html
+++ b/searx/templates/simple/messages/no_results.html
@@ -1,7 +1,21 @@
 {% from 'simple/icons.html' import icon_big %}
 <div class="dialog-error-block" role="alert">
-  <p><strong>{{ _('Sorry!') }}</strong></p>
-  <p>{{ _("No results were found. You can try to:") }}</p>
+  <p>
+    <strong>
+      {%- if pageno == 1 -%}
+        {{ _('Sorry!') }}
+      {%- else -%}
+        {{ _("Oops!") }}
+      {%- endif -%}
+    </strong>
+  </p>
+  <p>
+    {%- if pageno == 1 -%}
+      {{ _("No results were found. You can try to:") }}
+    {%- else -%}
+      {{ _("Looks like there isn't any more results. You can try to:") }}
+    {%- endif -%}
+  </p>
   <ul>
     <li>{{ _("Refresh the page.") }}</li>
     <li>{{ _("Search for another query or select another category (above).") }}</li>

--- a/searx/templates/simple/messages/no_results.html
+++ b/searx/templates/simple/messages/no_results.html
@@ -1,25 +1,28 @@
 {% from 'simple/icons.html' import icon_big %}
-<div class="dialog-error-block" role="alert">
-  <p>
+<div class="dialog-error-block" role="alert">{{- '' -}}
+  <p>{{- '' -}}
     <strong>
       {%- if pageno == 1 -%}
         {{ _('Sorry!') }}
-      {%- else -%}
-        {{ _("Oops!") }}
       {%- endif -%}
-    </strong>
-  </p>
+    </strong>{{- '' -}}
+  </p>{{- '' -}}
   <p>
     {%- if pageno == 1 -%}
       {{ _("No results were found. You can try to:") }}
     {%- else -%}
-      {{ _("Looks like there isn't any more results. You can try to:") }}
+      {{ _("There are no more results. You can try to:") }}
     {%- endif -%}
-  </p>
+  </p>{{- '' -}}
   <ul>
-    <li>{{ _("Refresh the page.") }}</li>
-    <li>{{ _("Search for another query or select another category (above).") }}</li>
-    <li>{{ _("Change the search engine used in the preferences:") }} <a href="/preferences">/preferences</a></li>
-    <li>{{ _("Switch to another instance:") }} <a href="https://searx.space">https://searx.space</a></li>
+    {%- if pageno == 1 -%}
+      <li>{{ _("Refresh the page.") }}</li>{{- '' -}}
+      <li>{{ _("Search for another query or select another category (above).") }}</li>{{- '' -}}
+      <li>{{ _("Change the search engine used in the preferences:") }} <a href="/preferences">/preferences</a></li>{{- '' -}}
+      <li>{{ _("Switch to another instance:") }} <a href="https://searx.space">https://searx.space</a></li>{{- '' -}}
+    {%- else -%}
+      <li>{{ _("Search for another query or select another category.") }}</li>{{- '' -}}
+      <li>{{ _("Go back to the previous page using the previous page button.") }}</li>{{- '' -}}
+    {%- endif -%}
   </ul>
 </div>


### PR DESCRIPTION
## Dependency
This PR requires https://github.com/searxng/searxng/pull/3024 to be merged before.

## What does this PR do?

Currently, when the page number is above 1 and the results dictionary is empty, a message returns saying 'No results found'. It was proposed to change this message to something that more aligns with the actual error.

## Why is this change important?

It makes more sense to the user, and less inconspicuous errors.

## How to test this PR locally?

Search for something completely obscure or use a broken engine etc - this is the original message. The best way of getting the 'No more results' message, in my experience, is again using an obscure search term and then click through the page numbers at the bottom.

## Related issues

Closes #2815
