### PR TITLE
[mod] Retain page numbers even when there are no results

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -232,7 +232,7 @@ class ResultContainer:
         if engine_name in engines:
             histogram_observe(standard_result_count, 'engine', engine_name, 'result', 'count')
 
-        if not self.paging and standard_result_count > 0 and engine_name in engines and engines[engine_name].paging:
+        if not self.paging and engine_name in engines and engines[engine_name].paging:
             self.paging = True
 
     def _merge_infobox(self, infobox):

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -124,22 +124,24 @@
                 </div>
             </form>
         {% endif %}
-        <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="next_page">
-            <div class="{% if rtl %}left{% else %}right{% endif %}">
-              <input type="hidden" name="q" value="{{ q|e }}" >
-              {% for category in selected_categories %}
-              <input type="hidden" name="category_{{ category }}" value="1" >
-              {% endfor %}
-              <input type="hidden" name="pageno" value="{{ pageno+1 }}" >
-              <input type="hidden" name="language" value="{{ current_language }}" >
-              <input type="hidden" name="time_range" value="{{ time_range }}" >
-              <input type="hidden" name="safesearch" value="{{ safesearch }}" >
-              <input type="hidden" name="theme" value="{{ theme }}" >
-              {% if timeout_limit %}<input type="hidden" name="timeout_limit" value="{{ timeout_limit|e }}" >{% endif %}
-              {{- engine_data_form(engine_data) -}}
-              <button role="link"  type="submit">{{ _('Next page') }} {{ icon_small('chevron-right') }}</button>
-            </div>
-        </form>
+        {%- if results | count > 0 -%}
+          <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="next_page">
+              <div class="{% if rtl %}left{% else %}right{% endif %}">
+                <input type="hidden" name="q" value="{{ q|e }}" >
+                {% for category in selected_categories %}
+                <input type="hidden" name="category_{{ category }}" value="1" >
+                {% endfor %}
+                <input type="hidden" name="pageno" value="{{ pageno+1 }}" >
+                <input type="hidden" name="language" value="{{ current_language }}" >
+                <input type="hidden" name="time_range" value="{{ time_range }}" >
+                <input type="hidden" name="safesearch" value="{{ safesearch }}" >
+                <input type="hidden" name="theme" value="{{ theme }}" >
+                {% if timeout_limit %}<input type="hidden" name="timeout_limit" value="{{ timeout_limit|e }}" >{% endif %}
+                {{- engine_data_form(engine_data) -}}
+                <button role="link"  type="submit">{{ _('Next page') }} {{ icon_small('chevron-right') }}</button>
+              </div>
+          </form>
+        {%- endif -%}
         {% set pstart = 1 %}
         {% set pend = 11 %}
         {% if pageno > 5 %}


### PR DESCRIPTION
## What does this PR do?

It makes sure the page numbers (pagination) is retained, even when there are 0 results. It also hides the *Next page* button but retains the *Previous page* button.

## Why is this change important?

The current behaviour for page numbers is to hide if there is no results - this can be painful for the user, especially when using only POST requests and they have to hit back on their browser and re-send the previous POST request.

## How to test this PR locally?

Go through the page numbers until there are no results, you will see the pagination stay there, along with the *Next page* button not being outputted.

## Related issues

Closes #3007