### PR TITLE
Update "extra_proxy_timeout" in Settings.yml

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -189,7 +189,7 @@ outgoing:
   #
   # Extra seconds to add in order to account for the time taken by the proxy
   #
-  #  extra_proxy_timeout: 10.0
+  #  extra_proxy_timeout: 10
   #
   # uncomment below section only if you have more than one network interface
   # which can be the source of outgoing search requests


### PR DESCRIPTION
Changed value of "extra_proxy_timeout" from 10.0 to 10 as the variable expects an int. 
Uncommenting this value with a non-int value will throw many errors and crash all engines.

## What does this PR do?

Changes the default values of an optional setting

## Why is this change important?

Uncommenting this setting when attempting to use a proxy will crash all engines and not allow any connectivity.

## How to test this PR locally?

Uncomment option and set up proxy.

## Author's checklist


## Related issues

None. Directly troubleshooted and change submitted instead of opening issue.