### PR TITLE
[feat] engine: implementation of bahnhof.de

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -535,6 +535,23 @@ engines:
     categories: general
     shortcut: cc
 
+  - name: bahnhof
+    engine: json_engine
+    search_url: https://www.bahnhof.de/api/stations/search/{query}
+    url_prefix: https://www.bahnhof.de/
+    url_query: slug
+    title_query: name
+    content_query: state
+    shortcut: bf
+    disabled: true
+    about:
+      website: https://www.bahn.de
+      wikidata_id: Q22811603
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+      language: de
+
   - name: deezer
     engine: deezer
     shortcut: dz


### PR DESCRIPTION
## What does this PR do?
* implement support for searching train stations for German regions

## Why is this change important?
* it's useful to find train stations and information about them such as their train connections, accessibility, ...

## How to test this PR locally?
* !bahnhof Berlin
