### PR TITLE
[fix] do highlight replacement at once

### DIFF
--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -290,10 +290,8 @@ def highlight_content(content, query):
         if len(qs) > 0:
             queries.extend(re.findall(regex_highlight_cjk(qs), content, flags=re.I | re.U))
     if len(queries) > 0:
-        for q in set(queries):
-            content = re.sub(
-                regex_highlight_cjk(q), f'<span class="highlight">{q}</span>'.replace('\\', r'\\'), content
-            )
+        regex = re.compile("|".join(map(regex_highlight_cjk, queries)))
+        return regex.sub(lambda match: f'<span class="highlight">{match.group(0)}</span>'.replace('\\', r'\\'), content)
     return content
 
 

--- a/tests/unit/test_webutils.py
+++ b/tests/unit/test_webutils.py
@@ -57,6 +57,11 @@ class TestWebUtils(SearxTestCase):
                     ]
                 ),
             ),
+            (
+                'a class',
+                'a string with class.',
+                '<span class="highlight">a</span> string with <span class="highlight">class</span>.',
+            ),
         )
         for query, content, expected in data:
             self.assertEqual(webutils.highlight_content(content, query), expected)


### PR DESCRIPTION
Highlights all search queries in search result in one go.

Fixes the case where search query contains word from highlight HTML code, which causes broken HTML to appear in search results.

Closes #3057