### PR TITLE
[fix] engine - offical URL moved to https://lingva.thedaviddelta.com/

### DIFF
--- a/searx/engines/lingva.py
+++ b/searx/engines/lingva.py
@@ -16,7 +16,7 @@ about = {
 engine_type = 'online_dictionary'
 categories = ['general']
 
-url = "https://lingva.ml"
+url = "https://lingva.thedaviddelta.com/"
 search_url = "{url}/api/v1/{from_lang}/{to_lang}/{query}"
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1034,7 +1034,7 @@ engines:
     engine: lingva
     shortcut: lv
     # set lingva instance in url, by default it will use the official instance
-    # url: https://lingva.ml
+    # url: https://lingva.thedaviddelta.com/
 
   - name: lobste.rs
     engine: xpath


### PR DESCRIPTION
The ML top-level domain has been removed from Freenom ... moved the official instance to https://lingva.thedaviddelta.com  [1]

To test use translation syntax:

    !lv en-de Alternative front-end for Google Translate

[1] https://fosstodon.org/@thedaviddelta/111376540936289966

Closes: https://github.com/searxng/searxng/issues/2718
