### PR TITLE
[fix] Fix safesearch parameter in Google Videos engine (#2762)

### DIFF
--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -87,7 +87,7 @@ def request(query, params):
 
     if params['time_range'] in time_range_dict:
         query_url += '&' + urlencode({'tbs': 'qdr:' + time_range_dict[params['time_range']]})
-    if params['safesearch']:
+    if 'safesearch' in params:
         query_url += '&' + urlencode({'safe': filter_mapping[params['safesearch']]})
     params['url'] = query_url
 


### PR DESCRIPTION
## What does this PR do?
Fix safesearch parameter in Google Videos engine

As i said in #2762: 
> got it! 
look at here: 
https://github.com/searxng/searxng/blob/8dfc1dbc5c0ed4968a7111909dc597a755cc94c6/searx/engines/google_videos.py#L90-L91
if safesearch is set to 'off', the value of `params['safesearch']` will be `0`, which equals `False` in python, so the `if` codeblock won't be executed!

*PS: i won't put an image here ... you know why ...*

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

the usual `make run`

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues
I won't close the #2762 , because the problem of ddg hasn't been solved.
<!--
Closes #234
-->
