### PR TITLE
Searx to SearXNG change error message

### DIFF
--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -192,7 +192,7 @@ class OnlineProcessor(EngineProcessor):
             self.logger.exception('Too many requests')
         except SearxEngineAccessDeniedException as e:
             self.handle_exception(result_container, e, suspend=True)
-            self.logger.exception('Searx is blocked')
+            self.logger.exception('SearXNG is blocked')
         except Exception as e:  # pylint: disable=broad-except
             self.handle_exception(result_container, e)
             self.logger.exception('exception : {0}'.format(e))


### PR DESCRIPTION
Just changing the error message because the software is called SearXNG and not SearX.

I know it's not the only change needed from changing SearX to SearXNG but this is one step towards fixing the name in the source code, at least for user errors.