### PR TITLE
Fix development quickstart URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Resources in the documentation
 
-* [Development quickstart](https://docs.searxng.org/dev/contribution_guide.html)
+* [Development quickstart](https://docs.searxng.org/dev/quickstart.html)
 * [Contribution guide](https://docs.searxng.org/dev/contribution_guide.html)
 
 ## Submitting PRs


### PR DESCRIPTION
## What does this PR do?

The url seems to be incorrect; fixed it

## Why is this change important?

The URL should be correct :D
