### PR TITLE
[feat]: implementation of stract (autocompleter)

### DIFF
--- a/docs/dev/search_api.rst
+++ b/docs/dev/search_api.rst
@@ -69,7 +69,7 @@ Parameters
 
 ``autocomplete`` : default from :ref:`settings search`
   [ ``google``, ``dbpedia``, ``duckduckgo``, ``mwmbl``, ``startpage``,
-  ``wikipedia``, ``swisscows``, ``qwant`` ]
+  ``wikipedia``, ``stract``, ``swisscows``, ``qwant`` ]
 
   Service which completes words as you type.
 

--- a/searx/engines/stract.py
+++ b/searx/engines/stract.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Stract is an independent open source search engine. 
+At this state, it's still in beta and hence this implementation will need to be updated once beta ends.
+"""
+
+from json import dumps
+
+about = {
+    "website": "https://stract.com/",
+    "use_official_api": True,
+    "official_api_documentation": "https://stract.com/beta/api/docs/#/search/api",
+    "require_api_key": False,
+    "results": "JSON",
+}
+categories = ['general']
+paging = True
+
+search_url = "https://stract.com/beta/api/search"
+
+
+def request(query, params):
+    params['url'] = search_url
+    params['method'] = "POST"
+    params['headers'] = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+    params['data'] = dumps({'query': query, 'page': params['pageno'] - 1})
+
+    return params
+
+
+def response(resp):
+    results = []
+
+    for result in resp.json()["webpages"]:
+        results.append(
+            {
+                'url': result['url'],
+                'title': result['title'],
+                'content': ''.join(fragment['text'] for fragment in result['snippet']['text']['fragments']),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2079,6 +2079,11 @@ engines:
     timeout: 5.0
     disabled: true
 
+  - name: stract
+    engine: stract
+    shortcut: str
+    disabled: true
+
   - name: svgrepo
     engine: svgrepo
     shortcut: svg

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -24,7 +24,7 @@ search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
   # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "yandex", "mwmbl",
-  # "seznam", "startpage", "swisscows", "qwant", "wikipedia" - leave blank to turn it off
+  # "seznam", "startpage", "stract", "swisscows", "qwant", "wikipedia" - leave blank to turn it off
   # by default.
   autocomplete: ""
   # minimun characters to type before autocompleter starts


### PR DESCRIPTION
## What does this PR do?
* add stract for search and auto completion

## Why is this change important?
* stract is open source and someone recommended it in the matrix room

## How to test this PR locally?
* !stract foo
* set the autocompleter to stract and start typing in the search bar

## Additional notes
* the engine is in beta and might change soon/in the future
* it only supports 5 or 6 other locales at the moment, so I don't think it's worth adding support for it and adding it to the web category