### PR TITLE
Add loading time information

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -170,3 +170,4 @@ features or generally made searx better:
 - @blob42 `<https://blob42.xyz>`_
 - Paolo Basso `<https://github.com/paolobasso99>`
 - Bernie Huang `<https://github.com/BernieHuang2008>`
+- Myzel394 `<https://github.com/Myzel394>`

--- a/searx/results.py
+++ b/searx/results.py
@@ -441,5 +441,8 @@ class ResultContainer:
     def add_timing(self, engine_name: str, engine_time: float, page_load_time: float):
         self.timings.append(Timing(engine_name, total=engine_time, load=page_load_time))
 
-    def get_timings(self):
+    def get_timings(self) -> List[Timing]:
         return self.timings
+
+    def get_longest_loading_time(self) -> Timing:
+        return max(self.timings, key=itemgetter(1))

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -35,7 +35,22 @@
     <div id="sidebar">
 
         {%- if number_of_results != '0' -%}
-        <p id="result_count"><small>{{ _('Number of results') }}: {{ number_of_results }}</small></p>
+        <p id="result_count">
+            <small>{{ _('Number of results') }}: {{ number_of_results }}</small>
+        </p>
+        <details>
+            <summary>
+                <small>Longest loading time: {{ longest_loading_time.load }} from {{ longest_loading_time.engine }}</small>
+            </summary>
+            <div>
+                <ul>
+                    {% for timing in loading_times %}
+                        <li>
+                            <small>{{ timing.load }} from {{ timing.engine }}</small>
+                        </li>
+                    {% endfor %}
+                </ul>
+        </details>
         {%- endif -%}
 
         {%- if infoboxes -%}

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -35,21 +35,16 @@
     <div id="sidebar">
 
         {%- if number_of_results != '0' -%}
-        <p id="result_count">
-            <small>{{ _('Number of results') }}: {{ number_of_results }}</small>
-        </p>
         <details>
             <summary>
-                <small>Longest loading time: {{ longest_loading_time.load }} from {{ longest_loading_time.engine }}</small>
+                <small id="result_count">{{ _('Number of results') }}: {{ number_of_results }}</small>
+                <small>{{ longest_load_time_formatted }}</small>
             </summary>
-            <div>
-                <ul>
-                    {% for timing in loading_times %}
-                        <li>
-                            <small>{{ timing.load }} from {{ timing.engine }}</small>
-                        </li>
-                    {% endfor %}
-                </ul>
+            <ul>
+                {% for engine, timing in loading_times %}
+                    <li>{{ engine }}: {{ timing }}</li>
+                {% endfor %}
+            </ul>
         </details>
         {%- endif -%}
 

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -33,20 +33,21 @@
     {%- endif %}
 
     <div id="sidebar">
-
-        {%- if number_of_results != '0' -%}
-        <details>
-            <summary>
-                <small id="result_count">{{ _('Number of results') }}: {{ number_of_results }}</small>
-                <small>{{ longest_load_time_formatted }}</small>
-            </summary>
-            <ul>
-                {% for engine, timing in loading_times %}
-                    <li>{{ engine }}: {{ timing }}</li>
-                {% endfor %}
-            </ul>
-        </details>
-        {%- endif -%}
+        <div id="results_info">
+            <details class="sidebar-collapsable">
+                <summary class="title">
+                    {%- if number_of_results != '0' -%}
+                        <small id="result_count">{{ _('Number of results') }}: {{ number_of_results }}; </small>
+                    {%- endif -%}
+                    <small>{{ longest_load_time_formatted }}</small>
+                </summary>
+                <ul>
+                    {% for engine, timing in loading_times %}
+                        <li>{{ engine }}: <b>{{ timing }}</b></li>
+                    {% endfor %}
+                </ul>
+            </details>
+        </div>
 
         {%- if infoboxes -%}
           <div id="infoboxes">

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -673,7 +673,9 @@ def search():
 
     # 2. add Server-Timing header for measuring performance characteristics of
     # web applications
-    request.timings = result_container.get_timings()  # pylint: disable=assigning-non-slot
+    timings = result_container.get_timings()
+    request.timings = timings
+    longest_loading_time = result_container.get_longest_loading_time()
 
     # 3. formats without a template
 
@@ -791,7 +793,9 @@ def search():
             settings['search']['languages'],
             fallback=request.preferences.get_value("language")
         ),
-        timeout_limit = request.form.get('timeout_limit', None)
+        timeout_limit = request.form.get('timeout_limit', None),
+        longest_loading_time = longest_loading_time,
+        loading_times = timings,
         # fmt: on
     )
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -673,7 +673,7 @@ def search():
 
     # 2. add Server-Timing header for measuring performance characteristics of
     # web applications
-    timings = result_container.get_timings()
+    timings = result_container.get_timings()  # pylint: disable=assigning-non-slot
     request.timings = timings
     longest_loading_time = result_container.get_longest_loading_time()
 

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -794,8 +794,14 @@ def search():
             fallback=request.preferences.get_value("language")
         ),
         timeout_limit = request.form.get('timeout_limit', None),
-        longest_loading_time = longest_loading_time,
-        loading_times = timings,
+        longest_load_time_formatted = gettext("Took {seconds} second(s)")
+            .format(seconds="{:.2f}".format(longest_loading_time[1])),
+        # List of tuples of (engine, load time); Displayed in the sidebar
+        # Sorted by load time, descending
+        loading_times = sorted((
+            (timing.engine, "{:.2f}".format(timing.load))
+            for timing in timings
+        ), key=lambda x: x[1], reverse=True),
         # fmt: on
     )
 


### PR DESCRIPTION
## What does this PR do?

To see the durations it took each engine to load, this PR adds this information to the sidebar.
**This is still a WIP**, I opened this draft to see whether this is heading into the right direction :D.

## Why is this change important?

All major search engines show their duration. Having easy access also makes it more transparent to users what engine may be causing long loading times.

## How to test this PR locally?

Run like normally

## Related issues

Closes #3092 
