### PR TITLE
[fix] SyntaxWarning: invalid escape sequence '\>'

### DIFF
--- a/searx/search/checker/impl.py
+++ b/searx/search/checker/impl.py
@@ -36,7 +36,7 @@ HTML_TAGS = [
 
 
 def get_check_no_html():
-    rep = ['<' + tag + '[^\>]*>' for tag in HTML_TAGS]
+    rep = ['<' + tag + r'[^\>]*>' for tag in HTML_TAGS]
     rep += ['</' + tag + '>' for tag in HTML_TAGS]
     pattern = re.compile('|'.join(rep))
 


### PR DESCRIPTION
This patch fixes issue reported by ``make test.unit``::

    searx/search/checker/impl.py:39: SyntaxWarning: invalid escape sequence '\>'
      rep = ['<' + tag + '[^\>]*>' for tag in HTML_TAGS]
