### PR TITLE
[feat] footer: support for custom entries

### DIFF
--- a/searx/searxng.msg
+++ b/searx/searxng.msg
@@ -11,6 +11,7 @@ __all__ = [
     'CATEGORY_NAMES',
     'CATEGORY_GROUPS',
     'STYLE_NAMES',
+    'BRAND_CUSTOM_LINKS',
 ]
 
 CONSTANT_NAMES = {
@@ -50,4 +51,9 @@ STYLE_NAMES = {
     'AUTO': 'auto',
     'LIGHT': 'light',
     'DARK': 'dark',
+}
+
+BRAND_CUSTOM_LINKS = {
+    'UPTIME': 'Uptime',
+    'ABOUT': 'About',
 }

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -19,10 +19,12 @@ brand:
   public_instances: https://searx.space
   wiki_url: https://github.com/searxng/searxng/wiki
   issue_url: https://github.com/searxng/searxng/issues
-  # Custom entries in the footer: [title]: [link]
   # custom:
-  #  About instance: "https://searxng.org"
-  #  Instance admin: "https://searxng.org"
+  #   maintainer: "Jon Doe"
+  #   # Custom entries in the footer: [title]: [link]
+  #   links:
+  #     Uptime: https://uptime.searxng.org/history/darmarit-org
+  #     About: "https://searxng.org"
 
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -19,6 +19,10 @@ brand:
   public_instances: https://searx.space
   wiki_url: https://github.com/searxng/searxng/wiki
   issue_url: https://github.com/searxng/searxng/issues
+  # Custom entries in the footer: [title]: [link]
+  # custom:
+  #  About instance: "https://searxng.org"
+  #  Instance admin: "https://searxng.org"
 
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -151,7 +151,7 @@ SCHEMA = {
         'docs_url': SettingsValue(str, 'https://docs.searxng.org'),
         'public_instances': SettingsValue((False, str), 'https://searx.space'),
         'wiki_url': SettingsValue(str, 'https://github.com/searxng/searxng/wiki'),
-        'custom': SettingsValue(dict, {}),
+        'custom': SettingsValue(dict, {'links': {}}),
     },
     'search': {
         'safe_search': SettingsValue((0, 1, 2), 0),

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -151,6 +151,7 @@ SCHEMA = {
         'docs_url': SettingsValue(str, 'https://docs.searxng.org'),
         'public_instances': SettingsValue((False, str), 'https://searx.space'),
         'wiki_url': SettingsValue(str, 'https://github.com/searxng/searxng/wiki'),
+        'custom': SettingsValue(dict, {}),
     },
     'search': {
         'safe_search': SettingsValue((0, 1, 2), 0),

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -77,8 +77,8 @@
         {% if get_setting('general.contact_url') %}
         | <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact instance maintainer') }}</a>
         {% endif %}
-        {% for title, link in get_setting('brand.custom').items() %}
-        | <a href="{{ link }}">{{ title }}</a>
+        {% for title, link in get_setting('brand.custom.links').items() %}
+        | <a href="{{ link }}">{{ _(title) }}</a>
         {% endfor %}
     </p>
   </footer>

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -77,6 +77,9 @@
         {% if get_setting('general.contact_url') %}
         | <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact instance maintainer') }}</a>
         {% endif %}
+        {% for title, link in get_setting('brand.custom').items() %}
+        | <a href="{{ link }}">{{ title }}</a>
+        {% endfor %}
     </p>
   </footer>
   <!--[if gte IE 9]>-->


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->
* add a new setting which allows appending custom links to the footer

## Why is this change important?
* it's quite common that instance maintainers want to have the possibility to advertise a custom status/donation/instance info page, so I think it's a good step to allow instance maintainers to do so

## How to test this PR locally?
* go to `searx/settings.yml` and uncomment the `brand.custom` part
* make run -> view footer in browser

## Author's note
* in fact, we could replace all the other entries in that footer with that logic too, however with the downside that the entries can not be translated. Hence I think we should keep the common/default entries as they are.

## Related issues
closes #3131
