### PR TITLE
[feat] engine: implementation of goodreads

### DIFF
--- a/searx/engines/goodreads.py
+++ b/searx/engines/goodreads.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Goodreads (books)
+"""
+
+from urllib.parse import urlencode
+
+from lxml import html
+from searx.utils import extract_text, eval_xpath, eval_xpath_list
+
+about = {
+    'website': 'https://www.goodreads.com',
+    'wikidata_id': 'Q2359213',
+    'official_api_documentation': None,
+    'use_official_api': False,
+    'require_api_key': False,
+    'results': 'HTML',
+}
+categories = []
+paging = True
+
+base_url = "https://www.goodreads.com"
+
+results_xpath = "//table//tr"
+thumbnail_xpath = ".//img[contains(@class, 'bookCover')]/@src"
+url_xpath = ".//a[contains(@class, 'bookTitle')]/@href"
+title_xpath = ".//a[contains(@class, 'bookTitle')]"
+author_xpath = ".//a[contains(@class, 'authorName')]"
+info_text_xpath = ".//span[contains(@class, 'uitext')]"
+
+
+def request(query, params):
+    args = {
+        'q': query,
+        'page': params['pageno'],
+    }
+
+    params['url'] = f"{base_url}/search?{urlencode(args)}"
+    return params
+
+
+def response(resp):
+    results = []
+
+    dom = html.fromstring(resp.text)
+
+    for result in eval_xpath_list(dom, results_xpath):
+        results.append(
+            {
+                'url': base_url + extract_text(eval_xpath(result, url_xpath)),
+                'title': extract_text(eval_xpath(result, title_xpath)),
+                'img_src': extract_text(eval_xpath(result, thumbnail_xpath)),
+                'content': extract_text(eval_xpath(result, info_text_xpath)),
+                'metadata': extract_text(eval_xpath(result, author_xpath)),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -807,6 +807,12 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name: goodreads
+    engine: goodreads
+    shortcut: good
+    timeout: 4.0
+    disabled: true
+
   - name: google
     engine: google
     shortcut: go


### PR DESCRIPTION
## What does this PR do?
* implement a new engine, goodreads, for searching books by their names, authors or citations

## Why is this change important?
* we currently only have one single search engine for books (afaik), which is Anna's archive. Anna's archive however has a way smaller library of books than goodreads, which is backed by Amazon

## Notes
* There also is a JSON Api for suggestions, but it only returns 5 items and doesn't support pagination, but it's helpful to get an overview of the engines capabilities: https://www.goodreads.com/book/auto_complete?format=json&q=foo
