### PR TITLE
[test.robot] update gecko driver / v0.34.0 required by firefox 121.*

### DIFF
--- a/manage
+++ b/manage
@@ -41,7 +41,7 @@ PATH="${REPO_ROOT}/node_modules/.bin:${PATH}"
 
 PYOBJECTS="searx"
 PY_SETUP_EXTRAS='[test]'
-GECKODRIVER_VERSION="v0.33.0"
+GECKODRIVER_VERSION="v0.34.0"
 # SPHINXOPTS=
 BLACK_OPTIONS=("--target-version" "py311" "--line-length" "120" "--skip-string-normalization")
 BLACK_TARGETS=("--exclude" "(searx/static|searx/languages.py)" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")


### PR DESCRIPTION
## What does this PR do?

Update gecko driver to v0.34.0 [1]

[1] https://github.com/mozilla/geckodriver/releases/tag/v0.34.0

## Why is this change important?

required by firefox 121.*

## How to test this PR locally?

Check error message from #3141 is no longer in the [build log](https://github.com/searxng/searxng/actions/runs/7697841280/job/20975743950?pr=3166#step:7:120).


Closes: https://github.com/searxng/searxng/issues/3141