### PR TITLE
[mod] remove X-XSS-Protection headers

### DIFF
--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -16,7 +16,6 @@
        image_proxy: false
        default_http_headers:
          X-Content-Type-Options : nosniff
-         X-XSS-Protection : 1; mode=block
          X-Download-Options : noopen
          X-Robots-Tag : noindex, nofollow
          Referrer-Policy : no-referrer

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -88,7 +88,6 @@ server:
   method: "POST"
   default_http_headers:
     X-Content-Type-Options: nosniff
-    X-XSS-Protection: 1; mode=block
     X-Download-Options: noopen
     X-Robots-Tag: noindex, nofollow
     Referrer-Policy: no-referrer

--- a/tests/unit/settings/user_settings.yml
+++ b/tests/unit/settings/user_settings.yml
@@ -19,7 +19,6 @@ server:
   method: "POST"
   default_http_headers:
     X-Content-Type-Options: nosniff
-    X-XSS-Protection: 1; mode=block
     X-Download-Options: noopen
     X-Robots-Tag: noindex, nofollow
     Referrer-Policy: no-referrer


### PR DESCRIPTION
Deprecated header not used by browsers nowadays[1]:

"""In modern browsers, X-XSS-Protection has been deprecated in favor of the Content-Security-Policy to disable the use of inline JavaScript. Its use can introduce XSS vulnerabilities in otherwise safe websites. This should not be used unless you need to support older web browsers that don’t yet support CSP. It is thus recommended to set the header as X-XSS-Protection: 0."""[2]

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
[2] https://infosec.mozilla.org/guidelines/web_security#x-xss-protection

Closes: https://github.com/searxng/searxng/issues/3171