### PR TITLE
[fix] remove certifi from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-certifi==2023.11.17
 babel==2.14.0
 flask-babel==4.0.0
 flask==3.0.1


### PR DESCRIPTION

- Requirement certify was added in 35a2bc5650b

- Since commit 93f7f7eee certifi is no longer needed.  Not sure why 93f7f7eee upgraded certifi while removing the usage of this package from the source code in the same commit.

Closes: https://github.com/searxng/searxng/pull/3182

@dalf do you see any reasons not to remove certifi?