### PR TITLE
[fix] KeyError: 'title' in results using key-value.html template

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -354,10 +354,13 @@ class ResultContainer:
         for result in self._merged_results:
             score = result_score(result)
             result['score'] = score
+
+            # removing html content and whitespace duplications
             if result.get('content'):
                 result['content'] = utils.html_to_text(result['content']).strip()
-            # removing html content and whitespace duplications
-            result['title'] = ' '.join(utils.html_to_text(result['title']).strip().split())
+            if result.get('title'):
+                result['title'] = ' '.join(utils.html_to_text(result['title']).strip().split())
+
             for result_engine in result['engines']:
                 counter_add(score, 'engine', result_engine, 'score')
 


### PR DESCRIPTION
Since #2508 a title is required --> this is a bug when an engine uses the key-value.html template [1], where no title is needed.

[1] https://github.com/searxng/searxng/blob/master/searx/templates/simple/result_templates/key-value.html

Closes: https://github.com/searxng/searxng/issues/3130
