### PR TITLE
[feat] engine: implementation of pixiv

### DIFF
--- a/searx/engines/pixiv.py
+++ b/searx/engines/pixiv.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Pixiv (images)"""
+
+from urllib.parse import urlencode
+import random
+
+# Engine metadata
+about = {
+    "website": 'https://www.pixiv.net/',
+    "wikidata_id": 'Q306956',
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+# Engine configuration
+paging = True
+categories = ['images']
+
+# Search URL
+base_url = "https://www.pixiv.net/ajax/search/illustrations"
+pixiv_image_proxies: list = []
+
+
+def request(query, params):
+    query_params = {
+        "word": query,
+        "order": "date_d",
+        "mode": "all",
+        "p": params["pageno"],
+        "s_mode": "s_tag_full",
+        "type": "illust_and_ugoira",
+        "lang": "en",
+    }
+
+    params["url"] = f"{base_url}/{query}?{urlencode(query_params)}"
+
+    return params
+
+
+def response(resp):
+    results = []
+    data = resp.json()
+
+    for item in data["body"]["illust"]["data"]:
+
+        image_url = item["url"]
+        pixiv_proxy = random.choice(pixiv_image_proxies)
+        proxy_image_url = image_url.replace("https://i.pximg.net", pixiv_proxy)
+        proxy_full_image_url = (
+            proxy_image_url.replace("/c/250x250_80_a2/", "/")
+            .replace("_square1200.jpg", "_master1200.jpg")
+            .replace("custom-thumb", "img-master")
+            .replace("_custom1200.jpg", "_master1200.jpg")
+        )
+
+        results.append(
+            {
+                "title": item.get("title"),
+                "url": proxy_full_image_url,
+                'content': item.get('alt'),
+                "author": f"{item.get('userName')} (ID: {item.get('userId')})",
+                "img_src": proxy_full_image_url,
+                "thumbnail_src": proxy_image_url,
+                "source": 'pixiv.net',
+                "template": "images.html",
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1334,6 +1334,31 @@ engines:
     url: https://thepiratebay.org/
     timeout: 3.0
 
+  - name: pixiv
+    shortcut: pv
+    engine: pixiv
+    disabled: true
+    inactive: true
+    pixiv_image_proxies:
+      - pximg.example.org
+      # A proxy is required to load the images. Hosting an image proxy server
+      # for Pixiv:
+      #    --> https://codeberg.org/VnPower/PixivFE/wiki/Hosting-an-image-proxy-server-for-Pixiv
+      # Proxies from public instances.  Ask the public instances owners if they
+      # agree to receive traffic from SearXNG!
+      #    --> https://codeberg.org/VnPower/PixivFE#instances
+      #    --> https://github.com/searxng/searxng/pull/3192#issuecomment-1941095047
+      # image proxy of https://pixiv.cat
+      # - https://i.pixiv.cat
+      # image proxy of https://www.pixiv.pics
+      # - https://pximg.cocomi.eu.org
+      # image proxy of https://pixivfe.exozy.me
+      # - https://pximg.exozy.me
+      # image proxy of https://pixivfe.ducks.party
+      # - https://pixiv.ducks.party
+      # image proxy of https://pixiv.perennialte.ch
+      # - https://pximg.perennialte.ch
+
   - name: podcastindex
     engine: podcastindex
     shortcut: podcast


### PR DESCRIPTION
## What does this PR do?

adds the pixiv engine

## Why is this change important?

pixiv is a popular alternative to deviantart

## How to test this PR locally?

jigglypuff !pv

## Author's checklist

we cannot load the images directly from pixiv, see here: https://github.com/searxng/searxng/pull/2772

However, there is an alternative frontend for pixiv: https://codeberg.org/VnPower/PixivFE
using proxy from a random instance to load the images.

## Related issues

<!--
Closes #234
-->
