### PR TITLE
Add UI feature: shortcut to focus searchbar

### DIFF
--- a/searx/static/themes/simple/src/js/main/search.js
+++ b/searx/static/themes/simple/src/js/main/search.js
@@ -37,8 +37,9 @@
 
   searxng.ready(function () {
     qinput = d.getElementById(qinput_id);
+    const wasSearchBarFound = qinput !== null;
 
-    if (qinput !== null) {
+    if (wasSearchBarFound) {
       // clear button
       createClearButton(qinput);
 
@@ -155,7 +156,7 @@
     // filter (safesearch, time range or language) (this requires JavaScript
     // though)
     if (
-      qinput !== null
+      wasSearchBarFound
         && searxng.settings.search_on_category_select
       // If .search_filters is undefined (invisible) we are on the homepage and
       // hence don't have to set any listeners
@@ -180,6 +181,17 @@
           selected.classList.remove("selected");
         })
       }
+    }
+
+    // shortcut to focus search bar
+    if (wasSearchBarFound) {
+      d.addEventListener('keyup', function (event) {
+        if (event.key == "/") {
+          const queryLength = qinput.value.length;
+          qinput.setSelectionRange(queryLength, queryLength);
+          qinput.focus();
+        }
+      });
     }
   });
 


### PR DESCRIPTION
## add "/" shortcut to focus searchbar

focus the searchbar with the cursor placed after the last input character by just typing `/` ("shift" + "7" or numpad "/").
implemented by a few lines of js in `searx/static/themes/simple/src/js/main/search.js`.

## Why is this change important?
It solves partially the feature request [Add Shortcut for focusing on search bar, focusing subject tabs, navigating search items with arrow key.](https://github.com/searxng/searxng/issues/2568)

## How to test this PR locally?
### Just manual testing
there are various test cases
1. setup:
    - test case 1: open the root page `<base-url>/`, leave the searchbar empty and remove the focus
    - test case 2: open the root page `<base-url>/`, type some text into the searchbar and remove the focus
    - test case 3: open the result page `<base-url>/search?q=searxng`
    - test case 4: open the result page `<base-url>/search?q=searxng`, clear the searchbar and remove the focus
2. execution: type "/"
3. assertion: the searchbar should be focused and the cursor should be placed after the last input character
