### PR TITLE
[fix] lingva: redirect and parsing error

### DIFF
--- a/searx/engines/lingva.py
+++ b/searx/engines/lingva.py
@@ -16,7 +16,7 @@ about = {
 engine_type = 'online_dictionary'
 categories = ['general']
 
-url = "https://lingva.thedaviddelta.com/"
+url = "https://lingva.thedaviddelta.com"
 search_url = "{url}/api/v1/{from_lang}/{to_lang}/{query}"
 
 
@@ -48,8 +48,6 @@ def response(resp):
     infobox = ""
 
     for translation in info["extraTranslations"]:
-        infobox += f"<b>{translation['type']}</b>"
-
         for word in translation["list"]:
             infobox += f"<dl><dt>{word['word']}</dt>"
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1044,7 +1044,7 @@ engines:
     engine: lingva
     shortcut: lv
     # set lingva instance in url, by default it will use the official instance
-    # url: https://lingva.thedaviddelta.com/
+    # url: https://lingva.thedaviddelta.com
 
   - name: lobste.rs
     engine: xpath


### PR DESCRIPTION
## What does this PR do and how to test it?
- see #3194

## Notes
- the 'type' of a definition only seems to exist in the documentation, couldn't find it in any of the api responses. I assume it's partially broken at lingva's side as it's been unmaintained for a year ...

## Related issues
closes #3194
