### PR TITLE
[feat] engine: implementation of mozhi

### DIFF
--- a/searx/engines/mozhi.py
+++ b/searx/engines/mozhi.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Mozhi (alternative frontend for popular translation engines)"""
+
+import random
+import re
+from urllib.parse import urlencode
+
+about = {
+    "website": 'https://codeberg.org/aryak/mozhi',
+    "wikidata_id": None,
+    "official_api_documentation": 'https://mozhi.aryak.me/api/swagger/index.html',
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+engine_type = 'online_dictionary'
+categories = ['general']
+
+base_url = "https://mozhi.aryak.me"
+mozhi_engine = "google"
+
+re_transliteration_unsupported = "Direction '.*' is not supported"
+
+
+def request(_query, params):
+    request_url = random.choice(base_url) if isinstance(base_url, list) else base_url
+
+    args = {'from': params['from_lang'][1], 'to': params['to_lang'][1], 'text': params['query'], 'engine': mozhi_engine}
+    params['url'] = f"{request_url}/api/translate?{urlencode(args)}"
+    return params
+
+
+def response(resp):
+    translation = resp.json()
+
+    infobox = ""
+
+    if translation['target_transliteration'] and not re.match(
+        re_transliteration_unsupported, translation['target_transliteration']
+    ):
+        infobox = f"<b>{translation['target_transliteration']}</b>"
+
+    if translation['word_choices']:
+        for word in translation['word_choices']:
+            infobox += f"<dl><dt>{word['word']}</dt>"
+
+            for example in word['examples_target']:
+                infobox += f"<dd>{re.sub(r'<|>', '', example)}</dd>"
+
+            infobox += "</dl>"
+
+    result = {
+        'infobox': translation['translated-text'],
+        'content': infobox,
+    }
+
+    return [result]

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1153,6 +1153,17 @@ engines:
   #   collection: 'reviews'  # name of the db collection
   #   key: 'name'  # key in the collection to search for
 
+  - name: mozhi
+    engine: mozhi
+    base_url:
+      - https://mozhi.aryak.me
+      - https://translate.bus-hit.me
+      - https://nyc1.mz.ggtyler.dev
+    # mozhi_engine: google - see https://mozhi.aryak.me for supported engines
+    timeout: 4.0
+    shortcut: mz
+    disabled: true
+
   - name: mwmbl
     engine: mwmbl
     # api_url: https://api.mwmbl.org


### PR DESCRIPTION
## What does this PR do?
- mozhi is a self-hostable wrapper around different translation APIs such as DeepL, Yandex, Google, DuckDuckGo, ...

## Why is this change important?
- it's what I personally use instead of lingva now, due to the fact lingva is no longer maintained

## How to test this PR locally?
- !mozhi en-de Hello World
- Change `mozhi_engine` to `google` in settings.yml for example -> redo step 1

## Author notes
- could be interesting for @return42 maybe? :)