### PR TITLE
[fix] presearch videos: move to videos category

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1375,7 +1375,7 @@ engines:
     engine: presearch
     network: presearch
     search_type: videos
-    categories: [general, web]
+    categories: [videos, web]
     timeout: 4.0
     shortcut: psvid
     disabled: true


### PR DESCRIPTION
## What does this PR do?
- the changes are self-explaining