### PR TITLE
[fix] remove twine from requirements-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,6 @@ MANAGE += gecko.driver
 MANAGE += node.env node.env.dev node.clean
 MANAGE += py.build py.clean
 MANAGE += pyenv pyenv.install pyenv.uninstall
-MANAGE += pypi.upload pypi.upload.test
 MANAGE += format.python
 MANAGE += test.yamllint test.pylint test.pyright test.black test.pybabel test.unit test.coverage test.robot test.rst test.clean
 MANAGE += themes.all themes.simple themes.simple.test pygments.less

--- a/docs/dev/reST.rst
+++ b/docs/dev/reST.rst
@@ -292,7 +292,7 @@ content becomes smart.
    files & folders origin     :origin:`docs/dev/reST.rst`        ``:origin:`docs/dev/reST.rst```
    pull request               :pull:`4`                          ``:pull:`4```
    patch                      :patch:`af2cae6`                   ``:patch:`af2cae6```
-   PyPi package               :pypi:`searx`                      ``:pypi:`searx```
+   PyPi package               :pypi:`httpx`                      ``:pypi:`httpx```
    manual page man            :man:`bash`                        ``:man:`bash```
    intersphinx_
    --------------------------------------------------------------------------------------------------

--- a/manage
+++ b/manage
@@ -109,8 +109,6 @@ pyenv.:
   uninstall : uninstall developer installation
   cmd ...   : run command ... in virtualenv
   OK        : test if virtualenv is OK
-pypi.upload:
-  Upload python packages to PyPi (to test use pypi.upload.test)
 format.:
   python    : format Python code source using black
 pygments.:
@@ -332,19 +330,6 @@ pyenv.uninstall() {
     pyenv.cmd python setup.py develop --uninstall 2>&1 \
         | prefix_stdout "${_Blue}PYENV     ${_creset}[pyenv.uninstall] "
 
-}
-
-pypi.upload() {
-    py.clean
-    py.build
-    # https://github.com/pypa/twine
-    pyenv.cmd twine upload "${PYDIST}"/*
-}
-
-pypi.upload.test() {
-    py.clean
-    py.build
-    pyenv.cmd twine upload -r testpypi "${PYDIST}"/*
 }
 
 format.python() {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ black==22.12.0
 pylint==3.0.3
 splinter==0.21.0
 selenium==4.17.2
-twine==4.0.2
 Pallets-Sphinx-Themes==2.1.1
 Sphinx<=7.1.2; python_version == '3.8'
 Sphinx==7.2.6; python_version > '3.8'


### PR DESCRIPTION
SearXNG is a rolling release / we do not deploy packages on PyPi
