### PR TITLE
[feat] engine: Add LiveSpace livestreams

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -171,3 +171,4 @@ features or generally made searx better:
 - Paolo Basso `<https://github.com/paolobasso99>`
 - Bernie Huang `<https://github.com/BernieHuang2008>`
 - Austin Olacsi `<https://github.com/Austin-Olacsi>`
+- @micsthepick

--- a/searx/engines/livespace.py
+++ b/searx/engines/livespace.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""LiveSpace (Videos)
+
+.. hint::
+
+   This engine only search for **live streams**!
+
+"""
+
+from urllib.parse import urlencode
+from datetime import datetime
+from babel import dates
+
+about = {
+    "website": 'https://live.space',
+    "wikidata_id": None,
+    "official_api_documentation": None,
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+categories = ['videos']
+
+base_url = 'https://backend.live.space'
+
+# engine dependent config
+paging = True
+results_per_page = 10
+
+
+def request(query, params):
+
+    args = {'page': params['pageno'] - 1, 'searchKey': query, 'size': results_per_page}
+    params['url'] = f"{base_url}/search/public/stream?{urlencode(args)}"
+    params['headers'] = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+
+    return params
+
+
+def response(resp):
+
+    results = []
+    json = resp.json()
+    now = datetime.now()
+
+    # for live videos
+
+    for result in json.get('result', []):
+
+        title = result.get("title")
+        thumbnailUrl = result.get("thumbnailUrl")
+        category = result.get("category/name")
+        username = result.get("user", {}).get("userName", "")
+        url = f'https://live.space/watch/{username}'
+
+        # stream tags
+        # currently the api seems to always return null before the first tag,
+        # so strip that unless it's not already there
+        tags = ''
+        if result.get("tags"):
+            tags = [x for x in result.get("tags").split(';') if x and x != 'null']
+            tags = ', '.join(tags)
+
+        content = []
+        if category:
+            content.append(f'category - {category}')
+
+        if tags and len(tags) > 0:
+            content.append(f'tags - {tags}')
+
+        # time & duration
+        start_time = None
+        if result.get("startTimeStamp"):
+            start_time = datetime.fromtimestamp(result.get("startTimeStamp") / 1000)
+
+        # for VODs (videos on demand)
+        end_time = None
+        if result.get("endTimeStamp"):
+            end_time = datetime.fromtimestamp(result.get("endTimeStamp") / 1000)
+
+        timestring = ""
+        if start_time:
+            delta = (now if end_time is None else end_time) - start_time
+            timestring = dates.format_timedelta(delta, granularity='second')
+
+        results.append(
+            {
+                'url': url,
+                'title': title,
+                'content': "No category or tags." if len(content) == 0 else ' '.join(content),
+                'author': username,
+                'length': (">= " if end_time is None else "") + timestring,
+                'publishedDate': start_time,
+                'thumbnail': thumbnailUrl,
+                'template': 'videos.html',
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2042,6 +2042,13 @@ engines:
     categories: videos
     disabled: true
 
+  - name: livespace
+    engine: livespace
+    shortcut: ls
+    categories: videos
+    disabled: true
+    timeout: 5.0
+
   - name: wordnik
     engine: wordnik
     shortcut: def


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Adds a new search engine that pulls from https://backend.live.space/search/public/stream - which is disabled by default

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Rumble is nice to have even if disabled by default, so I thought I'd add this one, since it looked easy enough to do

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->
find `livespace` under `searxng/settings.yml`, enable it.
run `make run`
in web browser, open `http://127.0.0.1:8888/search?q=%21ls%20hello`
(adjust search term as necessary) and verify that the results look ok.

## Author's checklist

<!-- additional notes for reviewers -->
[X] I have run `make python.format`
[X] I have added my username to `AUTHORS.rst`
[X] I have run make test (completed with warnings, not sure if the below errors are relevant:)

https://pastebin.com/qPiVijdT

## Related issues

none?
