### PR TITLE
[fix] sort RTL_LOCALES before written into locales.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test.shell:
 # wrap ./manage script
 
 MANAGE += weblate.translations.commit weblate.push.translations
-MANAGE += data.all data.traits data.useragents
+MANAGE += data.all data.traits data.useragents data.locales
 MANAGE += docs.html docs.live docs.gh-pages docs.prebuild docs.clean
 MANAGE += docker.build docker.push docker.buildx
 MANAGE += gecko.driver

--- a/searx/data/locales.json
+++ b/searx/data/locales.json
@@ -62,8 +62,8 @@
     "zh-Hant-TW": "中文, 台灣 (Chinese, Taiwan)"
   },
   "RTL_LOCALES": [
-    "fa-IR",
     "ar",
+    "fa-IR",
     "he"
   ]
 }

--- a/searxng_extra/update/update_locales.py
+++ b/searxng_extra/update/update_locales.py
@@ -58,7 +58,7 @@ def main():
 
     content = {
         "LOCALE_NAMES": LOCALE_NAMES,
-        "RTL_LOCALES": list(RTL_LOCALES),
+        "RTL_LOCALES": sorted(RTL_LOCALES),
     }
 
     with open(LOCALE_DATA_FILE, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
To avoid unnecessary changes to the file, the list should be sorted before it is written to the file.

You can test it by calling multiple times::

    make data.locales

and `searx/data/locales.json` should be unchanged.