### PR TITLE
[fix] opensearch.xml: firefox v123 does not except self-URI (URL with param)

### DIFF
--- a/searx/templates/simple/opensearch.xml
+++ b/searx/templates/simple/opensearch.xml
@@ -15,7 +15,7 @@
   {% if autocomplete %}
     <Url rel="suggestions" type="application/x-suggestions+json" method="{{ opensearch_method }}" template="{{ url_for('autocompleter', _external=True) }}?q={searchTerms}"/>
   {% endif %}
-  <Url rel="self" type="application/opensearchdescription+xml"  method="{{ opensearch_method }}" template="{{ opensearch_url }}" />
+  <Url rel="self" type="application/opensearchdescription+xml"  method="{{ opensearch_method }}" template="{{ url_for('opensearch', _external=True) }}" />
   <Query role="example" searchTerms="SearXNG" />
   <moz:SearchForm>{{ url_for('search', _external=True) }}</moz:SearchForm>
 </OpenSearchDescription>

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -438,16 +438,6 @@ def render(template_name: str, **kwargs):
     kwargs['cache_url'] = settings['ui']['cache_url']
     kwargs['get_result_template'] = get_result_template
     kwargs['doi_resolver'] = get_doi_resolver(request.preferences)
-    kwargs['opensearch_url'] = (
-        url_for('opensearch')
-        + '?'
-        + urlencode(
-            {
-                'method': request.preferences.get_value('method'),
-                'autocomplete': request.preferences.get_value('autocomplete'),
-            }
-        )
-    )
     kwargs['urlparse'] = urlparse
 
     # scripts from plugins


### PR DESCRIPTION
Before this patch we had a address in the rel-self-template with params [1]:

GET:

```xml
    <Url method="GET"
         rel="self"
         template="/opensearch.xml?method=GET&amp;autocomplete=google"
         type="application/opensearchdescription+xml"/>
```

POST:

```xml
    <Url method="POST"
         rel="self"
         template="/opensearch.xml?method=POST&amp;autocomplete=google"
         type="application/opensearchdescription+xml"/>
```

The first one (GET) is no longer accepted by firefox since v123, the latter one was always been wrong (since it mixes GET params with a POST request).

Since Firefox v123 a template syntax [2] in the rel-self-template is no longer supported / Firefox will report an error::

    Firefox could not download the search plugin from:
    http://127.0.0.1:8888/opensearch.xml?method=GET&autocomplete=google

This patch reduce the URL to::

    template="http://127.0.0.1:8888/opensearch.xml"

[1] https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#url-rel-values
[2] https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#opensearch-url-template-syntax

Closes: https://github.com/searxng/searxng/issues/3227