### PR TITLE
[fix] re-add opensearch_url / its used in based.html

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -438,6 +438,16 @@ def render(template_name: str, **kwargs):
     kwargs['cache_url'] = settings['ui']['cache_url']
     kwargs['get_result_template'] = get_result_template
     kwargs['doi_resolver'] = get_doi_resolver(request.preferences)
+    kwargs['opensearch_url'] = (
+        url_for('opensearch')
+        + '?'
+        + urlencode(
+            {
+                'method': request.preferences.get_value('method'),
+                'autocomplete': request.preferences.get_value('autocomplete'),
+            }
+        )
+    )
     kwargs['urlparse'] = urlparse
 
     # scripts from plugins


### PR DESCRIPTION
The URL was accidentally deleted in a85907a98, but is still required in base.html for auto-discovery / from base.html::

```html
  <link title="{{ instance_name }}"
        type="application/opensearchdescription+xml"
	rel="search" href="{{ opensearch_url }}"
	/>
```

Related:

- https://github.com/searxng/searxng/issues/3227#issuecomment-1962993803