### PR TITLE
pypi engine: use packages.html

### DIFF
--- a/searx/engines/pypi.py
+++ b/searx/engines/pypi.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""pypi.org
+
+"""
+
+from urllib.parse import urlencode
+from dateutil import parser
+
+from lxml import html
+from searx.utils import (
+    eval_xpath_getindex,
+    eval_xpath_list,
+    extract_text,
+)
+
+# about
+about = {
+    "website": "https://pypi.org",
+    "wikidata_id": "Q2984686",
+    "official_api_documentation": "https://warehouse.readthedocs.io/api-reference/index.html",
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "HTML",
+}
+
+categories = ['it', 'packages']
+
+
+# engine dependent config
+first_page_num = 1
+base_url = "https://pypi.org"
+search_url = base_url + '/search/?{query}'
+
+
+def request(query, params):
+    args = {
+        "q": query,
+        "page": params['pageno'],
+    }
+    params['url'] = search_url.format(query=urlencode(args))
+    return params
+
+
+def response(resp):
+    results = []
+    dom = html.fromstring(resp.text)
+    for entry in eval_xpath_list(dom, '/html/body/main/div/div/div/form/div/ul/li/a[@class="package-snippet"]'):
+        url = base_url + extract_text(eval_xpath_getindex(entry, './@href', 0))  # type: ignore
+        title = extract_text(eval_xpath_getindex(entry, './h3/span[@class="package-snippet__name"]', 0))
+        version = extract_text(eval_xpath_getindex(entry, './h3/span[@class="package-snippet__version"]', 0))
+        created_at = extract_text(
+            eval_xpath_getindex(entry, './h3/span[@class="package-snippet__created"]/time/@datetime', 0)
+        )
+        content = extract_text(eval_xpath_getindex(entry, './p', 0))
+        results.append(
+            {
+                "template": "packages.html",
+                "url": url,
+                "title": title,
+                'package_name': title,
+                "content": content,
+                "version": version,
+                'publishedDate': parser.parse(created_at),  # type: ignore
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1457,23 +1457,7 @@ engines:
 
   - name: pypi
     shortcut: pypi
-    engine: xpath
-    paging: true
-    search_url: https://pypi.org/search/?q={query}&page={pageno}
-    results_xpath: /html/body/main/div/div/div/form/div/ul/li/a[@class="package-snippet"]
-    url_xpath: ./@href
-    title_xpath: ./h3/span[@class="package-snippet__name"]
-    content_xpath: ./p
-    suggestion_xpath: /html/body/main/div/div/div/form/div/div[@class="callout-block"]/p/span/a[@class="link"]
-    first_page_num: 1
-    categories: [it, packages]
-    about:
-      website: https://pypi.org
-      wikidata_id: Q2984686
-      official_api_documentation: https://warehouse.readthedocs.io/api-reference/index.html
-      use_official_api: false
-      require_api_key: false
-      results: HTML
+    engine: pypi
 
   - name: qwant
     qwant_categ: web


### PR DESCRIPTION
## What does this PR do?

The pypi engine uses the template packages.html

![image](https://github.com/searxng/searxng/assets/1594191/ed83b0e2-5134-42f6-9509-0565c12b8280)

## Why is this change important?

Without this change, the version is not displayed

## How to test this PR locally?


## Author's checklist

The field `name` and the title are redundant.
Why the field `name` is mandatory?

## Related issues

https://github.com/searxng/searxng/issues/3210