### PR TITLE
Run the checker on Friday

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -1,0 +1,31 @@
+name: "Checker"
+on:
+  schedule:
+    - cron: "0 4 * * 5"
+  workflow_dispatch:
+
+jobs:
+  checker:
+    name: Checker
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Ubuntu packages
+        run: |
+          sudo ./utils/searxng.sh install packages
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          architecture: 'x64'
+
+      - name: Install Python dependencies
+        run: |
+          make V=1 install
+
+      - name: Checker
+        run: |
+          make search.checker

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ lxc.clean:
 
 PHONY += search.checker search.checker.%
 search.checker: install
-	$(Q)./manage pyenv.cmd searx-checker -v
+	$(Q)./manage pyenv.cmd searxng-checker -v
 
 search.checker.%: install
-	$(Q)./manage pyenv.cmd searx-checker -v "$(subst _, ,$(patsubst search.checker.%,%,$@))"
+	$(Q)./manage pyenv.cmd searxng-checker -v "$(subst _, ,$(patsubst search.checker.%,%,$@))"
 
 PHONY += test ci.test test.shell
 ci.test: test.yamllint test.black test.pyright test.pylint test.unit test.robot test.rst test.pybabel

--- a/searx/search/checker/__main__.py
+++ b/searx/search/checker/__main__.py
@@ -55,7 +55,7 @@ def iter_processor(engine_name_list):
             if processor is not None:
                 yield name, processor
             else:
-                stdout.write(f'{BOLD_SEQ}Engine {name:30}{RESET_SEQ}{RED}Engine does not exist{RESET_SEQ}')
+                stdout.write(f'{BOLD_SEQ}Engine {name:30}{RESET_SEQ}{RED}Engine does not exist{RESET_SEQ}\n')
     else:
         for name, processor in searx.search.PROCESSORS.items():
             yield name, processor
@@ -64,12 +64,17 @@ def iter_processor(engine_name_list):
 # actual check & display
 def run(engine_name_list, verbose):
     searx.search.initialize()
+    name_checker_list = []
     for name, processor in iter_processor(engine_name_list):
         stdout.write(f'{BOLD_SEQ}Engine {name:30}{RESET_SEQ}Checking\n')
         if not sys.stdout.isatty():
             stderr.write(f'{BOLD_SEQ}Engine {name:30}{RESET_SEQ}Checking\n')
         checker = searx.search.checker.Checker(processor)
         checker.run()
+        name_checker_list.append((name, checker))
+
+    stdout.write(f'\n== {BOLD_SEQ}Results{RESET_SEQ} ' + '=' * 70 + '\n')
+    for name, checker in name_checker_list:
         if checker.test_results.successful:
             stdout.write(f'{BOLD_SEQ}Engine {name:30}{RESET_SEQ}{GREEN}OK{RESET_SEQ}\n')
             if verbose:


### PR DESCRIPTION
## What does this PR do?

* Run the checker on Friday.
* The checker runs all the tests and then display the results to make them more readable.

## Why is this change important?

Give an overview of which engines works or not.
Related to the growing number of engines.

## How to test this PR locally?

* `make search.checker`
* or verbose mode: `./local/py3/bin/searxng-checker -v google`

## Author's checklist

An extension might be this:
* the GH workflows create a json from the results
* this json is included in source code
* the instances can notify the users about the broken the engines (broken according to the checker)

## Related issues

<!--
Closes #234
-->
