### PR TITLE
npm engine: use packages.html

### DIFF
--- a/searx/engines/npm.py
+++ b/searx/engines/npm.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""npms.io
+
+"""
+
+from urllib.parse import urlencode
+from dateutil import parser
+
+
+about = {
+    "website": "https://npms.io/",
+    "wikidata_id": "Q7067518",
+    "official_api_documentation": "https://api-docs.npms.io/",
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+categories = ['it', 'packages']
+
+
+# engine dependent config
+paging = True
+page_size = 25
+search_api = "https://api.npms.io/v2/search?"
+
+
+def request(query: str, params):
+
+    args = urlencode(
+        {
+            'from': (params["pageno"] - 1) * page_size,
+            'q': query,
+            'size': page_size,
+        }
+    )
+    params['url'] = search_api + args
+    return params
+
+
+def response(resp):
+    results = []
+    content = resp.json()
+    for entry in content["results"]:
+        package = entry["package"]
+        publishedDate = package.get("date")
+        if publishedDate:
+            publishedDate = parser.parse(publishedDate)
+        tags = list(entry.get("flags", {}).keys()) + package.get("keywords", [])
+        results.append(
+            {
+                "template": "packages.html",
+                "url": package["links"]["npm"],
+                "title": package["name"],
+                'package_name': package["name"],
+                "content": package.get("description", ""),
+                "version": package.get("version"),
+                "maintainer": package.get("author", {}).get("name"),
+                'publishedDate': publishedDate,
+                "tags": tags,
+                "homepage": package["links"].get("homepage"),
+                "source_code_url": package["links"].get("repository"),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1176,26 +1176,10 @@ engines:
     disabled: true
 
   - name: npm
-    engine: json_engine
-    paging: true
-    first_page_num: 0
-    search_url: https://api.npms.io/v2/search?q={query}&size=25&from={pageno}
-    results_query: results
-    url_query: package/links/npm
-    title_query: package/name
-    content_query: package/description
-    page_size: 25
-    categories: [it, packages]
-    disabled: true
-    timeout: 5.0
+    engine: npm
     shortcut: npm
-    about:
-      website: https://npms.io/
-      wikidata_id: Q7067518
-      official_api_documentation: https://api-docs.npms.io/
-      use_official_api: false
-      require_api_key: false
-      results: JSON
+    timeout: 5.0
+    disabled: true
 
   - name: nyaa
     engine: nyaa


### PR DESCRIPTION
## What does this PR do?

![image](https://github.com/searxng/searxng/assets/1594191/55ed042b-9d6c-498d-8226-f94bab8af9cd)

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

@return42 / @Bnyro feel free to take over this PR.

Also the API provides authors, publisher and maintainers: the authors are mapping into the maintainer field inside the packages.html template because this is the expected value (I guess?).

In the API, the field named `flags` might contains `unstable` or `deprecated`. These values are displayed as `tags`.

In the API there are 4 fields about the quality:
* quality
* popularity
* maintenance
* a global score

In packages.html there is only quality, to avoid misunderstanding, all the values are ignored. If quality is included, from the user point of view the question will be "is it the score displayed as quality? or is it only the quality but what about the other values?"

## Related issues

#3210