### PR TITLE
Drop typing-extensions dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,5 @@ httpx-socks[asyncio]==0.7.7
 setproctitle==1.3.3
 redis==5.0.2
 markdown-it-py==3.0.0
-typing_extensions==4.9.0
 fasttext-predict==0.9.2.2
 pytomlpp==1.0.13

--- a/searx/enginelib/traits.py
+++ b/searx/enginelib/traits.py
@@ -14,16 +14,13 @@ from __future__ import annotations
 import json
 import dataclasses
 import types
-from typing import Dict, Literal, Iterable, Union, Callable, TypeVar, Optional, TYPE_CHECKING
+from typing import Dict, Literal, Iterable, Union, Callable, Optional, TYPE_CHECKING
 
 from searx import locales
 from searx.data import data_dir, ENGINE_TRAITS
 
 if TYPE_CHECKING:
     from . import Engine
-
-
-Self = TypeVar("Self", bound="EngineTraits")  # Python 3.11, to replace by typing.Self
 
 
 class EngineTraitsEncoder(json.JSONEncoder):
@@ -138,7 +135,7 @@ class EngineTraits:
         return EngineTraits(**dataclasses.asdict(self))
 
     @classmethod
-    def fetch_traits(cls, engine: Engine) -> Union[Self, None]:
+    def fetch_traits(cls, engine: Engine) -> Union['EngineTraits', None]:
         """Call a function ``fetch_traits(engine_traits)`` from engines namespace to fetch
         and set properties from the origin engine in the object ``engine_traits``.  If
         function does not exists, ``None`` is returned.
@@ -206,7 +203,7 @@ class EngineTraitsMap(Dict[str, EngineTraits]):
             json.dump(self, f, indent=2, sort_keys=True, cls=EngineTraitsEncoder)
 
     @classmethod
-    def from_data(cls) -> Self:
+    def from_data(cls) -> 'EngineTraitsMap':
         """Instantiate :class:`EngineTraitsMap` object from :py:obj:`ENGINE_TRAITS`"""
         obj = cls()
         for k, v in ENGINE_TRAITS.items():
@@ -214,7 +211,7 @@ class EngineTraitsMap(Dict[str, EngineTraits]):
         return obj
 
     @classmethod
-    def fetch_traits(cls, log: Callable) -> Self:
+    def fetch_traits(cls, log: Callable) -> 'EngineTraitsMap':
         from searx import engines  # pylint: disable=cyclic-import, import-outside-toplevel
 
         names = list(engines.engines)

--- a/searx/enginelib/traits.py
+++ b/searx/enginelib/traits.py
@@ -14,14 +14,16 @@ from __future__ import annotations
 import json
 import dataclasses
 import types
-from typing import Dict, Iterable, Union, Callable, Optional, TYPE_CHECKING
-from typing_extensions import Literal, Self
+from typing import Dict, Literal, Iterable, Union, Callable, TypeVar, Optional, TYPE_CHECKING
 
 from searx import locales
 from searx.data import data_dir, ENGINE_TRAITS
 
 if TYPE_CHECKING:
     from . import Engine
+
+
+Self = TypeVar("Self", bound="EngineTraits")  # Python 3.11, to replace by typing.Self
 
 
 class EngineTraitsEncoder(json.JSONEncoder):

--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -8,8 +8,7 @@ import time
 import threading
 import os
 import signal
-from typing import Dict, Union, List, Any, Tuple, Optional
-from typing_extensions import TypedDict, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union
 
 import redis.exceptions
 


### PR DESCRIPTION
## What does this PR do?

* typing.TypedDict, typing.Literal exist in Python 3.8

## Why is this change important?

Reduce the number of dependencies

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

Draft : Self removed without tests (and this is Friday afternoon, GitHub Action free tier is saturated)

## Related issues

Close #3260