### PR TITLE
Drop pytomlpp dependency for Python >= 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ redis==5.0.2
 markdown-it-py==3.0.0
 typing_extensions==4.9.0
 fasttext-predict==0.9.2.2
-pytomlpp==1.0.13
+pytomlpp==1.0.13; python_version < '3.11'

--- a/searx/botdetection/config.py
+++ b/searx/botdetection/config.py
@@ -14,7 +14,18 @@ import copy
 import typing
 import logging
 import pathlib
-import pytomlpp as toml
+
+try:
+    import tomllib
+
+    pytomlpp = None
+    USE_TOMLLIB = True
+except ImportError:
+    import pytomlpp
+
+    tomllib = None
+    USE_TOMLLIB = False
+
 
 __all__ = ['Config', 'UNSET', 'SchemaIssue']
 
@@ -62,7 +73,7 @@ class Config:
         # init schema
 
         log.debug("load schema file: %s", schema_file)
-        cfg = cls(cfg_schema=toml.load(schema_file), deprecated=deprecated)
+        cfg = cls(cfg_schema=toml_load(schema_file), deprecated=deprecated)
         if not cfg_file.exists():
             log.warning("missing config file: %s", cfg_file)
             return cfg
@@ -70,12 +81,7 @@ class Config:
         # load configuration
 
         log.debug("load config file: %s", cfg_file)
-        try:
-            upd_cfg = toml.load(cfg_file)
-        except toml.DecodeError as exc:
-            msg = str(exc).replace('\t', '').replace('\n', ' ')
-            log.error("%s: %s", cfg_file, msg)
-            raise
+        upd_cfg = toml_load(cfg_file)
 
         is_valid, issue_list = cfg.validate(upd_cfg)
         for msg in issue_list:
@@ -175,6 +181,25 @@ class Config:
         (modulename, name) = str(fqn).rsplit('.', 1)
         m = __import__(modulename, {}, {}, [name], 0)
         return getattr(m, name)
+
+
+def toml_load(file_name):
+    if USE_TOMLLIB:
+        # Python >= 3.11
+        try:
+            with open(file_name, "rb") as f:
+                return tomllib.load(f)
+        except tomllib.TOMLDecodeError as exc:
+            msg = str(exc).replace('\t', '').replace('\n', ' ')
+            log.error("%s: %s", file_name, msg)
+            raise
+    # fallback to pytomlpp for Python < 3.11
+    try:
+        return pytomlpp.load(file_name)
+    except pytomlpp.DecodeError as exc:
+        msg = str(exc).replace('\t', '').replace('\n', ' ')
+        log.error("%s: %s", file_name, msg)
+        raise
 
 
 # working with dictionaries


### PR DESCRIPTION
## What does this PR do?

Rely on tomllib for Python >= 3.11

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

- https://github.com/searxng/searxng/discussions/3267
- #2981