### PR TITLE
Checker: tests for bahnhof and wikispecies

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -565,6 +565,16 @@ engines:
       require_api_key: false
       results: JSON
       language: de
+    tests:
+      bahnhof:
+        matrix:
+          query: berlin
+          lang: en
+        result_container:
+          - not_empty
+          - ['one_title_contains', 'Berlin Hauptbahnhof']
+        test:
+          - unique_results
 
   - name: deezer
     engine: deezer

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1870,6 +1870,16 @@ engines:
     about:
       website: https://species.wikimedia.org/
       wikidata_id: Q13679
+    tests:
+      wikispecies:
+        matrix:
+          query: "Campbell, L.I. et al. 2011: MicroRNAs"
+          lang: en
+        result_container:
+          - not_empty
+          - ['one_title_contains', 'Tardigrada']
+        test:
+          - unique_results
 
   - name: wiktionary
     engine: mediawiki


### PR DESCRIPTION
## What does this PR do?

Add a dedicated checker test for the bahnhof and wikispecies engines.

## Why is this change important?

On the weekly checker tests, avoid a false negative for the bahnhof and wikispecies engines.

## How to test this PR locally?

`make search.checker.bahnhof`

Expected result:

```
Engine bahnhof                       Checking

== Results ======================================================================
Engine bahnhof                       OK
    found languages: de
```

Same for `make search.checker.wikispecies`

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
