### PR TITLE
internetarchivescholar engine: set timeout to 15 seconds

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1570,7 +1570,7 @@ engines:
   - name: internetarchivescholar
     engine: internet_archive_scholar
     shortcut: ias
-    timeout: 5.0
+    timeout: 15.0
 
   - name: superuser
     engine: stackexchange


### PR DESCRIPTION
## What does this PR do?

5 seconds is not enough

## Why is this change important?

In the master branch, the internetarchivescholar engine is broken (timeout)

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
