### PR TITLE
[fix] engine searchcode.com - paging is broken in searchcode.com's API

### DIFF
--- a/searx/engines/searchcode_code.py
+++ b/searx/engines/searchcode_code.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""
- Searchcode (IT)
+# lint: pylint
+"""Searchcode (IT)
+
 """
 
 from json import loads
@@ -18,24 +19,29 @@ about = {
 
 # engine dependent config
 categories = ['it']
-paging = True
-
-# search-url
-url = 'https://searchcode.com/'
-search_url = url + 'api/codesearch_I/?{query}&p={pageno}'
+search_api = 'https://searchcode.com/api/codesearch_I/?'
 
 # special code-endings which are not recognised by the file ending
 code_endings = {'cs': 'c#', 'h': 'c', 'hpp': 'cpp', 'cxx': 'cpp'}
 
+# paging is broken in searchcode.com's API .. not sure it will ever been fixed
+# paging = True
 
-# do search-request
+
 def request(query, params):
-    params['url'] = search_url.format(query=urlencode({'q': query}), pageno=params['pageno'] - 1)
-
+    args = urlencode(
+        {
+            'q': query,
+            # paging is broken in searchcode.com's API
+            # 'p': params['pageno'] - 1,
+            # 'per_page': 10,
+        }
+    )
+    params['url'] = search_api + args
+    logger.debug("query_url --> %s", params['url'])
     return params
 
 
-# get response from search-request
 def response(resp):
     results = []
 
@@ -47,7 +53,7 @@ def response(resp):
         title = "" + result['name'] + " - " + result['filename']
         repo = result['repo']
 
-        lines = dict()
+        lines = {}
         for line, code in result['lines'].items():
             lines[int(line)] = code
 


### PR DESCRIPTION
paging is broken in searchcode.com's API .. not sure it will ever been fixed / this commit disables paging in the engine and BTW pylint `searchcode_code.py`.

Closes: https://github.com/searxng/searxng/issues/3287