### PR TITLE
[fix] XPath engine azlyrics - new parameter `x` is needed.

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1093,7 +1093,8 @@ engines:
     disabled: true
     categories: [music, lyrics]
     paging: true
-    search_url: https://search.azlyrics.com/search.php?q={query}&w=lyrics&p={pageno}
+    search_url:
+      https://search.azlyrics.com/search.php?q={query}&w=lyrics&p={pageno}&x=7f889302d4f34f629e1fc4adbdd48e67b4e7c6c2cdf3add48438b16b5299d2cb
     url_xpath: //td[@class="text-left visitedlyr"]/a/@href
     title_xpath: //span/b/text()
     content_xpath: //td[@class="text-left visitedlyr"]/a/small


### PR DESCRIPTION
This commit adds a static `x` argument to the GET URL.  Its not clear how long this static value will work.  The alternative is to implement a python modul for this engine to get the `x` argument from the HTML form of

https://search.azlyrics.com/search.php / the XPath selector to get the value is::

        //input[@name='x']@value

Closes: https://github.com/searxng/searxng/issues/3280