### PR TITLE
[fix] XPath engine hoogle - hoogle.haskell.org has no paging support

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -940,8 +940,7 @@ engines:
 
   - name: hoogle
     engine: xpath
-    paging: true
-    search_url: https://hoogle.haskell.org/?hoogle={query}&start={pageno}
+    search_url: https://hoogle.haskell.org/?hoogle={query}
     results_xpath: '//div[@class="result"]'
     title_xpath: './/div[@class="ans"]//a'
     url_xpath: './/div[@class="ans"]//a/@href'


### PR DESCRIPTION
Search on hoogle.haskell.org does no longer have pages.

I assume paging support has never been worked since we switched from JSON to HTML --> 6255b33c9

Closes: https://github.com/searxng/searxng/issues/3278
