### PR TITLE
[mod] CI: tag commits with leading scope/type of the modification

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   - package-ecosystem: "pip"
@@ -8,6 +8,9 @@ updates:
       day: "friday"
     open-pull-requests-limit: 5
     target-branch: "master"
+    commit-message:
+      prefix: "[upd] pypi:"
+
   - package-ecosystem: "npm"
     directory: "/searx/static/themes/simple"
     schedule:
@@ -15,3 +18,5 @@ updates:
       day: "friday"
     open-pull-requests-limit: 5
     target-branch: "master"
+    commit-message:
+      prefix: "[upd] npm:"

--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -48,16 +48,16 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: Update searx.data - ${{ matrix.fetch }}
+          commit-message: [data] update searx.data - ${{ matrix.fetch }}
           committer: searxng-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: update_data_${{ matrix.fetch }}
           delete-branch: true
           draft: false
-          title: 'Update searx.data - ${{ matrix.fetch }}'
+          title: '[data] update searx.data - ${{ matrix.fetch }}'
           body: |
-            Update searx.data - ${{ matrix.fetch }}
+            update searx.data - ${{ matrix.fetch }}
           labels: |
             data
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -120,7 +120,7 @@ jobs:
         FOLDER: dist/docs
         CLEAN: true # Automatically remove deleted files from the deploy branch
         SINGLE_COMMIT: True
-        COMMIT_MESSAGE: build from commit ${{ github.sha }}
+        COMMIT_MESSAGE: [doc] build from commit ${{ github.sha }}
 
   babel:
     name: Update translations branch

--- a/.github/workflows/translations-update.yml
+++ b/.github/workflows/translations-update.yml
@@ -45,15 +45,15 @@ jobs:
       uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.WEBLATE_GITHUB_TOKEN }}
-        commit-message: Update translations
+        commit-message: [l10n] update translations from Weblate
         committer: searxng-bot <searxng-bot@users.noreply.github.com>
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         signoff: false
         branch: translations_update
         delete-branch: true
         draft: false
-        title: 'Update translations'
+        title: '[l10n] update translations from Weblate'
         body: |
-          Update translations
+          update translations from Weblate
         labels: |
           translation

--- a/utils/lib_sxng_weblate.sh
+++ b/utils/lib_sxng_weblate.sh
@@ -102,7 +102,7 @@ weblate.translations.commit() {
 
         # git add/commit (no push)
         commit_body=$(cd "${TRANSLATIONS_WORKTREE}"; git log --pretty=format:'%h - %as - %aN <%ae>' "${existing_commit_hash}..HEAD")
-        commit_message=$(echo -e "[translations] update from Weblate\n\n${commit_body}")
+        commit_message=$(echo -e "[l10n] update translations from Weblate\n\n${commit_body}")
         git add searx/translations
         git add searx/data/locales.json
         git commit -m "${commit_message}"


### PR DESCRIPTION
Add a leading tag (in square brackets) about the scope/type to commit messages from automated tasks (commits from CI).

dependantbot::

    [upd] pypi: Bump .. from .. to ..
    [upd] npm: Bump .. from .. to .. in /searx/static/themes/simple

Weblate translation updates::

    [l10n] update translations from Weblate

updates of ./data::

    [data] update searx.data ..

build commit of gh-pages::

    [doc] build from commit ..