### PR TITLE
[fix] duckduckgo.fetch_traist - URL of region definitions has changed

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -379,8 +379,8 @@ def fetch_traits(engine_traits: EngineTraits):
 
     engine_traits.all_locale = 'wt-wt'
 
-    # updated from u588 to u661 / should be updated automatically?
-    resp = get('https://duckduckgo.com/util/u661.js')
+    # updated from u661.js to u.7669f071a13a7daa57cb / should be updated automatically?
+    resp = get('https://duckduckgo.com/dist/util/u.7669f071a13a7daa57cb.js')
 
     if not resp.ok:  # type: ignore
         print("ERROR: response from DuckDuckGo is not OK.")


### PR DESCRIPTION
- https://duckduckgo.com/dist/util/u.7669f071a13a7daa57cb.js

updated from `u661.js` to `u.7669f071a13a7daa57cb.js` / should be updated automatically?  The last change was on March 23rd in dba8977b098 [1]

- [1] https://github.com/searxng/searxng/pull/2269
