### PR TITLE
[fix] .pylintrc mode signature to conf-unix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: conf -*-
+# -*- coding: utf-8; mode: conf-unix -*-
 # lint Python modules using external checkers.
 #
 # This is the main checker controlling the other ones and the reports


### PR DESCRIPTION
In pylint and python's config parser [1] the default symbol for comments is '#'. The dialect is based on unix, while the classic dialect comes from windows and uses a semicolon for comments.

[1] https://docs.python.org/3/library/configparser.html#module-configparser