### PR TITLE
Add user-agent to stract requests

### DIFF
--- a/searx/engines/stract.py
+++ b/searx/engines/stract.py
@@ -6,6 +6,7 @@ ends.
 """
 
 from json import dumps
+from searx.utils import searx_useragent
 
 about = {
     "website": "https://stract.com/",
@@ -23,7 +24,11 @@ search_url = "https://stract.com/beta/api/search"
 def request(query, params):
     params['url'] = search_url
     params['method'] = "POST"
-    params['headers'] = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+    params['headers'] = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'User-Agent': searx_useragent(),
+    }
     params['data'] = dumps({'query': query, 'page': params['pageno'] - 1})
 
     return params


### PR DESCRIPTION
Hi,

I am the core maintainer of [Stract](https://stract.com/). We got a sudden huge spike in search requests/hr (~4x-5x) yesterday which almost took down the site and I am pretty sure it came from some searxng instances. It seems to be much better now, but it would be nice if we could add a user agent to the requests from searxng so we can better handle such spikes in the future and make sure the site doesn't crash.

Cheers!

## What does this PR do?
Adds the user-agent from `searx_useragent()` for search requests to stract.
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->



## Why is this change important?
Almost took down the search engine yesterday.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
