### PR TITLE
Update BASE.HTML To Use Title Case In Links

### DIFF
--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -64,18 +64,18 @@
   </main>
   <footer>
     <p>
-    {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searx_version }} — {{ _('a privacy-respecting, open metasearch engine') }}<br/>
-        <a href="{{ searx_git_url }}">{{ _('Source code') }}</a>
-        | <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a>
-        {% if enable_metrics %}| <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a>{% endif %}
+    {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">SearXNG</a> - {{ searx_version }} — {{ _('A Privacy-Respecting, Open Metasearch Engine') }}<br/>
+        <a href="{{ searx_git_url }}">{{ _('Source Code') }}</a>
+        | <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue Tracker') }}</a>
+        {% if enable_metrics %}| <a href="{{ url_for('stats') }}">{{ _('Engine Stats') }}</a>{% endif %}
         {% if get_setting('brand.public_instances') %}
-        | <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public instances') }}</a>
+        | <a href="{{ get_setting('brand.public_instances') }}">{{ _('Public Instances') }}</a>
         {% endif %}
         {% if get_setting('general.privacypolicy_url') %}
-        | <a href="{{ get_setting('general.privacypolicy_url') }}">{{ _('Privacy policy') }}</a>
+        | <a href="{{ get_setting('general.privacypolicy_url') }}">{{ _('Privacy Policy') }}</a>
         {% endif %}
         {% if get_setting('general.contact_url') %}
-        | <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact instance maintainer') }}</a>
+        | <a href="{{ get_setting('general.contact_url') }}">{{ _('Contact Instance Maintainer') }}</a>
         {% endif %}
         {% for title, link in get_setting('brand.custom.links').items() %}
         | <a href="{{ link }}">{{ _(title) }}</a>


### PR DESCRIPTION
Simply makes cosmetic changes so that the links on the search page use Title Case.

## What does this PR do?

Changes the display of the footer links to use the internationally recognized "Title Case" to display text not intended to be a complete sentence with punctuation.

## Why is this change important?

This makes the links more visually appealing, and more professional looking.  It also improves consistency of the visually displayed information.

## How to test this PR locally?

This change is cosmetic in nature, and does not change the core functionality in any way.

## Author's Checklist

N/A

## Related Issues

N/A
