### PR TITLE
[mod] Ask engine: remove tracking paramaters and set max page to 5

### DIFF
--- a/searx/engines/ask.py
+++ b/searx/engines/ask.py
@@ -19,6 +19,7 @@ about = {
 # Engine Configuration
 categories = ['general']
 paging = True
+max_page = 5
 
 # Base URL
 base_url = "https://www.ask.com/web"
@@ -61,7 +62,7 @@ def response(resp):
 
         results.append(
             {
-                "url": item['url'],
+                "url": item['url'].split('&ueid')[0],
                 "title": item['title'],
                 "content": item['abstract'],
                 "publishedDate": pubdate_original,


### PR DESCRIPTION
## What does this PR do?

explained in the title

## Why is this change important?

1. privacy
2. this search engine has 5 pages... 6th page does not exist and will not work.

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

!ask best museums in usa

the ueid=some_id that was previously at the end of most urls is GONE from all of these urls.

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

closes #3357
