### PR TITLE
[mod] engine 'mwmbl': Update API URL

### DIFF
--- a/searx/engines/mwmbl.py
+++ b/searx/engines/mwmbl.py
@@ -17,7 +17,6 @@ from urllib.parse import urlencode
 
 about = {
     "website": 'https://github.com/mwmbl/mwmbl',
-    "official_api_documentation": 'https://api.mwmbl.org/docs',
     "use_official_api": True,
     "require_api_key": False,
     "results": 'JSON',
@@ -25,11 +24,11 @@ about = {
 paging = False
 categories = ['general']
 
-api_url = "https://api.mwmbl.org"
+api_url = "https://api.mwmbl.org/api/v1"
 
 
 def request(query, params):
-    params['url'] = f"{api_url}/search?{urlencode({'s': query})}"
+    params['url'] = f"{api_url}/search/?{urlencode({'s': query})}"
     return params
 
 


### PR DESCRIPTION
## What does this PR do?

Update the API for the Mwmbl engine to the latest one from last year. Also remove a stale link to API documentation.
To my knowledge there is no new API documentation to replace the stale one. As there is no change in functionality this is not important.

The current URL is deprecated as per the TODO comment in  https://github.com/mwmbl/mwmbl/blob/main/mwmbl/urls.py and may be removed in the future.