### PR TITLE
[fix] Add key check for videoId to youtube_api to prevent exceptions …

### DIFF
--- a/searx/engines/youtube_api.py
+++ b/searx/engines/youtube_api.py
@@ -56,6 +56,10 @@ def response(resp):
 
     # parse results
     for result in search_results['items']:
+        if "videoId" not in result["id"]:
+            # ignore channels
+            continue
+
         videoid = result['id']['videoId']
 
         title = result['snippet']['title']


### PR DESCRIPTION
## What does this PR do?

youtube_api.py throws an exception if the search results contain a channel, as channels have no videoId. This PR adds a keycheck for parsing the json response.

## Why is this change important?

YouTube API searches can fail, returning no results.

## How to test this PR locally?

- Enable youtube_api with a valid API key
- Search for any phrase that returns a channel, i.e. Fat Electrician
- The search fails with an exception with the current version of youtube_api.py
- After adding the keycheck on line 59, it sucessfully skips channels, and returns videos as expected.

## Author's checklist

# With live version:

ERROR   searx.engines.youtube         : exception : 'videoId'
  File "/Users/singletail/dev/searxng/searx/engines/youtube_api.py", line 59, in response
    videoid = result['id']['videoId']
              ~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'videoId'

# With proposed fix:

DEBUG   searx.network.youtube         : HTTP Request: GET https://www.googleapis.com/youtube/v3/search?part=snippet&q=fat+electrician&maxResults=20&key=XXXXXXXXXXXXXXXXXXXX-XXXXXXXXXXXXXX_XXX&relevanceLanguage=en "HTTP/2 200 OK" (application/json; charset=UTF-8)

## Related issues