### PR TITLE
[feat] template: add apple-touch-icon in html header

### DIFF
--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -29,6 +29,7 @@
   {% endblock %}
   <link rel="icon" href="{{ url_for('static', filename='img/favicon.png') }}" sizes="any">
   <link rel="icon" href="{{ url_for('static', filename='img/favicon.svg') }}" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/favicon.png') }}"/>
 </head>
 <body class="{{ endpoint }}_endpoint" >
   <main id="main_{{  self._TemplateReference__context.name|replace("simple/", "")|replace(".html", "") }}" class="{{body_class}}">


### PR DESCRIPTION
## What does this PR do?

Adds link tag to `base.html` head to make it possible for iOS devices to get proper SearXNG icon when adding SearXNG to homescreen as PWA

## Why is this change important?

This makes it possible to add SearXNG to iOS devices homescreen with a proper icon

## How to test this PR locally?

`make run`

Contribution from Sascha via Email and should work on iOS devices.

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
