### PR TITLE
[fix] add missing localizable (gettext) messages to searxng.msg

### DIFF
--- a/searx/engines/yummly.py
+++ b/searx/engines/yummly.py
@@ -68,7 +68,7 @@ def response(resp):
                 'title': result['display']['displayName'],
                 'content': content,
                 'img_src': img_src,
-                'metadata': f"{gettext('Language')}: {result['locale'].split('-')[0]}",
+                'metadata': gettext('Language') + f": {result['locale'].split('-')[0]}",
             }
         )
 

--- a/searx/searxng.msg
+++ b/searx/searxng.msg
@@ -12,6 +12,8 @@ __all__ = [
     'CATEGORY_GROUPS',
     'STYLE_NAMES',
     'BRAND_CUSTOM_LINKS',
+    'WEATHER_TERMS',
+    'SOCIAL_MEDIA_TERMS',
 ]
 
 CONSTANT_NAMES = {
@@ -27,6 +29,8 @@ CATEGORY_NAMES = {
     'SOCIAL_MEDIA': 'social media',
     'IMAGES': 'images',
     'VIDEOS': 'videos',
+    'RADIO': 'radio',
+    'TV': 'tv',
     'IT': 'it',
     'NEWS': 'news',
     'MAP': 'map',
@@ -56,4 +60,38 @@ STYLE_NAMES = {
 BRAND_CUSTOM_LINKS = {
     'UPTIME': 'Uptime',
     'ABOUT': 'About',
+}
+
+WEATHER_TERMS = {
+    'AVERAGE TEMP.': 'Average temp.',
+    'CLOUD COVER': 'Cloud cover',
+    'CONDITION': 'Condition',
+    'CURRENT CONDITION': 'Current condition',
+    'EVENING': 'Evening',
+    'FEELS LIKE': 'Feels like',
+    'HUMIDITY': 'Humidity',
+    'MAX TEMP.': 'Max temp.',
+    'MIN TEMP.': 'Min temp.',
+    'MORNING': 'Morning',
+    'NIGHT': 'Night',
+    'NOON': 'Noon',
+    'PRESSURE': 'Pressure',
+    'SUNRISE': 'Sunrise',
+    'SUNSET': 'Sunset',
+    'TEMPERATURE': 'Temperature',
+    'UV INDEX': 'UV index',
+    'VISIBILITY': 'Visibility',
+    'WIND': 'Wind',
+}
+
+SOCIAL_MEDIA_TERMS = {
+    'SUBSCRIBERS': 'subscribers',
+    'POSTS': 'posts',
+    'ACTIVE USERS': 'active users',
+    'COMMENTS': 'comments',
+    'USER': 'user',
+    'COMMUNITY': 'community',
+    'POINTS': 'points',
+    'TITLE': 'title',
+    'AUTHOR': 'author',
 }


### PR DESCRIPTION
To test this patch I used .. and checked the diff of the `messages.pot` file::

    $ ./manage pyenv.cmd pybabel extract -F babel.cfg \
              -o ./searx/translations/messages.pot searx/
    $ git diff ./searx/translations/messages.pot

----

[hint from @dalf](https://github.com/searxng/searxng/issues/3412#issuecomment-2068010674): f-string are not supported [1] but there is no error [2].

[1] python-babel/babel#594
[2] python-babel/babel#715

Closes: https://github.com/searxng/searxng/issues/3412