### PR TITLE
fix bing returning same results, page numbering, minor refactor

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -72,16 +72,7 @@ base_url = 'https://www.bing.com/search'
 
 
 def _page_offset(pageno):
-    """
-    Page 1 => 1 (returns 10 results)
-    Page 2 => 11 (returns 14 results)
-    Page 3 => 25 (returns 14 results)
-    Page 4 => 39 (returns 14 results)
-    """
-    pageno_int = int(pageno)
-    if pageno_int <= 1:
-        return 1
-    return 11 + (pageno_int - 2) * 14
+    return (int(pageno) - 1) * 10 + 1
 
 
 def set_bing_cookies(params, engine_language, engine_region):
@@ -104,8 +95,14 @@ def request(query, params):
         # don't ask why it is only sometimes / its M$ and they have never been
         # deterministic ;)
         'pq': query,
-        # Unsure meaning of sc, but breaks bing if not present
+        # TODO: Figure out how below parameters are populated
         'sc': '0-0',
+		"sp": "-1",
+		"lq": "0",
+		"qs": "n",
+		"ghsh": "0",
+		"ghacc": "0",
+		"ghpl": "",
     }
 
     # To get correct page, arg first and this arg FORM is needed, the value PERE

--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -72,7 +72,16 @@ base_url = 'https://www.bing.com/search'
 
 
 def _page_offset(pageno):
-    return (int(pageno) - 1) * 10 + 1
+    """
+    Page 1 => 1 (returns 10 results)
+    Page 2 => 11 (returns 14 results)
+    Page 3 => 25 (returns 14 results)
+    Page 4 => 39 (returns 14 results)
+    """
+    pageno_int = int(pageno)
+    if pageno_int <= 1:
+        return 1
+    return 11 + (pageno_int - 2) * 14
 
 
 def set_bing_cookies(params, engine_language, engine_region):
@@ -95,18 +104,19 @@ def request(query, params):
         # don't ask why it is only sometimes / its M$ and they have never been
         # deterministic ;)
         'pq': query,
+        # Unsure meaning of sc, but breaks bing if not present
+        'sc': '0-0',
     }
 
     # To get correct page, arg first and this arg FORM is needed, the value PERE
     # is on page 2, on page 3 its PERE1 and on page 4 its PERE2 .. and so forth.
     # The 'first' arg should never send on page 1.
-
     if page > 1:
         query_params['first'] = _page_offset(page)  # see also arg FORM
-    if page == 2:
-        query_params['FORM'] = 'PERE'
-    elif page > 2:
-        query_params['FORM'] = 'PERE%s' % (page - 2)
+        if page == 2:
+            query_params['FORM'] = 'PERE'
+        else:  # page > 2:
+            query_params['FORM'] = 'PERE%s' % (page - 2)
 
     params['url'] = f'{base_url}?{urlencode(query_params)}'
 


### PR DESCRIPTION
## What does this PR do?
The  'sc' parameter, whatever it means, needs to be present in order to not return the same results.

Bing page numbering doesn't increase by 10 each time. The first page returns 10 results, and all pages thereafter return 14 results. This means we need to update the page numbering to account for this. This also seems to be the case when running on searxng.

Finally, the code to check the page had some duplicate checks, so I refactored the code in this section which seems low-risk. I can undo this if we want a dedicated PR for this.

## Why is this change important?
Fixes 3402

## How to test this PR locally?
1. Run searxng
2. Use `!bing {...}`
3. Validate that each pages results are unique

## Author's checklist
n/a

## Related issues
Closes #3402 

## Local Testing

### Page 1
![image](https://github.com/searxng/searxng/assets/58887802/ef9ebbe4-cc95-44a5-bd41-f2d3b4fdadfb)

### Page 2
![image](https://github.com/searxng/searxng/assets/58887802/dce0771f-a8d8-42dc-9489-2b0d525ed539)

### Page 3
![image](https://github.com/searxng/searxng/assets/58887802/155deb55-02f8-4a04-acb9-c321ba7ad837)
