### PR TITLE
[feat] media.ccc.de: implement module with pagination and iframe

### DIFF
--- a/searx/engines/ccc_media.py
+++ b/searx/engines/ccc_media.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""media.ccc.de"""
+
+import datetime
+from urllib.parse import urlencode
+
+from dateutil import parser
+
+about = {
+    'website': 'https://media.ccc.de',
+    'official_api_documentation': 'https://github.com/voc/voctoweb',
+    'use_official_api': True,
+    'require_api_key': False,
+    'results': 'JSON',
+}
+categories = ['videos']
+paging = True
+
+api_url = "https://api.media.ccc.de"
+
+
+def request(query, params):
+    args = {'q': query, 'page': params['pageno']}
+    params['url'] = f"{api_url}/public/events/search?{urlencode(args)}"
+
+    return params
+
+
+def response(resp):
+    results = []
+
+    for item in resp.json()['events']:
+        publishedDate = None
+        if item.get('date'):
+            publishedDate = parser.parse(item['date'])
+
+        iframe_src = None
+        if len(item['recordings']) > 0:
+            iframe_src = item['recordings'][0]['recording_url']
+
+        results.append(
+            {
+                'template': 'videos.html',
+                'url': item['frontend_link'],
+                'title': item['title'],
+                'content': item['description'],
+                'thumbnail': item['thumb_url'],
+                'publishedDate': publishedDate,
+                'length': datetime.timedelta(seconds=item['length']),
+                'iframe_src': iframe_src,
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -438,31 +438,18 @@ engines:
     shortcut: bt
     disabled: true
 
-  - name: ccc-tv
-    engine: xpath
-    paging: false
-    search_url: https://media.ccc.de/search/?q={query}
-    url_xpath: //div[@class="caption"]/h3/a/@href
-    title_xpath: //div[@class="caption"]/h3/a/text()
-    content_xpath: //div[@class="caption"]/h4/@title
-    categories: videos
-    disabled: true
-    shortcut: c3tv
-    about:
-      website: https://media.ccc.de/
-      wikidata_id: Q80729951
-      official_api_documentation: https://github.com/voc/voctoweb
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-      # We don't set language: de here because media.ccc.de is not just
-      # for a German audience. It contains many English videos and many
-      # German videos have English subtitles.
-
   - name: openverse
     engine: openverse
     categories: images
     shortcut: opv
+
+  - name: media.ccc.de
+    engine: ccc_media
+    shortcut: c3tv
+    # We don't set language: de here because media.ccc.de is not just
+    # for a German audience. It contains many English videos and many
+    # German videos have English subtitles.
+    disabled: true
 
   - name: chefkoch
     engine: chefkoch


### PR DESCRIPTION
## What does this PR do?
- implement media.ccc.de as a dedicated python module

## Why is this change important?
- the CCC hosts some interesting talks about cyber security and the impact of CS on the society, partially in German and partially in English

## How to test this PR locally?
- !c3tv linux
