### PR TITLE
[fix] yep engine: invcrease timeout from defaul 3sec to 5sec

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -508,6 +508,7 @@ engines:
     shortcut: yep
     categories: general
     search_type: web
+    timeout: 5
     disabled: true
 
   - name: yep images


### PR DESCRIPTION
In the "Engines" tab on searx.space [1] nearly all engines report a

    TimeoutException: yep engine

As documented in issue #2444 [2], this problem can be fixed by increasing the timeout. Note: on a local instance (`make run`) the timeout of 3sec was sufficient / at least in my local test, but the balance of searx.space leads me to believe that this tight timeout is usually not sufficient.

[1] https://searx.space/
[2] https://github.com/searxng/searxng/issues/2444

Closes https://github.com/searxng/searxng/issues/3421
