### PR TITLE
Add uWSGI `die-on-term` flag

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -42,6 +42,10 @@ buffer-size = 8192
 # See https://github.com/searx/searx-docker/issues/24
 add-header = Connection: close
 
+# Follow SIGTERM convention
+# See https://github.com/searxng/searxng/issues/3427
+die-on-term
+
 # uwsgi serves the static files
 static-map = /static=/usr/local/searxng/searx/static
 # expires set to one day


### PR DESCRIPTION
## What does this PR do?
Adds the `die-on-term` flag on uWSGI config.

## Why is this change important?
Container managers (podman at least) send a SIGTERM to gracefully stop the container, uWSGI by default interprets this as a reload signal. Adding the flag shown above corrects this issue.

More of this behavior can be seen [here](https://uwsgi-docs.readthedocs.io/en/latest/Management.html#signals-for-controlling-uwsgi).

## How to test this PR locally?
Add this flag on a uWSGI config file and try to send a SIGTERM to the application.

## Related issues
Fixes [#3427](https://github.com/searxng/searxng/issues/3427)