### PR TITLE
[fix] ccc_media engine: filter video formats and ignore audio & SubRip

### DIFF
--- a/searx/engines/ccc_media.py
+++ b/searx/engines/ccc_media.py
@@ -35,8 +35,13 @@ def response(resp):
             publishedDate = parser.parse(item['date'])
 
         iframe_src = None
-        if len(item['recordings']) > 0:
-            iframe_src = item['recordings'][0]['recording_url']
+        for rec in item['recordings']:
+            if rec['mime_type'].startswith('video'):
+                if not iframe_src:
+                    iframe_src = rec['recording_url']
+                elif rec['mime_type'] == 'video/mp4':
+                    # prefer mp4 (minimal data rates)
+                    iframe_src = rec['recording_url']
 
         results.append(
             {


### PR DESCRIPTION
CCC media serves several recording formats, to name a few:

- application/x-subrip
- video/mp4
- video/webm
- audio/mpeg
- audio/opus
- audio/mpeg

not all of them are suitable for a video frame.  If available we should prefer video/mp4 due to its minimal data rates.

Closes: https://github.com/searxng/searxng/issues/3431