### PR TITLE
[fix] drop broken azlyrics XPath engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1082,25 +1082,6 @@ engines:
       require_api_key: false
       results: HTML
 
-  - name: azlyrics
-    shortcut: lyrics
-    engine: xpath
-    timeout: 4.0
-    disabled: true
-    categories: [music, lyrics]
-    paging: true
-    search_url: https://search.azlyrics.com/search.php?q={query}&w=lyrics&p={pageno}
-    url_xpath: //td[@class="text-left visitedlyr"]/a/@href
-    title_xpath: //span/b/text()
-    content_xpath: //td[@class="text-left visitedlyr"]/a/small
-    about:
-      website: https://azlyrics.com
-      wikidata_id: Q66372542
-      official_api_documentation:
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-
   - name: mastodon users
     engine: mastodon
     mastodon_type: accounts


### PR DESCRIPTION
Unfortunately, azlyrics has a bot blocker that makes it impossible to implement an XPath engine for it [1][2].

[1] https://github.com/searxng/searxng/pull/3302#issuecomment-2013529271
[2] https://github.com/searxng/searxng/issues/3280