### PR TITLE
[fix] respect user preferences to open links in new tab for short answers

### DIFF
--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -24,8 +24,12 @@
         {%- for answer in answers.values() -%}
         <div class="answer">
         <span>{{ answer.answer }}</span>
-          {% if answer.url -%}
-          <a href="{{ answer.url }}" class="answer-url">{{ urlparse(answer.url).hostname }}</a>
+          {%- if answer.url -%}
+          <a href="{{ answer.url }}" class="answer-url"
+             {%- if results_on_new_tab %} target="_blank" rel="noopener noreferrer"
+             {%- else -%} rel="noreferrer"
+             {%- endif -%}
+             >{{ urlparse(answer.url).hostname }}</a>
           {% endif -%}
         </div>
         {%- endfor -%}


### PR DESCRIPTION

## What does this PR do?

*Same as in commit description*

Previously only result urls were set to open in new tab by default, this
should make the behaviour consistent.

Also adds the missing rel="noreferrer" to the anchor tag. Although this
should not be needed as long as the `referrer-policy: no-referrer`
header is set, it's always nice to play safer than to have to say sorry.
For example some reverse proxy configurations might strip off
unwhitelisted headers in which case it's nice to have this set.

## Why is this change important?

*Pretty much explained in commit message and above as well

## How to test this PR locally?

```bash
make run
```

## Author's checklist

- [X] It works

## Related issues

*None*
