### PR TITLE
[feat] engine: add hex.pm package search

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -172,3 +172,4 @@ features or generally made searx better:
 - Bernie Huang `<https://github.com/BernieHuang2008>`
 - Austin Olacsi `<https://github.com/Austin-Olacsi>`
 - @micsthepick
+- Daniel Kukula `<https://github.com/dkuku>`

--- a/searx/engines/hex.py
+++ b/searx/engines/hex.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""hex.pm"""
+
+from urllib.parse import urlencode
+from dateutil import parser
+
+
+about = {
+    # pylint: disable=line-too-long
+    "website": "https://hex.pm/",
+    "wikidata_id": None,
+    "official_api_documentation": "https://github.com/hexpm/hexpm/blob/main/lib/hexpm_web/controllers/api/package_controller.ex",
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+categories = ["it", "packages"]
+
+
+# engine dependent config
+paging = True
+search_url = "https://hex.pm/api/packages/"
+
+
+def request(query: str, params):
+    args = urlencode({"page": params["pageno"], "search": query})
+    params["url"] = f"{search_url}?{args}"
+    return params
+
+
+def response(resp):
+    results = []
+    for package in resp.json():
+        meta = package["meta"]
+        publishedDate = package.get("inserted_at")
+        if publishedDate:
+            publishedDate = parser.parse(publishedDate)
+        tags = meta.get("licenses", [])
+        results.append(
+            {
+                "template": "packages.html",
+                "url": package["url"],
+                "title": package["name"],
+                "package_name": package["name"],
+                "content": meta.get("description", ""),
+                "version": meta.get("latest_version"),
+                "maintainer": ", ".join(meta.get("maintainers", [])),
+                "publishedDate": publishedDate,
+                "tags": tags,
+                "homepage": meta.get("links", {}).get("homepage"),
+                "source_code_url": meta.get("links", {}).get("github"),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -926,6 +926,11 @@ engines:
     shortcut: hn
     disabled: true
 
+  - name: hex
+    engine: hex
+    shortcut: hex
+    disabled: true
+
   - name: hoogle
     engine: xpath
     search_url: https://hoogle.haskell.org/?hoogle={query}


### PR DESCRIPTION
## What does this PR do?
Add search for elixir/erlang/gleam packages on hex.pm
Code is copied from the npm search. I'm just not sure how to test it.
There is no documentation page but the code is open source so I linked to the search controller as api link
<!-- MANDATORY -->
![image](https://github.com/searxng/searxng/assets/904179/b022ffed-11f0-43cc-b765-29289228bbda)

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
