### PR TITLE
[fix] unit converter plugin: can't be disabled in settings

### DIFF
--- a/searx/plugins/unit_converter.py
+++ b/searx/plugins/unit_converter.py
@@ -10,6 +10,9 @@ name = "Unit converter plugin"
 description = gettext("Convert between units")
 default_on = True
 
+plugin_id = "unit_converter"
+preference_section = "general"
+
 CONVERT_KEYWORDS = ["in", "to", "as"]
 
 


### PR DESCRIPTION
## What does this PR do?
- this fixes that there's no option to disable the unit converter plugin in the settings (or enable it if it's been disable by default by the instance admin)

## How to test this PR locally?
- go to the general settings and toggle the unit converter plugin
