### PR TITLE
[feat] gitea: implement dedicated module

### DIFF
--- a/docs/dev/engines/online/gitea.rst
+++ b/docs/dev/engines/online/gitea.rst
@@ -1,0 +1,8 @@
+.. _gitea engine:
+
+=====
+Gitea
+=====
+
+.. automodule:: searx.engines.gitea
+  :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ If you don't trust anyone, you can set up your own, see :ref:`installation`.
    - :ref:`no user tracking / no profiling <SearXNG protect privacy>`
    - script & cookies are optional
    - secure, encrypted connections
-   - :ref:`about 130 search engines <configured engines>`
+   - :ref:`about 200 search engines <configured engines>`
    - `about 60 translations <https://translate.codeberg.org/projects/searxng/searxng/>`_
    - about 100 `well maintained <https://uptime.searxng.org/>`__ instances on searx.space_
    - :ref:`easy integration of search engines <demo online engine>`

--- a/searx/engines/gitea.py
+++ b/searx/engines/gitea.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Engine to search in collaborative software platforms based on Gitea_.
+
+.. _Gitea: https://about.gitea.com/
+
+Configuration
+=============
+
+The engine has the following mandatory setting:
+
+- :py:obj:`base_url`
+
+Optional settings are:
+
+- :py:obj:`sort`
+- :py:obj:`order`
+- :py:obj:`page_size`
+
+.. code:: yaml
+
+  - name: gitea.com
+    engine: gitea
+    base_url: https://gitea.com
+    shortcut: gitea
+
+If you would like to use additional instances, just configure new engines in the
+:ref:`settings <settings engine>` and set the ``base_url``.
+
+
+Implementation
+==============
+
+"""
+
+from urllib.parse import urlencode
+from dateutil import parser
+
+about = {
+    "website": 'https://about.gitea.com',
+    "wikidata_id": None,
+    "official_api_documentation": 'https://docs.gitea.com/next/development/api-usage',
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+categories = ['it', 'repos']
+paging = True
+
+base_url: str = ''
+"""URL of the Gitea_ instance."""
+
+sort: str = "updated"
+"""Sort criteria, possible values:
+
+- ``updated`` (default)
+- ``alpha``
+- ``created``
+- ``size``
+- ``id``
+"""
+
+order = "desc"
+"""Sort order, possible values:
+
+- ``desc`` (default)
+- ``asc``
+"""
+
+page_size: int = 10
+"""Maximum number of results per page (default 10)."""
+
+
+def init(_):
+    if not base_url:
+        raise ValueError('gitea engine: base_url is unset')
+
+
+def request(query, params):
+    args = {'q': query, 'limit': page_size, 'sort': sort, 'order': order, 'page': params['pageno']}
+    params['url'] = f"{base_url}/api/v1/repos/search?{urlencode(args)}"
+
+    return params
+
+
+def response(resp):
+    results = []
+
+    for item in resp.json().get('data', []):
+        content = [item.get(i) for i in ['language', 'description'] if item.get(i)]
+
+        results.append(
+            {
+                'template': 'packages.html',
+                'url': item.get('html_url'),
+                'title': item.get('full_name'),
+                'content': ' / '.join(content),
+                'img_src': item.get('owner', {}).get('avatar_url'),
+                'package_name': item.get('name'),
+                'maintainer': item.get('owner', {}).get('login'),
+                'publishedDate': parser.parse(item.get("updated_at") or item.get("created_at")),
+                'tags': item.get('topics', []),
+                'popularity': item.get('stargazers_count'),
+                'homepage': item.get('homepage'),
+                'source_code_url': item.get('clone_url'),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -800,26 +800,12 @@ engines:
     engine: github
     shortcut: gh
 
-    # This a Gitea service. If you would like to use a different instance,
-    # change codeberg.org to URL of the desired Gitea host. Or you can create a
-    # new engine by copying this and changing the name, shortcut and search_url.
-
   - name: codeberg
-    engine: json_engine
-    search_url: https://codeberg.org/api/v1/repos/search?q={query}&limit=10
-    url_query: html_url
-    title_query: name
-    content_query: description
-    categories: [it, repos]
+    # https://docs.searxng.org/dev/engines/online/gitea.html
+    engine: gitea
+    base_url: https://codeberg.org
     shortcut: cb
     disabled: true
-    about:
-      website: https://codeberg.org/
-      wikidata_id:
-      official_api_documentation: https://try.gitea.io/api/swagger
-      use_official_api: false
-      require_api_key: false
-      results: JSON
 
   - name: gitea.com
     engine: gitea

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -821,6 +821,12 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name: gitea.com
+    engine: gitea
+    base_url: https://gitea.com
+    shortcut: gitea
+    disabled: true
+
   - name: goodreads
     engine: goodreads
     shortcut: good


### PR DESCRIPTION
## What does this PR do?
- implement a module for gitea
- by default we only have a codeberg engine available (as before)

## Why is this change important?
- it provides more details than before
- see #3268

## How to test this PR locally?
- !cb foot
- !cb gadgetbridge

## Related issues
see #3268
