### PR TITLE
[fix] docutils dependencies (docutils>=0.21.2)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,12 @@ sphinx-tabs==3.4.5
 sphinxcontrib-programoutput==0.17
 sphinx-autobuild==2021.3.14
 sphinx-notfound-page==1.0.0
-myst-parser==2.0.0
-linuxdoc==20231020
+myst-parser==3.0.1
+linuxdoc==20240509
 aiounittest==1.4.2
 yamllint==1.35.1
 wlc==1.14
 coloredlogs==15.0.1
+docutils<=0.21; python_version == '3.8'
+docutils>=0.21.2; python_version > '3.8'
+

--- a/utils/lib_sxng_test.sh
+++ b/utils/lib_sxng_test.sh
@@ -89,10 +89,17 @@ test.robot() {
     dump_return $?
 }
 
+
 test.rst() {
     build_msg TEST "[reST markup] ${RST_FILES[*]}"
+
+    local rst2html=rst2html
+    if [ "3.8" == "$(python -c 'import sys; print(".".join([str(x) for x in sys.version_info[:2]]))')" ]; then
+       rst2html=rst2html.py
+    fi
+
     for rst in "${RST_FILES[@]}"; do
-        pyenv.cmd rst2html.py --halt error "$rst" > /dev/null || die 42 "fix issue in $rst"
+        pyenv.cmd "${rst2html}" --halt error "$rst" > /dev/null || die 42 "fix issue in $rst"
     done
 }
 


### PR DESCRIPTION
Another trip into the hell of dependencies: docutils tends to put major changes
in minor patches: the executables have been renamed / e.g.

     rst2html.py --> rts2html

so we have to use docutils at least from version 0.21.2, but this version of
docutils is only supported by myst-parser from version 3.0.1 on.

Additionally, docutils decided to drop python 3.8 in version 0.21 [1]

Further, linuxdoc needed an update to cope with docutils 0.21 [2]

[1] https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09
[2] https://github.com/return42/linuxdoc/pull/36