### PR TITLE
[fix] google: don't display that keyword is missing in content field

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -62,7 +62,7 @@ filter_mapping = {0: 'off', 1: 'medium', 2: 'high'}
 results_xpath = './/div[contains(@jscontroller, "SC7lYd")]'
 title_xpath = './/a/h3[1]'
 href_xpath = './/a[h3]/@href'
-content_xpath = './/div[@data-sncf]'
+content_xpath = './/div[@data-sncf="1"]'
 
 # Suggestions are links placed in a *card-section*, we extract only the text
 # from the links not the links itself.


### PR DESCRIPTION
## What does this PR do?
- only shows the result description in Google search results as content, and not also other Google-generated stuff, i.e. `missing: {keyword}`, ...

## Why is this change important?
- see #3484

## How to test this PR locally?
- !go searxng stats

## Related issues
closes #3484
