### PR TITLE
[mod] sort hex packages by popularity

### DIFF
--- a/searx/engines/hex.py
+++ b/searx/engines/hex.py
@@ -21,6 +21,9 @@ categories = ["it", "packages"]
 # engine dependent config
 paging = True
 search_url = "https://hex.pm/api/packages/"
+# Valid values: name inserted_at updated_at total_downloads recent_downloads
+sort_criteria = "recent_downloads"
+page_size = 10
 
 linked_terms = {
     # lower-case : replacement
@@ -47,7 +50,7 @@ linked_terms = {
 
 
 def request(query: str, params):
-    args = urlencode({"page": params["pageno"], "search": query})
+    args = urlencode({"page": params["pageno"], "per_page": page_size, "sort": sort_criteria, "search": query})
     params["url"] = f"{search_url}?{args}"
     return params
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -923,6 +923,9 @@ engines:
     engine: hex
     shortcut: hex
     disabled: true
+    # Valid values: name inserted_at updated_at total_downloads recent_downloads
+    sort_criteria: "recent_downloads"
+    page_size: 10
 
   - name: crates.io
     engine: crates


### PR DESCRIPTION
## What does this PR do?
Last modification to hex search:
Put popular packages on top of search result, instead of sorting alphabetically.
The search results are much more relevant.
<!-- MANDATORY -->
![image](https://github.com/searxng/searxng/assets/904179/3972b6af-9c24-4781-b6f9-eee1a116f0d7)
![image](https://github.com/searxng/searxng/assets/904179/eefe3fc7-fcb0-45f5-af9f-c8d80799a646)

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
