### PR TITLE
[fix] fix elixir docs search

### DIFF
--- a/searx/data/external_bangs.json
+++ b/searx/data/external_bangs.json
@@ -4888,8 +4888,8 @@
             "lix": {
                 "\u0010": "//www.elix-lsf.fr/spip.php?page=recherche_definitions&recherche=\u0002&lang=fr\u00010",
                 "ir": {
-                    "\u0010": "//hexdocs.pm/elixir/search.html?q=\u0002\u000164",
-                    "-docs": "//duckduckgo.com/?q=site%3Aelixir-lang.org%2Fdocs+\u0002\u00010",
+                    "\u0010": "//duckduckgo.com/?q=site%3Ahexdocs.pm%2F+\u0002\u00010",
+                    "-docs": "//hexdocs.pm/elixir/search.html?q=\u0002\u00010",
                     "forum": "//elixirforum.com/search?q=\u0002\u00010"
                 }
             },


### PR DESCRIPTION
## What does this PR do?
The elixir-docs search currently does not work.
The documentation was [moved to hexdocs](https://github.com/elixir-lang/elixir/issues/12747)
This pr changes the behaviour:
`!!elixir-docs` searches directly in elixir documentation
`!!elixir` returns results from all the packages including elixir
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
