### PR TITLE
[fix] unit converter operating backwards (from_si <-> to_si)

### DIFF
--- a/searx/plugins/unit_converter.py
+++ b/searx/plugins/unit_converter.py
@@ -138,8 +138,8 @@ def symbol_to_si():
                 (
                     item['symbol'],
                     item['si_name'],
-                    item['to_si_factor'],  # from_si
-                    1 / item['to_si_factor'],  # to_si
+                    1 / item['to_si_factor'],  # from_si
+                    item['to_si_factor'],  # to_si
                     item['symbol'],
                 )
             )


### PR DESCRIPTION
The factors for from_si and to_si were reversed.

Closes: https://github.com/searxng/searxng/issues/3497