### PR TITLE
[feature] add engine google-2000 / a "disables AI support" google

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -56,6 +56,8 @@ time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
 # Filter results. 0: None, 1: Moderate, 2: Strict
 filter_mapping = {0: 'off', 1: 'medium', 2: 'high'}
 
+extra_args = ""
+
 # specific xpath variables
 # ------------------------
 
@@ -292,6 +294,8 @@ def request(query, params):
             }
         )
     )
+    if extra_args:
+        query_url += extra_args
 
     if params['time_range'] in time_range_dict:
         query_url += '&' + urlencode({'tbs': 'qdr:' + time_range_dict[params['time_range']]})

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -820,6 +820,11 @@ engines:
     timeout: 4.0
     disabled: true
 
+  - name: google-2000
+    engine: google
+    shortcut: go2
+    extra_args: "&udm=14"
+
   - name: google
     engine: google
     shortcut: go


### PR DESCRIPTION
AI Overviews has been rolling out to all US based searchers in the mid/end of May 2024.  AI Overviews will launch in more countries soon and be available to more than a billion users by the end of the year. [3]

By adding extra argument ``&udm=14`` the AI overviews [2] from google are disabled. Suggested by @cocoonkid in [1].

[1] https://github.com/searxng/searxng/discussions/3503
[2] https://tedium.co/2024/05/17/google-web-search-make-default/
[3] https://searchengineland.com/google-rolls-out-ai-overviews-in-us-with-more-countries-coming-soon-440418

----

This PR is a POC .. both engines (google & google-2000) are enabled by default to compare the results .. Since the rollout of the AI-Overviews is currently only for US users, we need testers with IPs from different countries (I only have IPs in DE)

While testing, I would remind what @unixfox mentioned in https://github.com/searxng/searxng/discussions/3503#discussioncomment-9531130 ..

> .. but the issue is that you *(google-2000)* won't get suggestions and answers anymore from google.
