### PR TITLE
[fix] Do not show DDG IP zero click

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -331,7 +331,7 @@ def response(resp):
     zero_click_info_xpath = '//html/body/form/div/table[2]/tr[2]/td/text()'
     zero_click = extract_text(eval_xpath(doc, zero_click_info_xpath)).strip()
 
-    if zero_click:
+    if zero_click and "Your IP address is" not in zero_click:
         current_query = resp.search_params["data"].get("q")
 
         results.append(


### PR DESCRIPTION


## What does this PR do?

Currently, the DDG zero click results are being displayed if the user search includes `IP`.

This will return the IP of the searxng server—not the user's IP—and conflicts with the `self_info` plugin.

For example, if the searxng server's IP is `1.2.3.4` and the user's ip is `4.3.2.1`—and if the `self_info` plugin is enabled—the results will look like this:

![Screenshot_20240529_004145](https://github.com/searxng/searxng/assets/16124077/84f56fd7-c6fe-4782-af01-cf43c65d3908)

_Note: the full zero click answer from DDG includes a link to the user's location as well, but this gets dropped by searxng:_

![Screenshot_20240529_010102](https://github.com/searxng/searxng/assets/16124077/072076dc-5d98-40f6-90c9-53f104e6275c)


<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
This issue affects end-user usability, but could also represent a minor security issue as it will result in the searxng server IP being leaked to the user. Instances behind a proxy that are not proxying their outbound traffic may not want their server's IP to be easily obtained this way.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

This is a minor UI fix, it was tested visually in the browser:
![Screenshot_20240529_004302](https://github.com/searxng/searxng/assets/16124077/7c661b4d-4f07-4fd3-af2a-64b658e437e4)


<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

I have not been able to find an exhaustive list of zero click result types. If IP is the only one which needs to be excluded then this simple fix is probably sufficient, but it's possible there are others that would need to be excluded.

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
