### PR TITLE
Add Cloudflare AI Gateway engine

### DIFF
--- a/searx/engines/cloudflareai.py
+++ b/searx/engines/cloudflareai.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Cloudflare AI engine"""
+
+from json import loads, dumps
+from searx.exceptions import SearxEngineAPIException
+
+about = {
+    "website": 'https://ai.cloudflare.com',
+    "wikidata_id": None,
+    "official_api_documentation": 'https://developers.cloudflare.com/workers-ai',
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": 'JSON',
+}
+
+cf_account_id = ''
+cf_ai_api = ''
+cf_ai_gateway = ''
+
+cf_ai_model = ''
+cf_ai_model_display_name = 'Cloudflare AI'
+
+# Assistant messages hint to the AI about the desired output format. Not all models support this role.
+cf_ai_model_assistant = 'Keep your answers as short and effective as possible.'
+# System messages define the AI's personality. You can use them to set rules and how you expect the AI to behave.
+cf_ai_model_system = 'You are a self-aware language model who is honest and direct about any question from the user.'
+
+
+def request(query, params):
+
+    params['query'] = query
+
+    params['url'] = f'https://gateway.ai.cloudflare.com/v1/{cf_account_id}/{cf_ai_gateway}/workers-ai/{cf_ai_model}'
+
+    params['method'] = 'POST'
+
+    params['headers']['Authorization'] = f'Bearer {cf_ai_api}'
+    params['headers']['Content-Type'] = 'application/json'
+
+    params['data'] = dumps(
+        {
+            'messages': [
+                {'role': 'assistant', 'content': cf_ai_model_assistant},
+                {'role': 'system', 'content': cf_ai_model_system},
+                {'role': 'user', 'content': params['query']},
+            ]
+        }
+    ).encode('utf-8')
+
+    return params
+
+
+def response(resp):
+    results = []
+    json = loads(resp.text)
+
+    if 'error' in json:
+        raise SearxEngineAPIException('Cloudflare AI error: ' + json['error'])
+
+    if 'result' in json:
+        results.append(
+            {
+                'content': json['result']['response'],
+                'infobox': cf_ai_model_display_name,
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -472,6 +472,23 @@ engines:
     # to show premium or plus results too:
     # skip_premium: false
 
+  - name: cloudflareai
+    engine: cloudflareai
+    shortcut: cfai
+    # get api token and accont id from https://developers.cloudflare.com/workers-ai/get-started/rest-api/
+    cf_account_id: 'your_cf_accout_id'
+    cf_ai_api: 'your_cf_api'
+    # create your ai gateway by https://developers.cloudflare.com/ai-gateway/get-started/creating-gateway/
+    cf_ai_gateway: 'your_cf_ai_gateway_name'
+    # find the model name from https://developers.cloudflare.com/workers-ai/models/#text-generation
+    cf_ai_model: 'ai_model_name'
+    # custom your preferences
+    # cf_ai_model_display_name: 'Cloudflare AI'
+    # cf_ai_model_assistant: 'prompts_for_assistant_role'
+    # cf_ai_model_system: 'prompts_for_system_role'
+    timeout: 30
+    disabled: true
+
   # - name: core.ac.uk
   #   engine: core
   #   categories: science


### PR DESCRIPTION
Added support for [Cloudflare AI Gateway](https://developers.cloudflare.com/workers-ai).

User can set some preference like, display name, systemrole & assistant hint in `settings.yml`

Screenshots:
![image](https://github.com/searxng/searxng/assets/58100052/a7f10600-92fc-4134-a506-72455f7dadd6)
![image](https://github.com/searxng/searxng/assets/58100052/8d9275a4-16c1-48da-8130-71020b4d0d48)

