### PR TITLE
cleanup: remove usage of gen_useragent in mojeek, add default useragent unit test

### DIFF
--- a/searx/engines/mojeek.py
+++ b/searx/engines/mojeek.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from lxml import html
 
 from dateutil.relativedelta import relativedelta
-from searx.utils import eval_xpath, eval_xpath_list, extract_text, gen_useragent
+from searx.utils import eval_xpath, eval_xpath_list, extract_text
 
 about = {
     'website': 'https://mojeek.com',
@@ -63,7 +63,6 @@ def request(query, params):
         logger.debug(args["since"])
 
     params['url'] = f"{base_url}/search?{urlencode(args)}"
-    params['headers'] = {'User-Agent': gen_useragent()}
 
     return params
 

--- a/tests/unit/processors/__init__.py
+++ b/tests/unit/processors/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring

--- a/tests/unit/processors/test_online.py
+++ b/tests/unit/processors/test_online.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring
+
+from searx.search import SearchQuery, EngineRef
+from searx.search.processors import online
+from searx.engines import load_engines
+from searx import engines
+
+from tests import SearxTestCase
+
+TEST_ENGINE_NAME = 'dummy engine'
+TEST_ENGINE = {
+    'name': TEST_ENGINE_NAME,
+    'engine': 'dummy',
+    'categories': 'general',
+    'shortcut': 'du',
+    'timeout': 3.0,
+    'tokens': [],
+}
+
+
+class TestOnlineProcessor(SearxTestCase):  # pylint: disable=missing-class-docstring
+
+    def setUp(self):
+        load_engines([TEST_ENGINE])
+
+    def tearDown(self):
+        load_engines([])
+
+    def _get_params(self, online_processor, search_query, engine_category):
+        params = online_processor.get_params(search_query, engine_category)
+        self.assertIsNotNone(params)
+        assert params is not None
+        return params
+
+    def test_get_params_default_params(self):
+        engine = engines.engines[TEST_ENGINE_NAME]
+        online_processor = online.OnlineProcessor(engine, TEST_ENGINE_NAME)
+        search_query = SearchQuery('test', [EngineRef(TEST_ENGINE_NAME, 'general')], 'all', 0, 1, None, None, None)
+        params = self._get_params(online_processor, search_query, 'general')
+        self.assertIn('method', params)
+        self.assertIn('headers', params)
+        self.assertIn('data', params)
+        self.assertIn('url', params)
+        self.assertIn('cookies', params)
+        self.assertIn('auth', params)
+
+    def test_get_params_useragent(self):
+        engine = engines.engines[TEST_ENGINE_NAME]
+        online_processor = online.OnlineProcessor(engine, TEST_ENGINE_NAME)
+        search_query = SearchQuery('test', [EngineRef(TEST_ENGINE_NAME, 'general')], 'all', 0, 1, None, None, None)
+        params = self._get_params(online_processor, search_query, 'general')
+        self.assertIn('User-Agent', params['headers'])


### PR DESCRIPTION
## What does this PR do?

- Remove usage of gen_useragent in engines
- Implement a unit test to validate that `gen_useragent` is provided by default for `online` processors

## Why is this change important?

- Reduce tech debt - clarify usage of `gen_useragent` in requests where not needed
- Validate existing default behavior of headers

## How to test this PR locally?

- Ensure mojeek engine works as expected
- Ensure unit test runs as expected

## Author's checklist
n/a

## Related issues
context for changes [here](https://github.com/searxng/searxng/pull/3556#issuecomment-2156461261)