### PR TITLE
Fix packaging for answerers

### DIFF
--- a/searx/answerers/random/__init__.py
+++ b/searx/answerers/random/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring

--- a/searx/answerers/random/answerer.py
+++ b/searx/answerers/random/answerer.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring
 
 import hashlib
 import random

--- a/searx/answerers/statistics/__init__.py
+++ b/searx/answerers/statistics/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring

--- a/searx/answerers/statistics/answerer.py
+++ b/searx/answerers/statistics/answerer.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring
+
 from functools import reduce
 from operator import mul
 
@@ -18,27 +20,27 @@ def answer(query):
 
     try:
         args = list(map(float, parts[1:]))
-    except:
+    except:  # pylint: disable=bare-except
         return []
 
     func = parts[0]
-    answer = None
+    _answer = None
 
     if func == 'min':
-        answer = min(args)
+        _answer = min(args)
     elif func == 'max':
-        answer = max(args)
+        _answer = max(args)
     elif func == 'avg':
-        answer = sum(args) / len(args)
+        _answer = sum(args) / len(args)
     elif func == 'sum':
-        answer = sum(args)
+        _answer = sum(args)
     elif func == 'prod':
-        answer = reduce(mul, args, 1)
+        _answer = reduce(mul, args, 1)
 
-    if answer is None:
+    if _answer is None:
         return []
 
-    return [{'answer': str(answer)}]
+    return [{'answer': str(_answer)}]
 
 
 # required answerer function


### PR DESCRIPTION
## What does this PR do?

Fix installing answerers when installing searxng through a wheel.

## Why is this change important?

It breaks the answerers page on NixOS.

## How to test this PR locally?

Deployed the equivalent of the PR to my searx installation

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

- https://github.com/NixOS/nixpkgs/issues/319040
- https://github.com/searxng/searxng/pull/3045#issuecomment-1868519526
