### PR TITLE
[enh] Self Info Plugin usability enhancements

### DIFF
--- a/searx/plugins/self_info.py
+++ b/searx/plugins/self_info.py
@@ -13,17 +13,20 @@ preference_section = 'query'
 query_keywords = ['user-agent']
 query_examples = ''
 
+# "ip" or "my ip" regex
+ip_regex = re.compile('^ip$|my ip', re.IGNORECASE)
+
 # Self User Agent regex
-p = re.compile('.*user[ -]agent.*', re.IGNORECASE)
+ua_regex = re.compile('.*user[ -]agent.*', re.IGNORECASE)
 
 
 def post_search(request, search):
     if search.search_query.pageno > 1:
         return True
-    if search.search_query.query == 'ip':
+    if ip_regex.search(search.search_query.query):
         ip = get_real_ip(request)
-        search.result_container.answers['ip'] = {'answer': ip}
-    elif p.match(search.search_query.query):
+        search.result_container.answers['ip'] = {'answer': gettext('Your IP is: ') + ip}
+    elif ua_regex.match(search.search_query.query):
         ua = request.user_agent
-        search.result_container.answers['user-agent'] = {'answer': ua}
+        search.result_container.answers['user-agent'] = {'answer': gettext('Your user-agent is: ') + ua}
     return True


### PR DESCRIPTION
## What does this PR do?

These two small commits improve the usability of the Self Info Plugin.

### Better keyword matching
https://github.com/searxng/searxng/commit/3376940c6ff982b5f77f83c30fd7cbe8e4b331cc 

This change does two things:

- the `ip` keyword is now case-insensitive
- if the query includes `my ip` it will now also match

In order to avoid too many false matches, the `ip` keyword alone matches only if it's the _only_ word, but the inclusion of `my` loosens that to be inclusive of users typing a phrase.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

The regex `'^ip$|my ip'` may still trigger false negatives (`where's my ipecac`) but I've kept it simple as:

- there are only a very small number of English words that start with `ip`, [none of which are common](https://www.merriam-webster.com/wordfinder/classic/begins/all/-1/ip/1) or are likely to follow the word `my`
- false positives are not a major usability issue
- simpler regex will remain easy to understand and maintain

###  Better answer context 

https://github.com/searxng/searxng/commit/4b7e038c953cfdcb6da699c36557b217fe4fd11a

Previously this plugin simply dumped your IP or user-agent string as an
answer. This tiny change just adds some text to contextualize those
answers (eg, "Your IP is: 1.2.3.4" instead of just "1.2.3.4").

## Why is this change important?

### Better keyword matching

The IP keyword was previously an exact match for the string `ip` in the query, which works fine if you already know the keyword and doesn't match user expectations from other platforms where the matching more flexible. It's common for users to type phrases like `"what is my ip"`, `"tell me my ip"`, `"my IP  address"`, etc.

###  Better answer context 

While more savvy users will not need to be told "this is your `IP`/`user-agent`", the added context makes it more clear to users that we are providing a direct answer to their query.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?


I tested locally with the following strings
```
test_strings = ["ip",
    "IP",
    "tip",
    "my ip address",
    "My IP is",
    "what is MY ip",
    "not related",
    ]
```

And received the expected results:

```
Matched: ip
Matched: IP
Not Matched: tip
Matched: my ip address
Matched: My IP is
Matched: what is MY ip
Not Matched: not related
```

Words including `ip` such as `tip` _do not_ match, but `ip` alone matches and the inclusion of `my ip` (case insensitive) matches.

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

N/A
<!-- additional notes for reviewers -->

## Related issues
N/A
<!--
Closes #234
-->
