### PR TITLE
[feat] docker: add env vars for common public instance settings

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -173,3 +173,4 @@ features or generally made searx better:
 - Austin Olacsi `<https://github.com/Austin-Olacsi>`
 - @micsthepick
 - Daniel Kukula `<https://github.com/dkuku>`
+- Patrick Evans `https://github.com/holysoles`

--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -31,13 +31,13 @@
 ``secret_key`` : ``$SEARXNG_SECRET``
   Used for cryptography purpose.
 
-``limiter`` :
+``limiter`` :  ``$SEARXNG_LIMITER``
   Rate limit the number of request on the instance, block some bots.  The
   :ref:`limiter` requires a :ref:`settings redis` database.
 
 .. _public_instance:
 
-``public_instance`` :
+``public_instance`` :  ``$SEARXNG_PUBLIC_INSTANCE``
 
   Setting that allows to enable features specifically for public instances (not
   needed for local usage).  By set to ``true`` the following features are
@@ -47,7 +47,7 @@
 
 .. _image_proxy:
 
-``image_proxy`` :
+``image_proxy`` : ``$SEARXNG_IMAGE_PROXY``
   Allow your instance of SearXNG of being able to proxy images.  Uses memory space.
 
 .. _HTTP headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers

--- a/docs/admin/settings/settings_ui.rst
+++ b/docs/admin/settings/settings_ui.rst
@@ -24,7 +24,7 @@
 
 .. _static_use_hash:
 
-``static_use_hash`` :
+``static_use_hash`` : ``$SEARXNG_STATIC_USE_HASH``
   Enables `cache busting`_ of static files.
 
 ``default_locale`` :

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -78,14 +78,18 @@ server:
   # public URL of the instance, to ensure correct inbound links. Is overwritten
   # by ${SEARXNG_URL}.
   base_url: false  # "http://example.com/location"
-  limiter: false  # rate limit the number of request on the instance, block some bots
-  public_instance: false  # enable features designed only for public instances
+  # rate limit the number of request on the instance, block some bots.
+  # Is overwritten by ${SEARXNG_LIMITER}
+  limiter: false
+  # enable features designed only for public instances.
+  # Is overwritten by ${SEARXNG_PUBLIC_INSTANCE}
+  public_instance: false
 
   # If your instance owns a /etc/searxng/settings.yml file, then set the following
   # values there.
 
   secret_key: "ultrasecretkey"  # Is overwritten by ${SEARXNG_SECRET}
-  # Proxying image results through searx
+  # Proxy image results through SearXNG. Is overwritten by ${SEARXNG_IMAGE_PROXY}
   image_proxy: false
   # 1.0 and 1.1 are supported
   http_protocol_version: "1.0"
@@ -106,6 +110,7 @@ redis:
 ui:
   # Custom static path - leave it blank if you didn't change
   static_path: ""
+  # Is overwritten by ${SEARXNG_STATIC_USE_HASH}.
   static_use_hash: false
   # Custom templates path - leave it blank if you didn't change
   templates_path: ""

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -174,11 +174,11 @@ SCHEMA = {
     'server': {
         'port': SettingsValue((int, str), 8888, 'SEARXNG_PORT'),
         'bind_address': SettingsValue(str, '127.0.0.1', 'SEARXNG_BIND_ADDRESS'),
-        'limiter': SettingsValue(bool, False),
-        'public_instance': SettingsValue(bool, False),
+        'limiter': SettingsValue(bool, False, 'SEARXNG_LIMITER'),
+        'public_instance': SettingsValue(bool, False, 'SEARXNG_PUBLIC_INSTANCE'),
         'secret_key': SettingsValue(str, environ_name='SEARXNG_SECRET'),
         'base_url': SettingsValue((False, str), False, 'SEARXNG_BASE_URL'),
-        'image_proxy': SettingsValue(bool, False),
+        'image_proxy': SettingsValue(bool, False, 'SEARXNG_IMAGE_PROXY'),
         'http_protocol_version': SettingsValue(('1.0', '1.1'), '1.0'),
         'method': SettingsValue(('POST', 'GET'), 'POST'),
         'default_http_headers': SettingsValue(dict, {}),
@@ -188,7 +188,7 @@ SCHEMA = {
     },
     'ui': {
         'static_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'static')),
-        'static_use_hash': SettingsValue(bool, False),
+        'static_use_hash': SettingsValue(bool, False, 'SEARXNG_STATIC_USE_HASH'),
         'templates_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'templates')),
         'default_theme': SettingsValue(str, 'simple'),
         'default_locale': SettingsValue(str, ''),


### PR DESCRIPTION
## What does this PR do?

This PR adds support for recommended configuration settings from `settings.yml` when setting up public instances:
- image_proxy
- limiter
- static_use_hash
- public_instance

## Why is this change important?

When possible, its expected that docker images can be configured primarily through environment variables. Lessening the reliance upon manually configuring the settings.yml file helps with making this more deployable.

`limiter.toml` generation isn't in scope for this PR, but will be needed to fully realize the benefits of supporting enabling the limiter explicitly. However, the goal of this PR is to support the common public instance options, and setting `SEARXNG_PUBLIC_INSTANCE` still achieves this.

## How to test this PR locally?

[Build the docker image](https://docs.searxng.org/admin/installation-docker.html#build-the-image): `make docker.build`

Then run it with the new environment variables, but with the public instance one false, so we test it separate from the limiter variable.

```bash
docker run --rm -ti \
             -e SEARXNG_IMAGE_PROXY=true  \
             -e SEARXNG_LIMITER=true \
             -e SEARXNG_PUBLIC_INSTANCE=false \
             -e SEARXNG_STATIC_USE_HASH=true \
             -d -p 8080:8080 \
             ${GITHUB_LOGIN}/searxng
```

Validate the contents of the `settings.yml` file have had their default values overridden. Validate logs as well as contents of the `/config` endpoint.

Do the same, but with the inverse case
```bash
docker run --rm -ti \
             -e SEARXNG_IMAGE_PROXY=true  \
             -e SEARXNG_LIMITER=false \
             -e SEARXNG_PUBLIC_INSTANCE=true \
             -e SEARXNG_STATIC_USE_HASH=true \
             -d -p 8080:8080 \
             ${GITHUB_LOGIN}/searxng
```

## Author's checklist

Any feedback on the way I implemented the documentation for these new environment variables would be welcomed.

## Related issues
