### PR TITLE
[feat] mozhi: fix crash, support synonyms and definition

### DIFF
--- a/searx/engines/mozhi.py
+++ b/searx/engines/mozhi.py
@@ -4,6 +4,7 @@
 import random
 import re
 from urllib.parse import urlencode
+from flask_babel import gettext
 
 about = {
     "website": 'https://codeberg.org/aryak/mozhi',
@@ -43,12 +44,17 @@ def response(resp):
 
     if translation['word_choices']:
         for word in translation['word_choices']:
-            infobox += f"<dl><dt>{word['word']}</dt>"
+            infobox += f"<dl><dt>{word['word']}: {word['definition']}</dt>"
 
-            for example in word['examples_target']:
-                infobox += f"<dd>{re.sub(r'<|>', '', example)}</dd>"
+            if word['examples_target']:
+                for example in word['examples_target']:
+                    infobox += f"<dd>{re.sub(r'<|>', '', example)}</dd>"
+                    infobox += f"<dd>{re.sub(r'<|>', '', example)}</dd>"
 
             infobox += "</dl>"
+
+    if translation['source_synonyms']:
+        infobox += f"<dl><dt>{gettext('Synonyms')}: {', '.join(translation['source_synonyms'])}</dt></dl>"
 
     result = {
         'infobox': translation['translated-text'],


### PR DESCRIPTION
## What does this PR do?
- fix a crash when searching, reproducible with queries like `hey`, `test`, ...
- show the definition of the inserted and translated word if available
- show synonyms if available

## How to test this PR locally?
- !mozhi en-de bird

