### PR TITLE
[fix] !goi irrelevant results AND display more results

### DIFF
--- a/searx/engines/google_images.py
+++ b/searx/engines/google_images.py
@@ -63,16 +63,11 @@ def request(query, params):
         'https://'
         + google_info['subdomain']
         + '/search'
-        + "?"
-        + urlencode(
-            {
-                'q': query,
-                'tbm': "isch",
-                **google_info['params'],
-                'asearch': 'isch',
-                'async': '_fmt:json,p:1,ijn:' + str(params['pageno']),
-            }
-        )
+        + '?'
+        + urlencode({'q': query, 'tbm': "isch", **google_info['params'], 'asearch': 'isch'})
+        # don't urlencode this because wildly different AND bad results
+        # pagination uses Zero-based numbering
+        + f'&async=_fmt:json,p:1,ijn:{params["pageno"] - 1}'
     )
 
     if params['time_range'] in time_range_dict:
@@ -80,9 +75,13 @@ def request(query, params):
     if params['safesearch']:
         query_url += '&' + urlencode({'safe': filter_mapping[params['safesearch']]})
     params['url'] = query_url
-
     params['cookies'] = google_info['cookies']
     params['headers'].update(google_info['headers'])
+    # this ua will allow getting ~50 results instead of 10. #1641
+    params['headers']['User-Agent'] = (
+        'NSTN/3.60.474802233.release Dalvik/2.1.0 (Linux; U; Android 12;' f' {google_info.get("country", "US")}) gzip'
+    )
+
     return params
 
 
@@ -96,7 +95,6 @@ def response(resp):
     json_data = loads(resp.text[json_start:])
 
     for item in json_data["ischj"].get("metadata", []):
-
         result_item = {
             'url': item["result"]["referrer_url"],
             'title': item["result"]["page_title"],


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Fixes results from second page displaying on first page.
Adds ua from android app to get more results instead of just 10.
## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
Better and more results.
## How to test this PR locally?

make format.python
make run
`!goi your query`

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->
The custom headers have been removed from https://github.com/searxng/searxng/pull/1792 / commit cf7ee67f71f6c6b0c2e357ffef12a79d88fea73b but could not see why.
## Related issues

<!--
Closes #234
-->
Closes https://github.com/searxng/searxng/issues/1864