### PR TITLE
Fix search_url construction for elasticsearch/opensearch.

### DIFF
--- a/searx/engines/elasticsearch.py
+++ b/searx/engines/elasticsearch.py
@@ -49,7 +49,7 @@ base_url = 'http://localhost:9200'
 username = ''
 password = ''
 index = ''
-search_url = base_url + '/' + index + '/_search'
+search_url = '{base_url}/{index}/_search'
 query_type = 'match'
 custom_query_json = {}
 show_metadata = False
@@ -71,7 +71,7 @@ def request(query, params):
     if username and password:
         params['auth'] = (username, password)
 
-    params['url'] = search_url
+    params['url'] = search_url.format(base_url=base_url, index=index)
     params['method'] = 'GET'
     params['data'] = dumps(_available_query_types[query_type](query))
     params['headers']['Content-Type'] = 'application/json'


### PR DESCRIPTION
## What does this PR do?

Fixes the `search_url` construction to take the values of `base_url` and `index` into account.

## Why is this change important?

It's impossible to connect to an elasticsearch/opensearch instance not running on localhost:9200.

## How to test this PR locally?

1.  Uncomment elasticsearch in settings.yml.
2. Change `base_url` to http://localhost:9201, delete `disabled` line, add `enable_http: true`.
3.  Run a fake elasticsearch instance: `echo -e 'HTTP/1.0 200 OK\n\n{"hits":{"hits":[{"_source":{"content":"stuff"}}]}}' | nc -l -p 9201`.
4. Start searxng and search for `!es key:value`.

## Author's checklist

Not sure this ever worked because `index` would always have been empty, resulting in a call to localhost:9200//_search.

## Related issues

Issue https://github.com/searxng/searxng/issues/2034 raised this but was closed without an update.

<!--
Closes #234
-->
