### PR TITLE
[fix] disable Reddit engine by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1540,6 +1540,7 @@ engines:
     engine: reddit
     shortcut: re
     page_size: 25
+    disabled: true
 
   - name: rottentomatoes
     engine: rottentomatoes


### PR DESCRIPTION
Reddit is enabled by default .. many bot request will go through Reddit .. we should disable Reddit by default to cool down the IP [1].

[1] https://github.com/searxng/searxng/issues/3444#issuecomment-2180415057

Closes: https://github.com/searxng/searxng/issues/3444