### PR TITLE
[fix] unit test_xpath.py: name 'logger' is not defined

### DIFF
--- a/tests/unit/engines/test_xpath.py
+++ b/tests/unit/engines/test_xpath.py
@@ -3,8 +3,13 @@
 
 from collections import defaultdict
 import mock
+
 from searx.engines import xpath
+from searx import logger
+
 from tests import SearxTestCase
+
+logger = logger.getChild('engines')
 
 
 class TestXpathEngine(SearxTestCase):  # pylint: disable=missing-class-docstring
@@ -22,6 +27,9 @@ class TestXpathEngine(SearxTestCase):  # pylint: disable=missing-class-docstring
         </div>
     </div>
     """
+
+    def setUp(self):
+        xpath.logger = logger.getChild('test_xpath')
 
     def test_request(self):
         xpath.search_url = 'https://url.com/{query}'


### PR DESCRIPTION
Depending on the order in which the unit tests are executed, the python modules of the engines are initialized (monkey patched) or not. As the order of the tests is not static, random errors may occur.

To avaoid random `NameError: name 'logger' is not defined` in the unit tests of the xpath engine, a logger is monkey patched into the xpath py-module.

```
make test.unit
TEST      tests/unit
......EE...................
======================================================================
ERROR: test_response (tests.unit.engines.test_xpath.TestXpathEngine.test_response)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/unit/engines/test_xpath.py", line 60, in test_response
    self.assertEqual(xpath.response(response), [])
                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "./searx/engines/xpath.py", line 309, in response
    logger.debug("found %s results", len(results))
    ^^^^^^
NameError: name 'logger' is not defined

======================================================================
ERROR: test_response_results_xpath (tests.unit.engines.test_xpath.TestXpathEngine.test_response_results_xpath)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/unit/engines/test_xpath.py", line 102, in test_response_results_xpath
    self.assertEqual(xpath.response(response), [])
                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "./searx/engines/xpath.py", line 309, in response
    logger.debug("found %s results", len(results))
    ^^^^^^
NameError: name 'logger' is not defined
```
