### PR TITLE
[doc] adds the missing documentation of the server.method settings

### DIFF
--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -72,4 +72,4 @@
 .. _HTTP headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
 
 ``default_http_headers`` :
-  Set additional HTTP headers, see `#755 <https://github.com/searx/searx/issues/715>`__
+  Set additional `HTTP headers`_, see `#755 <https://github.com/searx/searx/issues/715>`__

--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -55,11 +55,21 @@
 
 .. _method:
 
-``method`` : ``$SEARXNG_METHOD``
-  Whether to use ``GET`` or ``POST`` HTTP method when searching.
+``method`` : ``GET`` | ``POST``
+  HTTP method.  By defaults ``POST`` is used / The ``POST`` method has the
+  advantage with some WEB browsers that the history is not easy to read, but
+  there are also various disadvantages that sometimes **severely restrict the
+  ease of use for the end user** (e.g. back button to jump back to the previous
+  search page and drag & drop of search term to new tabs do not work as
+  expected .. and several more).  We had a lot of long discussions about the
+  *pros v2 cons*:
+
+  - `set HTTP GET method by default
+    <https://github.com/searxng/searxng/pull/3619>`__
+  - `http methods GET & POST
+    <https://github.com/search?q=repo%3Asearxng%2Fsearxng+label%3A%22http+methods+GET+%26+POST%22>`__
 
 .. _HTTP headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
 
 ``default_http_headers`` :
   Set additional HTTP headers, see `#755 <https://github.com/searx/searx/issues/715>`__
-

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -100,8 +100,9 @@ server:
   image_proxy: false
   # 1.0 and 1.1 are supported
   http_protocol_version: "1.0"
-  # POST queries are more secure as they don't show up in history but may cause
-  # problems when using Firefox containers.
+  # POST queries are "more secure!" but are also the source of hard-to-locate
+  # annoyances, which is why GET may be better for end users and their browsers.
+  # see https://github.com/searxng/searxng/pull/3619
   # Is overwritten by ${SEARXNG_METHOD}
   method: "POST"
   default_http_headers:


### PR DESCRIPTION
TL;DR; For all the issues that comes with HTTP POST I recommend instance maintainers to switch to GET and lock the property in the preferences:

```yaml
server:
  method: GET

preferences:
  lock:
    - method
```

We don't want this in the defaults of the SearXNG distributions for the pro vs cons reasons named in the discussion below: 


-----------


HTTP GET vs POST
================

Already diskussed in "Method POST harms UX without providing a tangible privacy benefit" [1].  At that time we agreed to POST.  However, as we are having more and more drawbacks with POST, I suggest that we reconsider our previous decision. The latest cause was [2], but we also have other problems that negatively affect the UI [1]:

* Open Link in New Tab: does not work for our search result tabs because they aren't actual links.

* Bookmarking: a search becomes more difficult with POST. You cannot just press a browser keyboard shortcut `Ctrl+D` ... no you have to copy the Search URL from the sidebar. This can pose a real struggle for less technically-minded users.

* Sharing: a search with somebody else becomes more difficult with POST (for the same reason).

* [While autocompletion in the search field of SearXNG sends a cookie, the autocompletion in the URL bar does not send a cookie.](https://github.com/searxng/searxng/issues/1889#issuecomment-1565366772)
* https://github.com/searxng/searxng/pull/2333#issuecomment-1565392120
* [POST vs GET --> some broswers don't like HTTP POST requests in a OpenSearch query ](https://github.com/searxng/searxng/issues/431)

* https://github.com/searxng/searxng/issues/3590#issuecomment-2196891552

Lock HTTP method in the preferences
===================================

If the user changes the HTTP method in his settings, e.g. from GET to POST, but has not removed the SearXNG instance from the WEB browser and added it again, the WEB browser will continue to work with the old setting (GET), while entries in the HTML form use the newly set method (POST). Not realted to this commit, but this complication is also known from autocomplete[3].

Only very few maintainers are aware of this fact and probably none of the users know about it.  We should provide a setup in our defaults that is manageable in its entirety and comprehensible for the user.  For this reason, the option to select the HTTP method in the preferences is also disabled in this commit.

- [1] https://github.com/searxng/searxng/issues/711
- [2] https://github.com/searxng/searxng/issues/3590
- [3] https://github.com/searxng/searxng/pull/2333#issuecomment-1565392120
