### PR TITLE
[mod] libretranslate: add direct link to translation (engine)

### DIFF
--- a/searx/engines/libretranslate.py
+++ b/searx/engines/libretranslate.py
@@ -31,6 +31,7 @@ def request(_query, params):
 
     params['method'] = 'POST'
     params['headers'] = {'Content-Type': 'application/json'}
+    params['req_url'] = request_url
 
     return params
 
@@ -40,7 +41,13 @@ def response(resp):
 
     json_resp = resp.json()
     text = json_resp.get('translatedText')
+
+    from_lang = resp.search_params["from_lang"][1]
+    to_lang = resp.search_params["to_lang"][1]
+    query = resp.search_params["query"]
+    req_url = resp.search_params["req_url"]
+
     if text:
-        results.append({'answer': text})
+        results.append({"answer": text, "url": f"{req_url}/?source={from_lang}&target={to_lang}&q={query}"})
 
     return results


### PR DESCRIPTION
This may help for further translations.

## What does this PR do?

This adds a link to the used libretranslate instance. It uses `from_lang`, `to_lang`, and `query` to transfer the translation parameters.

## Why is this change important?

This can be helpful to do further translations on the libretranslate instance.

## How to test this PR locally?

Search string: `!lt en-de this is a nice test` - will output the search string in the answer field (as before) and in addition the link to the instance.

## Author's checklist

-

## Related issues

-