### PR TITLE
[enh] Allow using multiple autocompleters

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -96,6 +96,10 @@ class MultipleChoiceSetting(Setting):
     """Setting of values which can only come from the given choices"""
 
     def __init__(self, default_value: List[str], choices: Iterable[str], locked=False):
+        # backwards compat for autocomplete setting (was string, now is a list of strings)
+        if isinstance(default_value, str):
+            default_value = [str(val) for val in default_value.split(",")]
+
         super().__init__(default_value, locked)
         self.choices = choices
         self._validate_selections(self.value)
@@ -401,7 +405,7 @@ class Preferences:
                 locked=is_locked('locale'),
                 choices=list(LOCALE_NAMES.keys()) + ['']
             ),
-            'autocomplete': EnumStringSetting(
+            'autocomplete': MultipleChoiceSetting(
                 settings['search']['autocomplete'],
                 locked=is_locked('autocomplete'),
                 choices=list(autocomplete.backends.keys()) + ['']

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -29,10 +29,12 @@ brand:
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
-  # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "yandex", "mwmbl",
-  # "seznam", "startpage", "stract", "swisscows", "qwant", "wikipedia" - leave blank to turn it off
-  # by default.
-  autocomplete: ""
+  # Existing autocomplete backends: "dbpedia", "duckduckgo", "google",
+  # "yandex", "mwmbl", "seznam", "startpage", "stract", "swisscows", "qwant", "wikipedia"
+  # Uncomment the section below and edit/add/remove each engine to turn them on by default.
+  # autocomplete:
+  #  - duckduckgo
+  #  - stract
   # minimun characters to type before autocompleter starts
   autocomplete_min: 4
   # Default search language - leave blank to detect from browser information or

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -154,7 +154,7 @@ SCHEMA = {
     },
     'search': {
         'safe_search': SettingsValue((0, 1, 2), 0),
-        'autocomplete': SettingsValue(str, ''),
+        'autocomplete': SettingsValue((list, str, False), ['']),
         'autocomplete_min': SettingsValue(int, 4),
         'default_lang': SettingsValue(tuple(SXNG_LOCALE_TAGS + ['']), ''),
         'languages': SettingSublistValue(SXNG_LOCALE_TAGS, SXNG_LOCALE_TAGS),

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -329,6 +329,17 @@ def dict_subset(dictionary: MutableMapping, properties: Set[str]) -> Dict:
     return {k: dictionary[k] for k in properties if k in dictionary}
 
 
+def unique(iterable):
+    """Yield unique elements from 'iterable' while preserving order
+    https://github.com/mikf/gallery-dl/blob/e03b99ba0ecbf653b89e68d00245da78694071fb/gallery_dl/util.py#L64C1-L71C26"""
+    seen = set()
+    add = seen.add
+    for element in iterable:
+        if element not in seen:
+            add(element)
+            yield element
+
+
 def get_torrent_size(filesize: str, filesize_multiplier: str) -> Optional[int]:
     """
 

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -66,6 +66,14 @@ class TestSettings(SearxTestCase):  # pylint: disable=missing-class-docstring
 
     # multiple choice settings
 
+    def test_multiple_setting_default_value_invalid_commma_seperated(self):
+        with self.assertRaises(ValidationException):
+            MultipleChoiceSetting("duckduckgo,doesnotexist", choices=['duckduckgo', 'stract', 'qwant'])
+
+    def test_multiple_setting_default_value_valid_commma_seperated(self):
+        setting = MultipleChoiceSetting("duckduckgo,stract", choices=['duckduckgo', 'stract', 'qwant'])
+        self.assertEqual(setting.get_value(), ['duckduckgo', 'stract'])
+
     def test_multiple_setting_invalid_default_value(self):
         with self.assertRaises(ValidationException):
             MultipleChoiceSetting(['3', '4'], choices=['0', '1', '2'])

--- a/tests/unit/test_settings_loader.py
+++ b/tests/unit/test_settings_loader.py
@@ -121,3 +121,4 @@ class TestUserSettings(SearxTestCase):  # pylint: disable=missing-class-docstrin
             self.assertEqual(settings['server']['secret_key'], "user_settings_secret")
             engine_names = [engine['name'] for engine in settings['engines']]
             self.assertEqual(engine_names, ['wikidata', 'wikibooks', 'wikinews', 'wikiquote'])
+            self.assertIsInstance(settings['search']['autocomplete'], (list, str))


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Allows setting multiple autocompleters.
## Why is this change important?
Get different suggestions at the same time.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

1. make test
2. make run
3. enable multiple autocomplete engines in your settings, e.x
```yaml
autocomplete:
  - duckduckgo
  - stract
```
####
Note: the existing string value will still continue to work and will be comma seperated to set more multiple ones.
  

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->
Are there any edge cases?
## Related issues
https://github.com/searxng/searxng/issues/1889

<!--
Closes #234
-->
