### PR TITLE
[fix] html.unescape stract autocomplete suggestions

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -5,6 +5,7 @@
 # pylint: disable=use-dict-literal
 
 import json
+import html
 from urllib.parse import urlencode, quote_plus
 
 import lxml
@@ -162,7 +163,7 @@ def stract(query, _lang):
     if not resp.ok:
         return []
 
-    return [suggestion['raw'] for suggestion in resp.json()]
+    return [html.unescape(suggestion['raw']) for suggestion in resp.json()]
 
 
 def startpage(query, sxng_locale):


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Unescape html entities for better readability of autocomplete suggestions.
## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

1. `make format.python`
2. `make test`
3. `make run`
4. set stract as autocompleter and search for ```who is``` or ```what is```.

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->
Is more unescaping needed?
## Related issues
N/A
<!--
Closes #234
-->
