### PR TITLE
[fix] engine yacy: update list of base URLs

### DIFF
--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -118,6 +118,8 @@ def _base_url() -> str:
     url = engines['yacy'].base_url  # type: ignore
     if isinstance(url, list):
         url = random.choice(url)
+    if url.endswith("/"):
+        url = url[:-1]
     return url
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2125,21 +2125,25 @@ engines:
     disabled: true
 
   - name: yacy
+    # https://docs.searxng.org/dev/engines/online/yacy.html
     engine: yacy
     categories: general
     search_type: text
     base_url:
       - https://yacy.searchlab.eu
-      - https://search.lomig.me
-      - https://yacy.ecosys.eu
-      - https://search.webproject.link
+      # see https://github.com/searxng/searxng/pull/3631#issuecomment-2240903027
+      # - https://search.kyun.li
+      # - https://yacy.securecomcorp.eu
+      # - https://yacy.myserv.ca
+      # - https://yacy.nsupdate.info
+      # - https://yacy.electroncash.de
     shortcut: ya
     disabled: true
-    # required if you aren't using HTTPS for your local yacy instance
-    # https://docs.searxng.org/dev/engines/online/yacy.html
-    # enable_http: true
-    # timeout: 3.0
-    # search_mode: 'global'
+    # if you aren't using HTTPS for your local yacy instance disable https
+    # enable_http: false
+    search_mode: 'global'
+    # timeout can be reduced in 'local' search mode
+    timeout: 5.0
 
   - name: yacy images
     engine: yacy


### PR DESCRIPTION
https://search.lomig.me
  Poor results / tested `!yacy :en hello` and got zero results

https://yacy.ecosys.eu
  Slow response (> 6sec for trivial search terms)

https://search.webproject.link
  Dead instance / URL offline

## we need more stable yacy instances 

.. suggestions are welcome

-----

Related:

- https://github.com/searxng/searxng/issues/3428
- https://github.com/searxng/searxng/pull/3472