### PR TITLE
[mod] remove py 3.6 leftovers

### DIFF
--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -11,16 +11,12 @@ from typing import Any, Dict
 import httpx
 from httpx_socks import AsyncProxyTransport
 from python_socks import parse_proxy_url, ProxyConnectionError, ProxyTimeoutError, ProxyError
+import uvloop
 
 from searx import logger
 
-# Optional uvloop (support Python 3.6)
-try:
-    import uvloop
-except ImportError:
-    pass
-else:
-    uvloop.install()
+
+uvloop.install()
 
 
 logger = logger.getChild('searx.network.client')


### PR DESCRIPTION
## What does this PR do?
Removes `uvloop`.
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?
Python 3.6 is not supported.
<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?
 
- `make test` 
- `make run` 
- search `contrafibularities`.

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->
Will this break anything? Because the above worked.
https://github.com/search?q=repo%3Asearxng%2Fsearxng%20uvloop&type=code

## Related issues
https://github.com/MagicStack/uvloop/pull/578
<!--
Closes #234
-->
N/A