### PR TITLE
Update Mullvad Leta to account for new img element

### DIFF
--- a/searx/engines/mullvad_leta.py
+++ b/searx/engines/mullvad_leta.py
@@ -128,7 +128,14 @@ def request(query: str, params: dict):
 
 
 def extract_result(dom_result: list[html.HtmlElement]):
-    [a_elem, h3_elem, p_elem] = dom_result
+    # Infoboxes sometimes appear in the beginning and will have a length of 0
+    if len(dom_result) == 3:
+        [a_elem, h3_elem, p_elem] = dom_result
+    elif len(dom_result) == 4:
+        [_, a_elem, h3_elem, p_elem] = dom_result
+    else:
+        return None
+
     return {
         'url': extract_text(a_elem.text),
         'title': extract_text(h3_elem),
@@ -139,9 +146,9 @@ def extract_result(dom_result: list[html.HtmlElement]):
 def extract_results(search_results: html.HtmlElement):
     for search_result in search_results:
         dom_result = eval_xpath_list(search_result, 'div/div/*')
-        # sometimes an info box pops up, will need to filter that out
-        if len(dom_result) == 3:
-            yield extract_result(dom_result)
+        result = extract_result(dom_result)
+        if result is not None:
+            yield result
 
 
 def response(resp: Response):


### PR DESCRIPTION
## What does this PR do?

A recent update from Mullvad Leta introduced the img element as the favicon icon in the returned results. This update broke the existing logic. Now, by checking the length of the dom_result to see if it was included in the return results, we can handle the logic accordingly. 

## Why is this change important?

Fixes a regression in the Mullvad Leta integration.

## How to test this PR locally?

1. Ensure you have Mullvad VPN enabled and connected
2. Uncomment the engine from the `settings.yml`
3. Run Searxng, and search via `!ml foobar`, with the following settings:
  - `leta_engine = google`
  - `leta_engine = brave`

## Author's checklist
n/a

## Related issues
n/a

## Screenshots

**Updated HTML results**
![image](https://github.com/searxng/searxng/assets/58887802/17ce40cf-6761-4195-89bc-3cd647789fef)

**Google**
![image](https://github.com/searxng/searxng/assets/58887802/32cb9a68-19eb-4345-a5d8-880d08413217)

**Brave**
I copied the settings for a brave specific engine for `mlb`
![image](https://github.com/searxng/searxng/assets/58887802/1f455d41-b87f-436b-b947-4a6c314d64a9)
