### PR TITLE
Flush flag icon to the right in the search_language select option values

### DIFF
--- a/searx/templates/simple/filters/languages.html
+++ b/searx/templates/simple/filters/languages.html
@@ -1,12 +1,19 @@
 <select class="language" id="language" name="language" aria-label="{{ _('Search language') }}">{{- '' -}}
-	<option value="all" {% if current_language == 'all' %}selected="selected"{% endif %}>{{ _('Default language') }} [all]</option>
-	<option value="auto" {% if current_language == 'auto' %}selected="selected"{% endif %}>
-		{{- _('Auto-detect') -}}
-		{%- if current_language == 'auto' %} ({{ search_language }}){%- endif -%}
-	</option>
-	{%- for sxng_tag,lang_name,country_name,english_name,flag in sxng_locales | sort(attribute=1) -%}
-	<option value="{{ sxng_tag }}" {% if sxng_tag == current_language %}selected="selected"{% endif %}>
-		{% if flag %}{{ flag }} {% endif%} {{- lang_name }} {% if country_name %} - {{ country_name }} {% endif %} [{{sxng_tag}}]
-	</option>
-	{%- endfor -%}
+  <option value="all" {% if current_language == 'all' %}selected="selected"{% endif %}>{{ _('Default language') }} [all]</option>{{- '' -}}
+  <option value="all"
+          {%- if current_language == 'all' %} selected="selected" {%- endif -%}>
+          {{- _('Default language') }} [all] {{- '' -}}
+  </option>{{- '' -}}
+  <option value="auto"
+          {%- if current_language == 'auto' %} selected="selected" {%- endif -%}>
+          {{- _('Auto-detect') }} [auto] {{- '' -}}
+  </option>{{- '' -}}
+  {% for sxng_tag,lang_name,country_name,english_name,flag in sxng_locales | sort(attribute=1) -%}
+    <option value="{{ sxng_tag }}"
+            {%- if sxng_tag == current_language %} selected="selected" {%- endif -%}>
+            {{ lang_name }}{%- if country_name -%}-{{ country_name }}{%- endif -%}
+            {{- ' ' -}}[{{sxng_tag}}]{{- ' ' -}}
+            {%- if flag -%}{{ flag }}{%- endif -%}
+    </option>
+  {%- endfor -%}
 </select>

--- a/searx/templates/simple/preferences/language.html
+++ b/searx/templates/simple/preferences/language.html
@@ -13,9 +13,9 @@
       {% for sxng_tag,lang_name,country_name,english_name,flag in sxng_locales | sort(attribute=1) -%}
         <option value="{{ sxng_tag }}"
                 {%- if sxng_tag == current_language %} selected="selected" {%- endif -%}>
-                {%- if flag -%}{{ flag }} {% endif -%}
                 {{ lang_name }}{%- if country_name -%}-{{ country_name }}{%- endif -%}
-                {{- ' ' -}}[{{sxng_tag}}]{{- '' -}}
+                {{- ' ' -}}[{{sxng_tag}}]{{- ' ' -}}
+                {%- if flag -%}{{ flag }}{%- endif -%}
         </option>
       {%- endfor -%}
     </select>{{- '' -}}


### PR DESCRIPTION
## What does this PR do?

Move the flag icon next to the language to the right in the option value for languages.

## Why is this change important?

If the flag icon is first, it prevents easily searching the select list on the keyboard. By moving the icon fully to the right, this will enable a user to search the select list.

## How to test this PR locally?
1. Run SearXNG locally
2. Navigate to the preferences page
3. Click on the select option for `Search language`
4. Validate the icons are to the right instead of to the left

## Author's checklist
n/a

## Related issues

- closes: #3645
- closes: #1885

## Screenshots

![image](https://github.com/searxng/searxng/assets/58887802/a943842b-f663-4e9c-9f64-ba6b88eec3fa)

