### PR TITLE
[fix] tear down TEST_ENGINES after TestBang is proceeded

### DIFF
--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=missing-module-docstring
 
-from searx import settings
 from searx.engines import load_engines
 from searx.query import RawTextQuery
 from tests import SearxTestCase
@@ -234,8 +233,13 @@ class TestBang(SearxTestCase):  # pylint:disable=missing-class-docstring
     SPECIFIC_BANGS = ['!dummy_engine', '!du', '!general']
     THE_QUERY = 'the query'
 
-    def test_bang(self):
+    def setUp(self):
         load_engines(TEST_ENGINES)
+
+    def tearDown(self):
+        load_engines([])
+
+    def test_bang(self):
 
         for bang in TestBang.SPECIFIC_BANGS:
             with self.subTest(msg="Check bang", bang=bang):
@@ -247,7 +251,6 @@ class TestBang(SearxTestCase):  # pylint:disable=missing-class-docstring
                 self.assertEqual(query.user_query_parts, TestBang.THE_QUERY.split(' '))
 
     def test_specific(self):
-        load_engines(TEST_ENGINES)
         for bang in TestBang.SPECIFIC_BANGS:
             with self.subTest(msg="Check bang is specific", bang=bang):
                 query_text = TestBang.THE_QUERY + ' ' + bang
@@ -255,12 +258,10 @@ class TestBang(SearxTestCase):  # pylint:disable=missing-class-docstring
                 self.assertTrue(query.specific)
 
     def test_bang_not_found(self):
-        load_engines(TEST_ENGINES)
         query = RawTextQuery('the query !bang_not_found', [])
         self.assertEqual(query.getFullQuery(), 'the query !bang_not_found')
 
     def test_bang_autocomplete(self):
-        load_engines(TEST_ENGINES)
         query = RawTextQuery('the query !dum', [])
         self.assertEqual(query.autocomplete_list, ['!dummy_engine'])
 
@@ -269,7 +270,6 @@ class TestBang(SearxTestCase):  # pylint:disable=missing-class-docstring
         self.assertEqual(query.getQuery(), '!dum the query')
 
     def test_bang_autocomplete_empty(self):
-        load_engines(settings['engines'])
         query = RawTextQuery('the query !', [])
         self.assertEqual(query.autocomplete_list, ['!images', '!wikipedia', '!osm'])
 


### PR DESCRIPTION
Engines are loaded into global name `searx.engines.engines` other applications such as statistics or the histogram use this global variable to search for values in their own memories, which can lead to key errors as described in

- https://github.com/searxng/searxng/issues/2988

## Related issues

Closes: https://github.com/searxng/searxng/issues/2988
