### PR TITLE
Dockerfile: use Alpine 3.20 & Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.20
 ENTRYPOINT ["/sbin/tini","--","/usr/local/searxng/dockerfiles/docker-entrypoint.sh"]
 EXPOSE 8080
 VOLUME /etc/searxng


### PR DESCRIPTION
## What does this PR do?

Use Alpine 3.20 and Python 3.12

EOL of 3.19 is [2025-11-01](https://alpinelinux.org/releases/), so there is time (only security issues are fixed, but we never has specific issues related to Alpine).

## Why is this change important?

Up to date dependency.
Slightly faster Python 3.12.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

We might want to add a `linux/riscv64` docker image ?

Ref: https://github.com/searxng/searxng/blob/5468d97d39d47701e652db88920eb40068312152/manage#L190

Note: I know the branch should have been in my fork.

## Related issues

<!--
Closes #234
-->
