### PR TITLE
Fixes #3649

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN apk add --no-cache -t build-dependencies \
     git \
  && apk add --no-cache \
     ca-certificates \
-    su-exec \
     python3 \
     py3-pip \
     libxml2 \

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -175,4 +175,4 @@ unset MORTY_KEY
 
 # Start uwsgi
 printf 'Listen on %s\n' "${BIND_ADDRESS}"
-exec su-exec searxng:searxng uwsgi --master --http-socket "${BIND_ADDRESS}" "${UWSGI_SETTINGS_PATH}"
+exec uwsgi --master --uid searxng --gid searxng --http-socket "${BIND_ADDRESS}" "${UWSGI_SETTINGS_PATH}"


### PR DESCRIPTION
## What does this PR do?

Uses uWSGI own setuid/setgid options on docker-entrypoint, removes unused `su-exec`.

## Why is this change important?

https://github.com/searxng/searxng/issues/3649#issuecomment-2238914327

## How to test this PR locally?

Build & run image, see journal for container logs and check priority for each entry.

## Related issues

Fixes https://github.com/searxng/searxng/issues/3649
