### PR TITLE
[enh] Add API Key support for discourse.org forums

### DIFF
--- a/searx/engines/discourse.py
+++ b/searx/engines/discourse.py
@@ -10,6 +10,8 @@ engine offers some additional settings:
 - :py:obj:`api_order`
 - :py:obj:`search_endpoint`
 - :py:obj:`show_avatar`
+- :py:obj:`api_key`
+- :py:obj:`api_username`
 
 Example
 =======
@@ -26,6 +28,20 @@ for the ``paddling.com`` forum:
      api_order: views
      categories: ['social media', 'sports']
      show_avatar: true
+
+If the forum is private, you need to add an API key and username for the search:
+
+.. code:: yaml
+
+   - name: paddling
+     engine: discourse
+     shortcut: paddle
+     base_url: 'https://forums.paddling.com/'
+     api_order: views
+     categories: ['social media', 'sports']
+     show_avatar: true
+     api_key: '<KEY>'
+     api_username: 'system'
 
 
 Implementations
@@ -65,6 +81,12 @@ api_order = 'likes'
 show_avatar = False
 """Show avatar of the user who send the post."""
 
+api_key = ''
+"""API key of the Discourse forum."""
+
+api_username = ''
+"""API username of the Discourse forum."""
+
 paging = True
 time_range_support = True
 
@@ -97,6 +119,12 @@ def request(query, params):
         'Accept': 'application/json, text/javascript, */*; q=0.01',
         'X-Requested-With': 'XMLHttpRequest',
     }
+
+    if api_key != '':
+        params['headers']['Api-Key'] = api_key
+
+    if api_username != '':
+        params['headers']['Api-Username'] = api_username
 
     return params
 


### PR DESCRIPTION
## What does this PR do?

This PR adds the option to connect to private discourse instances using the API Key and API Username.

[API Documentation](https://docs.discourse.org)

Example provided by the documentation.

```shell
curl -X GET "http://127.0.0.1:3000/admin/users/list/active.json" \
-H "Api-Key: 714552c6148e1617aeab526d0606184b94a80ec048fc09894ff1a72b740c5f19" \
-H "Api-Username: system"
```

## Why is this change important?

This PR allows to use private instances of Discourse. Discourse is already supported but only for publicly accessible content.

## How to test this PR locally?

You will need to deploy a test discourse environment (I recommend [this documentation](https://meta.discourse.org/t/install-discourse-for-development-using-docker/102009))

Once the instance is running, go in `Admin > Community > Login & Authentication > Login` and check the option `login required - Require authentication to read content on this site, disallow anonymous access.`

Then to create an API Key, go in `Admin > Advanced > API Keys`, then `New API Key`:
* User Level: `All users`
* Scope: `Read-Only`

In `settings.yml`:
```yaml
  - name: discuss.private
    engine: discourse
    shortcut: dprv
    base_url: 'https://<HOST>'
    categories: [it, q&a]
    disabled: false
    api_key: '<KEY>'
    api_username: 'system'
```

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
