### PR TITLE
[fix] remove unused code / `_STORAGE_UNIT_VALUE`

### DIFF
--- a/searx/utils.py
+++ b/searx/utils.py
@@ -44,16 +44,6 @@ _JS_QUOTE_KEYS_RE = re.compile(r'([\{\s,])(\w+)(:)')
 _JS_VOID_RE = re.compile(r'void\s+[0-9]+|void\s*\([0-9]+\)')
 _JS_DECIMAL_RE = re.compile(r":\s*\.")
 
-_STORAGE_UNIT_VALUE: Dict[str, int] = {
-    'TB': 1024 * 1024 * 1024 * 1024,
-    'GB': 1024 * 1024 * 1024,
-    'MB': 1024 * 1024,
-    'TiB': 1000 * 1000 * 1000 * 1000,
-    'GiB': 1000 * 1000 * 1000,
-    'MiB': 1000 * 1000,
-    'KiB': 1000,
-}
-
 _XPATH_CACHE: Dict[str, XPath] = {}
 _LANG_TO_LC_CACHE: Dict[str, Dict[str, str]] = {}
 


### PR DESCRIPTION
The `_STORAGE_UNIT_VALUE` dictionary is a left over from:

- https://github.com/searxng/searxng/pull/3570

in this PR we removed the old implementations but forgot to delete this `_STORAGE_UNIT_VALUE`.

Closes: https://github.com/searxng/searxng/pull/3672
