### PR TITLE
[feat] use instance_name for index page title

### DIFF
--- a/searx/templates/simple/index.html
+++ b/searx/templates/simple/index.html
@@ -2,7 +2,7 @@
 {% from 'simple/icons.html' import icon_big %}
 {% block content %}
 <div class="index">
-    <div class="title"><h1>SearXNG</h1></div>
+    <div class="title"><h1>{{instance_name}}</h1></div>
     {% include 'simple/simple_search.html' %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## What does this PR do?

This uses `instance_name` from the settings file to configure the `<title>` node in index.html.

## Why is this change important?

I think the name 'searxng' is confusing/weird for the folks I share my instance with, and would like to have the `instance_name` I set in settings.yml show up instead on index.html

## How to test this PR locally?

`make run`

## Author's checklist

**NOTE**: this isn't actually working correctly and I'm not sure why. In the screenshot below, the big blue "SearXNG" should have been replaced by a big blue "boop":

![2024-07-27-102830_grim](https://github.com/user-attachments/assets/383a576c-2325-4d79-8831-82f8b6cb58b3)


## Related issues

n/a