### PR TITLE
[fix] fix issues in the language menue introduced by PR #3645

### DIFF
--- a/searx/templates/simple/filters/languages.html
+++ b/searx/templates/simple/filters/languages.html
@@ -1,12 +1,11 @@
 <select class="language" id="language" name="language" aria-label="{{ _('Search language') }}">{{- '' -}}
-  <option value="all" {% if current_language == 'all' %}selected="selected"{% endif %}>{{ _('Default language') }} [all]</option>{{- '' -}}
   <option value="all"
           {%- if current_language == 'all' %} selected="selected" {%- endif -%}>
           {{- _('Default language') }} [all] {{- '' -}}
   </option>{{- '' -}}
   <option value="auto"
           {%- if current_language == 'auto' %} selected="selected" {%- endif -%}>
-          {{- _('Auto-detect') }} [auto] {{- '' -}}
+          {{- _('Auto-detect') }} ({{ search_language }})  {{- '' -}}
   </option>{{- '' -}}
   {% for sxng_tag,lang_name,country_name,english_name,flag in sxng_locales | sort(attribute=1) -%}
     <option value="{{ sxng_tag }}"


### PR DESCRIPTION
In my review of [1] I tried to reformat the template code of the language menue whereby I have made two mistakes.

- default language was added twice
- in the 'Auto-detect' item a hard coded `[auto]` was implemented where the
  search_language variable was needed.

[1] https://github.com/searxng/searxng/issues/3645
