### PR TITLE
[fix] engine geizhals: if there are no offers, there is no best price

### DIFF
--- a/searx/engines/geizhals.py
+++ b/searx/engines/geizhals.py
@@ -86,12 +86,12 @@ def response(resp):
             'title': extract_text(eval_xpath(result, ".//h3[contains(@class, 'listview__name')]")),
             'content': ' | '.join(content),
             'thumbnail': extract_text(eval_xpath(result, ".//img[contains(@class, 'listview__image')]/@src")),
-            'price': "Bestes Angebot: "
-            + extract_text(eval_xpath(result, ".//a[contains(@class, 'listview__price-link')]")).split(" ")[1]
-            + "€",
             'metadata': ', '.join(item for item in metadata if item),
         }
 
+        best_price = extract_text(eval_xpath(result, ".//a[contains(@class, 'listview__price-link')]")).split(" ")
+        if len(best_price) > 1:
+            item["price"] = f"Bestes Angebot: {best_price[1]}€"
         results.append(item)
 
     return results


### PR DESCRIPTION
Fault pattern: if there are no offers, then an exception has been thrown:

    IndexError: list index out of range

This patch makes the addition of “best price” dependent on whether one exists.

Closes: #3685

