### PR TITLE
[fix] brave fetch_traits: Brave added Chinese (zh-hant) to UI

### DIFF
--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -6,20 +6,21 @@
         "book_nonfiction",
         "book_fiction",
         "book_unknown",
-        "book_comic",
         "magazine",
-        "standards_document"
+        "book_comic",
+        "standards_document",
+        "musical_score"
       ],
       "ext": [
         "pdf",
         "epub",
         "fb2",
-        "cbr",
         "mobi",
-        "cbz",
-        "azw3",
+        "cbr",
         "djvu",
-        "txt"
+        "txt",
+        "cbz",
+        "azw3"
       ],
       "sort": [
         "",
@@ -46,6 +47,7 @@
       "cy": "cy",
       "da": "da",
       "de": "de",
+      "dz": "dz",
       "el": "el",
       "en": "en",
       "eo": "eo",
@@ -77,7 +79,6 @@
       "ml": "ml",
       "mn": "mn",
       "mr": "mr",
-      "ms": "ms",
       "nl": "nl",
       "no": "no",
       "pl": "pl",
@@ -85,7 +86,6 @@
       "ro": "ro",
       "ru": "ru",
       "rw": "rw",
-      "sa": "sa",
       "sk": "sk",
       "sl": "sl",
       "sr": "sr",
@@ -1761,6 +1761,7 @@
         "fr-FR": "fr-fr",
         "hr": "hr",
         "hu": "hu",
+        "id": "id",
         "it": "it",
         "ja-JP": "ja-jp",
         "lt": "lt",
@@ -1777,7 +1778,8 @@
         "sv": "sv",
         "sw-KE": "sw-ke",
         "tr": "tr",
-        "uk": "uk"
+        "uk": "uk",
+        "zh_Hant": "zh-hant"
       }
     },
     "data_type": "traits_v1",
@@ -1853,6 +1855,7 @@
         "fr-FR": "fr-fr",
         "hr": "hr",
         "hu": "hu",
+        "id": "id",
         "it": "it",
         "ja-JP": "ja-jp",
         "lt": "lt",
@@ -1869,7 +1872,8 @@
         "sv": "sv",
         "sw-KE": "sw-ke",
         "tr": "tr",
-        "uk": "uk"
+        "uk": "uk",
+        "zh_Hant": "zh-hant"
       }
     },
     "data_type": "traits_v1",
@@ -1945,6 +1949,7 @@
         "fr-FR": "fr-fr",
         "hr": "hr",
         "hu": "hu",
+        "id": "id",
         "it": "it",
         "ja-JP": "ja-jp",
         "lt": "lt",
@@ -1961,7 +1966,8 @@
         "sv": "sv",
         "sw-KE": "sw-ke",
         "tr": "tr",
-        "uk": "uk"
+        "uk": "uk",
+        "zh_Hant": "zh-hant"
       }
     },
     "data_type": "traits_v1",
@@ -2037,6 +2043,7 @@
         "fr-FR": "fr-fr",
         "hr": "hr",
         "hu": "hu",
+        "id": "id",
         "it": "it",
         "ja-JP": "ja-jp",
         "lt": "lt",
@@ -2053,7 +2060,8 @@
         "sv": "sv",
         "sw-KE": "sw-ke",
         "tr": "tr",
-        "uk": "uk"
+        "uk": "uk",
+        "zh_Hant": "zh-hant"
       }
     },
     "data_type": "traits_v1",
@@ -6243,7 +6251,6 @@
         "MQ",
         "MT",
         "MU",
-        "MV",
         "MW",
         "MX",
         "MY",
@@ -6270,6 +6277,7 @@
         "PR",
         "PS",
         "PT",
+        "PW",
         "PY",
         "QA",
         "RE",
@@ -6337,7 +6345,6 @@
       "am": "amharic",
       "ar": "arabic",
       "as": "assamese",
-      "ast": "asturian",
       "az": "azerbaijani",
       "ba": "bashkir",
       "be": "belarusian",
@@ -6380,7 +6387,6 @@
       "hu": "hungarian",
       "hy": "armenian",
       "id": "indonesian",
-      "ig": "igbo",
       "is": "icelandic",
       "it": "italian",
       "iu": "inuktitut",
@@ -6393,9 +6399,11 @@
       "kn": "kannada",
       "ko": "korean",
       "ku": "kurdish",
+      "kw": "cornish",
       "la": "latin",
       "lb": "luxembourgish",
       "ln": "lingala",
+      "lo": "lao",
       "lt": "lithuanian",
       "lv": "latvian",
       "mg": "malagasy",
@@ -6698,7 +6706,6 @@
       "ml": "ml",
       "mn": "mn",
       "mr": "mr",
-      "ms": "ms",
       "nb": "no",
       "ne": "ne",
       "or": "or",
@@ -7131,7 +7138,6 @@
         "ml": "ml.wikipedia.org",
         "mn": "mn.wikipedia.org",
         "mr": "mr.wikipedia.org",
-        "ms": "ms.wikipedia.org",
         "ne": "ne.wikipedia.org",
         "no": "no.wikipedia.org",
         "or": "or.wikipedia.org",
@@ -7220,7 +7226,6 @@
       "ml": "ml",
       "mn": "mn",
       "mr": "mr",
-      "ms": "ms",
       "nb": "no",
       "ne": "ne",
       "or": "or",

--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -430,10 +430,10 @@ def fetch_traits(engine_traits: EngineTraits):
 
         ui_lang = option.get('value')
         try:
-            if '-' in ui_lang:
+            if '-' in ui_lang and not ui_lang.startswith("zh-"):
                 sxng_tag = region_tag(babel.Locale.parse(ui_lang, sep='-'))
             else:
-                sxng_tag = language_tag(babel.Locale.parse(ui_lang))
+                sxng_tag = language_tag(babel.Locale.parse(ui_lang, sep='-'))
 
         except babel.UnknownLocaleError:
             print("ERROR: can't determine babel locale of Brave's (UI) language %s" % ui_lang)

--- a/searx/sxng_locales.py
+++ b/searx/sxng_locales.py
@@ -76,7 +76,6 @@ sxng_locales = (
     ('lv', 'Latviešu', '', 'Latvian', '\U0001f310'),
     ('ml', 'മലയാളം', '', 'Malayalam', '\U0001f310'),
     ('mr', 'मराठी', '', 'Marathi', '\U0001f310'),
-    ('ms', 'Melayu', '', 'Malay', '\U0001f310'),
     ('nb', 'Norsk Bokmål', '', 'Norwegian Bokmål', '\U0001f310'),
     ('nb-NO', 'Norsk Bokmål', 'Norge', 'Norwegian Bokmål', '\U0001f1f3\U0001f1f4'),
     ('nl', 'Nederlands', '', 'Dutch', '\U0001f310'),


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the fetch traits function from the brave engine (reported in CI [1]) and in the second commit a `make data.traits` updates the `searx/data/engine_traits.json`

[1] https://github.com/searxng/searxng/actions/runs/10135834050/job/28023757191