### PR TITLE
fix[google]: Strip bubble text from answers

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -338,7 +338,7 @@ def response(resp):
             bubble.drop_tree()
         results.append(
             {
-                'answer': item.xpath("normalize-space()"),
+                'answer': extract_text(item),
                 'url': (eval_xpath(item, '../..//a/@href') + [None])[0],
             }
         )

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -334,6 +334,8 @@ def response(resp):
     # results --> answer
     answer_list = eval_xpath(dom, '//div[contains(@class, "LGOjhe")]')
     for item in answer_list:
+        for bubble in eval_xpath(item, './/div[@class="nnFGuf"]'):
+            bubble.drop_tree()
         results.append(
             {
                 'answer': item.xpath("normalize-space()"),


### PR DESCRIPTION
## What does this PR do?

Google underlines words inside of answers that can be clicked to show additional definitions (bubbles). These definitions inside the answer were not correctly handled and ended up in the middle of the answer text. With this fix, the extra definitions are stripped from the answer shown by the frontend.

## Why is this change important?

The answer text contains undesired text in the middle of the sentences.

## How to test this PR locally?

Example query “distance earth to sun” with language set to en.

## Author's checklist

N/A

## Related issues

N/A

## Screenshots

### Google

![2024-07-29-21-50-06](https://github.com/user-attachments/assets/6ff2563d-7664-44cd-91be-77c9ed630037)

### Before

![2024-07-29-21-52-12](https://github.com/user-attachments/assets/20b4a132-11e3-45bc-9ab1-0800db09a0f2)

### After

![2024-07-29-21-52-50](https://github.com/user-attachments/assets/50840e40-f8a3-4d48-b94a-66b3c710678c)

~(Don't mind the different URL in the corner. That's just because I used a public instance for the before screenshot and the URL for the answer happened to be slightly different.)~