### PR TITLE
[fix] pip install -e: legacy editable install (setup.py develop) is deprecated

### DIFF
--- a/docs/build-templates/searxng.rst
+++ b/docs/build-templates/searxng.rst
@@ -123,7 +123,7 @@ ${fedora_build}
 
        # jump to SearXNG's working tree and install SearXNG into virtualenv
        (${SERVICE_USER})$ cd \"$SEARXNG_SRC\"
-       (${SERVICE_USER})$ pip install -e .
+       (${SERVICE_USER})$ pip install --use-pep517 --no-build-isolation -e .
 
 
 .. END manage.sh update_packages

--- a/docs/dev/makefile.rst
+++ b/docs/dev/makefile.rst
@@ -61,7 +61,7 @@ working tree and release a ``make install`` to get a virtualenv with a
    $ make install
    PYENV     [virtualenv] installing ./requirements*.txt into local/py3
    ...
-   PYENV     [install] pip install -e 'searx[test]'
+   PYENV     [install] pip install --use-pep517 --no-build-isolation -e 'searx[test]'
    ...
    Successfully installed searxng-2023.7.19+a446dea1b
 
@@ -78,7 +78,7 @@ the check fails if you edit the requirements listed in
    ...
    PYENV     [virtualenv] installing ./requirements*.txt into local/py3
    ...
-   PYENV     [install] pip install -e 'searx[test]'
+   PYENV     [install] pip install --use-pep517 --no-build-isolation -e 'searx[test]'
    ...
    Successfully installed searxng-2023.7.19+a446dea1b
 

--- a/manage
+++ b/manage
@@ -299,8 +299,8 @@ pyenv.install() {
 
     (   set -e
         pyenv
-        build_msg PYENV "[install] pip install -e 'searx${PY_SETUP_EXTRAS}'"
-        "${PY_ENV_BIN}/python" -m pip install -e ".${PY_SETUP_EXTRAS}"
+        build_msg PYENV "[install] pip install --use-pep517 --no-build-isolation -e 'searx${PY_SETUP_EXTRAS}'"
+        "${PY_ENV_BIN}/python" -m pip install --use-pep517 --no-build-isolation -e ".${PY_SETUP_EXTRAS}"
     )
     local exit_val=$?
     if [ ! $exit_val -eq 0 ]; then

--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -663,8 +663,8 @@ pyenv.install() {
             pyenv
         fi
         for i in ${PYOBJECTS}; do
-    	    build_msg PYENV "[install] pip install -e '$i${PY_SETUP_EXTRAS}'"
-    	    "${PY_ENV_BIN}/python" -m pip install -e "$i${PY_SETUP_EXTRAS}"
+    	    build_msg PYENV "[install] pip install --use-pep517 --no-build-isolation -e '$i${PY_SETUP_EXTRAS}'"
+    	    "${PY_ENV_BIN}/python" -m pip install --use-pep517 --no-build-isolation -e "$i${PY_SETUP_EXTRAS}"
         done
     fi
     pyenv.install.OK

--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -505,7 +505,7 @@ pip install -U setuptools
 pip install -U wheel
 pip install -U pyyaml
 cd ${SEARXNG_SRC}
-pip install -e .
+pip install --use-pep517 --no-build-isolation -e .
 EOF
 }
 
@@ -573,7 +573,7 @@ pip install -U pip
 pip install -U setuptools
 pip install -U wheel
 pip install -U pyyaml
-pip install -U -e .
+pip install -U --use-pep517 --no-build-isolation -e .
 EOF
     rst_para "update instance's settings.yml from ${SEARXNG_SETTINGS_PATH}"
     DEFAULT_SELECT=2 \


### PR DESCRIPTION
From [1]: There is now a standardized mechanism [2] for an installer like pip to request an editable install of a project.  pip is transitioning to using this standard only instead of invoking the deprecated `setup.py develop` command.

For backward compatibility, we can use switches:

`--use-pep517`: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-use-pep517
`--no-build-isolation`: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-build-isolation

- [1] https://github.com/pypa/pip/issues/11457
- [2] https://peps.python.org/pep-0660/

Closes: https://github.com/searxng/searxng/issues/3701