### PR TITLE
[fix] online_currency.py: if more alternatives, use the last in the list

### DIFF
--- a/searx/search/processors/online_currency.py
+++ b/searx/search/processors/online_currency.py
@@ -23,7 +23,7 @@ def name_to_iso4217(name):
     currency = CURRENCIES['names'].get(name, [name])
     if isinstance(currency, str):
         return currency
-    return currency[0]
+    return currency[-1]
 
 
 def iso4217_to_name(iso4217, language):


### PR DESCRIPTION
If there are more than one ISO 4217 numeric codes [1] for a currency use the last one in the list of alternatives [2].

[1] https://en.wikipedia.org/wiki/ISO_4217#Active_codes_(list_one)
[2] https://en.wikipedia.org/wiki/ISO_4217#Historical_codes

Closes: https://github.com/searxng/searxng/issues/3713

