### PR TITLE
[enh] improved answer handling for Google engine

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -324,12 +324,12 @@ def _eval_answers(results, dom, xpath):
     answer_list = eval_xpath(dom, xpath)
     drop_elements = [
         './/div[@class="nnFGuf"]',
-        './/script',                        # Scripts like the calculator
-        './/table[@class="HOoTuc"]',        # The actual calculator controls
-        './/table[@class="ElumCf"]',        # The actual calculator buttons
-        './/div[@class="mDRaHd"]',          # Instructions with links
+        './/script',  # Scripts like the calculator
+        './/table[@class="HOoTuc"]',  # The actual calculator controls
+        './/table[@class="ElumCf"]',  # The actual calculator buttons
+        './/div[@class="mDRaHd"]',  # Instructions with links
         './/span[@class="W7GCoc CNbPnc"]',  # Feedback
-        './/*[@style="display:none"]',      # Hidden elements
+        './/*[@style="display:none"]',  # Hidden elements
     ]
     for item in answer_list:
         for element in eval_xpath(item, ' | '.join(drop_elements)):
@@ -340,20 +340,20 @@ def _eval_answers(results, dom, xpath):
         if table_elements:
             extracted_table = table_elements[0]
             extracted_table.attrib.clear()
-            for element in extracted_table.xpath(f'.//*'):
+            for element in extracted_table.xpath('.//*'):
                 element.attrib.clear()
             extracted_table.set('cellpadding', '2')
             extracted_table.set('cellspacing', '2')
             extracted_table.set('border', '0')
             extracted_table_html = html.tostring(extracted_table, pretty_print=True, encoding='unicode')
             is_safe = True
-        for element in eval_xpath(item, './/table'): # Drop all remaining tables
+        for element in eval_xpath(item, './/table'):  # Drop all remaining tables
             element.drop_tree()
         answer_content = extract_text(item)
         if extracted_table_html:
             answer_content += '<p>' + extracted_table_html
         url = (eval_xpath(item, '../..//a/@href') + [None])[0]
-        if url and url.startswith('/search?'): # If the answer is a Google search link, don't use it
+        if url and url.startswith('/search?'):  # If the answer is a Google search link, don't use it
             url = None
         results.append(
             {
@@ -376,21 +376,21 @@ def response(resp):
     dom = html.fromstring(resp.text)
     data_image_map = _parse_data_images(dom)
 
-    results = _eval_answers(results, dom, '//div[contains(@class, "card-section")]') # Look for cards first
+    results = _eval_answers(results, dom, '//div[contains(@class, "card-section")]')  # Look for cards first
     if not results:
-        results = _eval_answers(results, dom, '//div[contains(@class, "LGOjhe")]') # Look for rendered answers next
+        results = _eval_answers(results, dom, '//div[contains(@class, "LGOjhe")]')  # Look for rendered answers next
     # Look for JS DOM encoded string answers last
     if not results:
-        pattern = r"'\\x3c.*?\\x3e'" # These are DOM encoded strings that Google will push into the DOM
+        pattern = r"'\\x3c.*?\\x3e'"  # These are DOM encoded strings that Google will push into the DOM
         matches = re.findall(pattern, resp.text)
         for match in matches:
             decoded_html = match.encode().decode('unicode_escape')
             encoded_dom = html.fromstring(decoded_html)
             sub_doms = eval_xpath(encoded_dom, '//div[contains(@class, "LGOjhe")]')
             if sub_doms:
-                if '<span class="hgKElc"><b>' in decoded_html: # Main answers start with a bold
+                if '<span class="hgKElc"><b>' in decoded_html:  # Main answers start with a bold
                     results = _eval_answers(results, encoded_dom, '//div[contains(@class, "LGOjhe")]')
-                break # If it's a JS encoded answer, we only want the first one if it has bold above
+                break  # If it's a JS encoded answer, we only want the first one if it has bold above
 
     # parse results
 

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -23,7 +23,11 @@
     <div id="answers" role="complementary" aria-labelledby="answers-title"><h4 class="title" id="answers-title">{{ _('Answers') }} : </h4>
         {%- for answer in answers.values() -%}
         <div class="answer">
-        <span>{{ answer.answer }}</span>
+          {%- if answer.safe -%}
+            <span>{{ answer.answer | safe }}</span>
+          {%- else -%}
+            <span>{{ answer.answer }}</span>
+          {%- endif -%}
           {%- if answer.url -%}
           <a href="{{ answer.url }}" class="answer-url"
              {%- if results_on_new_tab %} target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
## What does this PR do?

Enhances the Google answer usage to include elements that Google obfuscates by default. This includes features such as asking specific questions, using the calculator, "table" support for answers that require a specific layout, and of course the original answer grabber. Some examples below include:

- `is vanilla antibacterial` - leveraging the original methodology
- `what is the capital of england` - specific question answer
- `what time is it in the united states` - specific question answer, with table support
- `what is 3+17` - calculator tool

![01](https://github.com/user-attachments/assets/0ec82c32-3d23-4b90-8c2b-c5eef3367da2)
![02](https://github.com/user-attachments/assets/cdde5f54-958a-46a0-af5a-62f3b6cab8ff)
![03](https://github.com/user-attachments/assets/87c0f150-9a28-42b8-b835-4dd1333f7eb8)
![04](https://github.com/user-attachments/assets/47db6c38-ee5b-4c0c-ab6f-3fbf0b9ed5ca)

## Why is this change important?

The current answer methodology for Google left out any obfuscated answers that existed in the Javascript. This leaves users coming from Google to SearXNG feeling like they may be missing out on something they used regularly.

## How to test this PR locally?

The best method is to set your only engine to Google and test out a number of different search strings.

## Related issues

Addresses latest comments in:

- https://github.com/searxng/searxng/discussions/2065#discussioncomment-10313761
