### PR TITLE
[upd] update to gecko driver v35

### DIFF
--- a/manage
+++ b/manage
@@ -41,7 +41,7 @@ PATH="${REPO_ROOT}/node_modules/.bin:${PATH}"
 
 PYOBJECTS="searx"
 PY_SETUP_EXTRAS='[test]'
-GECKODRIVER_VERSION="v0.34.0"
+GECKODRIVER_VERSION="v0.35.0"
 # SPHINXOPTS=
 BLACK_OPTIONS=("--target-version" "py311" "--line-length" "120" "--skip-string-normalization")
 BLACK_TARGETS=("--exclude" "(searx/static|searx/languages.py)" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")


### PR DESCRIPTION
## What does this PR do?

As of Firefox  129 (latest) Gecko driver v35 (latest) is recommended. v34 (current in repo) results in warnings in the tests.

## Why is this change important?

To avoid:
```
The geckodriver version (0.34.0) detected in PATH at /.../local/py3/bin/geckodriver might not be compatible with the detected firefox version (129.0.1); currently, geckodriver 0.35.0 is recommended for firefox 129.*, so it is advised to delete the driver in PATH and retry
```

## How to test this PR locally?

`make test`


## Related:

- https://github.com/searxng/searxng/issues/3141