### PR TITLE
[docs] improve Hostname plugin documentation

### DIFF
--- a/searx/plugins/hostnames.py
+++ b/searx/plugins/hostnames.py
@@ -1,7 +1,19 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=too-many-branches
-"""In addition to rewriting/replace reslut URLs, the *hoostnames* plugin offers
-other features.
+"""
+.. attention::
+
+    The **"Hostname replace"** plugin has been replace by **"Hostnames
+    plugin"**, see :pull:`3463` & :pull:`3552`.
+
+The **Hostnames plugin** can be enabled by adding it to the
+``enabled_plugins`` **list** in the ``setting.yml`` like so.
+
+  .. code:: yaml
+
+     enabled_plugins:
+       - 'Hostnames plugin'
+       ...
 
 - ``hostnames.replace``: A **mapping** of regular expressions to hostnames to be
   replaced by other hostnames.


### PR DESCRIPTION
## What does this PR do?

It clearly defines in the docs that `Hostname replace` has been deprecated and replaced by `Hostnames plugin`. It also provides some additional references material to make it easier on admins to port to the new plugin. And on top of all that as an exiting bonus it also fixes a few typos.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

It makes it easier for people who don't actively follow Searx development channels to port after this breaking change on their own. This should reduce questions in the eg. Matrix and issue reports on Git. 

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

I build the docs and validated it all works and looks properly by running it in a local Podman Apache webserver container.

## Related issues

Lack of proper docs about this breaking change was discussed here; https://github.com/searxng/searxng/issues/3722

----

update: see new docs: https://docs.searxng.org/dev/plugins/hostnames.html

