### PR TITLE
[fix] unit tests: fix load / unload engines & fix messages

### DIFF
--- a/tests/unit/test_engines_init.py
+++ b/tests/unit/test_engines_init.py
@@ -10,6 +10,7 @@ class TestEnginesInit(SearxTestCase):  # pylint: disable=missing-class-docstring
     def tearDownClass(cls):
         settings['outgoing']['using_tor_proxy'] = False
         settings['outgoing']['extra_proxy_timeout'] = 0
+        engines.load_engines([])
 
     def test_initialize_engines_default(self):
         engine_list = [

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-module-docstring, invalid-name
 
 from copy import copy
+import logging
 
 import searx.search
 from searx.search import SearchQuery, EngineRef
@@ -46,7 +47,12 @@ class SearchQueryTestCase(SearxTestCase):  # pylint: disable=missing-class-docst
 class SearchTestCase(SearxTestCase):  # pylint: disable=missing-class-docstring
     def setUp(self):
 
+        log = logging.getLogger("searx")
+        log_lev = log.level
+        log.setLevel(logging.ERROR)
         from searx import webapp  # pylint: disable=import-outside-toplevel
+
+        log.setLevel(log_lev)
 
         self.app = webapp.app
 

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=missing-module-docstring
 
+import logging
 import json
 from urllib.parse import ParseResult
 from mock import Mock
@@ -20,7 +21,12 @@ class ViewsTestCase(SearxTestCase):  # pylint: disable=missing-class-docstring, 
 
         self.setattr4test(searx.search.processors, 'initialize_processor', dummy)
 
+        log = logging.getLogger("searx")
+        log_lev = log.level
+        log.setLevel(logging.ERROR)
         from searx import webapp  # pylint: disable=import-outside-toplevel
+
+        log.setLevel(log_lev)
 
         webapp.app.config['TESTING'] = True  # to get better error messages
         self.app = webapp.app.test_client()


### PR DESCRIPTION
Our tests are poorly programmed and there are many global variables & monkey patching in SearXNG.  Depending on the order in which the tests are called, parts of SearXNG may or may not be initialized, and global variables may or may not contain values ​​left over from previous tests.

This patch of the unit tests cannot solve all problems, but improves the current state. It is required for 3746 to pass the CI test.

Related:

- https://github.com/searxng/searxng/pull/3746#issuecomment-2300965005
- https://github.com/searxng/searxng/issues/2988#issuecomment-2226929084

