### PR TITLE
[fix] Don't show categories without an active engine

### DIFF
--- a/searx/templates/simple/categories.html
+++ b/searx/templates/simple/categories.html
@@ -14,7 +14,7 @@
 <div id="categories" class="search_categories">{{- '' -}}
     <div id="categories_container">
         {%- if not search_on_category_select or not display_tooltip -%}
-            {%- for category in categories_as_tabs -%}
+            {%- for category in categories -%}
                 <div class="category category_checkbox">{{- '' -}}
                     <input type="checkbox" id="checkbox_{{ category|replace(' ', '_') }}" name="category_{{ category }}"{% if category in selected_categories %} checked="checked"{% endif %}/>
                     <label for="checkbox_{{ category|replace(' ', '_') }}" class="tooltips">
@@ -25,7 +25,7 @@
             {%- endfor -%}
             {%- if display_tooltip %}<div class="help">{{ _('Click on the magnifier to perform search') }}</div>{% endif -%}
         {%- else -%}
-            {%- for category in categories_as_tabs -%}{{- '\n' -}}
+            {%- for category in categories -%}{{- '\n' -}}
                 <button type="submit" name="category_{{ category }}" class="category category_button {% if category in selected_categories %}selected{% endif %}">
                     {{- icon_big(category_icons[category]) if category in category_icons else icon_big('globe-outline') -}}
                     <div class="category_name">{{- _(category) -}}</div>{{- '' -}}


### PR DESCRIPTION
## What does this PR do?

When all engines in a category are disabled, that category shouldn't be shown.
This seems to be a regression introduced with #2740 

## Why is this change important?

A search will always result in an error if no engine is enabled in a category and it's just unnecessary UI clutter to show them.

## How to test this PR locally?

Disable all engines in any of the categories and check if it's gone on the result page.
Test with "Search on category select" both enabled and disabled because this was working before changes related to that features where made.

## Related

* [Search on category select without JavaScript #2740](https://github.com/searxng/searxng/pull/2740)
* [[fix] don't show a category if there is no active engine in #2311](https://github.com/searxng/searxng/pull/2311)
