### PR TITLE
[feat] Create a Git pre-commit hook which formats changed Python files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "$SEARXNG_PRECOMMIT" = "true" ]; then
+    # inspired from: https://prettier.io/docs/en/precommit.html#option-4-shell-script
+    staged_files=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+    python_files=$(echo "$staged_files" | grep '\.py$')
+    # Only attempt to run the formatter if Python files were changes
+    if [ -n "$python_files" ]; then
+        echo "$python_files" | xargs ./manage format.python
+        echo "$python_files" | xargs git add
+    fi
+fi

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ run:  install
 PHONY += install uninstall
 install uninstall:
 	$(Q)./manage pyenv.$@
+	$(Q)./manage git.$@
 
 PHONY += clean
 clean: py.clean docs.clean node.clean nvm.clean test.clean

--- a/docs/dev/quickstart.rst
+++ b/docs/dev/quickstart.rst
@@ -28,6 +28,13 @@ Here is how a minimal workflow looks like:
 2. *run* your code: :ref:`make run`
 3. *format & test* your code: :ref:`make format.python` and :ref:`make test`
 
+.. tip::
+
+   If you run `make install`, and you export the environment variable
+   `SEARXNG_PRECOMMIT="true"`, a git pre-commit hook will run which will auto format
+   all python files you check into git for you. If you find this would be
+   better to enable by default, let us know.
+
 If you think at some point something fails, go back to *start*.  Otherwise,
 choose a meaningful commit message and we are happy to receive your pull
 request. To not end in *wild west* we have some directives, please pay attention

--- a/manage
+++ b/manage
@@ -94,6 +94,9 @@ pyenv.:
   OK        : test if virtualenv is OK
 format.:
   python    : format Python code source using black
+git.:
+  install   : Installs developer git utilities, such as hooks
+  uninstall : Removes developer git utilities previously installed
 pygments.:
   less      : build LESS files for pygments
 EOF
@@ -316,9 +319,27 @@ pyenv.uninstall() {
 }
 
 format.python() {
-    build_msg TEST "[format.python] black \$BLACK_TARGETS"
-    pyenv.cmd black "${BLACK_OPTIONS[@]}" "${BLACK_TARGETS[@]}"
-    dump_return $?
+    if [ -z "$1" ]; then
+        build_msg TEST "[format.python] black \$BLACK_OPTIONS \$BLACK_TARGETS"
+        pyenv.cmd black "${BLACK_OPTIONS[@]}" "${BLACK_TARGETS[@]}"
+    else
+        build_msg TEST "[format.python] black \$BLACK_OPTIONS $@"
+        pyenv.cmd black "${BLACK_OPTIONS[@]}" "$@"
+    fi
+}
+
+git.install() {
+    if [ -d ".git/hooks" ]; then
+        cp .githooks/pre-commit .git/hooks/pre-commit
+    else
+        build_msg INSTALL "Could not find '.git/hooks', hooks were not installed"
+    fi
+}
+
+git.uninstall() {
+    if [ -f ".git/hooks/pre-commit" ]; then
+        rm .git/hooks/pre-commit
+    fi
 }
 
 # shellcheck disable=SC2119


### PR DESCRIPTION
## What does this PR do?

1. Update `manage format.python` to accept arguments to only format specific files (if no arguments, will go back to default behavior of formatting everything).
2. Update `manage format.python` to include all information in the `build_msg`.
3. A `.githooks/pre-commit` file is created containing the python formatting hook, passing in only the files to format for python
4. Update `manage` to install/uninstall these git hook updates
5. Update the Makefile to install/uninstall these hooks at the same time as  `pyenv`.
6. Update documentation to add a tip for this new behavior

The only downside to the current implementation is that if anyone else uses pre-commit hooks and we don't know about it today, this will override it. Not sure how much of an issue this really is.

I would have also updated `make format.python` to allow propagating arguments, but I'm not familiar enough with Makefiles to even know how to make this change. Directly calling `manage` works for now. If someone else wants to assist with this, let me know.

With this, I'm also thinking just add a new make option "git-hook.install" and "git-hook.uninstall", and just skip the env enable method and entirely. I'll probably do this and update the PR if the concept is OK to the reviewer.

## Why is this change important?

Improved Developer Experience

Context is provided in related issue.

## How to test this PR locally?

1. Ensure you have exported `SEARXNG_PRECOMMIT="true"` to your current environment
2. Modify any 2 Python files with a whitespace change
3. Stage the file and commit it
7. Ensure the formatter is ran

## Author's checklist

 - n/a

## Related issues

Closes #3760 

## Screenshots

After running `make install`. This screenshot is outdated - now the git hook only formats the staged files.

![image](https://github.com/user-attachments/assets/ceab5238-0ce6-4a97-8094-097a31bb01ce)

