### PR TITLE
[fix] reduce traceback logging in search checker

### DIFF
--- a/searx/metrics/error_recorder.py
+++ b/searx/metrics/error_recorder.py
@@ -4,6 +4,7 @@
 import typing as t
 
 import inspect
+import logging
 from json import JSONDecodeError
 from urllib.parse import urlparse
 from httpx import HTTPError, HTTPStatusError
@@ -34,6 +35,7 @@ class ErrorContext:  # pylint: disable=missing-class-docstring
         log_message: str,
         log_parameters: LogParametersType,
         secondary: bool,
+        log_level: int,
     ):
         self.filename: str = filename
         self.function: str = function
@@ -43,6 +45,7 @@ class ErrorContext:  # pylint: disable=missing-class-docstring
         self.log_message: str = log_message
         self.log_parameters: LogParametersType = log_parameters
         self.secondary: bool = secondary
+        self.log_level: int = log_level
 
     def __eq__(self, o) -> bool:  # pylint: disable=invalid-name
         if not isinstance(o, ErrorContext):
@@ -56,6 +59,7 @@ class ErrorContext:  # pylint: disable=missing-class-docstring
             and self.log_message == o.log_message
             and self.log_parameters == o.log_parameters
             and self.secondary == o.secondary
+            and self.log_level == o.log_level
         )
 
     def __hash__(self):
@@ -69,11 +73,12 @@ class ErrorContext:  # pylint: disable=missing-class-docstring
                 self.log_message,
                 self.log_parameters,
                 self.secondary,
+                self.log_level,
             )
         )
 
     def __repr__(self):
-        return "ErrorContext({!r}, {!r}, {!r}, {!r}, {!r}, {!r}) {!r}".format(
+        return "ErrorContext({!r}, {!r}, {!r}, {!r}, {!r}, {!r}), {!r}, {!r}".format(
             self.filename,
             self.line_no,
             self.code,
@@ -81,13 +86,14 @@ class ErrorContext:  # pylint: disable=missing-class-docstring
             self.log_message,
             self.log_parameters,
             self.secondary,
+            self.log_level,
         )
 
 
 def add_error_context(engine_name: str, error_context: ErrorContext) -> None:
     errors_for_engine = errors_per_engines.setdefault(engine_name, {})
     errors_for_engine[error_context] = errors_for_engine.get(error_context, 0) + 1
-    engines[engine_name].logger.warning('%s', str(error_context))
+    engines[engine_name].logger.log(error_context.log_level, '%s', str(error_context))
 
 
 def get_trace(traces):
@@ -158,7 +164,7 @@ def get_exception_classname(exc: BaseException) -> str:
 
 
 def get_error_context(
-    framerecords, exception_classname, log_message, log_parameters: LogParametersType, secondary: bool
+    framerecords, exception_classname, log_message, log_parameters: LogParametersType, secondary: bool, log_level: int
 ) -> ErrorContext:
     searx_frame = get_trace(framerecords)
     filename = searx_frame.filename
@@ -168,17 +174,19 @@ def get_error_context(
     line_no = searx_frame.lineno
     code = searx_frame.code_context[0].strip()
     del framerecords
-    return ErrorContext(filename, function, line_no, code, exception_classname, log_message, log_parameters, secondary)
+    return ErrorContext(
+        filename, function, line_no, code, exception_classname, log_message, log_parameters, secondary, log_level
+    )
 
 
-def count_exception(engine_name: str, exc: BaseException, secondary: bool = False) -> None:
+def count_exception(engine_name: str, exc: BaseException, secondary: bool = False, log_level=logging.WARN) -> None:
     if not settings['general']['enable_metrics']:
         return
     framerecords = inspect.trace()
     try:
         exception_classname = get_exception_classname(exc)
         log_parameters = get_messages(exc, framerecords[-1][1])
-        error_context = get_error_context(framerecords, exception_classname, None, log_parameters, secondary)
+        error_context = get_error_context(framerecords, exception_classname, None, log_parameters, secondary, log_level)
         add_error_context(engine_name, error_context)
     finally:
         del framerecords
@@ -189,12 +197,13 @@ def count_error(
     log_message: str,
     log_parameters: LogParametersType | None = None,
     secondary: bool = False,
+    log_level: int = logging.WARN,
 ) -> None:
     if not settings['general']['enable_metrics']:
         return
     framerecords = list(reversed(inspect.stack()[1:]))
     try:
-        error_context = get_error_context(framerecords, None, log_message, log_parameters or (), secondary)
+        error_context = get_error_context(framerecords, None, log_message, log_parameters or (), secondary, log_level)
         add_error_context(engine_name, error_context)
     finally:
         del framerecords

--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -221,6 +221,7 @@ class OnlineProcessor(EngineProcessor):
                 "{} redirects, maximum: {}".format(len(response.history), soft_max_redirects),
                 (status_code, reason, hostname),
                 secondary=True,
+                log_level=self.metrics_log_level,
             )
 
         return response
@@ -273,7 +274,8 @@ class OnlineProcessor(EngineProcessor):
             self.logger.exception(
                 "requests exception (search duration : {0} s, timeout: {1} s) : {2}".format(
                     default_timer() - start_time, timeout_limit, e
-                )
+                ),
+                exc_info=self.log_engine_exc_info,
             )
         except (
             SearxEngineCaptchaException,
@@ -285,3 +287,43 @@ class OnlineProcessor(EngineProcessor):
         except Exception as e:  # pylint: disable=broad-except
             self.handle_exception(result_container, e)
             self.logger.exception("exception : {0}".format(e))
+
+    def get_default_tests(self):
+        tests = {}
+
+        tests['simple'] = {
+            'matrix': {'query': ('life', 'computer')},
+            'result_container': ['not_empty'],
+        }
+
+        if getattr(self.engine, 'paging', False):
+            tests['paging'] = {
+                'matrix': {'query': 'time', 'pageno': (1, 2, 3)},
+                'result_container': ['not_empty'],
+                'test': ['unique_results'],
+            }
+            if 'general' in self.engine.categories:
+                # avoid documentation about HTML tags (<time> and <input type="time">)
+                tests['paging']['matrix']['query'] = 'news'
+
+        if getattr(self.engine, 'time_range', False):
+            tests['time_range'] = {
+                'matrix': {'query': 'news', 'time_range': (None, 'day')},
+                'result_container': ['not_empty'],
+                'test': ['unique_results'],
+            }
+
+        if getattr(self.engine, 'traits', False):
+            tests['lang_fr'] = {
+                'matrix': {'query': 'paris', 'lang': 'fr'},
+                'result_container': ['not_empty', ('has_language', 'fr')],
+            }
+            tests['lang_en'] = {
+                'matrix': {'query': 'paris', 'lang': 'en'},
+                'result_container': ['not_empty', ('has_language', 'en')],
+            }
+
+        if getattr(self.engine, 'safesearch', False):
+            tests['safesearch'] = {'matrix': {'query': 'porn', 'safesearch': (0, 2)}, 'test': ['unique_results']}
+
+        return tests


### PR DESCRIPTION
## What does this PR do?

 - Implement `EngineProcessor.log_engine_exc_info` to allow removing exception logging in Checker. Enabled to its default value `True`.
 - In the Checker, disable this value
 - In the ErrorContext, we currently log all ErrorContext as `warning`, including more noise. Here, I propagate the log_level by allowing it to be injected (defaulting to warning). Then, it is set to NOTSET in the online processor if `enging_exc_info` is False (this may not be the best approach, but works for this scenario).
 - With the greatly reduced log lines, we can now log which test is occurring, which may single out which test failed for better investigation. This doesn't have to be done, but thought it may aid in debugging (see screenshots)

All changes are backwards compatible. Most of the changes largely sum up to injecting parameters, such that injected parameters default to the original implementation.

## Why is this change important?

See related issue.

## How to test this PR locally?

 - run `make search.checker`
 - ensure noisy logs are not generated

## Author's checklist

 - n/a

## Related issues

closes #3310 

## Screenshots

Removed exception details, added logging for which test is occurring.

![image](https://github.com/user-attachments/assets/3f43e393-cfb7-4751-8e45-eeac9e4f2b6a)


