### PR TITLE
[fix] search: titles and content including html brackets are not shown properly

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -9,7 +9,6 @@ from typing import List, NamedTuple, Set
 from urllib.parse import urlparse, unquote
 
 from searx import logger
-from searx import utils
 from searx.engines import engines
 from searx.metrics import histogram_observe, counter_add, count_error
 
@@ -366,9 +365,9 @@ class ResultContainer:
             result['score'] = result_score(result, result.get('priority'))
             # removing html content and whitespace duplications
             if result.get('content'):
-                result['content'] = utils.html_to_text(result['content']).strip()
+                result['content'] = result['content'].strip()
             if result.get('title'):
-                result['title'] = ' '.join(utils.html_to_text(result['title']).strip().split())
+                result['title'] = ' '.join(result['title'].strip().split())
 
             for result_engine in result['engines']:
                 counter_add(result['score'], 'engine', result_engine, 'score')


### PR DESCRIPTION
## What does this PR do?
- don't try to convert to convert the title and content from html to text by default
- that never made much sense in my opinion for the following reasons
  - I'm not aware of any search engines that use html in titles
  - The specific engine can handle this perfectly fine by itself in its own module
  - The same applies for the content: I'm aware of some engines that manually call html_to_text already, I don't think that this should be generally done for all results
  - This unnecessarily decreases the performance because the html_to_text algorithm is not the fastest and called a lot unnecessarily.
  - If the algorithm is called twice (which is currently the case for some engines that calls the functions too), it's possible that things get really broken

## Why is this change important?
- currently, result titles are missing text that are between `<` and `>`

## How to test this PR locally?
- search for `C Library - <string.h>`

## Related issues
closes #3767