### PR TITLE
[fix] self_info: request.user_agent is not a str

### DIFF
--- a/searx/plugins/self_info.py
+++ b/searx/plugins/self_info.py
@@ -28,5 +28,5 @@ def post_search(request, search):
         search.result_container.answers['ip'] = {'answer': gettext('Your IP is: ') + ip}
     elif ua_regex.match(search.search_query.query):
         ua = request.user_agent
-        search.result_container.answers['user-agent'] = {'answer': gettext('Your user-agent is: ') + ua}
+        search.result_container.answers['user-agent'] = {'answer': gettext('Your user-agent is: ') + ua.string}
     return True

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -74,7 +74,7 @@ class SelfIPTest(SearxTestCase):  # pylint: disable=missing-class-docstring
         self.assertFalse('ip' in search.result_container.answers)
 
         # User agent test
-        request = Mock(user_agent='Mock')
+        request = Mock(user_agent=Mock(string='Mock'))
 
         search = get_search_mock(query='user-agent', pageno=1)
         store.call(store.plugins, 'post_search', request, search)


### PR DESCRIPTION
The `user_agent` attribute of the Flask request object is an instance of the [`werkzeug.user_agent.UserAgent`](https://werkzeug.palletsprojects.com/en/3.0.x/utils/#werkzeug.user_agent.UserAgent) class.

This will fix the following error of the self_info plugin:

```
ERROR:searx.plugins.self_info: Exception while calling post_search
Traceback (most recent call last):
  File "searx/plugins/__init__.py", line 203, in call
    ret = getattr(plugin, plugin_type)(*args, **kwargs)
  File "searx/plugins/self_info.py", line 31, in post_search
    search.result_container.answers['user-agent'] = {'answer': gettext('Your user-agent is: ') + ua}
TypeError: can only concatenate str (not "UserAgent") to str
```
