### PR TITLE
[fix] Do not show DDG user-agent from zero click

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -331,7 +331,7 @@ def response(resp):
     zero_click_info_xpath = '//html/body/form/div/table[2]/tr[2]/td/text()'
     zero_click = extract_text(eval_xpath(doc, zero_click_info_xpath)).strip()
 
-    if zero_click and "Your IP address is" not in zero_click:
+    if zero_click and "Your IP address is" not in zero_click and "Your user agent:" not in zero_click:
         current_query = resp.search_params["data"].get("q")
 
         results.append(


### PR DESCRIPTION
We do not want to show the user-agent information from the duckduckgo zero click info. This is the user-agent used by searxng and not the user-agent used by the user.

This was already done for the IP address in: 0fb3f0e4aeecf62612cb6568910cf0f97c98cab9