### PR TITLE
[feat] add paramaterized package for unit testing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,4 +22,4 @@ wlc==1.14
 coloredlogs==15.0.1
 docutils<=0.21; python_version == '3.8'
 docutils>=0.21.2; python_version > '3.8'
-
+parameterized==0.9.0


### PR DESCRIPTION
## What does this PR do?

 - Install `paramaterized` as part of the dev-requirements.txt
 - Refactor some existing unit tests to showcase how this would be used (also removed the `assertLogs` as it wasn't used).

## Why is this change important?

When I was writing unit tests in prior PRs, I was sad to see that paramaterization of test cases was not supported by default. I've used this style extensively in other languages and projects, and thought it would be nice to include in here. I'm hoping this aids others in reducing boilerplace for writing tests.

## How to test this PR locally?

 - run `make.unit`, ensure both test cases run

## Author's checklist

 - n/a

## Related issues

 - n/a

## Additional Context

See below for compatibility outlined in the [PyPi docs](https://pypi.org/project/parameterized/). searxng currently uses `unittest`, so `parameterized.expand` works fine for all versions of Python. If we want to switch to `nose2`, that works fine. If we want to switch to `pytest`, well they have their own paramaterization framework that `paramaterized` doesn't try to target, which we would have to do migration for anyway. [unittest2](https://pypi.org/project/unittest2/) is a backport of the latest `unittest` features for Python 3.4 and earlier + PyPy, so likely not our focus. With this, I see no issues with this compatibility chart and the projects current focus.

![image](https://github.com/user-attachments/assets/c0cc24c4-8c93-4059-9142-0d7fe01ee56b)

