### PR TITLE
[engine] bahnhof.de: remove engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -562,33 +562,6 @@ engines:
     categories: general
     shortcut: cc
 
-  - name: bahnhof
-    engine: json_engine
-    search_url: https://www.bahnhof.de/api/stations/search/{query}
-    url_prefix: https://www.bahnhof.de/
-    url_query: slug
-    title_query: name
-    content_query: state
-    shortcut: bf
-    disabled: true
-    about:
-      website: https://www.bahn.de
-      wikidata_id: Q22811603
-      use_official_api: false
-      require_api_key: false
-      results: JSON
-      language: de
-    tests:
-      bahnhof:
-        matrix:
-          query: berlin
-          lang: en
-        result_container:
-          - not_empty
-          - ['one_title_contains', 'Berlin Hauptbahnhof']
-        test:
-          - unique_results
-
   - name: deezer
     engine: deezer
     shortcut: dz


### PR DESCRIPTION
## What does this PR do?
- This PR removes bahnhof.de since they changed their API

## Author notes
- They no longer use JSON responses, their responses are in an other strange format now that contains the JSON. So this engine would need to get its own module to work again.

## Related issues
closes https://github.com/searxng/searxng/issues/3784
