### PR TITLE
Update html code to properly set closing tag on void elements

### DIFF
--- a/docs/admin/api.rst
+++ b/docs/admin/api.rst
@@ -84,9 +84,9 @@ HTML of the site.  URL of the SearXNG instance and values are customizable.
 .. code:: html
 
    <form method="post" action="https://example.org/">
-     <!-- search      --> <input type="text" name="q" />
-     <!-- categories  --> <input type="hidden" name="categories" value="general,social media" />
-     <!-- language    --> <input type="hidden" name="lang" value="all" />
-     <!-- locale      --> <input type="hidden" name="locale" value="en" />
-     <!-- date filter --> <input type="hidden" name="time_range" value="month" />
+     <!-- search      --> <input type="text" name="q">
+     <!-- categories  --> <input type="hidden" name="categories" value="general,social media">
+     <!-- language    --> <input type="hidden" name="lang" value="all">
+     <!-- locale      --> <input type="hidden" name="locale" value="en">
+     <!-- date filter --> <input type="hidden" name="time_range" value="month">
    </form>

--- a/searx/botdetection/link_token.py
+++ b/searx/botdetection/link_token.py
@@ -28,7 +28,7 @@ And in the HTML template from flask a stylesheet link is needed (the value of
 
    <link rel="stylesheet"
          href="{{ url_for('client_token', token=link_token) }}"
-         type="text/css" />
+         type="text/css" >
 
 .. _X-Forwarded-For:
    https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

--- a/searx/engines/btdigg.py
+++ b/searx/engines/btdigg.py
@@ -54,7 +54,6 @@ def response(resp):
 
         excerpt = result.xpath('.//div[@class="torrent_excerpt"]')[0]
         content = html.tostring(excerpt, encoding='unicode', method='text', with_tail=False)
-        # it is better to emit <br/> instead of |, but html tags are verboten
         content = content.strip().replace('\n', ' | ')
         content = ' '.join(content.split())
 

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="no-js theme-{{ preferences.get_value('simple_style') or 'auto' }} center-aligment-{{ preferences.get_value('center_alignment') and 'yes' or 'no' }}" lang="{{ locale_rfc5646 }}" {% if rtl %} dir="rtl"{% endif %}>
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="UTF-8">
   <meta name="description" content="SearXNG — a privacy-respecting, open metasearch engine">
   <meta name="keywords" content="SearXNG, search, search engine, metasearch, meta search">
   <meta name="generator" content="searxng/{{ searx_version }}">
@@ -13,23 +13,23 @@
   <title>{% block title %}{% endblock %}{{ instance_name }}</title>
   {% block meta %}{% endblock %}
   {% if rtl %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/searxng-rtl.min.css') }}" type="text/css" media="screen" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/searxng-rtl.min.css') }}" type="text/css" media="screen">
   {% else %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/searxng.min.css') }}" type="text/css" media="screen" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/searxng.min.css') }}" type="text/css" media="screen">
   {% endif %}
   {% if get_setting('server.limiter') or get_setting('server.public_instance') %}
-  <link rel="stylesheet" href="{{ url_for('client_token', token=link_token) }}" type="text/css" />
+  <link rel="stylesheet" href="{{ url_for('client_token', token=link_token) }}" type="text/css">
   {% endif %}
   {% block styles %}{% endblock %}
   <!--[if gte IE 9]>-->
   <script src="{{ url_for('static', filename='js/searxng.head.min.js') }}" client_settings="{{ client_settings }}"></script>
   <!--<![endif]-->
   {% block head %}
-  <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ opensearch_url }}"/>
+  <link title="{{ instance_name }}" type="application/opensearchdescription+xml" rel="search" href="{{ opensearch_url }}">
   {% endblock %}
   <link rel="icon" href="{{ url_for('static', filename='img/favicon.png') }}" sizes="any">
   <link rel="icon" href="{{ url_for('static', filename='img/favicon.svg') }}" type="image/svg+xml">
-  <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/favicon.png') }}"/>
+  <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/favicon.png') }}">
 </head>
 <body class="{{ endpoint }}_endpoint" >
   <main id="main_{{  self._TemplateReference__context.name|replace("simple/", "")|replace(".html", "") }}" class="{{body_class}}">
@@ -65,7 +65,7 @@
   </main>
   <footer>
     <p>
-    {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searx_version }} — {{ _('a privacy-respecting, open metasearch engine') }}<br/>
+    {{ _('Powered by') }} <a href="{{ url_for('info', pagename='about') }}">searxng</a> - {{ searx_version }} — {{ _('a privacy-respecting, open metasearch engine') }}<br>
         <a href="{{ searx_git_url }}">{{ _('Source code') }}</a>
         | <a href="{{ get_setting('brand.issue_url') }}">{{ _('Issue tracker') }}</a>
         {% if enable_metrics %}| <a href="{{ url_for('stats') }}">{{ _('Engine stats') }}</a>{% endif %}

--- a/searx/templates/simple/categories.html
+++ b/searx/templates/simple/categories.html
@@ -16,7 +16,7 @@
         {%- if not search_on_category_select or not display_tooltip -%}
             {%- for category in categories -%}
                 <div class="category category_checkbox">{{- '' -}}
-                    <input type="checkbox" id="checkbox_{{ category|replace(' ', '_') }}" name="category_{{ category }}"{% if category in selected_categories %} checked="checked"{% endif %}/>
+                    <input type="checkbox" id="checkbox_{{ category|replace(' ', '_') }}" name="category_{{ category }}"{% if category in selected_categories %} checked="checked"{% endif %}>
                     <label for="checkbox_{{ category|replace(' ', '_') }}" class="tooltips">
                         {{- icon_big(category_icons[category]) if category in category_icons  else icon_big('globe-outline') -}}
                         <div class="category_name">{{- _(category) -}}</div>

--- a/searx/templates/simple/elements/infobox.html
+++ b/searx/templates/simple/elements/infobox.html
@@ -38,7 +38,7 @@
               <input type="hidden" name="safesearch" value="{{ safesearch }}">
               <input type="hidden" name="theme" value="{{ theme }}">
               {%- if timeout_limit -%}<input type="hidden" name="timeout_limit" value="{{ timeout_limit|e }}" >{%- endif -%}
-              <input type="submit" value="{{ suggestion }}" />
+              <input type="submit" value="{{ suggestion }}">
             </form>
           {%- endfor -%}
         </div>

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -6,7 +6,7 @@
 {%- endmacro -%}
 
 {%- macro tab_header(name, id, label, checked) -%}
-<input type="radio" name="{{ name }}" id="tab-{{ id }}" {% if checked is sameas true %}checked="checked"{% endif %} />
+<input type="radio" name="{{ name }}" id="tab-{{ id }}" {% if checked is sameas true %}checked="checked"{% endif %}>
 <label id="tab-label-{{ id }}" for="tab-{{ id }}" role="tab" aria-controls="tab-content-{{ id }}">{{ label }}</label>
 <section id="tab-content-{{ id }}" role="tabpanel" aria-labelledby="tab-label-{{ id }}" aria-hidden="false">
 {%- endmacro -%}
@@ -23,7 +23,7 @@
   {%- if checked == '?' -%}
     {{- icon_small('warning') -}}
   {%- else -%}
-    <input type="checkbox" {%- if name %} name="{{ name }}" {%- endif %} value="None" {%- if checked %} checked {%- endif -%}{%- if disabled %} disabled {%- endif -%}/>
+    <input type="checkbox" {%- if name %} name="{{ name }}" {%- endif %} value="None" {%- if checked %} checked {%- endif -%}{%- if disabled %} disabled {%- endif -%}>
   {%- endif -%}
 {%- endmacro -%}
 
@@ -33,7 +33,7 @@
          id="{{ name }}" {{- ' ' -}}
          aria-labelledby="pref_{{ name }}"{{- ' ' -}}
          class="checkbox-onoff reversed-checkbox"{{- ' ' -}}
-         {%- if checked -%} checked{%- endif -%}/>
+         {%- if checked -%} checked{%- endif -%}>
 {%- endmacro -%}
 
 {%- macro plugin_preferences(section) -%}

--- a/searx/templates/simple/preferences/cookies.html
+++ b/searx/templates/simple/preferences/cookies.html
@@ -1,7 +1,7 @@
 <p class="text-muted">
   {{- _('This is the list of cookies and their values SearXNG is storing on your computer.') }}
-  <br />{{- _('With that list, you can assess SearXNG transparency.') -}}
-  <br />{{- '' -}}
+  <br>{{- _('With that list, you can assess SearXNG transparency.') -}}
+  <br>{{- '' -}}
 </p>
 {% if cookies %}
   <table class="cookies">

--- a/searx/templates/simple/preferences/footer.html
+++ b/searx/templates/simple/preferences/footer.html
@@ -1,9 +1,9 @@
 <p class="small_font">
   {{- _('These settings are stored in your cookies, this allows us not to store this data about you.') -}}
-  <br />{{- _("These cookies serve your sole convenience, we don't use these cookies to track you.") -}}
+  <br>{{- _("These cookies serve your sole convenience, we don't use these cookies to track you.") -}}
 </p>{{- '' -}}
 
-<input type="submit" value="{{ _('Save') }}" />{{- '' -}}
+<input type="submit" value="{{ _('Save') }}">{{- '' -}}
 
 <div class="{% if rtl %}left{% else %}right{% endif %} preferences_back">{{- '' -}}
   <a href="{{ url_for('clear_cookies') }}">{{ _('Reset defaults') }}</a>{{- '' -}}

--- a/searx/templates/simple/result_templates/map.html
+++ b/searx/templates/simple/result_templates/map.html
@@ -18,12 +18,12 @@
                 <span itemprop="streetAddress">
                     {%- if result.address.house_number -%}{{- result.address.house_number -}}, {% endif %}
                     {{- result.address.road -}}
-                </span><br/>
+                </span><br>
             {%- endif %}
             {%- if result.address.locality -%}
                 <span itemprop="addressLocality">{{- result.address.locality -}}</span>
                 {%- if result.address.postcode -%}, <span itemprop="postalCode">{{- result.address.postcode -}}</span>{% endif %}
-                <br/>
+                <br>
             {%- endif -%}
             {%- if result.address.country -%}
                 <span itemprop="addressCountry">{{- result.address.country -}}</span>

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -3,7 +3,7 @@
 {% macro engine_data_form(engine_data) -%}
     {% for engine_name, kv_data in engine_data.items() %}
         {% for k, v in kv_data.items() %}
-            <input type="hidden" name="engine_data-{{ engine_name }}-{{ k|e }}" value="{{ v|e }}" />
+            <input type="hidden" name="engine_data-{{ engine_name }}-{{ k|e }}" value="{{ v|e }}">
         {% endfor %}
     {% endfor %}
 {%- endmacro %}


### PR DESCRIPTION
## What does this PR do?

- Removes `/>` ending tags for [void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements) and replaces them with `>`.

## Why is this change important?

 - Part of the larger cleanup to cleanup invalid HTML throughout the codebase.

## How to test this PR locally?

 - Ensure unit tests run
 - `make run` to ensure none of the affected pages display invalid
 - Check the rendered pages against the NU Html Checker

## Author's checklist

 - [ ] Manually check all void elements for proper ending tags. I did a quick regex sweep to get the simplest cases, and now need to validate each file manually.

## Related issues

#3793 
