### PR TITLE
[feat] engine: add right dao

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1553,9 +1553,9 @@ engines:
     paging: true
     page_size: 12
     search_url: https://rightdao.com/search?q={query}&start={pageno}
-    results_xpath: //div[@class="description"]
-    url_xpath: ../div[@class="title"]/a/@href
-    title_xpath: ../div[@class="title"]
+    results_xpath: //div[contains(@class, "description")]
+    url_xpath: ../div[contains(@class, "title")]/a/@href
+    title_xpath: ../div[contains(@class, "title")]
     content_xpath: .
     categories: general
     shortcut: rd

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1548,6 +1548,24 @@ engines:
     page_size: 25
     disabled: true
 
+  - name: right dao
+    engine: xpath
+    paging: true
+    page_size: 12
+    search_url: https://rightdao.com/search?q={query}&start={pageno}
+    results_xpath: //div[@class="description"]
+    url_xpath: ../div[@class="title"]/a/@href
+    title_xpath: ../div[@class="title"]
+    content_xpath: .
+    categories: general
+    shortcut: rd
+    disabled: true
+    about:
+      website: https://rightdao.com/
+      use_official_api: false
+      require_api_key: false
+      results: HTML
+
   - name: rottentomatoes
     engine: rottentomatoes
     shortcut: rt


### PR DESCRIPTION
## What does this PR do?

Add Right Dao as an engine.
https://rightdao.com

## Why is this change important?

Adding new engine.
Information on engine: https://seirdy.one/posts/2021/03/10/search-engines-with-own-indexes/ (ctrl-f for right dao)

## How to test this PR locally?

query `!rd …`

