### PR TITLE
[fix] yep engine: remove links to other engines

### DIFF
--- a/searx/engines/yep.py
+++ b/searx/engines/yep.py
@@ -67,6 +67,8 @@ def response(resp):
 
     for result in resp.json()[1]['results']:
         if search_type == "web":
+            if result['type'] != 'Organic':
+                continue
             results.append(_web_result(result))
         elif search_type == "images":
             results.append(_images_result(result))


### PR DESCRIPTION
## What does this PR do?

This PR removes links to other search engines from the Yep results.

## Why is this change important?

Yep includes links to search for the same query on Google and other search engines as a result in the search result.

## How to test this PR locally?

Search with `!yep` and compare the results w/ and w/o this PR
