### PR TITLE
[fix] json_engine: Fix result fields being mixed up

### DIFF
--- a/searx/engines/json_engine.py
+++ b/searx/engines/json_engine.py
@@ -146,7 +146,11 @@ def response(resp):
                 }
             )
     else:
-        for url, title, content in zip(query(json, url_query), query(json, title_query), query(json, content_query)):
+        for result in json:
+            url = query(result, url_query)[0]
+            title = query(result, title_query)[0]
+            content = query(result, content_query)[0]
+
             results.append(
                 {
                     'url': url_prefix + to_string(url),


### PR DESCRIPTION
## What does this PR do?

The JSON engine used to iterate over its response items in three separate runs to extract the `url`, `title` and `content` fields, then `zip` them to build the final result set. But without any guards for iteration order, and some results not containing certain fields, this `zip` ended up mixing fields from different results together.

Now, the response items are iterated once, and the three fields are extracted in the same iteration.

## Why is this change important?

It makes the results have the correct and matching title, URL and description. Since the JSON engine is a generic one used by various default or custom engine configurations, a lot of search queries will be affected. And if they are mixed with other engines, it might be hard to spot the mixed up values.

## How to test this PR locally?

Search for something like `!gitlab searx` without the change, then with this change.
Any other engine configuration that doesn't use `results_query` should exhibit the same issue.

## Author's checklist

N/A

## Related issues

Fixes #3810.
