### PR TITLE
[fix] search: crash when no engines are used to search

### DIFF
--- a/searx/templates/simple/elements/engines_msg.html
+++ b/searx/templates/simple/elements/engines_msg.html
@@ -1,5 +1,5 @@
 <div id="engines_msg">
-  {% if not results and not answers %}
+  {% if (not results and not answers) or not max_response_time %}
   <details class="sidebar-collapsable" open>
     <summary class="title" id="engines_msg-title">{{ _('Messages from the search engines') }}</summary>
   {% else %}


### PR DESCRIPTION
## What does this PR do?
- this fixes a bug introduced in https://github.com/searxng/searxng/pull/3755 that causes the app to crash when no search engines are used (e.g. when searching `random color`

## Related issues
closes #3820
