### PR TITLE
[fix] drop engine gpodder

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -900,26 +900,6 @@ engines:
     shortcut: mi
     disabled: true
 
-  - name: gpodder
-    engine: json_engine
-    shortcut: gpod
-    timeout: 4.0
-    paging: false
-    search_url: https://gpodder.net/search.json?q={query}
-    url_query: url
-    title_query: title
-    content_query: description
-    page_size: 19
-    categories: music
-    disabled: true
-    about:
-      website: https://gpodder.net
-      wikidata_id: Q3093354
-      official_api_documentation: https://gpoddernet.readthedocs.io/en/latest/api/
-      use_official_api: false
-      requires_api_key: false
-      results: JSON
-
   - name: habrahabr
     engine: xpath
     paging: true


### PR DESCRIPTION
gpodder is ultra slow on search terms like `foo`

  https://gpodder.net/search.json?q=foo

takes up to a minute to return an empty json response.

- Closes: https://github.com/searxng/searxng/issues/3785

