### PR TITLE
[fix] engine: qwant - detect captchaUrl and raise SearxEngineCaptchaException

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -49,7 +49,11 @@ from flask_babel import gettext
 import babel
 import lxml
 
-from searx.exceptions import SearxEngineAPIException, SearxEngineTooManyRequestsException
+from searx.exceptions import (
+    SearxEngineAPIException,
+    SearxEngineTooManyRequestsException,
+    SearxEngineCaptchaException,
+)
 from searx.network import raise_for_httperror
 from searx.enginelib.traits import EngineTraits
 
@@ -187,6 +191,8 @@ def parse_web_api(resp):
         error_code = data.get('error_code')
         if error_code == 24:
             raise SearxEngineTooManyRequestsException()
+        if search_results.get("data", {}).get("error_data", {}).get("captchaUrl") is not None:
+            raise SearxEngineCaptchaException()
         msg = ",".join(data.get('message', ['unknown']))
         raise SearxEngineAPIException(f"{msg} ({error_code})")
 


### PR DESCRIPTION
So far a CAPTCHA was not recognized in the response of the qwant engine and a `SearxEngineAPIException` was raised by mistake.  With this patch a CAPTCHA redirect is recognized and the correct `SearxEngineCaptchaException` is raised.

Closes: https://github.com/searxng/searxng/issues/3806