### PR TITLE
fix HTML generated by the simple templates

### DIFF
--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -27,11 +27,11 @@
   {%- endif -%}
 {%- endmacro -%}
 
-{%- macro checkbox_onoff_reversed(name, checked) -%}
+{%- macro checkbox_onoff_reversed(name, checked, labelledby) -%}
   <input type="checkbox" {{- ' ' -}}
          name="{{ name }}" {{- ' ' -}}
          id="{{ name }}" {{- ' ' -}}
-         aria-labelledby="pref_{{ name }}"{{- ' ' -}}
+         {%- if labelledby -%} aria-labelledby="{{ labelledby }}"{{- ' ' -}}{%- endif -%}
          class="checkbox-onoff reversed-checkbox"{{- ' ' -}}
          {%- if checked -%} checked{%- endif -%}>
 {%- endmacro -%}
@@ -42,9 +42,9 @@
 <fieldset>{{- '' -}}
     <legend>{{ _(plugin.name) }}</legend>{{- '' -}}
     <div class="value">
-      {{- checkbox_onoff_reversed('plugin_' + plugin.id, plugin.id not in allowed_plugins) -}}
+      {{- checkbox_onoff_reversed('plugin_' + plugin.id, plugin.id not in allowed_plugins, 'plugin_labelledby' + plugin.id) -}}
     </div>{{- '' -}}
-    <div class="description">
+    <div class="description" id="{{ 'plugin_labelledby' + plugin.id }}">
       {{- _(plugin.description) -}}
     </div>{{- '' -}}
 </fieldset>

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -8,7 +8,7 @@
 {%- macro tab_header(name, id, label, checked) -%}
 <input type="radio" name="{{ name }}" id="tab-{{ id }}" {% if checked is sameas true %}checked="checked"{% endif %}>
 <label id="tab-label-{{ id }}" for="tab-{{ id }}" role="tab" aria-controls="tab-content-{{ id }}">{{ label }}</label>
-<section id="tab-content-{{ id }}" role="tabpanel" aria-labelledby="tab-label-{{ id }}" aria-hidden="false">
+<section id="tab-content-{{ id }}" role="tabpanel" aria-hidden="false">
 {%- endmacro -%}
 
 {%- macro tab_footer() -%}
@@ -90,7 +90,7 @@
   <td class="{{ label }}">{{- '' -}}
     {%- if stats[engine_name].time != None -%}
     <span class="stacked-bar-chart-value">{{- stats[engine_name].time -}}</span>{{- '' -}}
-    <span class="stacked-bar-chart" aria-labelledby="{{engine_name}}_chart" aria-hidden="true">
+    <span class="stacked-bar-chart" aria-hidden="true">
         {%- if max_rate95 is not none and max_rate95 > 0 -%}
         <div class="stacked-bar-chart-median bar{{ (100 * (stats[engine_name].time / max_rate95))|round }}"></div>{{- '' -}}
         <div class="stacked-bar-chart-rate80 bar{{ (100 * ((stats[engine_name].rate80 - stats[engine_name].time) / max_rate95))|round }}"></div>{{- '' -}}
@@ -127,7 +127,7 @@
   {%- if checker_result or errors -%}
     <td class="{{ label }} column-reliability">{{- '' -}}
       <a href="{{ url_for('stats', engine=engine_name|e) }}">{{- '' -}}
-        <span aria-labelledby="{{engine_name}}_reliability">
+        <span>
           {{- icon_big('warning', 'The engine is not reliabled') }} {{ r -}}
         </span>{{- '' -}}
       </a>{{- '' -}}

--- a/searx/templates/simple/preferences/answerers.html
+++ b/searx/templates/simple/preferences/answerers.html
@@ -33,10 +33,10 @@
     {%- for plugin in plugins -%}
       {%- if plugin.preference_section == 'query' -%}
         <tr>{{- '' -}}
-          <td class="checkbox-col">{{- checkbox_onoff_reversed('plugin_' + plugin.id, plugin.id not in allowed_plugins) -}}</td>{{- '' -}}
+          <td class="checkbox-col">{{- checkbox_onoff_reversed('plugin_' + plugin.id, plugin.id not in allowed_plugins, 'plugin_labelledby' + plugin.id) -}}</td>{{- '' -}}
           <td>{{ plugin.query_keywords|join(', ') }}</td>{{- '' -}}
           <td>{{ _(plugin.name) }}</td>{{- '' -}}
-          <td>{{ _(plugin.description) }}</td>{{- '' -}}
+          <td id="{{ 'plugin_labelledby' + plugin.id }}">{{ _(plugin.description) }}</td>{{- '' -}}
           <td>{{ plugin.query_examples }}</td>{{- '' -}}
         </tr>
       {%- endif -%}

--- a/searx/templates/simple/preferences/center_alignment.html
+++ b/searx/templates/simple/preferences/center_alignment.html
@@ -8,7 +8,7 @@
            {%- if preferences.get_value('center_alignment') -%}
              checked
            {%- endif -%}{{- ' ' -}}
-           />{{- '' -}}
+           >{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Displays results in the center of the page (Oscar layout).') -}}

--- a/searx/templates/simple/preferences/image_proxy.html
+++ b/searx/templates/simple/preferences/image_proxy.html
@@ -8,7 +8,7 @@
            {%- if preferences.get_value('image_proxy') -%}
              checked
            {%- endif -%}{{- ' ' -}}
-           />{{- '' -}}
+           >{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Proxying image results through SearXNG') -}}

--- a/searx/templates/simple/preferences/infinite_scroll.html
+++ b/searx/templates/simple/preferences/infinite_scroll.html
@@ -10,7 +10,7 @@
            {%- endif -%}{{- ' ' -}}
            >{{- '' -}}
   </p>{{- '' -}}
-  <div class="description">
+  <div class="description" id="pref_infinite_scroll">
     {{- _('Automatically load next page when scrolling to bottom of current page') -}}
   </div>{{- '' -}}
 </fieldset>{{- '' -}}

--- a/searx/templates/simple/preferences/infinite_scroll.html
+++ b/searx/templates/simple/preferences/infinite_scroll.html
@@ -8,7 +8,7 @@
            {%- if preferences.get_value('infinite_scroll') -%}
              checked
            {%- endif -%}{{- ' ' -}}
-           />{{- '' -}}
+           >{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Automatically load next page when scrolling to bottom of current page') -}}

--- a/searx/templates/simple/preferences/query_in_title.html
+++ b/searx/templates/simple/preferences/query_in_title.html
@@ -8,7 +8,7 @@
            {%- if preferences.get_value('query_in_title') -%}
              checked
            {%- endif -%}{{- ' ' -}}
-           />{{- '' -}}
+           >{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _("When enabled, the result page's title contains your query. Your browser can record this title") -}}

--- a/searx/templates/simple/preferences/results_on_new_tab.html
+++ b/searx/templates/simple/preferences/results_on_new_tab.html
@@ -8,7 +8,7 @@
            {%- if preferences.get_value('results_on_new_tab') -%}
              checked
            {%- endif -%}{{- ' ' -}}
-           />{{- ' ' -}}
+           >{{- ' ' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Open result links on new browser tabs') -}}

--- a/searx/templates/simple/preferences/search_on_category_select.html
+++ b/searx/templates/simple/preferences/search_on_category_select.html
@@ -10,7 +10,7 @@
            {%- endif -%}{{- ' ' -}}
            >{{- '' -}}
   </p>{{- '' -}}
-  <div class="description">
+  <div class="description" id="pref_search_on_category_select">
     {{- _('Perform search immediately if a category selected. Disable to select multiple categories') -}}
   </div>{{- '' -}}
 </fieldset>{{- '' -}}

--- a/searx/templates/simple/preferences/search_on_category_select.html
+++ b/searx/templates/simple/preferences/search_on_category_select.html
@@ -8,7 +8,7 @@
            {%- if preferences.get_value('search_on_category_select') -%}
              checked
            {%- endif -%}{{- ' ' -}}
-           />{{- '' -}}
+           >{{- '' -}}
   </p>{{- '' -}}
   <div class="description">
     {{- _('Perform search immediately if a category selected. Disable to select multiple categories') -}}

--- a/searx/templates/simple/preferences/tokens.html
+++ b/searx/templates/simple/preferences/tokens.html
@@ -3,7 +3,7 @@
   <div class="value">{{- '' -}}
     <input name="tokens" aria-labelledby="pref_tokens" type="text"
            autocomplete="off" spellcheck="false" autocorrect="off"
-           value='{{ preferences.tokens.get_value() }}'/>{{- '' -}}
+           value='{{ preferences.tokens.get_value() }}'>{{- '' -}}
   </div>{{- '' -}}
   <div class="description">
     {{- _('Access tokens for private engines') -}}


### PR DESCRIPTION
This is another PR that improves the quality of the generated HTML markup from the ``simple`` templates.  The discussion on this topic is conducted under the incident https://github.com/searxng/searxng/issues/3793

> ``/preferences``
> 
> There are too many to list out, most of which point to aria-labelledby.

In its previous implementation, the macro ``checkbox_onoff_reversed`` always created an ``aria-labelledby`` attribute, even if there was no descriptive tag with the generated ID (used as the value of the ``aria-labelledby``).

Before this patch, the Nu-HTML-Checker [1] reported 255 issues of this type::

    The aria-labelledby attribute must point to an element in the same document. (255)

[1] https://validator.w3.org/nu/

---

For more details read the commit messages in this patch series