### PR TITLE
[fix] scripts: elimination of limitations on dedicated distributions

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -958,7 +958,6 @@ nginx_distro_setup() {
             ;;
     esac
 }
-nginx_distro_setup
 
 install_nginx(){
     info_msg "installing nginx ..."
@@ -1127,8 +1126,6 @@ apache_distro_setup() {
     esac
 }
 
-apache_distro_setup
-
 install_apache(){
     info_msg "installing apache ..."
     pkg_install "$APACHE_PACKAGES"
@@ -1290,8 +1287,6 @@ uWSGI_distro_setup() {
             ;;
 esac
 }
-
-uWSGI_distro_setup
 
 install_uwsgi(){
     info_msg "installing uwsgi ..."
@@ -1685,13 +1680,15 @@ LXC_BASE_PACKAGES_fedora="bash git @development-tools python"
 # yum packages
 LXC_BASE_PACKAGES_centos="bash git python3"
 
-case $DIST_ID in
-    ubuntu|debian) LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_debian}" ;;
-    arch)          LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_arch}" ;;
-    fedora)        LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_fedora}" ;;
-    centos)        LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_centos}" ;;
-    *) err_msg "$DIST_ID-$DIST_VERS: pkg_install LXC_BASE_PACKAGES not yet implemented" ;;
-esac
+lxc_distro_setup() {
+    case $DIST_ID in
+        ubuntu|debian) LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_debian}" ;;
+        arch)          LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_arch}" ;;
+        fedora)        LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_fedora}" ;;
+        centos)        LXC_BASE_PACKAGES="${LXC_BASE_PACKAGES_centos}" ;;
+        *) err_msg "$DIST_ID-$DIST_VERS: pkg_install LXC_BASE_PACKAGES not yet implemented" ;;
+    esac
+}
 
 lxc_install_base_packages() {
     info_msg "install LXC_BASE_PACKAGES in container $1"

--- a/utils/lxc.sh
+++ b/utils/lxc.sh
@@ -135,6 +135,8 @@ main() {
     local exit_val
     local _usage="unknown or missing $1 command $2"
 
+    lxc_distro_setup
+
     # don't check prerequisite when in recursion
     if [[ ! $1 == __* ]] && [[ ! $1 == --help  ]]; then
         if ! in_container; then

--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -164,9 +164,16 @@ EOF
 }
 
 main() {
-    required_commands \
-        sudo systemctl install git wget curl \
-        || exit
+    case $1 in
+        install|remove|instance)
+            nginx_distro_setup
+            apache_distro_setup
+            uWSGI_distro_setup
+            required_commands \
+                sudo systemctl install git wget curl \
+                || exit
+            ;;
+    esac
 
     local _usage="unknown or missing $1 command $2"
 
@@ -898,6 +905,10 @@ _searxng.instance.inspect() {
 }
 
 searxng.doc.rst() {
+
+    local APACHE_SITES_AVAILABLE="/etc/apache2/sites-available"
+    local NGINX_APPS_AVAILABLE="/etc/nginx/default.apps-available"
+
     local debian="${SEARXNG_PACKAGES_debian}"
     local arch="${SEARXNG_PACKAGES_arch}"
     local fedora="${SEARXNG_PACKAGES_fedora}"


### PR DESCRIPTION
The restriction of shell scripts to certain distributions is only required for certain actions such as the installation of a SearXNG instance. The maintenance scripts and build processes were previously also restricted to these specific distributions.  With this patch, the build processes (such as the build of online documentation) can now also be executed on all Linux distributions.
