### PR TITLE
[fix] use get accessor to pull desc from bing_images

### DIFF
--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -99,7 +99,7 @@ def response(resp):
                 'url': metadata['purl'],
                 'thumbnail_src': metadata['turl'],
                 'img_src': metadata['murl'],
-                'content': metadata['desc'],
+                'content': metadata.get('desc'),
                 'title': title,
                 'source': source,
                 'resolution': img_format[0],


### PR DESCRIPTION
## What does this PR do?

Use get accessor to pull desc from bing_images, fixing an edge case in the bing images engine where `desc` is not part of the `metadata` json object

## Why is this change important?

Bug fix / engine reliability

## How to test this PR locally?

 - `make run`
 - search for `!bing_images alpha beta pruning`

## Author's checklist

 - n/a

## Related issues

 - #3807 
