### PR TITLE
[enh] engine: stract - add language/region support

### DIFF
--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -6678,6 +6678,19 @@
       "zh-TW": "zh-TW_TW"
     }
   },
+  "stract": {
+    "all_locale": "All",
+    "custom": {},
+    "data_type": "traits_v1",
+    "languages": {},
+    "regions": {
+      "da-DK": "Denmark",
+      "de-DE": "Germany",
+      "en-US": "US",
+      "es-ES": "Spain",
+      "fr-FR": "France"
+    }
+  },
   "wikidata": {
     "all_locale": null,
     "custom": {


### PR DESCRIPTION
## What does this PR do?

Add region support to Stract. Stract supports selecting regions in the UI as well as the API with the selectedRegion field. Supported regions can be retrieved through the openapi specification.

## Why is this change important?

Region support enhances the experience.

## How to test this PR locally?

Test for example with an ambiguous query like `!stract test` and select different languages.