### PR TITLE
[mod] py3.8 EOL, upgrade to actions/setup-python@v5

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version:  ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version:  ["3.9", "3.10", "3.11", "3.12",]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
         sudo ./utils/searxng.sh install packages
         sudo apt install firefox
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
@@ -63,9 +63,9 @@ jobs:
     - name: Install Ubuntu packages
       run: sudo ./utils/searxng.sh install buildhost
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
@@ -75,7 +75,7 @@ jobs:
           ./local
           ./.nvm
           ./node_modules
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
+        key: python-ubuntu-20.04-3.12-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: Install node dependencies
       run: make V=1 node.env
     - name: Build themes
@@ -95,9 +95,9 @@ jobs:
     - name: Install Ubuntu packages
       run: sudo ./utils/searxng.sh install buildhost
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
@@ -107,7 +107,7 @@ jobs:
           ./local
           ./.nvm
           ./node_modules
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
+        key: python-ubuntu-20.04-3.12-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: Build documentation
       run: |
         make V=1 docs.clean docs.html
@@ -139,9 +139,9 @@ jobs:
         fetch-depth: '0'
         token: ${{ secrets.WEBLATE_GITHUB_TOKEN }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
@@ -151,7 +151,7 @@ jobs:
           ./local
           ./.nvm
           ./node_modules
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
+        key: python-ubuntu-20.04-3.12-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: weblate & git setup
       env:
         WEBLATE_CONFIG: ${{ secrets.WEBLATE_CONFIG }}
@@ -183,9 +183,9 @@ jobs:
           # make sure "make docker.push" can get the git history
           fetch-depth: '0'
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
       - name: Cache Python dependencies
         id: cache-python
@@ -195,7 +195,7 @@ jobs:
             ./local
             ./.nvm
             ./node_modules
-          key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
+          key: python-ubuntu-20.04-3.12-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
       - name: Set up QEMU
         if: env.DOCKERHUB_USERNAME != null
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/translations-update.yml
+++ b/.github/workflows/translations-update.yml
@@ -16,9 +16,9 @@ jobs:
         fetch-depth: '0'
         token: ${{ secrets.WEBLATE_GITHUB_TOKEN }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
         architecture: 'x64'
     - name: Cache Python dependencies
       id: cache-python
@@ -28,7 +28,7 @@ jobs:
           ./local
           ./.nvm
           ./node_modules
-        key: python-ubuntu-20.04-3.9-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
+        key: python-ubuntu-20.04-3.12-${{ hashFiles('requirements*.txt', 'setup.py','.nvmrc', 'package.json') }}
     - name: weblate & git setup
       env:
         WEBLATE_CONFIG: ${{ secrets.WEBLATE_CONFIG }}

--- a/docs/build-templates/searxng.rst
+++ b/docs/build-templates/searxng.rst
@@ -113,7 +113,7 @@ ${fedora_build}
 
        (${SERVICE_USER})$ command -v python && python --version
        $SEARXNG_PYENV/bin/python
-       Python 3.8.1
+       Python 3.11.10
 
        # update pip's boilerplate ..
        pip install -U pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,7 @@ pylint==3.2.7
 splinter==0.21.0
 selenium==4.25.0
 Pallets-Sphinx-Themes==2.1.3
-Sphinx<=7.1.2; python_version == '3.8'
-Sphinx==7.4.7; python_version > '3.8'
+Sphinx==7.4.7
 sphinx-issues==4.1.0
 sphinx-jinja==2.0.2
 sphinx-tabs==3.4.5
@@ -20,6 +19,5 @@ aiounittest==1.4.2
 yamllint==1.35.1
 wlc==1.15
 coloredlogs==15.0.1
-docutils<=0.21; python_version == '3.8'
-docutils>=0.21.2; python_version > '3.8'
+docutils>=0.21.2
 parameterized==0.9.0

--- a/utils/lib_sxng_test.sh
+++ b/utils/lib_sxng_test.sh
@@ -93,13 +93,8 @@ test.robot() {
 test.rst() {
     build_msg TEST "[reST markup] ${RST_FILES[*]}"
 
-    local rst2html=rst2html
-    if [ "3.8" == "$(python -c 'import sys; print(".".join([str(x) for x in sys.version_info[:2]]))')" ]; then
-       rst2html=rst2html.py
-    fi
-
     for rst in "${RST_FILES[@]}"; do
-        pyenv.cmd "${rst2html}" --halt error "$rst" > /dev/null || die 42 "fix issue in $rst"
+        pyenv.cmd rst2html --halt error "$rst" > /dev/null || die 42 "fix issue in $rst"
     done
 }
 


### PR DESCRIPTION
## What does this PR do?

- drop py 3.8 support
- add py 3.13 to CI
- lift py3.9 based builds to builds based on py3.12
- upgrade CI to actions/setup-python@v5

Related:

- https://github.com/searxng/searxng/pull/3663