### PR TITLE
[fix] fix float operations in calculator plugin

### DIFF
--- a/tests/unit/test_plugin_calculator.py
+++ b/tests/unit/test_plugin_calculator.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring
+
+from mock import Mock
+from parameterized.parameterized import parameterized
+from searx import plugins
+from tests import SearxTestCase
+from .test_utils import random_string
+
+from .test_plugins import get_search_mock
+
+
+class PluginCalculator(SearxTestCase):  # pylint: disable=missing-class-docstring
+    def setUp(self):
+        self.store = plugins.PluginStore()
+        plugin = plugins.load_and_initialize_plugin('searx.plugins.calculator', False, (None, {}))
+        self.store.register(plugin)
+
+    def test_plugin_store_init(self):
+        self.assertEqual(1, len(self.store.plugins))
+
+    def test_single_page_number_true(self):
+        request = Mock(remote_addr='127.0.0.1')
+        search = get_search_mock(query=random_string(10), pageno=2)
+        result = self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertTrue(result)
+        self.assertNotIn('calculate', search.result_container.answers)
+
+    def test_long_query_true(self):
+        request = Mock(remote_addr='127.0.0.1')
+        search = get_search_mock(query=random_string(101), pageno=1)
+        result = self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertTrue(result)
+        self.assertNotIn('calculate', search.result_container.answers)
+
+    def test_alpha_true(self):
+        request = Mock(remote_addr='127.0.0.1')
+        search = get_search_mock(query=random_string(10), pageno=1)
+        result = self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertTrue(result)
+        self.assertNotIn('calculate', search.result_container.answers)
+
+    @parameterized.expand(
+        [
+            "1+1",
+            "1-1",
+            "1*1",
+            "1/1",
+            "1**1",
+            "1^1",
+        ]
+    )
+    def test_int_operations(self, operation):
+        request = Mock(remote_addr='127.0.0.1')
+        search = get_search_mock(query=operation, pageno=1)
+        result = self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertTrue(result)
+        self.assertIn('calculate', search.result_container.answers)
+
+    @parameterized.expand(
+        [
+            "1/0",
+        ]
+    )
+    def test_invalid_operations(self, operation):
+        request = Mock(remote_addr='127.0.0.1')
+        search = get_search_mock(query=operation, pageno=1)
+        result = self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertTrue(result)
+        self.assertNotIn('calculate', search.result_container.answers)

--- a/tests/unit/test_plugin_calculator.py
+++ b/tests/unit/test_plugin_calculator.py
@@ -42,20 +42,35 @@ class PluginCalculator(SearxTestCase):  # pylint: disable=missing-class-docstrin
 
     @parameterized.expand(
         [
-            "1+1",
-            "1-1",
-            "1*1",
-            "1/1",
-            "1**1",
-            "1^1",
+            ("1+1", "2", "en-US"),
+            ("1-1", "0", "en-US"),
+            ("1*1", "1", "en-US"),
+            ("1/1", "1", "en-US"),
+            ("1**1", "1", "en-US"),
+            ("1^1", "1", "en-US"),
+            ("1,000.0+1,000.0", "2,000", "en-US"),
+            ("1.0+1.0", "2", "en-US"),
+            ("1.0-1.0", "0", "en-US"),
+            ("1.0*1.0", "1", "en-US"),
+            ("1.0/1.0", "1", "en-US"),
+            ("1.0**1.0", "1", "en-US"),
+            ("1.0^1.0", "1", "en-US"),
+            ("1.000,0+1.000,0", "2.000", "de-DE"),
+            ("1,0+1,0", "2", "de-DE"),
+            ("1,0-1,0", "0", "de-DE"),
+            ("1,0*1,0", "1", "de-DE"),
+            ("1,0/1,0", "1", "de-DE"),
+            ("1,0**1,0", "1", "de-DE"),
+            ("1,0^1,0", "1", "de-DE"),
         ]
     )
-    def test_int_operations(self, operation):
+    def test_localized_query(self, operation: str, contains_result: str, lang: str):
         request = Mock(remote_addr='127.0.0.1')
-        search = get_search_mock(query=operation, pageno=1)
+        search = get_search_mock(query=operation, lang=lang, pageno=1)
         result = self.store.call(self.store.plugins, 'post_search', request, search)
         self.assertTrue(result)
         self.assertIn('calculate', search.result_container.answers)
+        self.assertIn(contains_result, search.result_container.answers['calculate']['answer'])
 
     @parameterized.expand(
         [

--- a/tests/unit/test_plugin_hash.py
+++ b/tests/unit/test_plugin_hash.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring, invalid-name
+
+from mock import Mock
+from parameterized.parameterized import parameterized
+from searx import plugins
+from tests import SearxTestCase
+
+from .test_plugins import get_search_mock
+
+
+class PluginHashTest(SearxTestCase):  # pylint: disable=missing-class-docstring
+    def setUp(self):
+        self.store = plugins.PluginStore()
+        plugin = plugins.load_and_initialize_plugin('searx.plugins.hash_plugin', False, (None, {}))
+        self.store.register(plugin)
+
+    def test_plugin_store_init(self):
+        self.assertEqual(1, len(self.store.plugins))
+
+    @parameterized.expand(
+        [
+            ('md5 test', 'md5 hash digest: 098f6bcd4621d373cade4e832627b4f6'),
+            ('sha1 test', 'sha1 hash digest: a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'),
+            ('sha224 test', 'sha224 hash digest: 90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809'),
+            ('sha256 test', 'sha256 hash digest: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'),
+            (
+                'sha384 test',
+                'sha384 hash digest: 768412320f7b0aa5812fce428dc4706b3c'
+                'ae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf1'
+                '7a0a9',
+            ),
+            (
+                'sha512 test',
+                'sha512 hash digest: ee26b0dd4af7e749aa1a8ee3c10ae9923f6'
+                '18980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5'
+                'fa9ad8e6f57f50028a8ff',
+            ),
+        ]
+    )
+    def test_hash_digest_new(self, query: str, hash_str: str):
+        request = Mock(remote_addr='127.0.0.1')
+        search = get_search_mock(query=query, pageno=1)
+        self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertIn(hash_str, search.result_container.answers['hash']['answer'])
+
+    def test_md5_bytes_no_answer(self):
+        request = Mock(remote_addr='127.0.0.1')
+        search = get_search_mock(query=b'md5 test', pageno=2)
+        self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertNotIn('hash', search.result_container.answers)

--- a/tests/unit/test_plugin_self_info.py
+++ b/tests/unit/test_plugin_self_info.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring, invalid-name
+
+from mock import Mock
+from parameterized.parameterized import parameterized
+
+from searx import (
+    plugins,
+    limiter,
+    botdetection,
+)
+from tests import SearxTestCase
+from .test_plugins import get_search_mock
+
+
+class PluginIPSelfInfo(SearxTestCase):  # pylint: disable=missing-class-docstring
+    def setUp(self):
+        plugin = plugins.load_and_initialize_plugin('searx.plugins.self_info', False, (None, {}))
+        self.store = plugins.PluginStore()
+        self.store.register(plugin)
+        cfg = limiter.get_cfg()
+        botdetection.init(cfg, None)
+
+    def test_plugin_store_init(self):
+        self.assertEqual(1, len(self.store.plugins))
+
+    def test_ip_in_answer(self):
+        request = Mock()
+        request.remote_addr = '127.0.0.1'
+        request.headers = {'X-Forwarded-For': '1.2.3.4, 127.0.0.1', 'X-Real-IP': '127.0.0.1'}
+        search = get_search_mock(query='ip', pageno=1)
+        self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertIn('127.0.0.1', search.result_container.answers["ip"]["answer"])
+
+    def test_ip_not_in_answer(self):
+        request = Mock()
+        request.remote_addr = '127.0.0.1'
+        request.headers = {'X-Forwarded-For': '1.2.3.4, 127.0.0.1', 'X-Real-IP': '127.0.0.1'}
+        search = get_search_mock(query='ip', pageno=2)
+        self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertNotIn('ip', search.result_container.answers)
+
+    @parameterized.expand(
+        [
+            'user-agent',
+            'What is my User-Agent?',
+        ]
+    )
+    def test_user_agent_in_answer(self, query: str):
+        request = Mock(user_agent=Mock(string='Mock'))
+        search = get_search_mock(query=query, pageno=1)
+        self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertIn('Mock', search.result_container.answers["user-agent"]["answer"])
+
+    @parameterized.expand(
+        [
+            'user-agent',
+            'What is my User-Agent?',
+        ]
+    )
+    def test_user_agent_not_in_answer(self, query: str):
+        request = Mock(user_agent=Mock(string='Mock'))
+        search = get_search_mock(query=query, pageno=2)
+        self.store.call(self.store.plugins, 'post_search', request, search)
+        self.assertNotIn('user-agent', search.result_container.answers)

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=missing-module-docstring
 
+import babel
 from mock import Mock
 from searx import plugins
 from tests import SearxTestCase
 
 
 def get_search_mock(query, **kwargs):
+    lang = kwargs.get("lang", "en-US")
+    kwargs["locale"] = babel.Locale.parse(lang, sep="-")
     return Mock(search_query=Mock(query=query, **kwargs), result_container=Mock(answers={}))
 
 

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -2,14 +2,7 @@
 # pylint: disable=missing-module-docstring
 
 from mock import Mock
-from parameterized.parameterized import parameterized
-
-from searx import (
-    plugins,
-    limiter,
-    botdetection,
-)
-
+from searx import plugins
 from tests import SearxTestCase
 
 
@@ -52,97 +45,3 @@ class PluginStoreTest(SearxTestCase):  # pylint: disable=missing-class-docstring
         request = Mock()
         store.call([testplugin], 'asdf', request, Mock())
         self.assertTrue(getattr(testplugin, 'asdf').called)  # pylint: disable=E1101
-
-
-class PluginIPSelfInfo(SearxTestCase):  # pylint: disable=missing-class-docstring
-    def setUp(self):
-        plugin = plugins.load_and_initialize_plugin('searx.plugins.self_info', False, (None, {}))
-        self.store = plugins.PluginStore()
-        self.store.register(plugin)
-        cfg = limiter.get_cfg()
-        botdetection.init(cfg, None)
-
-    def test_plugin_store_init(self):
-        self.assertEqual(1, len(self.store.plugins))
-
-    def test_ip_in_answer(self):
-        request = Mock()
-        request.remote_addr = '127.0.0.1'
-        request.headers = {'X-Forwarded-For': '1.2.3.4, 127.0.0.1', 'X-Real-IP': '127.0.0.1'}
-        search = get_search_mock(query='ip', pageno=1)
-        self.store.call(self.store.plugins, 'post_search', request, search)
-        self.assertIn('127.0.0.1', search.result_container.answers["ip"]["answer"])
-
-    def test_ip_not_in_answer(self):
-        request = Mock()
-        request.remote_addr = '127.0.0.1'
-        request.headers = {'X-Forwarded-For': '1.2.3.4, 127.0.0.1', 'X-Real-IP': '127.0.0.1'}
-        search = get_search_mock(query='ip', pageno=2)
-        self.store.call(self.store.plugins, 'post_search', request, search)
-        self.assertNotIn('ip', search.result_container.answers)
-
-    @parameterized.expand(
-        [
-            'user-agent',
-            'What is my User-Agent?',
-        ]
-    )
-    def test_user_agent_in_answer(self, query: str):
-        request = Mock(user_agent=Mock(string='Mock'))
-        search = get_search_mock(query=query, pageno=1)
-        self.store.call(self.store.plugins, 'post_search', request, search)
-        self.assertIn('Mock', search.result_container.answers["user-agent"]["answer"])
-
-    @parameterized.expand(
-        [
-            'user-agent',
-            'What is my User-Agent?',
-        ]
-    )
-    def test_user_agent_not_in_answer(self, query: str):
-        request = Mock(user_agent=Mock(string='Mock'))
-        search = get_search_mock(query=query, pageno=2)
-        self.store.call(self.store.plugins, 'post_search', request, search)
-        self.assertNotIn('user-agent', search.result_container.answers)
-
-
-class PluginHashTest(SearxTestCase):  # pylint: disable=missing-class-docstring
-    def setUp(self):
-        self.store = plugins.PluginStore()
-        plugin = plugins.load_and_initialize_plugin('searx.plugins.hash_plugin', False, (None, {}))
-        self.store.register(plugin)
-
-    def test_plugin_store_init(self):
-        self.assertEqual(1, len(self.store.plugins))
-
-    @parameterized.expand(
-        [
-            ('md5 test', 'md5 hash digest: 098f6bcd4621d373cade4e832627b4f6'),
-            ('sha1 test', 'sha1 hash digest: a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'),
-            ('sha224 test', 'sha224 hash digest: 90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809'),
-            ('sha256 test', 'sha256 hash digest: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'),
-            (
-                'sha384 test',
-                'sha384 hash digest: 768412320f7b0aa5812fce428dc4706b3c'
-                'ae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf1'
-                '7a0a9',
-            ),
-            (
-                'sha512 test',
-                'sha512 hash digest: ee26b0dd4af7e749aa1a8ee3c10ae9923f6'
-                '18980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5'
-                'fa9ad8e6f57f50028a8ff',
-            ),
-        ]
-    )
-    def test_hash_digest_new(self, query: str, hash_str: str):
-        request = Mock(remote_addr='127.0.0.1')
-        search = get_search_mock(query=query, pageno=1)
-        self.store.call(self.store.plugins, 'post_search', request, search)
-        self.assertIn(hash_str, search.result_container.answers['hash']['answer'])
-
-    def test_md5_bytes_no_answer(self):
-        request = Mock(remote_addr='127.0.0.1')
-        search = get_search_mock(query=b'md5 test', pageno=2)
-        self.store.call(self.store.plugins, 'post_search', request, search)
-        self.assertNotIn('hash', search.result_container.answers)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,14 +1,19 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=missing-module-docstring, invalid-name
 
+import random
+import string
 import lxml.etree
 from lxml import html
 from parameterized.parameterized import parameterized
 
 from searx.exceptions import SearxXPathSyntaxException, SearxEngineXPathException
 from searx import utils
-
 from tests import SearxTestCase
+
+
+def random_string(length, choices=string.ascii_letters):
+    return ''.join(random.choice(choices) for _ in range(length))
 
 
 class TestUtils(SearxTestCase):  # pylint: disable=missing-class-docstring
@@ -234,4 +239,4 @@ class TestXPathUtils(SearxTestCase):  # pylint: disable=missing-class-docstring
         self.assertIsNone(l)
 
         with self.assertRaises(ValueError):
-            utils.detect_language(None)
+            utils.detect_language(None)  # type: ignore

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -4,6 +4,7 @@
 import logging
 import json
 from urllib.parse import ParseResult
+import babel
 from mock import Mock
 from searx.results import Timing
 
@@ -82,6 +83,7 @@ class ViewsTestCase(SearxTestCase):  # pylint: disable=missing-class-docstring, 
                 redirect_url=None,
                 engine_data={},
             )
+            search_self.search_query.locale = babel.Locale.parse("en-US", sep='-')
 
         self.setattr4test(Search, 'search', search_mock)
 


### PR DESCRIPTION
## What does this PR do?

This PR adds an additional isinstance check within the ast parser to check for float along with int, fixing the underlying issue.

This commit also includes some additional refactoring in unit tests. As we test more plugins, it seems unwieldy to include every test class in the test_plugins.py file. I split apart all of the test plugins to their own respective files, including the new test_plugin_calculator.py file.

**NOTE**

This PR does NOT intend to address localization issues, and was not explicitly tested.

## Why is this change important?

Fixes an issue that decimal numbers don't work for the calculator.

## How to test this PR locally?

I was able to recreate the issue entirely through unit tests, so all that is needed to assert this works is to run the unit tests.

 - `make test.unit`

## Author's checklist

 - n/a

## Related issues

- #3854