### PR TITLE
[fix] docker: alpine - install apk py3-pydantic-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apk add --no-cache -t build-dependencies \
     uwsgi \
     uwsgi-python3 \
     brotli \
+    py3-pydantic-core \
  && pip3 install --break-system-packages --no-cache -r requirements.txt \
  && apk del build-dependencies \
  && rm -rf /root/.cache


### PR DESCRIPTION
Alpine Linux uses musl libc (instead of glibc). However, there is no pre-build of the pydantic-core python package for musl lib on armv7.  Alternatively this patch installs py3-pydantic-core from Alpine packages [1]

[1] https://pkgs.alpinelinux.org/package/edge/community/armv7/py3-pydantic-core

- closes: https://github.com/searxng/searxng/issues/3887

----

I currently have no opportunity to test the patch .. maybe one of you has the opportunity .. would be a great help.