### PR TITLE
[mod] PR template: "Before You Submit" add hint about CONTRIBUTING.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,13 @@
 <!--
 Closes #234
 -->
+
+## Before You Submit
+<small>Please ensure you check the following items to indicate that you've read this section and completed each task</small>
+
+- [ ] My code follows the [Contribution Guidelines](https://github.com/searxng/searxng/blob/master/CONTRIBUTING.md)
+- [ ] I give expressed consent for my work to be used in this repo
+- [ ] I have tested my work and it functions as intended
+- [ ] I have included documentation if the change requires such
+
+If you have problems, e.g. with the documentation (reST markup), then we can help in the review process.


### PR DESCRIPTION

## What does this PR do?

Extend PR template by a new section "Before You Submit" and add hint about [CONTRIBUTING.md](https://github.com/searxng/searxng/blob/master/CONTRIBUTING.md)

## Why is this change important?

Contributors should be able to take note of our rules ([CONTRIBUTING.md](https://github.com/searxng/searxng/blob/master/CONTRIBUTING.md))

## How to test this PR locally?

HTML rendered preview: [PULL_REQUEST_TEMPLATE.md](
https://github.com/return42/searxng/blob/mod-PR-template/PULL_REQUEST_TEMPLATE.md)

## Before You Submit
<small>Please ensure you check the following items to indicate that you've read this section and completed each task</small>
- [x] My code follows the [Contribution Guidelines](https://github.com/searxng/searxng/blob/master/CONTRIBUTING.md)
- [x] I give expressed consent for my work to be used in this repo
- [x] I have tested my work and it functions as intended
- [x] I have included documentation if the change requires such
If you have problems, e.g. with the documentation (reST markup), then we can help in the review process.