### PR TITLE
[refactor] translation engines: common interface

### DIFF
--- a/searx/engines/deepl.py
+++ b/searx/engines/deepl.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Deepl translation engine"""
 
-from json import loads
-
 about = {
     "website": 'https://deepl.com',
     "wikidata_id": 'Q43968444',
@@ -41,16 +39,14 @@ def request(_query, params):
 
 def response(resp):
     results = []
-    result = loads(resp.text)
-    translations = result['translations']
 
-    infobox = "<dl>"
+    result = resp.json()
 
-    for translation in translations:
-        infobox += f"<dd>{translation['text']}</dd>"
+    if not result.get('translations'):
+        return results
 
-    infobox += "</dl>"
+    translations = [{'text': translation['text']} for translation in result['translations']]
 
-    results.append({'answer': infobox})
+    results.append({'answer': translations[0]['text'], 'answer_type': 'translations', 'translations': translations})
 
     return results

--- a/searx/engines/libretranslate.py
+++ b/searx/engines/libretranslate.py
@@ -24,7 +24,7 @@ def request(_query, params):
     request_url = random.choice(base_url) if isinstance(base_url, list) else base_url
     params['url'] = f"{request_url}/translate"
 
-    args = {'source': params['from_lang'][1], 'target': params['to_lang'][1], 'q': params['query']}
+    args = {'source': params['from_lang'][1], 'target': params['to_lang'][1], 'q': params['query'], 'alternatives': 3}
     if api_key:
         args['api_key'] = api_key
     params['data'] = dumps(args)
@@ -42,12 +42,11 @@ def response(resp):
     json_resp = resp.json()
     text = json_resp.get('translatedText')
 
-    from_lang = resp.search_params["from_lang"][1]
-    to_lang = resp.search_params["to_lang"][1]
-    query = resp.search_params["query"]
-    req_url = resp.search_params["req_url"]
+    if not text:
+        return results
 
-    if text:
-        results.append({"answer": text, "url": f"{req_url}/?source={from_lang}&target={to_lang}&q={query}"})
+    translations = [{'text': text}] + [{'text': alternative} for alternative in json_resp.get('alternatives', [])]
+
+    results.append({'answer': text, 'answer_type': 'translations', 'translations': translations})
 
     return results

--- a/searx/engines/translated.py
+++ b/searx/engines/translated.py
@@ -35,18 +35,16 @@ def request(query, params):  # pylint: disable=unused-argument
 
 
 def response(resp):
-    results = []
-    results.append(
-        {
-            'url': web_url.format(
-                from_lang=resp.search_params['from_lang'][2],
-                to_lang=resp.search_params['to_lang'][2],
-                query=resp.search_params['query'],
-            ),
-            'title': '[{0}-{1}] {2}'.format(
-                resp.search_params['from_lang'][1], resp.search_params['to_lang'][1], resp.search_params['query']
-            ),
-            'content': resp.json()['responseData']['translatedText'],
-        }
-    )
-    return results
+    json_resp = resp.json()
+    text = json_resp['responseData']['translatedText']
+
+    alternatives = [match['translation'] for match in json_resp['matches'] if match['translation'] != text]
+    translations = [{'text': translation} for translation in [text] + alternatives]
+
+    result = {
+        'answer': translations[0]['text'],
+        'answer_type': 'translations',
+        'translations': translations,
+    }
+
+    return [result]

--- a/searx/templates/simple/answerers/translate.html
+++ b/searx/templates/simple/answerers/translate.html
@@ -1,0 +1,38 @@
+<div class="answer-translations">
+{% for translation in translations %}
+  {% if loop.index > 1 %}
+  <hr />
+  {% endif %}
+  <h3>{{ translation.text }}</h3>
+  {% if translation.transliteration %}
+  <b>translation.transliteration</b>
+  {% endif %} {% if translation.definitions %}
+  <dl>
+    <dt>{{ _('Definitions') }}</dt>
+    <ul>
+    {% for definition in translation.definitions %}
+    <li>{{ definition }}</li>
+    {% endfor %}
+    <ul>
+  </dl>
+  {% endif %} {% if translation.examples %}
+  <dl>
+    <dt>{{ _('Examples') }}</dt>
+    <ul>
+    {% for example in translation.examples %}
+    <li>{{ example }}</li>
+    {% endfor %}
+    </ul>
+  </dl>
+  {% endif %} {% if translation.synonyms %}
+  <dl>
+    <dt>{{ _('Synonyms') }}</dt>
+    <ul>
+    {% for synonym in translation.synonyms %}
+    <li>{{ synonym }}</li>
+    {% endfor %}
+    </ul>
+  </dl>
+  {% endif %}
+{% endfor %}
+</div>

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -23,14 +23,20 @@
     <div id="answers" role="complementary" aria-labelledby="answers-title"><h4 class="title" id="answers-title">{{ _('Answers') }} : </h4>
         {%- for answer in answers.values() -%}
         <div class="answer">
-        <span>{{ answer.answer }}</span>
-          {%- if answer.url -%}
-          <a href="{{ answer.url }}" class="answer-url"
-             {%- if results_on_new_tab %} target="_blank" rel="noopener noreferrer"
-             {%- else -%} rel="noreferrer"
-             {%- endif -%}
-             >{{ urlparse(answer.url).hostname }}</a>
-          {% endif -%}
+          {%- if answer.answer_type == 'translations' -%}
+            {% with translations=answer.translations %}
+              {% include 'simple/answerers/translate.html' %}
+            {% endwith %}
+          {%- else -%}
+            <span>{{ answer.answer }}</span>
+            {%- if answer.url -%}
+              <a href="{{ answer.url }}" class="answer-url"
+                 {%- if results_on_new_tab %} target="_blank" rel="noopener noreferrer"
+                 {%- else -%} rel="noreferrer"
+                 {%- endif -%}
+                 >{{ urlparse(answer.url).hostname }}</a>
+            {% endif -%}
+          {%- endif -%}
         </div>
         {%- endfor -%}
     </div>


### PR DESCRIPTION
## What does this PR do?
- add a common answer template for translation engine results

## Why is this change important?
- see https://github.com/searxng/searxng/issues/3576

## How to test this PR locally?
- use mozhi, lingva, LibreTranslate, Dictzone, MyMemory Translated or DeepL

## Author's checklist
- this is just a basic idea, more engines need to be converted if the approach seems okay
- something similar should also be done to the weather engines

## Related issues
closes https://github.com/searxng/searxng/issues/3576
