### PR TITLE
[fix] ci: docker builds broken on armv7l (hack)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,14 @@ RUN apk add --no-cache -t build-dependencies \
     uwsgi \
     uwsgi-python3 \
     brotli \
- && pip3 install --break-system-packages --no-cache -r requirements.txt \
- && apk del build-dependencies \
+# For 32bit arm architecture install pydantic from the alpine repos instead of requirements.txt
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm" ]; then \
+        apk add --no-cache py3-pydantic && pip install --no-cache --break-system-packages -r <(grep -v '^pydantic' requirements.txt); \
+    else \
+        pip install --no-cache --break-system-packages -r requirements.txt; \
+    fi
+ RUN apk del build-dependencies \
  && rm -rf /root/.cache
 
 COPY --chown=searxng:searxng dockerfiles ./dockerfiles


### PR DESCRIPTION
Add temporary fix to broken docker builds in anticipation of yet to be released pydantic version v2.24.1

## What does this PR do?

Temporary fix for broken docker builds 


Closes #3887 
