### PR TITLE
[refactor] replace pydantic by msgspec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,7 @@ RUN apk add --no-cache -t build-dependencies \
     tini \
     uwsgi \
     uwsgi-python3 \
-    brotli
-
+    brotli \
 # For 32bit arm architecture install pydantic from the alpine repos instead of requirements.txt
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,8 @@ RUN apk add --no-cache -t build-dependencies \
     uwsgi \
     uwsgi-python3 \
     brotli \
-# For 32bit arm architecture install pydantic from the alpine repos instead of requirements.txt
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "arm" ]; then \
-        apk add --no-cache py3-pydantic && pip install --no-cache --break-system-packages -r <(grep -v '^pydantic' requirements.txt); \
-    else \
-        pip install --no-cache --break-system-packages -r requirements.txt; \
-    fi
- RUN apk del build-dependencies \
+ && pip3 install --break-system-packages --no-cache -r requirements.txt \
+ && apk del build-dependencies \
  && rm -rf /root/.cache
 
 COPY --chown=searxng:searxng dockerfiles ./dockerfiles

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ redis==5.0.8
 markdown-it-py==3.0.0
 fasttext-predict==0.9.2.2
 tomli==2.0.2; python_version < '3.11'
-pydantic==2.9.2
+msgspec==0.18.6
 eval_type_backport; python_version < '3.9'
 typer-slim==0.12.5

--- a/searx/favicons/cache.py
+++ b/searx/favicons/cache.py
@@ -30,7 +30,7 @@ import tempfile
 import time
 import typer
 
-from pydantic import BaseModel
+import msgspec
 
 from searx import sqlitedb
 from searx import logger
@@ -90,7 +90,7 @@ def init(cfg: "FaviconCacheConfig"):
         raise NotImplementedError(f"favicons db_type '{cfg.db_type}' is unknown")
 
 
-class FaviconCacheConfig(BaseModel):
+class FaviconCacheConfig(msgspec.Struct):  # pylint: disable=too-few-public-methods
     """Configuration of the favicon cache."""
 
     db_type: Literal["sqlite", "mem"] = "sqlite"

--- a/searx/favicons/config.py
+++ b/searx/favicons/config.py
@@ -4,9 +4,8 @@
 from __future__ import annotations
 
 import pathlib
-from pydantic import BaseModel
+import msgspec
 
-from searx.compat import tomllib
 from .cache import FaviconCacheConfig
 from .proxy import FaviconProxyConfig
 
@@ -19,7 +18,7 @@ TOML_CACHE_CFG: dict[str, "FaviconConfig"] = {}
 DEFAULT_CFG_TOML_PATH = pathlib.Path(__file__).parent / "favicons.toml"
 
 
-class FaviconConfig(BaseModel):
+class FaviconConfig(msgspec.Struct):  # pylint: disable=too-few-public-methods
     """The class aggregates configurations of the favicon tools"""
 
     cfg_schema: int
@@ -28,10 +27,10 @@ class FaviconConfig(BaseModel):
     By specifying a version, it is possible to ensure downward compatibility in
     the event of future changes to the configuration schema"""
 
-    cache: FaviconCacheConfig = FaviconCacheConfig()
+    cache: FaviconCacheConfig = FaviconCacheConfig
     """Setup of the :py:obj:`.cache.FaviconCacheConfig`."""
 
-    proxy: FaviconProxyConfig = FaviconProxyConfig()
+    proxy: FaviconProxyConfig = FaviconCacheConfig
     """Setup of the :py:obj:`.proxy.FaviconProxyConfig`."""
 
     @classmethod
@@ -45,18 +44,22 @@ class FaviconConfig(BaseModel):
             return cached
 
         with cfg_file.open("rb") as f:
+            data = f.read()
 
-            cfg = tomllib.load(f)
-            cfg = cfg.get("favicons", cfg)
+        cfg = msgspec.toml.decode(data, type=_FaviconConfig)
+        schema = cfg.favicons.cfg_schema
+        if schema != CONFIG_SCHEMA:
+            raise ValueError(
+                f"config schema version {CONFIG_SCHEMA} is needed, version {schema} is given in {cfg_file}"
+            )
 
-            schema = cfg.get("cfg_schema")
-            if schema != CONFIG_SCHEMA:
-                raise ValueError(
-                    f"config schema version {CONFIG_SCHEMA} is needed, version {schema} is given in {cfg_file}"
-                )
+        cfg = cfg.favicons
+        if use_cache and cached:
+            TOML_CACHE_CFG[str(cfg_file.resolve())] = cfg
 
-            cfg = cls(**cfg)
-            if use_cache and cached:
-                TOML_CACHE_CFG[str(cfg_file.resolve())] = cfg
+        return cfg
 
-            return cfg
+
+class _FaviconConfig(msgspec.Struct):  # pylint: disable=too-few-public-methods
+    # wrapper struct for root object "favicons."
+    favicons: FaviconConfig

--- a/searx/favicons/proxy.py
+++ b/searx/favicons/proxy.py
@@ -12,7 +12,7 @@ import urllib.parse
 
 import flask
 from httpx import HTTPError
-from pydantic import BaseModel
+import msgspec
 
 from searx import get_setting
 
@@ -41,7 +41,7 @@ def _initial_resolver_map():
     return d
 
 
-class FaviconProxyConfig(BaseModel):
+class FaviconProxyConfig(msgspec.Struct):
     """Configuration of the favicon proxy."""
 
     max_age: int = 60 * 60 * 24 * 7  # seven days
@@ -59,7 +59,7 @@ class FaviconProxyConfig(BaseModel):
     outgoing request of the resolver.  By default, the value from
     :ref:`outgoing.request_timeout <settings outgoing>` setting is used."""
 
-    resolver_map: dict[str, str] = _initial_resolver_map()
+    resolver_map: dict[str, str] = msgspec.field(default_factory=_initial_resolver_map)
     """The resolver_map is a key / value dictionary where the key is the name of
     the resolver and the value is the fully qualifying name (fqn) of resolver's
     function (the callable).  The resolvers from the python module


### PR DESCRIPTION
## What does this PR do?

replace pydantic by msgspec and revert:

- https://github.com/searxng/searxng/pull/3936
- https://github.com/searxng/searxng/pull/3937


## Why is this change important?

After we had the problems with pydantic in the docker build, we took a closer look at pydantic and are no longer convinced that this is the right solution for SearXNG ... @dalf suggested that we could also use msgspec for our purposes.
The core of msgspec is written in C and msgspec is generally considered to be more performant than pydantic, which also has a rust implementation that makes compiling the wheels (which are often required on platforms like armv7) easier.

## How to test this PR locally?

Activate the favicons:

```diff
diff --git a/searx/settings.yml b/searx/settings.yml
index b37134b88..b120378b6 100644
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -37,7 +37,7 @@ search:
   autocomplete_min: 4
   # backend for the favicon near URL in search results.
   # Available resolvers: "allesedv", "duckduckgo", "google", "yandex" - leave blank to turn it off by default.
-  favicon_resolver: ""
+  favicon_resolver: "duckduckgo"
   # Default search language - leave blank to detect from browser information or
   # use codes from 'languages.py'
   default_lang: "auto"
```

Start `make run` and in the result of a query you should see the favicons (and no ERROR in the log on stdout).

Stop instance by `CTRL-C`.

To test type checking of msgspec change a config setting to an invalid type / here an example for "str" where "int" is expected:

```diff
diff --git a/searx/favicons/favicons.toml b/searx/favicons/favicons.toml
index 0e433d3aa..5f664e72d 100644
--- a/searx/favicons/favicons.toml
+++ b/searx/favicons/favicons.toml
@@ -1,6 +1,6 @@
 [favicons]
 
-cfg_schema = 1   # config's schema version no.
+cfg_schema = "1"   # config's schema version no.
 
 [favicons.proxy]
```

Again try to start the instance `make run` / it should end up in an error:

```
msgspec.ValidationError: Expected `int`, got `str` - at `$.favicons.cfg_schema`
make: *** [Makefile:28: run] Error 1
```