### PR TITLE
[fix] favicons: don't hard code settings folder to /etc/searxng

### DIFF
--- a/searx/favicons/__init__.py
+++ b/searx/favicons/__init__.py
@@ -22,8 +22,9 @@ def init():
     # pylint: disable=import-outside-toplevel
 
     from . import config, cache, proxy
+    from .. import settings_loader
 
-    cfg_file = pathlib.Path("/etc/searxng/favicons.toml")
+    cfg_file = (settings_loader.get_user_cfg_folder() or pathlib.Path("/etc/searxng")) / "favicons.toml"
     if not cfg_file.exists():
         if is_active():
             logger.error(f"missing favicon config: {cfg_file}")
@@ -34,4 +35,4 @@ def init():
     cache.init(cfg.cache)
     proxy.init(cfg.proxy)
 
-    del cache, config, proxy, cfg
+    del cache, config, proxy, cfg, settings_loader


### PR DESCRIPTION

## What does this PR do?

The location of the local settings depends on environment ``SEARXNG_SETTINGS_PATH`` and can be different from ``/etc/searxng``.  Issue was reported on Matrix [1].

To get the location function ``searx.settings_loader.get_user_cfg_folder()`` should be used.

## How to test this PR locally?

Activate favicons .. and do a query ``make run``

```yaml
diff --git a/searx/settings.yml b/searx/settings.yml
index b37134b88..b120378b6 100644
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -37,7 +37,7 @@ search:
   autocomplete_min: 4
   # backend for the favicon near URL in search results.
   # Available resolvers: "allesedv", "duckduckgo", "google", "yandex" - leave blank to turn it off by default.
-  favicon_resolver: ""
+  favicon_resolver: "duckduckgo"
   # Default search language - leave blank to detect from browser information or
   # use codes from 'languages.py'
   default_lang: "auto"
```


## Related issues

[1] https://matrix.to/#/!vxScbLNEAmRvOraXBn:matrix.org/$5xNMYvONGB-mPt2B3ttoL27QncRFhkjGkO-TISdmP08?via=matrix.org&via=tchncs.de&via=envs.net
