### PR TITLE
[fix] google: display every result when keyword is contained in conte…

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -62,7 +62,7 @@ filter_mapping = {0: 'off', 1: 'medium', 2: 'high'}
 results_xpath = './/div[contains(@jscontroller, "SC7lYd")]'
 title_xpath = './/a/h3[1]'
 href_xpath = './/a[h3]/@href'
-content_xpath = './/div[@data-sncf="1"]'
+content_xpath = './/div[contains(@data-sncf, "1")]'
 
 # Suggestions are links placed in a *card-section*, we extract only the text
 # from the links not the links itself.


### PR DESCRIPTION
## What does this PR do?

- Display all results that contain keyword in Google search results, ensuring users have access to relevant content matching their search terms.

## Why is this change important?

In certain scenarios, using `!go` to search specific keywords may only yield a few results per page, while many relevant results are incorrectly filtered out. 

For example, searching for “Marvel Rivals !go” currently returns only two results, even though there are more that match the criteria. 

This change is important to ensure that all relevant results are displayed, improving the accuracy and comprehensiveness of search results for users.

## How to test this PR locally?

- !go searxng stats
