### PR TITLE
[fix] CI: remove target test.coverage from python's test matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,14 +45,6 @@ jobs:
         make V=1 gecko.driver
     - name: Run tests
       run: make V=1 ci.test
-    - name: Test coverage
-      run: make V=1 test.coverage
-    - name: Store coverage result
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage-${{ matrix.python-version }}
-        path: coverage/
-        retention-days: 60
 
   themes:
     name: Themes


### PR DESCRIPTION
The test.coverage cause a lot of failed CI jobs for reasons that cannot be explained.  As we do not monitor the coverage anyway, it is superfluous to run this job, especially as it only has a disruptive effect on the CI.

BTW and the CI action upload-artifact@v3 is depricated [1]

[1] https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact

Related: https://github.com/searxng/searxng/issues/3983
