### PR TITLE
Support SEARXNG_SETTINGS_PATH folder in docker

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -135,6 +135,10 @@ update_conf() {
     fi
 }
 
+if [ -d "${SEARXNG_SETTINGS_PATH}" ]; then
+    $SEARXNG_SETTINGS_PATH="${SEARXNG_SETTINGS_PATH}/settings.yml"
+fi
+
 # searx compatibility: copy /etc/searx/* to /etc/searxng/*
 SEARX_CONF=0
 if [ -f "/etc/searx/settings.yml" ]; then


### PR DESCRIPTION
## What does this PR do?

Support `SEARXNG_SETTINGS_PATH` folder in Docker in order use https://github.com/searxng/searxng/blob/master/searx/settings_loader.py#L64-L88.

## Why is this change important?

Without this change, it seems no way to config `settings.yml`, `limiter.toml`, and `favicons.toml` at the same time without mounting volume to `/etc/searxng`.

## How to test this PR locally?

Build docker image and set `SEARXNG_SETTINGS_PATH` to a folder.