### PR TITLE
Update enabled_plugins in settings

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -226,15 +226,12 @@ outgoing:
 #   - 'Hash plugin'
 #   - 'Self Information'
 #   - 'Tracker URL remover'
+#   - 'Unit converter plugin'
 #   - 'Ahmia blacklist'  # activation depends on outgoing.using_tor_proxy
 #   # these plugins are disabled if nothing is configured ..
 #   - 'Hostnames plugin'  # see 'hostnames' configuration below
 #   - 'Open Access DOI rewrite'
 #   - 'Tor check plugin'
-#   # Read the docs before activate: auto-detection of the language could be
-#   # detrimental to users expectations / users can activate the plugin in the
-#   # preferences if they want.
-#   - 'Autodetect search language'
 
 # Configuration of the "Hostnames plugin":
 #


### PR DESCRIPTION
## What does this PR do?

Remove 'Autodetect search language', which is no longer valid, from settings, and add 'Unit converter plugin', which is now default enabled, to settings.

## Why is this change important?

Reflect current, or default, settings in `settings.yml`.

## How to test this PR locally?

It's default commented.