### PR TITLE
Fix scheduler.lua

### DIFF
--- a/searx/search/checker/scheduler.lua
+++ b/searx/search/checker/scheduler.lua
@@ -20,7 +20,7 @@ if (next_call_ts == false or next_call_ts == nil) then
     -- 2/ the next call is a random time between start_after_from and start_after_to
     local initial_delay = math.random(start_after_from, start_after_to)
     redis.call('SET', redis_key, now + initial_delay)
-    return { false, delay }
+    return { false, initial_delay }
 end
 
 -- next_call_ts is defined


### PR DESCRIPTION
## What does this PR do?

Address this error `redis.exceptions.ResponseError: user_script:23: Script attempted to access nonexistent global variable 'delay' script: 2fd717dbd3dbbbb317f66c2d9691548f90902039, on @user_script:23.` when enable `checker.scheduling`.

## Why is this change important?

Make `checker.scheduling` work.

## How to test this PR locally?

Execute lua script locally.