### PR TITLE
[fix] engine: duckduckgo - only uses first word of the search terms 

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -6,7 +6,7 @@ DuckDuckGo Lite
 
 from typing import TYPE_CHECKING
 import re
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote_plus
 import json
 import babel
 import lxml.html
@@ -245,10 +245,12 @@ def request(query, params):
 
     # Advanced search syntax ends in CAPTCHA
     # https://duckduckgo.com/duckduckgo-help-pages/results/syntax/
-    query = [
-        x.removeprefix("site:").removeprefix("intitle:").removeprefix("inurl:").removeprefix("filetype:")
-        for x in query.split()
-    ]
+    query = " ".join(
+        [
+            x.removeprefix("site:").removeprefix("intitle:").removeprefix("inurl:").removeprefix("filetype:")
+            for x in query.split()
+        ]
+    )
     eng_region = traits.get_region(params['searxng_locale'], traits.all_locale)
     if eng_region == "wt-wt":
         # https://html.duckduckgo.com/html sets an empty value for "all".
@@ -261,7 +263,7 @@ def request(query, params):
 
     params['url'] = url
     params['method'] = 'POST'
-    params['data']['q'] = query
+    params['data']['q'] = quote_plus(query)
 
     # The API is not documented, so we do some reverse engineering and emulate
     # what https://html.duckduckgo.com/html does when you press "next Page" link


### PR DESCRIPTION
Suddenly I'm getting odd results from DuckDuckGo, like if only searches for the first word in the query.

This change improved the results and looks normal and expected to me.

## What does this PR do?

I'm getting the same issue as #4009, DuckDuckGo results are only for the first word in the query.
With this change, I'm getting normal results now.

## Why is this change important?

It's very annoying to have nonsense results, if I search for "history of Egypt", the only results from DuckDuckGo are definition of "history", wikipedia's page of "history", and so on. This is reported in #4009

So a fix to this issue is important.

## How to test this PR locally?

I don't know

## Author's checklist

I don't know why `query` was a list. Maybe it should work that way too, and instead of changing duckduckgo.py this should be changed somewhere else, like the module making the request.

## Related issues

Closes #4009
