### PR TITLE
[fix] engine Library of Congress: fix API URL loc.gov -> www.loc.gov

### DIFF
--- a/searx/engines/loc.py
+++ b/searx/engines/loc.py
@@ -27,7 +27,7 @@ categories = ['images']
 paging = True
 
 endpoint = 'photos'
-base_url = 'https://loc.gov'
+base_url = 'https://www.loc.gov'
 search_string = "/{endpoint}/?sp={page}&{query}&fo=json"
 
 


### PR DESCRIPTION
Avoid HTTP 404 and redirects. Requests to the JSON/YAML API use the base url [1]

    https://www.loc.gov/{endpoint}/?fo=json

[1] https://www.loc.gov/apis/json-and-yaml/requests/