### PR TITLE
[log] warning with URL in case of 'raise_for_httperror'

### DIFF
--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -137,9 +137,6 @@ class OnlineProcessor(EngineProcessor):
         self.engine.request(query, params)
 
         # ignoring empty urls
-        if params['url'] is None:
-            return None
-
         if not params['url']:
             return None
 


### PR DESCRIPTION
In order to be able to implement error handling, it is necessary to know which URL triggered the exception / the URL has not yet been logged.