### PR TITLE
[mod] add support for Python 3.13

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           architecture: 'x64'
 
       - name: Install Python dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,5 @@ markdown-it-py==3.0.0
 fasttext-predict==0.9.2.4
 tomli==2.0.2; python_version < '3.11'
 msgspec-python313-pre
-eval_type_backport; python_version < '3.9'
 typer-slim==0.15.1
 isodate==0.7.2


### PR DESCRIPTION
Python 3.13 has been released [1]

- fasttext-predict supports py3.13 from version 0.9.2.3 [2]

[1] https://www.python.org/downloads/release/python-3130/
[2] https://github.com/searxng/fasttext-predict/commit/f2da9cd173

------

* [ ] wait for dependencies
  * [ ] msgspec -> https://github.com/jcrist/msgspec/issues/764
        * https://github.com/searxng/searxng/pull/4129 
  * [x] fasttext-predict -> https://github.com/searxng/fasttext-predict/commit/f2da9cd173

------

Closes: https://github.com/searxng/searxng/issues/4015
