### PR TITLE
[chore] remove invalid base_url from settings.yml engines

### DIFF
--- a/searx/engines/wordnik.py
+++ b/searx/engines/wordnik.py
@@ -20,13 +20,9 @@ about = {
 categories = ['general']
 paging = False
 
-URL = 'https://www.wordnik.com'
-SEARCH_URL = URL + '/words/{query}'
-
 
 def request(query, params):
-    params['url'] = SEARCH_URL.format(query=query)
-    logger.debug(f"query_url --> {params['url']}")
+    params['url'] = f"https://www.wordnik.com/words/{query}"
     return params
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -443,7 +443,6 @@ engines:
     shortcut: wp
     # add "list" to the array to get results in the results list
     display_type: ["infobox"]
-    base_url: 'https://{language}.wikipedia.org/'
     categories: [general]
 
   - name: bilibili
@@ -2233,7 +2232,6 @@ engines:
   - name: wordnik
     engine: wordnik
     shortcut: def
-    base_url: https://www.wordnik.com/
     categories: [dictionaries]
     timeout: 5.0
 
@@ -2282,7 +2280,6 @@ engines:
   - name: sjp.pwn
     engine: sjp
     shortcut: sjp
-    base_url: https://sjp.pwn.pl/
     timeout: 5.0
     disabled: true
 


### PR DESCRIPTION
The engines do not have / do not need a property `base_url`, lets remove it from the settings.yml