### PR TITLE
[fix] wikicommons engine: remove HTML tags from result items

### DIFF
--- a/searx/engines/wikicommons.py
+++ b/searx/engines/wikicommons.py
@@ -7,6 +7,8 @@ import datetime
 
 from urllib.parse import urlencode
 
+from searx.utils import html_to_text, humanize_bytes
+
 # about
 about = {
     "website": 'https://commons.wikimedia.org/',
@@ -74,7 +76,7 @@ def response(resp):
         result = {
             'url': imageinfo["descriptionurl"],
             'title': title,
-            'content': item["snippet"],
+            'content': html_to_text(item["snippet"]),
         }
 
         if search_type == "images":
@@ -93,7 +95,7 @@ def response(resp):
         elif search_type == "files":
             result['template'] = 'files.html'
             result['metadata'] = imageinfo['mime']
-            result['size'] = imageinfo['size']
+            result['size'] = humanize_bytes(imageinfo['size'])
         elif search_type == "audio":
             result['iframe_src'] = imageinfo['url']
 


### PR DESCRIPTION
BTW: humanize filesize (Bytes) to KB, MB, GB ..

Search term for a test: `!wikicommons.files :en The Fog of War`

Before this patch ..

![grafik](https://github.com/user-attachments/assets/d5d07a88-f375-4c19-afcb-6a47728e617f)

After this patch:

![grafik](https://github.com/user-attachments/assets/f99c2e4c-c566-488a-ad2e-b8c23eeb0827)
