### PR TITLE
[fix]: fix engine name may break some css style

### DIFF
--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -19,7 +19,7 @@
 
 <!-- Draw result header -->
 {% macro result_header(result, favicons, image_proxify) -%}
-<article class="result {% if result['template'] %}result-{{ result.template|replace('.html', '') }}{% else %}result-default{% endif %} {% if result['category'] %}category-{{ result['category'] }}{% endif %}{% for e in result.engines %} {{ e|replace(' ', '') }}{% endfor %}">
+<article class="result {% if result['template'] %}result-{{ result.template|replace('.html', '') }}{% else %}result-default{% endif %} {% if result['category'] %}category-{{ result['category'] }}{% endif %}{% for e in result.engines %} engine-{{ e|replace(' ', '-') }}{% endfor %}">
   {{- result_open_link(result.url, "url_header") -}}
   {%- if favicon_resolver != "" %}
   <div class="favicon"><img loading="lazy" src="{{ favicon_url(result.parsed_url.netloc) }}"></div>

--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -19,7 +19,7 @@
 
 <!-- Draw result header -->
 {% macro result_header(result, favicons, image_proxify) -%}
-<article class="result {% if result['template'] %}result-{{ result.template|replace('.html', '') }}{% else %}result-default{% endif %} {% if result['category'] %}category-{{ result['category'] }}{% endif %}{% for e in result.engines %} {{ e }}{% endfor %}">
+<article class="result {% if result['template'] %}result-{{ result.template|replace('.html', '') }}{% else %}result-default{% endif %} {% if result['category'] %}category-{{ result['category'] }}{% endif %}{% for e in result.engines %} {{ e|replace(' ', '') }}{% endfor %}">
   {{- result_open_link(result.url, "url_header") -}}
   {%- if favicon_resolver != "" %}
   <div class="favicon"><img loading="lazy" src="{{ favicon_url(result.parsed_url.netloc) }}"></div>

--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -19,7 +19,7 @@
 
 <!-- Draw result header -->
 {% macro result_header(result, favicons, image_proxify) -%}
-<article class="result {% if result['template'] %}result-{{ result.template|replace('.html', '') }}{% else %}result-default{% endif %} {% if result['category'] %}category-{{ result['category'] }}{% endif %}{% for e in result.engines %} engine-{{ e|replace(' ', '-') }}{% endfor %}">
+<article class="result {% if result['template'] %}result-{{ result.template|replace('.html', '') }}{% else %}result-default{% endif %} {% if result['category'] %}category-{{ result['category'] }}{% endif %}">
   {{- result_open_link(result.url, "url_header") -}}
   {%- if favicon_resolver != "" %}
   <div class="favicon"><img loading="lazy" src="{{ favicon_url(result.parsed_url.netloc) }}"></div>


### PR DESCRIPTION
## What does this PR do?

If engine name contains some keyword like "right", "left", "center" will break css sytle.

Eg: `right dao` will add `.right` to css
https://github.com/searxng/searxng/blob/c60fe999cf6dd77599992918b0cdb6f6c5df4baf/searx/settings.yml#L1588-L1604

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Trim white space, if engine name contains. eg: `right dao` -> `rightdao`

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/0e6f6427-27d6-4683-8ff8-f5ea4d790c1f)|![image](https://github.com/user-attachments/assets/a0a97546-1206-45e4-be2f-710426023162)|

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

Closes #4107 

<!--
Closes #234
-->
