### PR TITLE
[feat] engine: implementation of alexandria

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -361,6 +361,25 @@ engines:
     timeout: 6
     disabled: true
 
+  - name: alexandria
+    engine: json_engine
+    shortcut: alx
+    categories: general
+    paging: true
+    search_url: https://api.alexandria.org/?a=1&q={query}&p={pageno}
+    results_query: results
+    title_query: title
+    url_query: url
+    content_query: snippet
+    timeout: 1.5
+    disabled: true
+    about:
+      website: https://alexandria.org/
+      official_api_documentation: https://github.com/alexandria-org/alexandria-api/raw/master/README.md
+      use_official_api: true
+      require_api_key: false
+      results: JSON
+
   - name: alpine linux packages
     engine: alpinelinux
     disabled: true


### PR DESCRIPTION
## What does this PR do?

adds alexandria.org engine

## Why is this change important?

This was originally added in https://github.com/searxng/searxng/pull/1207
Then it was removed in https://github.com/searxng/searxng/pull/3826 because the website alexandria.org was down.
It's back now and has been for at least a few weeks.

## How to test this PR locally?

use make run and the !alx bang

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
