### PR TITLE
Introducing SearXNG Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ A user_, admin_ and developer_ handbook is available on the homepage_.
 |commits|
 |weblate|
 |SearXNG logo|
+|Gurubase|
 
 ----
 
@@ -60,6 +61,9 @@ A user_, admin_ and developer_ handbook is available on the homepage_.
    :target: https://github.com/searxng/searxng/commits/master
 
 .. |weblate| image:: https://translate.codeberg.org/widgets/searxng/-/searxng/svg-badge.svg
+
+.. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20SearXNG%20Guru-006BFF
+   :target: https://gurubase.io/g/searxng
    :target: https://translate.codeberg.org/projects/searxng/
 
 

--- a/README.rst
+++ b/README.rst
@@ -61,10 +61,10 @@ A user_, admin_ and developer_ handbook is available on the homepage_.
    :target: https://github.com/searxng/searxng/commits/master
 
 .. |weblate| image:: https://translate.codeberg.org/widgets/searxng/-/searxng/svg-badge.svg
+   :target: https://translate.codeberg.org/projects/searxng/
 
 .. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20SearXNG%20Guru-006BFF
    :target: https://gurubase.io/g/searxng
-   :target: https://translate.codeberg.org/projects/searxng/
 
 
 Contact


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [SearXNG Guru](https://gurubase.io/g/searxng) has been manually added to Gurubase. SearXNG Guru uses the data from this repo and data from the [docs](https://docs.searxng.org/) to answer questions by leveraging the LLM.

This PR introduces the "SearXNG Guru", showcasing that SearXNG now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "SearXNG Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the SearXNG documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable SearXNG Guru in Gurubase, just let us know that's totally fine.
