### PR TITLE
[fix] dockerhub: switch to new api path

### DIFF
--- a/searx/engines/docker_hub.py
+++ b/searx/engines/docker_hub.py
@@ -19,14 +19,17 @@ about = {
 categories = ['it', 'packages']  # optional
 paging = True
 
-base_url = "https://hub.docker.com/"
-search_url = base_url + "api/content/v1/products/search?{query}&type=image&page_size=25"
+base_url = "https://hub.docker.com"
+page_size = 10
 
 
 def request(query, params):
-
-    params['url'] = search_url.format(query=urlencode(dict(q=query, page=params["pageno"])))
-    params["headers"]["Search-Version"] = "v3"
+    args = {
+        "query": query,
+        "from": page_size * (params['pageno'] - 1),
+        "size": page_size,
+    }
+    params['url'] = f"{base_url}/api/search/v3/catalog/search?{urlencode(args)}"
 
     return params
 
@@ -36,23 +39,32 @@ def response(resp):
     resp: requests response object
     '''
     results = []
-    body = resp.json()
+    json_resp = resp.json()
 
-    for item in body.get("summaries", []):
-        filter_type = item.get("filter_type")
-        is_official = filter_type in ["store", "official"]
+    for item in json_resp.get("results", []):
+        image_source = item.get("source")
+        is_official = image_source in ["store", "official"]
+
+        popularity_infos = [f"{item.get('star_count', 0)} stars"]
+
+        architectures = []
+        for rate_plan in item.get("rate_plans", []):
+            pull_count = rate_plan.get("repositories", [{}])[0].get("pull_count")
+            if pull_count:
+                popularity_infos.insert(0, f"{pull_count} pulls")
+            architectures.extend(arch['name'] for arch in rate_plan.get("architectures", []) if arch['name'])
 
         result = {
             'template': 'packages.html',
-            'url': base_url + ("_/" if is_official else "r/") + item.get("slug", ""),
+            'url': base_url + ("/_/" if is_official else "/r/") + item.get("slug", ""),
             'title': item.get("name"),
             'content': item.get("short_description"),
             'thumbnail': item["logo_url"].get("large") or item["logo_url"].get("small"),
             'package_name': item.get("name"),
             'maintainer': item["publisher"].get("name"),
             'publishedDate': parser.parse(item.get("updated_at") or item.get("created_at")),
-            'popularity': item.get("pull_count", "0") + " pulls",
-            'tags': [arch['name'] for arch in item["architectures"]],
+            'popularity': ', '.join(popularity_infos),
+            'tags': architectures,
         }
         results.append(result)
 


### PR DESCRIPTION
## What does this PR do?
- migrate to the new dockerhub search api

## Why is this change important?
- the previous docker hub search api has been removed

## How to test this PR locally?
- `!dh searx`
- `!dh alpine`

## Related issues
closes #4126
