### PR TITLE
[enh] add pyproject.toml listing build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "pyyaml"]


### PR DESCRIPTION
## What does this PR do?

This PR adds a pyproject.toml with the basic requirements of setuptools and pyyaml required to run the current setup.py.

## Why is this change important?

To run the setup.py pyyaml needs to already be installed. PEP 518 'Specifying Minimum Build System Requirements for Python Projects' introduced the pyproject.toml file to specify the required dependencies in a format that build tooling like pip can parse prior to executing the setup.py.

## How to test this PR locally?

Test e.g., `pip install .` in a clean environment. Prior to this PR pip would fail with a subprocess error of `ModuleNotFoundError: No module named 'yaml'` with this PR pip installs searxng nicely.