### PR TITLE
[fix] replace unoffical msgspec-python313-pre by offical msgspec 0.19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ redis==5.0.8
 markdown-it-py==3.0.0
 fasttext-predict==0.9.2.4
 tomli==2.0.2; python_version < '3.11'
-msgspec-python313-pre
+msgspec==0.19.0
 typer-slim==0.15.1
 isodate==0.7.2


### PR DESCRIPTION
unoffical msgspec-python313-pre was an inetrim solution from e710ebdf6

related:

- https://github.com/searxng/searxng/pull/4129
- https://github.com/jcrist/msgspec/issues/764#issuecomment-2561330165

closes: https://github.com/searxng/searxng/issues/4015
