### PR TITLE
[fix] only show and clear known cookies

### DIFF
--- a/searx/templates/simple/preferences/cookies.html
+++ b/searx/templates/simple/preferences/cookies.html
@@ -10,10 +10,12 @@
       <th>{{ _('Value') }}</th>{{- '' -}}
     </tr>
     {%- for cookie in cookies -%}
-      <tr>{{- '' -}}
-        <td>{{ cookie }}</td>{{- '' -}}
-        <td>{{ cookies[cookie] }}</td>{{- '' -}}
-      </tr>
+      {% if cookie in preferences.key_value_settings %}
+        <tr>{{- '' -}}
+          <td>{{ cookie }}</td>{{- '' -}}
+          <td>{{ cookies[cookie] }}</td>{{- '' -}}
+        </tr>
+      {% endif %}
     {%- endfor -%}
   </table>
 {%- else -%}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1289,7 +1289,8 @@ def favicon():
 def clear_cookies():
     resp = make_response(redirect(url_for('index', _external=True)))
     for cookie_name in request.cookies:
-        resp.delete_cookie(cookie_name)
+        if cookie_name in request.preferences.key_value_settings:
+            resp.delete_cookie(cookie_name)
     return resp
 
 


### PR DESCRIPTION
## What does this PR do?

This PR modifies the `clear_cookies` function to now only delete cookies related to user preferences. It also adjusts the cookie display logic to only show these relevant preference cookies. This ensures that session cookies and other non-preference cookies are preserved, preventing unintended side effects (see #3763).

## Why is this change important?

Previously, the `clear_cookies` function was deleting *all* cookies, including cookies from other services on the same domain, session cookies etc.

## How to test this PR locally?

1.  **Navigate to the preferences page.** 
2.  **Set and save some user preferences.**
3.  **Navigate to the cookies tab.**
4.  **Verify all searxng cookies are shown but no other cookies.** Foreign cookies can be simulated using Javascript, e.g. `document.cookie = "username=John Doe"` in the Browser console
5.  **Click the "Reset defaults" button.**
6.  **Verify all searxng cookies are deleted but other cookies are preserved.**

## Related issues

Closes #3763