### PR TITLE
[fix] requirements-dev.txt: remove autodoc_pydantic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,6 @@ extensions = [
     "sphinx_tabs.tabs", # https://github.com/djungelorm/sphinx-tabs
     'myst_parser',  # https://www.sphinx-doc.org/en/master/usage/markdown.html
     'notfound.extension',  # https://github.com/readthedocs/sphinx-notfound-page
-    'sphinxcontrib.autodoc_pydantic',  # https://github.com/mansenfranzen/autodoc_pydantic
 ]
 
 autodoc_default_options = {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,4 +21,3 @@ wlc==1.15
 coloredlogs==15.0.1
 docutils>=0.21.2
 parameterized==0.9.0
-autodoc_pydantic==2.2.0


### PR DESCRIPTION
## What does this PR do?

Remove autodoc_pydantic since we use msgspec

## Why is this change important?

Clean up dev dependencies

## How to test this PR locally?

Build the documentation

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

Related to #3727
