### PR TITLE
[Wallhaven] Fix usage of `api_key` engine setting

### DIFF
--- a/searx/engines/wallhaven.py
+++ b/searx/engines/wallhaven.py
@@ -57,7 +57,7 @@ def request(query, params):
     }
 
     if api_key:
-        params['api_key'] = api_key
+        params['headers']['X-API-Key'] = api_key
 
     params['url'] = f"{base_url}/api/v1/search?{urlencode(args)}"
     return params


### PR DESCRIPTION
## What does this PR do?

It ensures the `api_key` engine setting is actually used somewhere by setting the `X_API_Key` header.

> [Users can authenticate by including their API key either in a request URL by appending `?apikey=<API KEY>`, or by including the `X-API-Key: <API KEY>` header with the request.](https://wallhaven.cc/help/api)

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Currently, the value of `params['api_key']` isn't read anywhere, making the presence of the `api_key` setting rather pointless.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

1. Add the engine settings `api_key` to your `settings.yml`.
    ~~~ yaml
    engines:
      - name: wallhaven
        api_key: asd123asd
    ~~~
1. Search something using the engine: `!wh test`
2. Observe the request headers and find the `X-API-Key` header set to the settings value
    OR
    Search for images with safe mode off, the key has to be valid for this.

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
