### PR TITLE
[feat] engine: add selfh.st/icons for logos of common self-hosted programs

### DIFF
--- a/searx/engines/selfhst.py
+++ b/searx/engines/selfhst.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""selfh.st/icons - A collection of logos for self-hosted dashboards and
+documentation"""
+
+from dateutil import parser
+
+about = {
+    'website': 'https://selfh.st/icons/',
+    'official_api_documentation': 'https://selfh.st/icons-about/',
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+categories = ['images']
+
+
+icons_list_url = 'https://cdn.selfh.st/directory/icons.json'
+icons_cdn_base_url = 'https://cdn.jsdelivr.net'
+
+
+def request(query, params):
+    params['url'] = icons_list_url
+    params['query'] = query
+    return params
+
+
+def response(resp):
+    results = []
+
+    query_parts = resp.search_params['query'].lower().split(' ')
+    for item in resp.json():
+        keyword = item['Reference'].lower()
+        if not any(query_part in keyword for query_part in query_parts):
+            continue
+
+        img_format = None
+        for format_name in ('SVG', 'PNG', 'WebP'):
+            if item[format_name] == 'Yes':
+                img_format = format_name.lower()
+                break
+
+        img_src = f'{icons_cdn_base_url}/gh/selfhst/icons/{img_format}/{item["Reference"]}.{img_format}'
+        result = {
+            'template': 'images.html',
+            'url': img_src,
+            'title': item['Name'],
+            'content': '',
+            'img_src': img_src,
+            'img_format': img_format,
+            'publishedDate': parser.parse(item['CreatedAt']),
+        }
+        results.append(result)
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1658,6 +1658,12 @@ engines:
     about:
       website: https://searchmysite.net
 
+  - name: selfhst icons
+    engine: selfhst
+    shortcut: si
+    inactive: true
+    disabled: true
+
   - name: sepiasearch
     engine: sepiasearch
     shortcut: sep


### PR DESCRIPTION
## What does this PR do?
- This PR adds a new engine, [`selfh.st/icons`](https://selfh.st/icons/)
- the engine is disabled by default to reduce server load and avoid getting banned

## Why is this change important?
- can be useful to get logos for self-hosted dashboards

## How to test this PR locally?
- comment out `inactive: true`
- `!si docker`
- `!si go`
- `!si git`
