### PR TITLE
[feat] Added shell.nix (Nix development support)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ Done!
 (pkgs.buildFHSEnv {
   name = "searxng";
   multiPkgs = pkgs: (with pkgs; [
-    bash
+    bashInteractive
     wget
     gnumake
     git

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+/*
+nix shell for development usage
+1. run `nix-shell`
+2. run `make run` (or any other make scripts)
+Done!
+*/
+
+(pkgs.buildFHSEnv {
+  name = "searxng";
+  multiPkgs = pkgs: (with pkgs; [
+    bash
+    wget
+    gnumake
+    git
+    python3
+    geckodriver
+    shellcheck
+  ]);
+  runScript = "bash";
+}).env
+


### PR DESCRIPTION
## What does this PR do?

Add a `shell.nix` file. This is *not* for use in the Nix version of searchx, but instead allows developers to get a compatible development environment in one command. 


## Why is this change important?

Some developers are NixOS based, which cannot run arbitrary executables (e.g. the nvm-based node) by default. The nix-shell wraps it in an FHS environment, which fixes that thanks to Nix magic I do not understand.

## How to test this PR locally?

On a device with nix installed, navigate to the repository and run `make test`. This will probably not work. Then, run `nix-shell` and try `make test` again. It should work!
