### PR TITLE
[feat] engines: added NixOS Wiki

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -434,6 +434,14 @@ engines:
     engine: archlinux
     shortcut: al
 
+  - name: nixos wiki
+    engine: mediawiki
+    shortcut: nixw
+    base_url: https://wiki.nixos.org/
+    search_type: text
+    disabled: true
+    categories: [it, software wikis]
+
   - name: artic
     engine: artic
     shortcut: arc


### PR DESCRIPTION
## What does this PR do?

Implements the mediawiki-based NixOS Wiki! Also in comments, the base layout for the unofficial wiki. Haven't got that working though, but it may be useful in case someone wants to go for that.

## Why is this change important?

NixOS' community is held together with sticks and wiki pages. Quicker access to the latter would be nice!

## How to test this PR locally?

Try enabling the NixOS wiki locally and searching `!nixw Networking`

## Author's checklist

- Feel free to mention in case the commented out unofficial wiki should be removed!