### PR TITLE
[json_engine] Documentation and overhaul

### DIFF
--- a/docs/dev/engines/index.rst
+++ b/docs/dev/engines/index.rst
@@ -45,6 +45,7 @@ Online Engines
    demo/demo_online
    xpath
    mediawiki
+   json_engine
 
 .. toctree::
    :maxdepth: 1

--- a/docs/dev/engines/json_engine.rst
+++ b/docs/dev/engines/json_engine.rst
@@ -1,0 +1,13 @@
+.. _json_engine engine:
+
+============
+JSON Engine
+============
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.engines.json_engine
+  :members:

--- a/searx/engines/json_engine.py
+++ b/searx/engines/json_engine.py
@@ -8,6 +8,8 @@ Configuration
 Request:
 
 - :py:obj:`search_url`
+- :py:obj:`lang_all`
+- :py:obj:`soft_max_redirects`
 - :py:obj:`method`
 - :py:obj:`request_body`
 - :py:obj:`cookies`
@@ -19,10 +21,22 @@ Paging:
 - :py:obj:`page_size`
 - :py:obj:`first_page_num`
 
+Time Range:
+
+- :py:obj:`time_range_support`
+- :py:obj:`time_range_url`
+- :py:obj:`time_range_map`
+
+Safe-Search:
+
+- :py:obj:`safe_search_support`
+- :py:obj:`safe_search_map`
+
 Response:
 
 - :py:obj:`title_html_to_text`
 - :py:obj:`content_html_to_text`
+- :py:obj:`no_result_for_http_status`
 
 JSON query:
 
@@ -31,6 +45,8 @@ JSON query:
 - :py:obj:`url_prefix`
 - :py:obj:`title_query`
 - :py:obj:`content_query`
+- :py:obj:`thumbnail_query`
+- :py:obj:`thumbnail_prefix`
 - :py:obj:`suggestion_query`
 
 
@@ -61,12 +77,13 @@ from collections.abc import Iterable
 from json import loads
 from urllib.parse import urlencode
 from searx.utils import to_string, html_to_text
+from searx.network import raise_for_httperror
 
 search_url = None
 """
 Search URL of the engine.  Example::
 
-    https://example.org/?search={query}&page={pageno}
+    https://example.org/?search={query}&page={pageno}{time_range}{safe_search}
 
 Replacements are:
 
@@ -76,7 +93,40 @@ Replacements are:
 ``{pageno}``:
   Page number if engine supports paging :py:obj:`paging`
 
+``{lang}``:
+  ISO 639-1 language code (en, de, fr ..)
+
+``{time_range}``:
+  :py:obj:`URL parameter <time_range_url>` if engine :py:obj:`supports time
+  range <time_range_support>`.  The value for the parameter is taken from
+  :py:obj:`time_range_map`.
+
+``{safe_search}``:
+  Safe-search :py:obj:`URL parameter <safe_search_map>` if engine
+  :py:obj:`supports safe-search <safe_search_support>`.  The ``{safe_search}``
+  replacement is taken from the :py:obj:`safes_search_map`.  Filter results::
+
+      0: none, 1: moderate, 2:strict
+
+  If not supported, the URL parameter is an empty string.
+
 """
+
+lang_all = 'en'
+'''Replacement ``{lang}`` in :py:obj:`search_url` if language ``all`` is
+selected.
+'''
+
+no_result_for_http_status = []
+'''Return empty result for these HTTP status codes instead of throwing an error.
+
+.. code:: yaml
+
+    no_result_for_http_status: []
+'''
+
+soft_max_redirects = 0
+'''Maximum redirects, soft limit. Record an error but don't stop the engine'''
 
 method = 'GET'
 '''Some engines might require to do POST requests for search.'''
@@ -140,6 +190,12 @@ title_query = None
 content_query = None
 '''JSON query of result's ``content``. For the query string documentation see :py:obj:`results_query`'''
 
+thumbnail_query = False
+'''JSON query of result's ``thumbnail``. For the query string documentation see :py:obj:`results_query`'''
+
+thumbnail_prefix = ''
+'''String to prepend to the result's ``thumbnail``.'''
+
 suggestion_query = ''
 '''JSON query of result's ``suggestion``. For the query string documentation see :py:obj:`results_query`'''
 
@@ -148,6 +204,53 @@ title_html_to_text = False
 
 content_html_to_text = False
 '''Extract text from a HTML content string'''
+
+time_range_support = False
+'''Engine supports search time range.'''
+
+time_range_url = '&hours={time_range_val}'
+'''Time range URL parameter in the in :py:obj:`search_url`.  If no time range is
+requested by the user, the URL parameter is an empty string.  The
+``{time_range_val}`` replacement is taken from the :py:obj:`time_range_map`.
+
+.. code:: yaml
+
+    time_range_url : '&days={time_range_val}'
+'''
+
+time_range_map = {
+    'day': 24,
+    'week': 24 * 7,
+    'month': 24 * 30,
+    'year': 24 * 365,
+}
+'''Maps time range value from user to ``{time_range_val}`` in
+:py:obj:`time_range_url`.
+
+.. code:: yaml
+
+    time_range_map:
+      day: 1
+      week: 7
+      month: 30
+      year: 365
+'''
+
+safe_search_support = False
+'''Engine supports safe-search.'''
+
+safe_search_map = {0: '&filter=none', 1: '&filter=moderate', 2: '&filter=strict'}
+'''Maps safe-search value to ``{safe_search}`` in :py:obj:`search_url`.
+
+.. code:: yaml
+
+    safesearch: true
+    safes_search_map:
+      0: '&filter=none'
+      1: '&filter=moderate'
+      2: '&filter=strict'
+
+'''
 
 
 def iterate(iterable):
@@ -207,10 +310,26 @@ def query(data, query_string):
 
 def request(query, params):  # pylint: disable=redefined-outer-name
     '''Build request parameters (see :ref:`engine request`).'''
-    fp = {'query': urlencode({'q': query})[2:]}  # pylint: disable=invalid-name
+    lang = lang_all
+    if params['language'] != 'all':
+        lang = params['language'][:2]
 
-    if paging and search_url.find('{pageno}') >= 0:
-        fp['pageno'] = (params['pageno'] - 1) * page_size + first_page_num
+    time_range = ''
+    if params.get('time_range'):
+        time_range_val = time_range_map.get(params.get('time_range'))
+        time_range = time_range_url.format(time_range_val=time_range_val)
+
+    safe_search = ''
+    if params['safesearch']:
+        safe_search = safe_search_map[params['safesearch']]
+
+    fp = {  # pylint: disable=invalid-name
+        'query': urlencode({'q': query})[2:],
+        'lang': lang,
+        'pageno': (params['pageno'] - 1) * page_size + first_page_num,
+        'time_range': time_range,
+        'safe_search': safe_search,
+    }
 
     params['cookies'].update(cookies)
     params['headers'].update(headers)
@@ -223,6 +342,9 @@ def request(query, params):  # pylint: disable=redefined-outer-name
         fp['query'] = query
         params['data'] = request_body.format(**fp)
 
+    params['soft_max_redirects'] = soft_max_redirects
+    params['raise_for_httperror'] = False
+
     return params
 
 
@@ -234,10 +356,16 @@ def response(resp):
     '''Scrap *results* from the response (see :ref:`engine results`).'''
     results = []
 
+    if no_result_for_http_status and resp.status_code in no_result_for_http_status:
+        return results
+
+    raise_for_httperror(resp)
+
     if not resp.text:
         return results
 
     json = loads(resp.text)
+    is_onion = 'onions' in categories
 
     title_filter = html_to_text if title_html_to_text else identity
     content_filter = html_to_text if content_html_to_text else identity
@@ -256,13 +384,24 @@ def response(resp):
                 content = query(result, content_query)[0]
             except:  # pylint: disable=bare-except
                 content = ""
-            results.append(
-                {
-                    'url': url_prefix + to_string(url),
-                    'title': title_filter(to_string(title)),
-                    'content': content_filter(to_string(content)),
-                }
-            )
+
+            tmp_result = {
+                'url': url_prefix + to_string(url),
+                'title': title_filter(to_string(title)),
+                'content': content_filter(to_string(content)),
+            }
+
+            if thumbnail_query:
+                try:
+                    thumbnail_query_result = query(result, thumbnail_query)[0]
+                    tmp_result['thumbnail'] = thumbnail_prefix + to_string(thumbnail_query_result)
+                except:  # pylint: disable=bare-except
+                    continue
+
+            if is_onion:
+                tmp_result['is_onion'] = True
+
+            results.append(tmp_result)
     else:
         for result in json:
             url = query(result, url_query)[0]
@@ -274,6 +413,7 @@ def response(resp):
                     'url': url_prefix + to_string(url),
                     'title': title_filter(to_string(title)),
                     'content': content_filter(to_string(content)),
+                    'is_onion': is_onion,
                 }
             )
 

--- a/tests/unit/engines/test_json_engine.py
+++ b/tests/unit/engines/test_json_engine.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring
+
+from collections import defaultdict
+import mock
+
+from searx.engines import json_engine
+from searx import logger
+
+from tests import SearxTestCase
+
+logger = logger.getChild('engines')
+
+
+class TestJsonEngine(SearxTestCase):  # pylint: disable=missing-class-docstring
+    json = """
+    [
+        {
+            "title": "title0",
+            "content": "content0",
+            "url": "https://example.com/url0",
+            "images": [
+                {
+                    "thumb": "https://example.com/thumb00"
+                },
+                {
+                    "thumb": "https://example.com/thumb01"
+                }
+            ]
+        },
+        {
+            "title": "<h1>title1</h1>",
+            "content": "<h2>content1</h2>",
+            "url": "https://example.com/url1",
+            "images": [
+                {
+                    "thumb": "https://example.com/thumb10"
+                },
+                {
+                    "thumb": "https://example.com/thumb11"
+                }
+            ]
+        },
+        {
+            "title": "title2",
+            "content": "content2",
+            "url": 2,
+            "images": [
+                {
+                    "thumb": "thumb20"
+                },
+                {
+                    "thumb": 21
+                }
+            ]
+        }
+    ]
+    """
+
+    json_result_query = """
+    {
+        "data": {
+            "results": [
+                {
+                    "title": "title0",
+                    "content": "content0",
+                    "url": "https://example.com/url0",
+                    "images": [
+                        {
+                            "thumb": "https://example.com/thumb00"
+                        },
+                        {
+                            "thumb": "https://example.com/thumb01"
+                        }
+                    ]
+                },
+                {
+                    "title": "<h1>title1</h1>",
+                    "content": "<h2>content1</h2>",
+                    "url": "https://example.com/url1",
+                    "images": [
+                        {
+                            "thumb": "https://example.com/thumb10"
+                        },
+                        {
+                            "thumb": "https://example.com/thumb11"
+                        }
+                    ]
+                },
+                {
+                    "title": "title2",
+                    "content": "content2",
+                    "url": 2,
+                    "images": [
+                        {
+                            "thumb": "thumb20"
+                        },
+                        {
+                            "thumb": 21
+                        }
+                    ]
+                }
+            ],
+            "suggestions": [
+                "suggestion0",
+                "suggestion1"
+            ]
+        }
+    }
+    """
+
+    def setUp(self):
+        json_engine.logger = logger.getChild('test_json_engine')
+
+    def test_request(self):
+        json_engine.search_url = 'https://example.com/{query}'
+        json_engine.categories = []
+        json_engine.paging = False
+        query = 'test_query'
+        dicto = defaultdict(dict)
+        dicto['language'] = 'all'
+        dicto['pageno'] = 1
+        params = json_engine.request(query, dicto)
+        self.assertIn('url', params)
+        self.assertEqual('https://example.com/test_query', params['url'])
+
+        json_engine.search_url = 'https://example.com/q={query}&p={pageno}'
+        json_engine.paging = True
+        query = 'test_query'
+        dicto = defaultdict(dict)
+        dicto['language'] = 'all'
+        dicto['pageno'] = 1
+        params = json_engine.request(query, dicto)
+        self.assertIn('url', params)
+        self.assertEqual('https://example.com/q=test_query&p=1', params['url'])
+
+        json_engine.search_url = 'https://example.com/'
+        json_engine.paging = True
+        json_engine.request_body = '{{"page": {pageno}, "query": "{query}"}}'
+        query = 'test_query'
+        dicto = defaultdict(dict)
+        dicto['language'] = 'all'
+        dicto['pageno'] = 1
+        params = json_engine.request(query, dicto)
+        self.assertIn('data', params)
+        self.assertEqual('{"page": 1, "query": "test_query"}', params['data'])
+
+    def test_response(self):
+        # without results_query
+        json_engine.results_query = ''
+        json_engine.url_query = 'url'
+        json_engine.url_prefix = ''
+        json_engine.title_query = 'title'
+        json_engine.content_query = 'content'
+        json_engine.thumbnail_query = 'images/thumb'
+        json_engine.thumbnail_prefix = ''
+        json_engine.title_html_to_text = False
+        json_engine.content_html_to_text = False
+        json_engine.categories = []
+
+        self.assertRaises(AttributeError, json_engine.response, None)
+        self.assertRaises(AttributeError, json_engine.response, [])
+        self.assertRaises(AttributeError, json_engine.response, '')
+        self.assertRaises(AttributeError, json_engine.response, '[]')
+
+        response = mock.Mock(text='{}', status_code=200)
+        self.assertEqual(json_engine.response(response), [])
+
+        response = mock.Mock(text=self.json, status_code=200)
+        results = json_engine.response(response)
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0]['title'], 'title0')
+        self.assertEqual(results[0]['url'], 'https://example.com/url0')
+        self.assertEqual(results[0]['content'], 'content0')
+        self.assertEqual(results[0]['thumbnail'], 'https://example.com/thumb00')
+        self.assertEqual(results[1]['title'], '<h1>title1</h1>')
+        self.assertEqual(results[1]['url'], 'https://example.com/url1')
+        self.assertEqual(results[1]['content'], '<h2>content1</h2>')
+        self.assertEqual(results[1]['thumbnail'], 'https://example.com/thumb10')
+
+        # with prefix and suggestions without results_query
+        json_engine.url_prefix = 'https://example.com/url'
+        json_engine.thumbnail_query = 'images/1/thumb'
+        json_engine.thumbnail_prefix = 'https://example.com/thumb'
+
+        results = json_engine.response(response)
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[2]['title'], 'title2')
+        self.assertEqual(results[2]['url'], 'https://example.com/url2')
+        self.assertEqual(results[2]['content'], 'content2')
+        self.assertEqual(results[2]['thumbnail'], 'https://example.com/thumb21')
+        self.assertFalse(results[0].get('is_onion', False))
+
+        # results are onion urls without results_query
+        json_engine.categories = ['onions']
+        results = json_engine.response(response)
+        self.assertTrue(results[0]['is_onion'])
+
+    def test_response_results_json(self):
+        # with results_query
+        json_engine.results_query = 'data/results'
+        json_engine.url_query = 'url'
+        json_engine.url_prefix = ''
+        json_engine.title_query = 'title'
+        json_engine.content_query = 'content'
+        json_engine.thumbnail_query = 'images/1/thumb'
+        json_engine.thumbnail_prefix = ''
+        json_engine.title_html_to_text = True
+        json_engine.content_html_to_text = True
+        json_engine.categories = []
+
+        self.assertRaises(AttributeError, json_engine.response, None)
+        self.assertRaises(AttributeError, json_engine.response, [])
+        self.assertRaises(AttributeError, json_engine.response, '')
+        self.assertRaises(AttributeError, json_engine.response, '[]')
+
+        response = mock.Mock(text='{}', status_code=200)
+        self.assertEqual(json_engine.response(response), [])
+
+        response = mock.Mock(text=self.json_result_query, status_code=200)
+        results = json_engine.response(response)
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0]['title'], 'title0')
+        self.assertEqual(results[0]['url'], 'https://example.com/url0')
+        self.assertEqual(results[0]['content'], 'content0')
+        self.assertEqual(results[0]['thumbnail'], 'https://example.com/thumb01')
+        self.assertEqual(results[1]['title'], 'title1')
+        self.assertEqual(results[1]['url'], 'https://example.com/url1')
+        self.assertEqual(results[1]['content'], 'content1')
+        self.assertEqual(results[1]['thumbnail'], 'https://example.com/thumb11')
+
+        # with prefix and suggestions with results_query
+        json_engine.url_prefix = 'https://example.com/url'
+        json_engine.thumbnail_query = 'images/1/thumb'
+        json_engine.thumbnail_prefix = 'https://example.com/thumb'
+        json_engine.suggestion_query = 'data/suggestions'
+
+        results = json_engine.response(response)
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results[2]['title'], 'title2')
+        self.assertEqual(results[2]['url'], 'https://example.com/url2')
+        self.assertEqual(results[2]['content'], 'content2')
+        self.assertEqual(results[2]['thumbnail'], 'https://example.com/thumb21')
+        self.assertEqual(results[3]['suggestion'], ['suggestion0', 'suggestion1'])
+        self.assertFalse(results[0].get('is_onion', False))
+
+        # results are onion urls with results_query
+        json_engine.categories = ['onions']
+        results = json_engine.response(response)
+        self.assertTrue(results[0]['is_onion'])


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This PR overhauls the JSON engine, bringing it on par to the XPath engine with (almost) the same functionality.
I am not entirely sure what the caching option in the XPath engine is doing, so I ignored it.

Every step is (or should be) cleanly separated in own commits:
* First, the existing documentation is properly added to the sphinx generator.
* After that, the functionality from the XPath engine is mirrored to the JSON engine.
* I then added unit tests to catch errors, again, mirroring the XPath engine unit tests.
* ~The next commit might be a bit opinionated, but I exposed `publishedDate` from within the settings. The reason is that it's available in every single template. I also exposed the `template` parameter setting, allowing to choose a different template style which might be better fitting for the content.~
  Dropped it because of different python versions failing the tests.
* Now `make test` was complaining with `R0912 (too-many-branches)` which I tackled in the last commit. This combines the two possible branches (with and without a `request_query`) into a function.

If any of the commits don't appeal to you, they can be easily dropped.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

I played around, looking how to implement a JSON engine using the settings, but the information and functionality was rather lacking.
Crucially, the information about the `request_body` having to double the curly braces and the handling of arrays and paths wasn't easily available.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

Run 
* `make test`
* `make test.unit`
* `make docs.live` and visit http://0.0.0.0:8000/dev/engines/json_engine.html
* a search that uses the `json_engine`

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
