### PR TITLE
[feat] autocompletion: add baidu search autocompleter 

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -39,12 +39,7 @@ def post(*args, **kwargs):
 def baidu(query, _lang):
     # baidu search autocompleter
     base_url = "https://www.baidu.com/sugrec?"
-    response = get(base_url + urlencode({
-        'ie': 'utf-8',
-        'json': 1,
-        'prod': 'pc',
-        'wd': query
-    }))
+    response = get(base_url + urlencode({'ie': 'utf-8', 'json': 1, 'prod': 'pc', 'wd': query}))
 
     results = []
 

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -36,6 +36,26 @@ def post(*args, **kwargs):
     return http_post(*args, **kwargs)
 
 
+def baidu(query, _lang):
+    # baidu search autocompleter
+    base_url = "https://www.baidu.com/sugrec?"
+    response = get(base_url + urlencode({
+        'ie': 'utf-8',
+        'json': 1,
+        'prod': 'pc',
+        'wd': query
+    }))
+
+    results = []
+
+    if response.ok:
+        data = response.json()
+        if 'g' in data:
+            for item in data['g']:
+                results.append(item['q'])
+    return results
+
+
 def brave(query, _lang):
     # brave search autocompleter
     url = 'https://search.brave.com/api/suggest?'
@@ -238,6 +258,7 @@ def yandex(query, _lang):
 
 
 backends = {
+    'baidu': baidu,
     'dbpedia': dbpedia,
     'duckduckgo': duckduckgo,
     'google': google_complete,


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Add Baidu search autocompleter to SearXNG

URL: `https://www.baidu.com/sugrec?json=1&prod=pc&wd={query}`
Response:
```
{
    "q": "test",
    "p": false,
    "g": [
        {
            "type": "sug",
            "sa": "s_1",
            "q": "test的中文翻译"
        },
        {
            "type": "sug",
            "sa": "s_2",
            "q": "testflight"
        }
    ],
    "slid": "133315791788217",
    "queryid": "0x77940006998b9"
}
```

---

|Screenshot||
|-|-|
|![image](https://github.com/user-attachments/assets/de234be0-345a-42f0-9a60-1f3ec0f227ea)|![image](https://github.com/user-attachments/assets/0585be89-e940-4ed3-83f1-5dfff8b8999c)|
|![image](https://github.com/user-attachments/assets/76dcd398-8381-48f7-bf13-4b18f99ccc46)||

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

Set in `settings.yml`
```
search:
  autocomplete: "baidu"
```

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
