### PR TITLE
[chore] autocomplete.py: order autocompletion engines alphabetically

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -254,17 +254,17 @@ def yandex(query, _lang):
 
 backends = {
     'baidu': baidu,
+    'brave': brave,
     'dbpedia': dbpedia,
     'duckduckgo': duckduckgo,
     'google': google_complete,
     'mwmbl': mwmbl,
+    'qwant': qwant,
     'seznam': seznam,
     'startpage': startpage,
     'stract': stract,
     'swisscows': swisscows,
-    'qwant': qwant,
     'wikipedia': wikipedia,
-    'brave': brave,
     'yandex': yandex,
 }
 


### PR DESCRIPTION
## What does this PR do?
- this PR orders the autocompletion providers alphabetically
- I don't think we should predefine any specific order of the engines, users should decided themselves which autocompletion provider they want to use
- It's easier to find the autocompletion provider you're searching for if they're ordered alphabetically
