### PR TITLE
[docs] settings_search.rst: add missing autocompletion providers

### DIFF
--- a/docs/admin/settings/settings_search.rst
+++ b/docs/admin/settings/settings_search.rst
@@ -33,14 +33,19 @@
 ``autocomplete``:
   Existing autocomplete backends, leave blank to turn it off.
 
-  - ``dbpedia``
-  - ``duckduckgo``
-  - ``google``
-  - ``mwmbl``
-  - ``startpage``
-  - ``swisscows``
-  - ``qwant``
-  - ``wikipedia``
+  - ``baidu```
+  - ``brave```
+  - ``dbpedia```
+  - ``duckduckgo```
+  - ``google```
+  - ``mwmbl```
+  - ``qwant```
+  - ``seznam```
+  - ``startpage```
+  - ``stract```
+  - ``swisscows```
+  - ``wikipedia```
+  - ``yandex```
 
 ``favicon_resolver``:
   To activate favicons in SearXNG's result list select a default

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -33,9 +33,9 @@ brand:
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
-  # Existing autocomplete backends: "dbpedia", "duckduckgo", "google", "yandex", "mwmbl",
-  # "seznam", "startpage", "stract", "swisscows", "qwant", "wikipedia" - leave blank to turn it off
-  # by default.
+  # Existing autocomplete backends: "baidu", "brave", "dbpedia", "duckduckgo", "google", "yandex",
+  # "mwmbl", "seznam", "startpage", "stract", "swisscows", "qwant", "wikipedia" -
+  # leave blank to turn it off by default.
   autocomplete: ""
   # minimun characters to type before autocompleter starts
   autocomplete_min: 4


### PR DESCRIPTION
## What does this PR do?
- seems like we forgot to add some autocompletion providers to the documentation
- this PR adds the missing ones (baidu, brave, dbpedia, stract, seznam)
