### PR TITLE
[fix] gettext can't work with f-strings (i10n)

### DIFF
--- a/searx/answerers/statistics.py
+++ b/searx/answerers/statistics.py
@@ -33,7 +33,7 @@ class SXNGAnswerer(Answerer):
 
         return AnswererInfo(
             name=gettext(self.__doc__),
-            description=gettext(f"Compute {'/'.join(self.keywords)} of the arguments"),
+            description=gettext("Compute {func} of the arguments".format(func='/'.join(self.keywords))),
             keywords=self.keywords,
             examples=["avg 123 548 2.04 24.2"],
         )


### PR DESCRIPTION
``str.format`` is the pythonic way of handling strings returned by gettext.gettext that retain interpolation tokens.
