### PR TITLE
[engine] Update Openverse API and website URL

### DIFF
--- a/searx/engines/openverse.py
+++ b/searx/engines/openverse.py
@@ -10,9 +10,9 @@ from urllib.parse import urlencode
 
 
 about = {
-    "website": 'https://wordpress.org/openverse/',
+    "website": 'https://openverse.org/',
     "wikidata_id": None,
-    "official_api_documentation": 'https://api.openverse.engineering/v1/',
+    "official_api_documentation": 'https://api.openverse.org/v1/',
     "use_official_api": True,
     "require_api_key": False,
     "results": 'JSON',
@@ -23,7 +23,7 @@ categories = ['images']
 paging = True
 nb_per_page = 20
 
-base_url = 'https://api.openverse.engineering/v1/images/'
+base_url = 'https://api.openverse.org/v1/images/'
 search_string = '?page={page}&page_size={nb_per_page}&format=json&{query}'
 
 


### PR DESCRIPTION
## What does this PR do?

Change Openverse website and API endpoint

https://make.wordpress.org/openverse/2024/05/06/the-openverse-api-is-moving-to-api-openverse-org/
<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

In case they forgot or don't want to pay for `openverse.engineering`

<!-- MANDATORY -->

> explain the motivation behind your PR

It makes me eyesore

## How to test this PR locally?

Not needed
<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

None
<!-- additional notes for reviewers -->

## Related issues

None
<!--
Closes #234
-->
