### PR TITLE
[fix] public domain image archive: change name to lowercase

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1565,7 +1565,7 @@ engines:
       require_api_key: false
       results: HTML
 
-  - name: Public Domain Image Archive
+  - name: public domain image archive
     engine: public_domain_image_archive
     shortcut: pdia
 


### PR DESCRIPTION
Otherwise logs are flooded with warnings:
WARNING:searx.engines: Engine name is not lowercase: "Public Domain Image Archive", converting to lowercase