### PR TITLE
[chore] engines: replace datetime.utcfromtimestamp with datetime.fromtimestamp

### DIFF
--- a/searx/engines/9gag.py
+++ b/searx/engines/9gag.py
@@ -51,7 +51,7 @@ def response(resp):
                     'url': result['url'],
                     'title': result['title'],
                     'content': result['description'],
-                    'publishedDate': datetime.utcfromtimestamp(result['creationTs']),
+                    'publishedDate': datetime.fromtimestamp(result['creationTs']),
                     'img_src': result['images']['image700']['url'],
                     'thumbnail_src': thumbnail,
                 }
@@ -63,7 +63,7 @@ def response(resp):
                     'url': result['url'],
                     'title': result['title'],
                     'content': result['description'],
-                    'publishedDate': datetime.utcfromtimestamp(result['creationTs']),
+                    'publishedDate': datetime.fromtimestamp(result['creationTs']),
                     'thumbnail': thumbnail,
                     'iframe_src': result['images'].get('image460sv', {}).get('url'),
                 }

--- a/searx/engines/bilibili.py
+++ b/searx/engines/bilibili.py
@@ -82,7 +82,7 @@ def response(resp):
         video_id = item["aid"]
         unix_date = item["pubdate"]
 
-        formatted_date = datetime.utcfromtimestamp(unix_date)
+        formatted_date = datetime.fromtimestamp(unix_date)
         formatted_duration = format_duration(item["duration"])
         iframe_url = f"https://player.bilibili.com/player.html?aid={video_id}&high_quality=1&autoplay=false&danmaku=0"
 

--- a/searx/engines/bpb.py
+++ b/searx/engines/bpb.py
@@ -51,7 +51,7 @@ def response(resp):
 
         publishedDate = None
         if result['extension'].get('publishingDate'):
-            publishedDate = datetime.utcfromtimestamp(result['extension']['publishingDate'])
+            publishedDate = datetime.fromtimestamp(result['extension']['publishingDate'])
 
         results.append(
             {

--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -128,7 +128,7 @@ def _news_result(result):
         'title': result['title'],
         'content': result['excerpt'],
         'source': result['source'],
-        'publishedDate': datetime.utcfromtimestamp(result['date']),
+        'publishedDate': datetime.fromtimestamp(result['date']),
     }
 
 

--- a/searx/engines/findthatmeme.py
+++ b/searx/engines/findthatmeme.py
@@ -38,7 +38,7 @@ def response(resp):
         img = 'https://s3.thehackerblog.com/findthatmeme/' + item['image_path']
         thumb = 'https://s3.thehackerblog.com/findthatmeme/thumb/' + item.get('thumbnail', '')
         date = datetime.strptime(item["updated_at"].split("T")[0], "%Y-%m-%d")
-        formatted_date = datetime.utcfromtimestamp(date.timestamp())
+        formatted_date = datetime.fromtimestamp(date.timestamp())
 
         results.append(
             {

--- a/searx/engines/hackernews.py
+++ b/searx/engines/hackernews.py
@@ -87,7 +87,7 @@ def response(resp):
                 "content": hit.get("url") or hit.get("comment_text") or hit.get("story_text") or "",
                 "metadata": metadata,
                 "author": hit["author"],
-                "publishedDate": datetime.utcfromtimestamp(hit["created_at_i"]),
+                "publishedDate": datetime.fromtimestamp(hit["created_at_i"]),
             }
         )
 

--- a/searx/engines/odysee.py
+++ b/searx/engines/odysee.py
@@ -88,7 +88,7 @@ def response(resp):
         duration = item["duration"]
 
         release_date = datetime.strptime(release_time.split("T")[0], "%Y-%m-%d")
-        formatted_date = datetime.utcfromtimestamp(release_date.timestamp())
+        formatted_date = datetime.fromtimestamp(release_date.timestamp())
 
         url = f"https://odysee.com/{name}:{claim_id}"
         iframe_url = f"https://odysee.com/$/embed/{name}:{claim_id}"

--- a/searx/engines/open_meteo.py
+++ b/searx/engines/open_meteo.py
@@ -112,7 +112,7 @@ def response(resp):
 
         table_content = generate_condition_table(hourly_data)
 
-        infobox += f"<h3>{datetime.utcfromtimestamp(time).strftime('%Y-%m-%d %H:%M')}</h3>"
+        infobox += f"<h3>{datetime.fromtimestamp(time).strftime('%Y-%m-%d %H:%M')}</h3>"
         infobox += f"<table><tbody>{table_content}</tbody></table>"
 
     return [{'infobox': 'Open Meteo', 'content': infobox}]

--- a/searx/engines/podcastindex.py
+++ b/searx/engines/podcastindex.py
@@ -34,7 +34,7 @@ def response(resp):
                 'title': result['title'],
                 'content': result['description'],
                 'thumbnail': result['image'],
-                'publishedDate': datetime.utcfromtimestamp(result['newestItemPubdate']),
+                'publishedDate': datetime.fromtimestamp(result['newestItemPubdate']),
                 'metadata': f"{result['author']}, {result['episodeCount']} episodes",
             }
         )


### PR DESCRIPTION
## What does this PR do?
- replace `datetime.utcfromtimestamp` (deprecated) with `datetime.fromtimestamp`
- `datetime.fromtimestamp` seems to default to utc, so the optional timezone parameter can be omitted

## Related issues
closes #4257