### PR TITLE
[fix] botdetection: return error, do not fail silently

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -175,3 +175,4 @@ features or generally made searx better:
 - Daniel Kukula `<https://github.com/dkuku>`
 - Patrick Evans `https://github.com/holysoles`
 - Daniel Mowitz `<https://daniel.mowitz.rocks>`
+- `Bearz314 <https://github.com/bearz314>`_

--- a/searx/botdetection/ip_limit.py
+++ b/searx/botdetection/ip_limit.py
@@ -122,8 +122,7 @@ def filter_request(
             redis_client, 'ip_limit.SUSPICIOUS_IP_WINDOW' + network.compressed, SUSPICIOUS_IP_WINDOW
         )
         if c > SUSPICIOUS_IP_MAX:
-            logger.error("BLOCK: too many request from %s in SUSPICIOUS_IP_WINDOW (redirect to /)", network)
-            return flask.redirect(flask.url_for('index'), code=302)
+            return too_many_requests(network, "too many request in SUSPICIOUS_IP_WINDOW (SUSPICIOUS_IP_MAX)")
 
         c = incr_sliding_window(redis_client, 'ip_limit.BURST_WINDOW' + network.compressed, BURST_WINDOW)
         if c > BURST_MAX_SUSPICIOUS:


### PR DESCRIPTION
## What does this PR do?

Presently, if `SUSPICIOUS_IP_MAX` is exceeded, it fails silently to the user (though there is debug log) and returns to homepage with HTTP 302 Found.

This PR changes its behavior to match the other 5 bot detection. They all return HTTP 429 Too Many Requests, which is clear to the user. Prior to b8c7c2c, all of them return HTTP 429.

## Why is this change important?

Without this change, if users are in blocked state and type in a search term, they see the query disappears and nothing happens, causing confusion. This is also important during the initial setup where proxies incorrectly set up can trigger the bot limits. This change makes it obvious that some rate limiting applied.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

Refer #3191 for confusion.
