### PR TITLE
[fix] results.py: crashes when 'parsed_url' is None

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -318,8 +318,9 @@ class ResultContainer:
     def __find_duplicated_http_result(self, result):
         result_template = result.get('template')
         for merged_result in self._merged_results:
-            if 'parsed_url' not in merged_result:
+            if not merged_result.get('parsed_url'):
                 continue
+
             if compare_urls(result['parsed_url'], merged_result['parsed_url']) and result_template == merged_result.get(
                 'template'
             ):
@@ -385,6 +386,9 @@ class ResultContainer:
         categoryPositions = {}
 
         for res in results:
+            if not res.get('url'):
+                continue
+
             # do we need to handle more than one category per engine?
             engine = engines[res['engine']]
             res['category'] = engine.categories[0] if len(engine.categories) > 0 else ''


### PR DESCRIPTION
## What does this PR do?
- this fixes two possible crashes that can happen while results are being merged, that happen when the `url` of a result is `None`
- I'm not entirely sure if that's been the right place to do these checks, maybe we can already catch that somewhere earlier?

## How to test this PR locally?
- `!tagesschau demo`

## Author's checklist
- this bug causes SearXNG to crash reproducibly and not return any results

## Related issues
related to https://github.com/searxng/searxng/issues/4245