### PR TITLE
[fix] limiter: Disable caching of CSS token links

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -175,3 +175,4 @@ features or generally made searx better:
 - Daniel Kukula `<https://github.com/dkuku>`
 - Patrick Evans `https://github.com/holysoles`
 - Daniel Mowitz `<https://daniel.mowitz.rocks>`
+- `Bearz314 <https://github.com/bearz314>`_

--- a/searx/botdetection/ip_limit.py
+++ b/searx/botdetection/ip_limit.py
@@ -123,7 +123,9 @@ def filter_request(
         )
         if c > SUSPICIOUS_IP_MAX:
             logger.error("BLOCK: too many request from %s in SUSPICIOUS_IP_WINDOW (redirect to /)", network)
-            return flask.redirect(flask.url_for('index'), code=302)
+            response = flask.redirect(flask.url_for('index'), code=302)
+            response.headers["Cache-Control"] = "no-store, max-age=0"
+            return response
 
         c = incr_sliding_window(redis_client, 'ip_limit.BURST_WINDOW' + network.compressed, BURST_WINDOW)
         if c > BURST_MAX_SUSPICIOUS:

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -594,7 +594,7 @@ def health():
 @app.route('/client<token>.css', methods=['GET', 'POST'])
 def client_token(token=None):
     link_token.ping(sxng_request, token)
-    return Response('', mimetype='text/css')
+    return Response('', mimetype='text/css', headers={"Cache-Control": "no-store, max-age=0"})
 
 
 @app.route('/rss.xsl', methods=['GET', 'POST'])


### PR DESCRIPTION
## What does this PR do?

Link token method of bot detection requires user to request a CSS file. Depending on server/proxy/VPN/client setup, this CSS link with empty content may be cached, and the server does not reliably receive this request from client.

- This PR sets `cache-control` header directive to not cache the css link.
- For clients surpassing `SUSPICIOUS_IP_MAX` and redirected back to index, the same header is set to not cache the html page (which contains the css token).


## Why is this change important?

For example, in my setup CloudFlare automatically adds 14400s (4hours). As verified from logs, the CSS was not requested.

Without this PR, this is seen when loading the homepage through CF:
```
DEBUG   searx.webapp                  : set locale en (from browser)
DEBUG   searx.limiter                 : OK <redactedIP>/32: / || X-Forwarded-For: <redactedIP> || X-Real-IP: <redactedIP> || form: {'asdf': ''} || Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 || Accept-Language: en-US,en;q=0.5 || Accept-Encoding: gzip, br || Content-Type: None || Content-Length: None || Connection: None || User-Agent: Mozilla/5.0 <redacted>
DEBUG   searx.webapp                  : https%3A//<redactedURL>/%3Fasdf uses locale `en`
---
DEBUG   searx.webapp                  : set locale en (from browser)
DEBUG   searx.limiter                 : OK <redactedIP>/32: / || X-Forwarded-For: <redactedIP> || X-Real-IP: <redactedIP> || form: {'asdf': ''} || Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 || Accept-Language: en-US,en;q=0.5 || Accept-Encoding: gzip, br || Content-Type: None || Content-Length: None || Connection: None || User-Agent: Mozilla/5.0 <redacted>
DEBUG   searx.webapp                  : https%3A//<redactedURL>/%3Fasdf uses locale `en`
```
This is expected on every homepage refresh, but was not observed:
```
DEBUG   searx.botdetection.link_token : token is valid --> True
DEBUG   searx.botdetection.link_token : store ping_key for (client) network <redactedIP>/32 (IP <redactedIP>) -> SearXNG_limiter.ping[8d33813ac589e21cf8e1977883<redacted>]
DEBUG   searx.webapp                  : set locale en (from browser)
```

I tried this PR on a machine behind CF proxy, and the CSS can be reliably requested.

## How to test this PR locally?

Use Web Inspector > Network tab, and check that the css link has the `cache-control` header.

## Author's checklist

I am not sure why the tests are failing. I ran the tests on my computer and the last step for shellcheck complained about missing files, which are just right there...

## Related issues
