### PR TITLE
[refactor] engines: outsource cache implementation from duckduckgo engine source

### DIFF
--- a/searx/engine_cache.py
+++ b/searx/engine_cache.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""This provides an easy to use interface for engine implementations to store and read key-value pairs.
+
+For instance, this can be used to remember programmatically extracted API keys or other kinds of secret tokens.
+"""
+
+from typing import Optional
+from searx import redisdb, redislib
+
+
+class EngineCache:
+    def store(self, key: str, value: str):
+        pass
+
+    def get(self, key: str) -> Optional[str]:
+        pass
+
+
+class MemoryEngineCache(EngineCache):
+    def __init__(self, max_size: int = 100):
+        self.__STORAGE = {}
+        self.max_size = max_size
+
+    def store(self, key, value):
+        """Store the provided key-value pair in the cache."""
+        if len(self.__STORAGE) > self.max_size:
+            self.__STORAGE.popitem()
+
+        # remove the old value in order to add the new value to the top
+        # of the dictionary, as dictionaries are ordered since Python 3.7
+        if key in self.__STORAGE:
+            self.__STORAGE.pop(key)
+
+        self.__STORAGE[key] = value
+
+    def get(self, key):
+        return self.__STORAGE.get(key)
+
+
+class RedisEngineCache(EngineCache):
+    def __init__(self, key_prefix: str, expiration_seconds: int = 600):
+        self.key_prefix = key_prefix
+        self.expiration_seconds = expiration_seconds
+
+    def _get_cache_key(self, key):
+        return self.key_prefix + redislib.secret_hash(key)
+
+    def store(self, key, value):
+        c = redisdb.client()
+
+        cache_key = self._get_cache_key(key)
+        c.set(cache_key, value, ex=self.expiration_seconds)
+
+    def get(self, key):
+        c = redisdb.client()
+
+        cache_key = self._get_cache_key(key)
+        value = c.get(cache_key)
+        if value or value == b'':
+            return value
+
+        return None
+
+
+def get_or_create_cache(database_prefix: str) -> EngineCache:
+    if redisdb.client():
+        return RedisEngineCache(database_prefix)
+
+    return MemoryEngineCache()


### PR DESCRIPTION
## What does this PR do?
- This PR moves the caching logic from Redis into a separate file
- That allows us to re-use it for other engines in the future, i.e. for the `Public domain image archive` engine

## Why is this change important?
- It probably makes sense to provide an easy to use api to cache values to engine developers

## How to test this PR locally?
- use the duckduckgo engine, once with Redis configured and once without

## Author's checklist
- there's currently some issue in `duckduckgo.py` that initializing the `__CACHE` doesn't work properly - it should certainly be done in the `init(_)` method because `get_or_create_cache()` needs to be called **after** the Redis database has been initialized (if it's available)
