### PR TITLE
[feat] startpage: support for news and images

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1792,6 +1792,20 @@ engines:
     additional_tests:
       rosebud: *test_rosebud
 
+  - name: startpage news
+    engine: startpage
+    startpage_categ: news
+    shortcut: spn
+    timeout: 6.0
+    disabled: true
+
+  - name: startpage images
+    engine: startpage
+    startpage_categ: images
+    shortcut: spi
+    timeout: 6.0
+    disabled: true
+
   - name: tokyotoshokan
     engine: tokyotoshokan
     shortcut: tt

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -470,6 +470,21 @@ def ecma_unescape(string: str) -> str:
     return string
 
 
+def remove_pua_from_str(string):
+    """Removes unicode's "PRIVATE USE CHARACTER"s (PUA_) from a string.
+
+    _PUA: https://en.wikipedia.org/wiki/Private_Use_Areas
+    """
+    pua_ranges = ((0xE000, 0xF8FF), (0xF0000, 0xFFFFD), (0x100000, 0x10FFFD))
+    s = []
+    for c in string:
+        i = ord(c)
+        if any(a <= i <= b for (a, b) in pua_ranges):
+            continue
+        s.append(c)
+    return "".join(s)
+
+
 def get_string_replaces_function(replaces: Dict[str, str]) -> Callable[[str], str]:
     rep = {re.escape(k): v for k, v in replaces.items()}
     pattern = re.compile("|".join(rep.keys()))


### PR DESCRIPTION
## What does this PR do?
- this PR refactors the startpage engine to use the internally used JavaScript from Startpage instead of parsing the HTML
- additionally, this PR adds support for images and news

## Why is this change important?
- the current startpage implementation is broken

## How to test this PR locally?
- `!sp test`
- `!spi test`
- `!spn test`

## Related issues
- closes https://github.com/searxng/searxng/issues/4306
- closes https://github.com/searxng/searxng/issues/2540
- closes https://github.com/searxng/searxng/issues/2989 