### PR TITLE
[fix] Fix improper import of corrections.html

### DIFF
--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -59,7 +59,7 @@
     </div>
 
     {%- if corrections -%}
-      {%- include 'simple/elements/corrections' -%}
+      {%- include 'simple/elements/corrections.html' -%}
     {%- endif -%}
 
     <div id="urls" role="main">


### PR DESCRIPTION
## What does this PR do?
Fixes improper importing of the elements/corrections.html template in results.html by appending the html extension to the import.

## Why is this change important?
Without this change attempts to render results.html will cause an unhandled exception leading to an internal server error page.

## How to test this PR locally?
Search something that causes corrections to be present, like "ISO8601".

## Author's checklist
- [X] Searches with corrections no longer cause an internal server error

## Related issues
Closes #4341 
