### PR TITLE
[fix] autocomplete: remove broken startpage backend

### DIFF
--- a/docs/admin/settings/settings_search.rst
+++ b/docs/admin/settings/settings_search.rst
@@ -33,19 +33,18 @@
 ``autocomplete``:
   Existing autocomplete backends, leave blank to turn it off.
 
-  - ``baidu```
-  - ``brave```
-  - ``dbpedia```
-  - ``duckduckgo```
-  - ``google```
-  - ``mwmbl```
-  - ``qwant```
-  - ``seznam```
-  - ``startpage```
-  - ``stract```
-  - ``swisscows```
-  - ``wikipedia```
-  - ``yandex```
+  - ``baidu``
+  - ``brave``
+  - ``dbpedia``
+  - ``duckduckgo``
+  - ``google``
+  - ``mwmbl``
+  - ``qwant``
+  - ``seznam``
+  - ``stract``
+  - ``swisscows``
+  - ``wikipedia``
+  - ``yandex``
 
 ``favicon_resolver``:
   To activate favicons in SearXNG's result list select a default

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -183,15 +183,6 @@ def stract(query, _lang):
     return [html.unescape(suggestion['raw']) for suggestion in resp.json()]
 
 
-def startpage(query, sxng_locale):
-    """Autocomplete from Startpage. Supports Startpage's languages"""
-    lui = engines['startpage'].traits.get_language(sxng_locale, 'english')
-    url = 'https://startpage.com/suggestions?{query}'
-    resp = get(url.format(query=urlencode({'q': query, 'segment': 'startpage.udog', 'lui': lui})))
-    data = resp.json()
-    return [e['text'] for e in data.get('suggestions', []) if 'text' in e]
-
-
 def swisscows(query, _lang):
     # swisscows autocompleter
     url = 'https://swisscows.ch/api/suggest?{query}&itemsCount=5'
@@ -263,7 +254,6 @@ backends = {
     'mwmbl': mwmbl,
     'qwant': qwant,
     'seznam': seznam,
-    'startpage': startpage,
     'stract': stract,
     'swisscows': swisscows,
     'wikipedia': wikipedia,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -34,7 +34,7 @@ search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
   # Existing autocomplete backends: "baidu", "brave", "dbpedia", "duckduckgo", "google", "yandex",
-  # "mwmbl", "seznam", "startpage", "stract", "swisscows", "qwant", "wikipedia" -
+  # "mwmbl", "seznam", "stract", "swisscows", "qwant", "wikipedia" -
   # leave blank to turn it off by default.
   autocomplete: ""
   # minimun characters to type before autocompleter starts


### PR DESCRIPTION
as long we don't have a solution for #4334 we can't offer startpage as autocomplete backend.

Related:

- https://github.com/searxng/searxng/issues/4334