### PR TITLE
[feat] add HEALTHCHECK in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ RUN su searxng -c "/usr/bin/python3 -m compileall -q searx" \
     -o -name '*.svg' -o -name '*.ttf' -o -name '*.eot' \) \
     -type f -exec gzip -9 -k {} \+ -exec brotli --best {} \+
 
+HEALTHCHECK CMD wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
+
 # Keep these arguments at the end to prevent redundant layer rebuilds
 ARG LABEL_DATE=
 ARG GIT_URL=unknown


### PR DESCRIPTION
## What does this PR do?

Adds a HEALTHCHECK to the Dockerfile.

Finds the port being used via netstat as the port could be set by the user.

<img width="1033" alt="up" src="https://github.com/user-attachments/assets/adf81e47-7f28-426a-a06b-3191ab245464" />
<img width="1080" alt="starting" src="https://github.com/user-attachments/assets/1db6cb26-5576-42f0-a77e-87b7e71ae269" />


## Related issues

Closes: https://github.com/searxng/searxng/issues/4026