### PR TITLE
[engine] elasticsearch: add pagination support

### DIFF
--- a/searx/engines/elasticsearch.py
+++ b/searx/engines/elasticsearch.py
@@ -29,7 +29,7 @@ authentication configured to read from ``my-index`` index.
 .. code:: yaml
 
   - name: elasticsearch
-    shortcut: es
+    shortcut: els
     engine: elasticsearch
     base_url: http://localhost:9200
     username: elastic
@@ -46,16 +46,26 @@ from searx.exceptions import SearxEngineAPIException
 from searx.result_types import EngineResults
 from searx.extended_types import SXNG_Response
 
+categories = ['general']
+paging = True
+
+about = {
+    'website': 'https://www.elastic.co',
+    'wikidata_id': 'Q3050461',
+    'official_api_documentation': 'https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html',
+    'use_official_api': True,
+    'require_api_key': False,
+    'format': 'JSON',
+}
 
 base_url = 'http://localhost:9200'
 username = ''
 password = ''
 index = ''
-search_url = '{base_url}/{index}/_search'
 query_type = 'match'
 custom_query_json = {}
 show_metadata = False
-categories = ['general']
+page_size = 10
 
 
 def init(engine_settings):
@@ -73,9 +83,16 @@ def request(query, params):
     if username and password:
         params['auth'] = (username, password)
 
-    params['url'] = search_url.format(base_url=base_url, index=index)
+    args = {
+        'from': (params['pageno'] - 1) * page_size,
+        'size': page_size,
+    }
+    data = _available_query_types[query_type](query)
+    data.update(args)
+
+    params['url'] = f"{base_url}/{index}/_search"
     params['method'] = 'GET'
-    params['data'] = dumps(_available_query_types[query_type](query))
+    params['data'] = dumps(data)
     params['headers']['Content-Type'] = 'application/json'
 
     return params

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -773,17 +773,18 @@ engines:
       results: HTML
 
   # - name: elasticsearch
-  #   shortcut: es
+  #   shortcut: els
   #   engine: elasticsearch
   #   base_url: http://localhost:9200
   #   username: elastic
   #   password: changeme
   #   index: my-index
+  #   enable_http: true
   #   # available options: match, simple_query_string, term, terms, custom
   #   query_type: match
   #   # if query_type is set to custom, provide your query here
-  #   #custom_query_json: {"query":{"match_all": {}}}
-  #   #show_metadata: false
+  #   # custom_query_json: {"query":{"match_all": {}}}
+  #   # show_metadata: false
   #   disabled: true
 
   - name: wikidata


### PR DESCRIPTION
## What does this PR do?
- add support for pagination
- add some missing about information

## Why is this change important?
- this improves the user experience when using elasticsearch

## How to test this PR locally?
```
services:
  elasticsearch:
    image: elasticsearch:8.8.0
    ports:
      - 9200:9200
      - 9300:9300
    environment:
      - discovery.type=single-node
      - xpack.security.enabled=false
```
- Create an index: `curl -X PUT http://localhost:9200/my-index`
- Create items: `curl -X POST -H 'Content-Type: application/json' -d '{ "name": "Awesome T-Shirt", "description": "This is an awesome t-shirt for casual wear.", "price": 19.99, "category": "Clothing", "brand": "Example Brand" }' http://localhost:9200/my-index/_doc`
- Enable elasticsearch in `settings.yml` by uncommenting it

## Related issues
closes https://github.com/searxng/searxng/issues/4346
