### PR TITLE
[fix] engines: key-value result templates show no results and badly formatted

### DIFF
--- a/client/simple/src/less/style.less
+++ b/client/simple/src/less/style.less
@@ -1050,6 +1050,12 @@ summary.title {
   }
 }
 
+#main_results .key-value-table {
+  td {
+    padding: 0.3rem 0.5rem;
+  }
+}
+
 /*
   phone layout
 */

--- a/searx/results.py
+++ b/searx/results.py
@@ -386,9 +386,6 @@ class ResultContainer:
         categoryPositions = {}
 
         for res in results:
-            if not res.get('url'):
-                continue
-
             # do we need to handle more than one category per engine?
             engine = engines[res['engine']]
             res['category'] = engine.categories[0] if len(engine.categories) > 0 else ''

--- a/searx/templates/simple/result_templates/key-value.html
+++ b/searx/templates/simple/result_templates/key-value.html
@@ -1,4 +1,4 @@
-<table>
+<table class="key-value-table">
     {% for key, value in result.items() %}
     {% if key in ['engine', 'engines', 'template', 'score', 'category', 'positions', 'parsed_url'] %}
         {% continue %}


### PR DESCRIPTION
## What does this PR do?
- this fixes that templates without url don't work

## Why is this change important?
- key value templates currently don't work because they don't have a URL

## How to test this PR locally?
- see https://github.com/searxng/searxng/pull/4382

## Author's checklist
- I introduced this bug recently at https://github.com/searxng/searxng/pull/4300/files, so we will likely need another solution to fix that