### PR TITLE
[fix] add backward compatibility for the "enabled_plugins:" setting

### DIFF
--- a/tests/unit/test_plugin_calculator.py
+++ b/tests/unit/test_plugin_calculator.py
@@ -26,7 +26,7 @@ class PluginCalculator(SearxTestCase):
         engines = {}
 
         self.storage = searx.plugins.PluginStorage()
-        self.storage.register(ModulePlugin(mod))
+        self.storage.register(ModulePlugin(mod, "searx.plugins.calculator"))
         self.storage.init(self.app)
         self.pref = searx.preferences.Preferences(["simple"], ["general"], engines, self.storage)
         self.pref.parse_dict({"locale": "en"})


### PR DESCRIPTION
Before #4183 a builtin plugin was *defautlt_on* when it is listed in the "enabled_plugins" settings, this patch restores the previous behavior.

Not part of this patch but just to mentioning in context of #4263:

In the long term, we will abolish the "enabled_plugins:" setting and combine all options for the plugins in the "plugins:" setting, as is already planned in the PR #4282.

Closes: https://github.com/searxng/searxng/issues/4263