### PR TITLE
[feat] add tls support to the backend searxng flask application

### DIFF
--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -19,6 +19,9 @@
          X-Download-Options : noopen
          X-Robots-Tag : noindex, nofollow
          Referrer-Policy : no-referrer
+       enable_tls: false
+       certificate_path: "certs/searxng.crt"
+       certificate_key_path: "certs/searxng.key"
 
 ``base_url`` : ``$SEARXNG_URL``
   The base URL where SearXNG is deployed.  Used to create correct inbound links.
@@ -55,3 +58,15 @@
 ``default_http_headers`` :
   Set additional HTTP headers, see `#755 <https://github.com/searx/searx/issues/715>`__
 
+``enable_tls`` :
+  Enables TLS for the SearXNG flask application. Used to encrypt traffic between 
+  the reverse proxy and uWSGI server that hosts the SearXNG flask application.
+
+``certificate_path`` :
+  This is the path (relative to /etc/searxng) to the SearXNG certificate. It is used 
+  by the SearXNG flask application if enable_tls is set to true.
+
+``certificate_key_path`` :
+  This is the path (relative to /etc/searxng) to the key used to create the 
+  SearXNG certificate. It is used by the SearXNG flask application if enable_tls is 
+  set to true.

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -108,6 +108,12 @@ server:
     X-Download-Options: noopen
     X-Robots-Tag: noindex, nofollow
     Referrer-Policy: no-referrer
+  # Used to enable TLS on the searxng server itself
+  # If enable_tls is set to true, then you must specify certificate_path and certificate_key_path
+  enable_tls: false
+  # These are the paths to the searxng certificate and its private key relative to /etc/searxng/.
+  certificate_path: "certs/searxng.crt"
+  certificate_key_path: "certs/searxng.key"
 
 redis:
   # URL to connect redis database. Is overwritten by ${SEARXNG_REDIS_URL}.

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -184,6 +184,9 @@ SCHEMA = {
         'http_protocol_version': SettingsValue(('1.0', '1.1'), '1.0'),
         'method': SettingsValue(('POST', 'GET'), 'POST'),
         'default_http_headers': SettingsValue(dict, {}),
+        'enable_tls': SettingsValue(bool, False, 'SEARXNG_ENABLE_TLS'),
+        'certificate_path': SettingsValue(str, 'certs/searxng.crt', environ_name='SEARXNG_CERT_PATH'),
+        'certificate_key_path': SettingsValue(str, 'certs/searxng.key', environ_name='SEARXNG_CERT_KEY_PATH'),
     },
     'redis': {
         'url': SettingsValue((None, False, str), False, 'SEARXNG_REDIS_URL'),

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1359,14 +1359,30 @@ if not werkzeug_reloader or (werkzeug_reloader and os.environ.get("WERKZEUG_RUN_
 
 def run():
     logger.debug('starting webserver on %s:%s', settings['server']['bind_address'], settings['server']['port'])
-    app.run(
-        debug=searx_debug,
-        use_debugger=searx_debug,
-        port=settings['server']['port'],
-        host=settings['server']['bind_address'],
-        threaded=True,
-        extra_files=[DEFAULT_SETTINGS_FILE],
-    )
+
+    # If TLS support is enabled, use TLS
+    if settings['server']['enable_tls']:
+        app.run(
+            debug=searx_debug,
+            use_debugger=searx_debug,
+            port=settings['server']['port'],
+            host=settings['server']['bind_address'],
+            threaded=True,
+            extra_files=[DEFAULT_SETTINGS_FILE],
+            ssl_context=(
+                os.path.join('/etc/searxng/', settings['server']['certificate_path']),
+                os.path.join('/etc/searxng/', settings['server']['certificate_key_path']),
+            ),
+        )
+    else:
+        app.run(
+            debug=searx_debug,
+            use_debugger=searx_debug,
+            port=settings['server']['port'],
+            host=settings['server']['bind_address'],
+            threaded=True,
+            extra_files=[DEFAULT_SETTINGS_FILE],
+        )
 
 
 application = app


### PR DESCRIPTION
## What does this PR do?

- Adds support for TLS on the SearXNG flask application in webapp.py.
- Enables https-socket support for uwsgi in docker-entrypoint.sh.
- Adds three new configuration options to searx's settings.yml (enable_tls, certificate_path, and certificate_key_path).
- Updates the settings_server documentation to provide information on enable_tls, certificate_path, and certificate_key_path.

## Why is this change important?

Currently, the SearXNG Flask application and uWSGI implementation do not support HTTPS. This presents a significant security and privacy vulnerability, particularly in potentially hostile environments like cloud platforms. While a reverse proxy (like Caddy) might handle SSL termination for external users, the internal traffic between the proxy and the SearXNG backend remains unencrypted.

In the event that an adversary obtains access to the machine where SearXNG is hosted, either through a vulnerability or insider attack (particularly in cloud environments), they will be able to read and intercept every search made to SearXNG in plaintext. One might argue that if an adversary gets access to the machine where SearXNG is hosted, it's game over regardless, since they could just change the configuration to use HTTP for the backend again. However, it's much easier to detect and audit for configuration changes than it is to detect passive traffic sniffing.

This change is not forcing the use of TLS in the backend (in fact it is disabled by default); it simply adds support for those who wish to enable it.

Additionally, this change will make searches more private, reinforcing SearXNG's privacy-by-design approach.

## How to test this PR locally?
### To test HTTPS support
1. Generate an openssl private key and certificate.
2. Copy the private key to /etc/searxng/certs/searxng.key
3. Copy the generated certificate to /etc/searxng/certs/searxng.crt
4. Set enable_tls to true in the searx settings.yml file.
5. Run SearXNG.

### To test HTTP support
1. Set enable_tls to false in the searx settings.yml file.
2. Run SearXNG.

## Related issues

<!--
Closes #234
-->