### PR TITLE
[feat] add bilibili support to get_embeded_stream_url

### DIFF
--- a/searx/engines/360search_videos.py
+++ b/searx/engines/360search_videos.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from datetime import datetime
 
 from searx.exceptions import SearxEngineAPIException
-from searx.utils import html_to_text
+from searx.utils import html_to_text, get_embeded_stream_url
 
 about = {
     "website": "https://tv.360kan.com/",
@@ -58,6 +58,7 @@ def response(resp):
                 'template': 'videos.html',
                 'publishedDate': published_date,
                 'thumbnail': entry["cover_img"],
+                "iframe_src": get_embeded_stream_url(entry["play_url"]),
             }
         )
 

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -633,7 +633,7 @@ def _get_fasttext_model() -> "fasttext.FastText._FastText":  # type: ignore
 def get_embeded_stream_url(url):
     """
     Converts a standard video URL into its embed format. Supported services include Youtube,
-    Facebook, Instagram, TikTok, and Dailymotion.
+    Facebook, Instagram, TikTok, Dailymotion, and Bilibili.
     """
     parsed_url = urlparse(url)
     iframe_src = None
@@ -672,6 +672,22 @@ def get_embeded_stream_url(url):
         if len(path_parts) == 3:
             video_id = path_parts[2]
             iframe_src = 'https://www.dailymotion.com/embed/video/' + video_id
+
+    # Bilibili
+    elif parsed_url.netloc in ['www.bilibili.com', 'bilibili.com'] and parsed_url.path.startswith('/video/'):
+        path_parts = parsed_url.path.split('/')
+
+        video_id = path_parts[2]
+        param_key = None
+        if video_id.startswith('av'):
+            video_id = video_id[2:]
+            param_key = 'aid'
+        elif video_id.startswith('BV'):
+            param_key = 'bvid'
+
+        iframe_src = (
+            f'https://player.bilibili.com/player.html?{param_key}={video_id}&high_quality=1&autoplay=false&danmaku=0'
+        )
 
     return iframe_src
 


### PR DESCRIPTION
## What does this PR do?

Explained in the title.

## Why is this change important?

Improvement for users.

## How to test this PR locally?

Two types of URLS are handled. Test for both:

!360sov shanghai teahouse
!ddv site:bilibili.com shanghai teahouse

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
