### PR TITLE
[mod] enable CSS & JS cache busting by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -118,7 +118,7 @@ ui:
   # Custom static path - leave it blank if you didn't change
   static_path: ""
   # Is overwritten by ${SEARXNG_STATIC_USE_HASH}.
-  static_use_hash: false
+  static_use_hash: true
   # Custom templates path - leave it blank if you didn't change
   templates_path: ""
   # query_in_title: When true, the result page's titles contains the query


### PR DESCRIPTION
The static files (CSS & JS) are cached in the browser for one year.  If we have changes to the CSS or JS files, these are not yet transported to the client by default, which causes problems and irritations on the client side:

- see issues & discussions with [`label:"clear browser cache"`](https://github.com/search?q=repo%3Asearxng%2Fsearxng+label%3A%22clear+browser+cache%22)

Related:

- https://github.com/searxng/searxng/issues/4415#issuecomment-2702917901
- https://github.com/searxng/searxng/pull/932
