### PR TITLE
[fix] uwsgi: don't set static-expires

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -49,6 +49,5 @@ die-on-term
 # uwsgi serves the static files
 static-map = /static=/usr/local/searxng/searx/static
 # expires set to one day
-static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
@@ -81,7 +81,5 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one day
-static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
@@ -78,7 +78,5 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one day
-static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini
@@ -84,7 +84,5 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one day
-static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
@@ -81,7 +81,5 @@ buffer-size = 8192
 #     static_use_hash: true
 #
 static-map = /static=${SEARXNG_STATIC}
-# expires set to one day
-static-expires = /* 86400
 static-gzip-all = True
 offload-threads = %k


### PR DESCRIPTION
As long we don't have a working solution for cache busting [3][4] we should not set an expire time in the uWSGI config.

If we have changes to the CSS or JS files, these are not yet transported to the client by default, which causes problems and irritations on the client side [3]:

- see issues & discussions with [`label:"clear browser cache"`](https://github.com/search?q=repo%3Asearxng%2Fsearxng+label%3A%22clear+browser+cache%22)

The default procedure in every web browser is the "304 Not Modified" [2] and this default procedure should also be sufficient for us as long as we have not implemented a complete alternative (cache busting) / form [1]

> By default uWSGI will add a Last-Modified [2] header to all static responses,
> and will honor the If-Modified-Since [2] request header.

- [1] https://uwsgi-docs.readthedocs.io/en/latest/StaticFiles.html#setting-the-expires-headers
- [2] https://developer.mozilla.org/de/docs/Web/HTTP/Status/304
- [3] https://github.com/searxng/searxng/pull/4433
- [4] https://github.com/searxng/searxng/issues/964