### PR TITLE
container: add default support for IPv6

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -23,7 +23,7 @@ Volume:
 EOF
 }
 
-export DEFAULT_BIND_ADDRESS="0.0.0.0:8080"
+export DEFAULT_BIND_ADDRESS="[::]:8080"
 export BIND_ADDRESS="${BIND_ADDRESS:-${DEFAULT_BIND_ADDRESS}}"
 
 # Parse command line

--- a/docs/admin/settings/settings.rst
+++ b/docs/admin/settings/settings.rst
@@ -59,7 +59,7 @@ and can relied on the default configuration :origin:`searx/settings.yml` using:
     use_default_settings: true
     server:
         secret_key: "ultrasecretkey"   # change this!
-        bind_address: "0.0.0.0"
+        bind_address: "[::]"
 
 ``engines:``
   With ``use_default_settings: true``, each settings can be override in a

--- a/tests/unit/settings/user_settings.yml
+++ b/tests/unit/settings/user_settings.yml
@@ -12,7 +12,7 @@ search:
 
 server:
   port: 9000
-  bind_address: "0.0.0.0"
+  bind_address: "[::]"
   secret_key: "user_settings_secret"
   base_url: false
   image_proxy: false

--- a/tests/unit/settings/user_settings_keep_only.yml
+++ b/tests/unit/settings/user_settings_keep_only.yml
@@ -5,7 +5,7 @@ use_default_settings:
       - wikinews
 server:
   secret_key: "user_secret_key"
-  bind_address: "0.0.0.0"
+  bind_address: "[::]"
   default_http_headers:
     Custom-Header: Custom-Value
 engines:

--- a/tests/unit/settings/user_settings_remove.yml
+++ b/tests/unit/settings/user_settings_remove.yml
@@ -5,6 +5,6 @@ use_default_settings:
       - wikinews
 server:
   secret_key: "user_secret_key"
-  bind_address: "0.0.0.0"
+  bind_address: "[::]"
   default_http_headers:
     Custom-Header: Custom-Value

--- a/tests/unit/settings/user_settings_remove2.yml
+++ b/tests/unit/settings/user_settings_remove2.yml
@@ -5,7 +5,7 @@ use_default_settings:
       - wikinews
 server:
   secret_key: "user_secret_key"
-  bind_address: "0.0.0.0"
+  bind_address: "[::]"
   default_http_headers:
     Custom-Header: Custom-Value
 engines:

--- a/tests/unit/settings/user_settings_simple.yml
+++ b/tests/unit/settings/user_settings_simple.yml
@@ -1,7 +1,7 @@
 use_default_settings: true
 server:
   secret_key: "user_secret_key"
-  bind_address: "0.0.0.0"
+  bind_address: "[::]"
   default_http_headers:
     Custom-Header: Custom-Value
 result_proxy:


### PR DESCRIPTION
Related https://github.com/searxng/searxng/pull/4378

Closes https://github.com/searxng/searxng/issues/965

To be merged after https://github.com/searxng/searxng/pull/4424