### PR TITLE
[fix] presearch engine: Title showing <em> html code

### DIFF
--- a/searx/engines/presearch.py
+++ b/searx/engines/presearch.py
@@ -161,7 +161,7 @@ def parse_search_query(json_results):
     for item in json_results.get('specialSections', {}).get('topStoriesCompact', {}).get('data', []):
         result = {
             'url': item['link'],
-            'title': item['title'],
+            'title': html_to_text(item['title']),
             'thumbnail': item['image'],
             'content': '',
             'metadata': item.get('source'),
@@ -171,7 +171,7 @@ def parse_search_query(json_results):
     for item in json_results.get('standardResults', []):
         result = {
             'url': item['link'],
-            'title': item['title'],
+            'title': html_to_text(item['title']),
             'content': html_to_text(item['description']),
         }
         results.append(result)


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

Fixes an issue where Presearch would show HTML code in the title as shown in the screenshot below. To trigger the bug, go to page 2 or more.

![Screenshot_2025-03-07_10:26:27](https://github.com/user-attachments/assets/042e6505-a502-4ad8-a747-81372381256d)

There is actually 2 issues here, but only 1 issue is related to searxng. I do have another branch ready if you want to fix *their* bug: https://github.com/searxng/searxng/compare/master...Aadniz:searxng:presearch-fix

<!-- explain the changes in your PR, algorithms, design, architecture -->

The fix is simple, wrap `html_to_text` around `item['title']`

## Why is this change important?

<!-- MANDATORY -->

It is not pleasant to look at, and nobody wants to see HTML code when reading normal text. It also messes with the title if multiple engines find the same results.

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

```shell
$ git clone https://github.com/Aadniz/searxng.git
$ git switch presearch-title-fix
$ python3 setup.py build
$ sudo python3 setup.py install
$ searxng-run
```

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
