### PR TITLE
Fix Qwant engine

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -135,6 +135,7 @@ def request(query, params):
         args['locale'] = q_locale
         args['safesearch'] = params['safesearch']
         args['count'] = 50
+        args['tgp'] = 3
         args['offset'] = (params['pageno'] - 1) * args['count']
 
     else:  # web, news, videos
@@ -142,6 +143,8 @@ def request(query, params):
         args['locale'] = q_locale
         args['safesearch'] = params['safesearch']
         args['count'] = 10
+        args['llm'] = 'false'
+        args['tgp'] = 3
         args['offset'] = (params['pageno'] - 1) * args['count']
 
     params['url'] = url + urlencode(args)


### PR DESCRIPTION
## What does this PR do?

This PR add tgp and llm arguments in the Qwant API request, to avoid beeing detected as a bot.

## Why is this change important?

With current main, Qwant search engine is not useable.

## How to test this PR locally?

make a search with !qwant and check that the results are not blocked by a captcha

## Author's checklist

loorisr

## Related issues

Related  #3929 
