### PR TITLE
[fix] set language for engines from chinese market (no i18n index nor UI)

### DIFF
--- a/searx/engines/360search.py
+++ b/searx/engines/360search.py
@@ -14,6 +14,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "HTML",
+    "language": "zh",
 }
 
 # Engine Configuration

--- a/searx/engines/acfun.py
+++ b/searx/engines/acfun.py
@@ -16,6 +16,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "HTML",
+    "language": "zh",
 }
 
 # Engine Configuration

--- a/searx/engines/baidu.py
+++ b/searx/engines/baidu.py
@@ -19,6 +19,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "JSON",
+    "language": "zh",
 }
 
 paging = True

--- a/searx/engines/chinaso.py
+++ b/searx/engines/chinaso.py
@@ -13,6 +13,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "JSON",
+    "language": "zh",
 }
 
 paging = True

--- a/searx/engines/iqiyi.py
+++ b/searx/engines/iqiyi.py
@@ -12,6 +12,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "JSON",
+    "language": "zh",
 }
 
 paging = True

--- a/searx/engines/sogou.py
+++ b/searx/engines/sogou.py
@@ -13,6 +13,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "HTML",
+    "language": "zh",
 }
 
 # Engine Configuration

--- a/searx/engines/sogou_videos.py
+++ b/searx/engines/sogou_videos.py
@@ -11,6 +11,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "JSON",
+    "language": "zh",
 }
 
 categories = ["videos"]

--- a/searx/engines/sogou_wechat.py
+++ b/searx/engines/sogou_wechat.py
@@ -14,6 +14,7 @@ about = {
     "use_official_api": False,
     "require_api_key": False,
     "results": "HTML",
+    "language": "zh",
 }
 
 # Engine Configuration

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -504,7 +504,7 @@ engines:
   - name: baidu
     engine: baidu
     shortcut: baidu
-    disabled: false
+    disabled: true
 
   - name: wikipedia
     engine: wikipedia


### PR DESCRIPTION
## What does this PR do?

set language for engines from Chinese market (no i18n index nor UI)

## Why is this change important?

These engines do not support languages others than Chinese.

## Related issues

https://github.com/searxng/searxng/pull/4121#issuecomment-2707088987