### PR TITLE
[fix] "[fix] uwsgi: don't set static-expires": Clean comment that forgot to clean

### DIFF
--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -48,6 +48,5 @@ die-on-term
 
 # uwsgi serves the static files
 static-map = /static=/usr/local/searxng/searx/static
-# expires set to one day
 static-gzip-all = True
 offload-threads = %k


### PR DESCRIPTION

I noticed this when I tracking the difference between my current `settings.yml` and the `settings.yml`.

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
https://github.com/searxng/searxng/commit/523d2a76837cc8e94f29afc490c312e6af8398a7