### PR TITLE
fix unterminated string literal in google.py

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -110,7 +110,7 @@ def get_google_info(params, eng_traits):
     :param dict param: Request parameters of the engine.  At least
         a ``searxng_locale`` key should be in the dictionary.
 
-    :param eng_traits: Engine's traits fetched from google preferences
+    :param eng_traits: Engine\'s traits fetched from google preferences
         (:py:obj:`searx.enginelib.traits.EngineTraits`)
 
     :rtype: dict


### PR DESCRIPTION
## What does this PR do?

Fix an unterminated string literal at line 113 of google.py.

## Why is this change important?

I was getting an "Internal server error" page with every search after copying changes from 194f22220306b7949660492bdbc3e5418835f88f, `journalctl` revealed this unterminated string literal as the problem.

```Mar 14 11:51:36 waldo uwsgi[11431]: spawned uWSGI http 1 (pid: 11434)
Mar 14 11:51:37 waldo uwsgi[11431]: Traceback (most recent call last):
Mar 14 11:51:37 waldo uwsgi[11431]:   File "/var/lib/searxng/.venv/lib/python3.13/site-packages/searx/webapp.py", line 85, in <module>
Mar 14 11:51:37 waldo uwsgi[11431]:     from searx.webadapter import (
Mar 14 11:51:37 waldo uwsgi[11431]:     ...<3 lines>...
Mar 14 11:51:37 waldo uwsgi[11431]:     )
Mar 14 11:51:37 waldo uwsgi[11431]:   File "/var/lib/searxng/.venv/lib/python3.13/site-packages/searx/webadapter.py", line 11, in <module>
Mar 14 11:51:37 waldo uwsgi[11431]:     from searx.preferences import Preferences, is_locked
Mar 14 11:51:37 waldo uwsgi[11431]:   File "/var/lib/searxng/.venv/lib/python3.13/site-packages/searx/preferences.py", line 16, in <module>
Mar 14 11:51:37 waldo uwsgi[11431]:     from searx import settings, autocomplete, favicons
Mar 14 11:51:37 waldo uwsgi[11431]:   File "/var/lib/searxng/.venv/lib/python3.13/site-packages/searx/autocomplete.py", line 15, in <module>
Mar 14 11:51:37 waldo uwsgi[11431]:     from searx.engines import (
Mar 14 11:51:37 waldo uwsgi[11431]:     ...<2 lines>...
Mar 14 11:51:37 waldo uwsgi[11431]:     )
Mar 14 11:51:37 waldo uwsgi[11431]:   File "/var/lib/searxng/.venv/lib/python3.13/site-packages/searx/engines/google.py", line 105
Mar 14 11:51:37 waldo uwsgi[11431]:     :param eng_traits: Engine's traits fetched from google preferences
Mar 14 11:51:37 waldo uwsgi[11431]:                              ^
Mar 14 11:51:37 waldo uwsgi[11431]: SyntaxError: unterminated string literal (detected at line 105)
Mar 14 11:51:37 waldo uwsgi[11431]: unable to load app 0 (mountpoint='') (callable not found or import error)
Mar 14 11:51:37 waldo uwsgi[11431]: *** no app loaded. going in full dynamic mode ***
Mar 14 11:51:39 waldo uwsgi[11431]: --- no python application found, check your startup logs for errors ---
Mar 14 11:57:53 waldo uwsgi[11431]: --- no python application found, check your startup logs for errors ---
Mar 14 11:57:53 waldo uwsgi[11431]: --- no python application found, check your startup logs for errors ---
Mar 14 11:57:58 waldo uwsgi[11431]: --- no python application found, check your startup logs for errors ---
Mar 14 12:01:07 waldo systemd[1]: Stopping uWSGI service unit...
```

It seems nobody else had an issue with this? I'm on Arch Linux, using the searxng binary from the AUR.

This is my first pull request, I'm not sure if I was supposed to open an issue first, let me know what I should do next time.