### PR TITLE
[fix] engine: core.ac.uk implement API v3 / v2 is no longer supported

### DIFF
--- a/docs/dev/engines/online/core.rst
+++ b/docs/dev/engines/online/core.rst
@@ -1,0 +1,13 @@
+.. _core engine:
+
+====
+CORE
+====
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.engines.core
+   :members:

--- a/searx/engines/mariadb_server.py
+++ b/searx/engines/mariadb_server.py
@@ -29,7 +29,7 @@ Implementations
 from typing import TYPE_CHECKING
 
 try:
-    import mariadb
+    import mariadb  # pyright: ignore [reportMissingImports]
 except ImportError:
     # import error is ignored because the admin has to install mysql manually to use
     # the engine


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
I try to preserve the original output data, but remove ISSN and ISBN in the end, as it's too hard to get those two fields, as follows:

```
            {
                'template': 'paper.html',
                'title': result.get('title'),
                'url': url,
                'content': result.get('fullText', '') or '',
                # 'comments': '',
                'tags': result.get('fieldOfStudy', []),
                'publishedDate': published_date,
                'type': result.get('documentType', '') or '',
                'authors': result.get('authors', []),
                'editor': ', '.join(result.get('contributors', [])),
                'publisher': publisher,
                'journal': ', '.join(journals),
                'doi': result.get('doi'),
                # 'issn' : ''
                # 'isbn' : ''
                'pdf_url': result.get('downloadUrl', {}) or result.get("sourceFulltextUrls", {}),
            }
 ```

## Why is this change important?
Because current implementation for core.ac.uk api v2 is not working anymore, so I am upgrading to v3.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
As mentioned, the current implementation is not working anymore using api v2. 

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

I fork this repo and make the changes on Github Codespaces. After editing core.py file, I run `make run` and `make test` as instructed on https://docs.searxng.org/dev/quickstart.html.

But before running `make run`, you need to update the searx/settings.yml with your CORE_API_KEY:

```
  - name: core.ac.uk
    engine: core
    categories: science
    shortcut: cor
    # get your API key from: https://core.ac.uk/api-keys/register/ -> Default (api_key: 'unset')
    api_key: '<YOUR_CORE_API_KEY>'
    disabled: false
```

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
