### PR TITLE
[fix] duckduckgo: answer sometimes contains faulty (duplicated) url

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -20,6 +20,7 @@ from searx import (
 )
 from searx.utils import (
     eval_xpath,
+    eval_xpath_getindex,
     extr,
     extract_text,
 )
@@ -400,7 +401,7 @@ def response(resp) -> EngineResults:
         results.add(
             results.types.Answer(
                 answer=zero_click,
-                url=extract_text(eval_xpath(doc, '//div[@id="zero_click_abstract"]/a/@href')),
+                url=eval_xpath_getindex(doc, '//div[@id="zero_click_abstract"]/a/@href', 0),
             )
         )
 


### PR DESCRIPTION
## What does this PR do?
- fixes a regression from https://github.com/searxng/searxng/pull/4508 which only occurs for few queries, most weren't affected by this bug anyways

## How to test this PR locally?
- run `!ddg search algorithm`
- without the changes in this PR, the answer URL is `https://en.wikipedia.org/wiki/Search_algorithmhttps://en.wikipedia.org/wiki/Search_algorithm` instead of `https://en.wikipedia.org/wiki/Search_algorithm`, because multiple links are found for (although they're the same, they just occur multiple times)
