### PR TITLE
[fix] presearch videos: item description and duration are located in metadata

### DIFF
--- a/searx/engines/presearch.py
+++ b/searx/engines/presearch.py
@@ -264,14 +264,13 @@ def response(resp):
         # a video and not to a video stream --> SearXNG can't use the video template.
 
         for item in json_resp.get('videos', []):
-            metadata = [x for x in [item.get('description'), item.get('duration')] if x]
             results.append(
                 {
                     'title': html_to_text(item['title']),
                     'url': item.get('link'),
-                    'content': '',
-                    'metadata': ' / '.join(metadata),
+                    'content': item.get('description', ''),
                     'thumbnail': item.get('image'),
+                    'length': item.get('duration'),
                 }
             )
 


### PR DESCRIPTION
## Why is this change important?
- the metadata field should only be used for short information, however it appears that the `description` field from presearch is much more similar to a full content text than some metadata bullet points

## How to test this PR locally?
- `!psvid assassins creed`
