### PR TITLE
[fix] baidu engine: properly decoding HTML escape codes

### DIFF
--- a/searx/engines/baidu.py
+++ b/searx/engines/baidu.py
@@ -9,6 +9,7 @@
 
 from urllib.parse import urlencode
 from datetime import datetime
+from html import unescape
 import time
 import json
 
@@ -119,11 +120,15 @@ def parse_general(data):
             except (ValueError, TypeError):
                 published_date = None
 
+        # title and content sometimes containing characters such as &amp; &#39; &quot; etc...
+        title = unescape(entry["title"])
+        content = unescape(entry.get("abs", ""))
+
         results.append(
             {
-                "title": entry["title"],
+                "title": title,
                 "url": entry["url"],
-                "content": entry.get("abs", ""),
+                "content": content,
                 "publishedDate": published_date,
             }
         )


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

Some results on Baidu shows HTML escape codes such as `&amp;`, `&#39;`, `&quot;` etc...

In the screenshot below is shown the fix before and after.

![image](https://github.com/user-attachments/assets/c0345bcf-0d8a-4de2-a85a-c2386f8d9679)

I was not able to find this issue on the "it" nor "images" searching, only general search.

To fix this issue, I used import `unescape` from `html`.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

Looks ascetically bad. Is not shown like this on Baidu.com.

<!-- explain the motivation behind your PR -->