### PR TITLE
[fix] presearch engine: Unexpected crash if duration not in videos

### DIFF
--- a/searx/engines/presearch.py
+++ b/searx/engines/presearch.py
@@ -264,13 +264,17 @@ def response(resp):
         # a video and not to a video stream --> SearXNG can't use the video template.
 
         for item in json_resp.get('videos', []):
+            duration = item.get('duration')
+            if duration:
+                duration = parse_duration_string(duration)
+
             results.append(
                 {
                     'title': html_to_text(item['title']),
                     'url': item.get('link'),
                     'content': item.get('description', ''),
                     'thumbnail': item.get('image'),
-                    'length': parse_duration_string(item.get('duration')),
+                    'length': duration,
                 }
             )
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

There is a chance presearch videos doesn't return results with `duration` in the response, causing an unexpected crash.

You can test this on any instance newer than 2025.3.25, searching something like `testing 123`. It should be very rare to *not* get a crash.

```
ERROR:searx.engines.presearch videos: exception : 'NoneType' object has no attribute 'strip'
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/searxng-1.0.0-py3.11.egg/searx/search/processors/online.py", line 160, in search
    search_results = self._search_basic(query, params)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/searxng-1.0.0-py3.11.egg/searx/search/processors/online.py", line 148, in _search_basic
    return self.engine.response(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/searxng-1.0.0-py3.11.egg/searx/engines/presearch.py", line 273, in response
    'length': parse_duration_string(item.get('duration')),
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/searxng-1.0.0-py3.11.egg/searx/utils.py", line 840, in parse_duration_string
    duration_str = duration_str.strip()
                   ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```

This PR solves this issue by checking if the value was found, and only then send it over to the `parse_duration_string` function.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Fixes major issue.
