### PR TITLE
[feat] engine: add engine for italian online newspaper "il post"

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -176,3 +176,4 @@ features or generally made searx better:
 - Patrick Evans `https://github.com/holysoles`
 - Daniel Mowitz `<https://daniel.mowitz.rocks>`
 - `Bearz314 <https://github.com/bearz314>`_
+- Tommaso Colella `<https://github.com/gioleppe>`

--- a/searx/engines/il_post.py
+++ b/searx/engines/il_post.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Engine for Il Post, a largely independent online Italian newspaper.
+
+To use this engine add the following entry to your engines
+list in ``settings.yml``:
+
+.. code:: yaml
+
+  - name: il post
+    engine: il_post
+    shortcut: pst
+    disabled: false
+
+"""
+
+from urllib.parse import urlencode
+from searx.result_types import EngineResults
+
+engine_type = "online"
+language_support = False
+categories = ["news"]
+paging = True
+page_size = 10
+
+time_range_support = True
+time_range_args = {"month": "pub_date:ultimi_30_giorni", "year": "pub_date:ultimo_anno"}
+
+search_api = "https://api.ilpost.org/search/api/site_search/?"
+
+about = {
+    "website": "https://www.ilpost.it",
+    "wikidata_id": "Q3792882",
+    "official_api_documentation": None,
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": "JSON",
+    "language": "it",
+}
+
+
+def request(query, params):
+    query_params = {
+        "qs": query,
+        "pg": params["pageno"],
+        "sort": "date_d",
+        "filters": "ctype:articoli",
+    }
+
+    if params["time_range"]:
+        if params["time_range"] not in time_range_args:
+            return None
+        query_params["filters"] += f";{time_range_args.get(params['time_range'], 'pub_date:da_sempre')}"
+    params["url"] = search_api + urlencode(query_params)
+    return params
+
+
+def response(resp) -> EngineResults:
+    res = EngineResults()
+    json_data = resp.json()
+
+    for result in json_data["docs"]:
+        res.add(
+            res.types.MainResult(
+                url=result["link"],
+                title=result["title"],
+                content=result.get("summary", ""),
+                thumbnail=result.get("image"),
+            )
+        )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1121,6 +1121,11 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name: il post
+    engine: il_post
+    shortcut: pst
+    disabled: true
+
   - name: imdb
     engine: imdb
     shortcut: imdb


### PR DESCRIPTION
## What does this PR do?

This PR adds an engine for an Italian online newspaper, [Il Post](https://www.ilpost.it/).
I've added the engine and included configuration in settings.yml (disabled, of course).
The engine supports "month" and "year" range queries as well.

## Why is this change important?

Il Post is a great resource for Italian people as it's usually one the less biased newspapers.
This would greatly benefit the Italian userbase

## How to test this PR locally?

`make run`
Then enable the engine from settings 
Finally navigate to the news tab and search something