### PR TITLE
Don't hardcode uWSGI parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN addgroup -g ${SEARXNG_GID} searxng && \
 ENV INSTANCE_NAME=searxng \
     AUTOCOMPLETE= \
     BASE_URL= \
+    BIND_ADDRESS=[::]:8080 \
     MORTY_KEY= \
     MORTY_URL= \
     SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml \

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -170,4 +170,4 @@ unset MORTY_KEY
 
 # Start uwsgi
 printf 'Listen on %s\n' "${BIND_ADDRESS}"
-exec uwsgi "${UWSGI_SETTINGS_PATH}"
+exec uwsgi --http-socket "${BIND_ADDRESS}" "${UWSGI_SETTINGS_PATH}"

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -14,17 +14,12 @@ Environment variables:
   BASE_URL      settings.yml : server.base_url
   MORTY_URL     settings.yml : result_proxy.url
   MORTY_KEY     settings.yml : result_proxy.key
-  BIND_ADDRESS  uwsgi bind to the specified TCP socket using HTTP protocol.
-                Default value: ${DEFAULT_BIND_ADDRESS}
 Volume:
   /etc/searxng  the docker entry point copies settings.yml and uwsgi.ini in
                 this directory (see the -f command line option)"
 
 EOF
 }
-
-export DEFAULT_BIND_ADDRESS="[::]:8080"
-export BIND_ADDRESS="${BIND_ADDRESS:-${DEFAULT_BIND_ADDRESS}}"
 
 # Parse command line
 FORCE_CONF_UPDATE=0
@@ -175,4 +170,4 @@ unset MORTY_KEY
 
 # Start uwsgi
 printf 'Listen on %s\n' "${BIND_ADDRESS}"
-exec uwsgi --master --uid searxng --gid searxng --http-socket "${BIND_ADDRESS}" "${UWSGI_SETTINGS_PATH}"
+exec uwsgi "${UWSGI_SETTINGS_PATH}"

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -168,6 +168,8 @@ fi
 
 unset MORTY_KEY
 
-# Start uwsgi
 printf 'Listen on %s\n' "${BIND_ADDRESS}"
+
+# Start uwsgi
+# TODO: "--http-socket" will be removed in the future (see uwsgi.ini.new config file): https://github.com/searxng/searxng/pull/4578
 exec uwsgi --http-socket "${BIND_ADDRESS}" "${UWSGI_SETTINGS_PATH}"

--- a/dockerfiles/uwsgi.ini
+++ b/dockerfiles/uwsgi.ini
@@ -1,4 +1,8 @@
 [uwsgi]
+# Listening address
+# default value: [::]:8080 (see Dockerfile)
+http-socket = $(BIND_ADDRESS)
+
 # Who will run the code
 uid = searxng
 gid = searxng


### PR DESCRIPTION
## What does this PR do?

Moves all the config to `/etc/searxng/uwsgi.ini`

## Why is this change important?

We have special requirements and we must modify params that the flags overwrite. It is also confusing to have the configuration scattered in different files.

## How to test this PR locally?

`podman build .`