### PR TITLE
Added commented-out JSON option to search formats block

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -77,6 +77,7 @@ search:
   # formats: [html, csv, json, rss]
   formats:
     - html
+    # - json
 
 server:
   # Is overwritten by ${SEARXNG_PORT} and ${SEARXNG_BIND_ADDRESS}


### PR DESCRIPTION
## What does this PR do?

Added commented-out JSON option to the search formats block.

<!-- explain the changes in your PR, algorithms, design, architecture -->

Users can now know how to enable json without needing to search 'how-to' online.

<!--
Closes #234
-->
