### PR TITLE
[fix] Meilisearch engine: Authorization Token When Integrating Meilisearch

### DIFF
--- a/searx/engines/meilisearch.py
+++ b/searx/engines/meilisearch.py
@@ -13,7 +13,9 @@ for storing web pages you have visited and searching in the contents later.
 
 The engine supports faceted search, so you can search in a subset of documents
 of the collection.  Furthermore, you can search in MeiliSearch_ instances that
-require authentication by setting ``auth_token``.
+require authentication by setting `auth_key`_.
+
+.. auth_key: https://www.meilisearch.com/docs/reference/api/overview#authorization
 
 Example
 =======
@@ -28,6 +30,7 @@ Here is a simple example to query a Meilisearch instance:
     base_url: http://localhost:7700
     index: my-index
     enable_http: true
+    # auth_key: Bearer XXXXX
 
 """
 
@@ -56,7 +59,7 @@ def init(_):
 
 def request(query, params):
     if auth_key != '':
-        params['headers']['X-Meili-API-Key'] = auth_key
+        params['headers']['Authorization'] = auth_key
 
     params['headers']['Content-Type'] = 'application/json'
     params['url'] = _search_url

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1317,12 +1317,14 @@ engines:
     disabled: true
     number_of_results: 20
 
+  # https://docs.searxng.org/dev/engines/offline/search-indexer-engines.html#module-searx.engines.meilisearch
   # - name: meilisearch
   #   engine: meilisearch
   #   shortcut: mes
   #   enable_http: true
   #   base_url: http://localhost:7700
   #   index: my-index
+  #   auth_key: Bearer XXXX
 
   - name: mixcloud
     engine: mixcloud


### PR DESCRIPTION
`X-Meili-API-Key` has  been changed to `Authorization` [1]

[1] https://www.meilisearch.com/docs/reference/api/overview#authorization

Suggested-by: https://github.com/searxng/searxng/issues/4416#issuecomment-2781254841

Closes: https://github.com/searxng/searxng/issues/4416