### PR TITLE
[fix] engine radio browser: get servers from DNS api.radio-browser.info

### DIFF
--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -7196,6 +7196,7 @@
       "km": "khmer",
       "kn": "kannada",
       "ko": "korean",
+      "ks": "kashmiri",
       "ku": "kurdish",
       "kw": "cornish",
       "la": "latin",


### PR DESCRIPTION
Do a DNS-lookup of `all.api.radio-browser.info`, add reverse lookup and select randomly a URL from available servers.

Closes: https://github.com/searxng/searxng/issues/4576
