### PR TITLE
[fix] issues when launching a local development server

### DIFF
--- a/docs/admin/settings/settings_general.rst
+++ b/docs/admin/settings/settings_general.rst
@@ -16,8 +16,14 @@
      open_metrics: ''
 
 ``debug`` : ``$SEARXNG_DEBUG``
-  Allow a more detailed log if you run SearXNG directly. Display *detailed* error
-  messages in the browser too, so this must be deactivated in production.
+  In debug mode, the server provides an interactive debugger, will reload when
+  code is changed and activates a verbose logging.
+
+  .. attention::
+
+     The debug setting is intended for local development server.  Don't
+     activate debug (don't use a development server) when deploying to
+     production.
 
 ``donation_url`` :
   Set value to ``true`` to use your own donation page written in the

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -22,18 +22,18 @@ searx_dir = abspath(dirname(__file__))
 searx_parent_dir = abspath(dirname(dirname(__file__)))
 
 settings = {}
-searx_debug = False
+sxng_debug = False
 logger = logging.getLogger('searx')
 
 _unset = object()
 
 
 def init_settings():
-    """Initialize global ``settings`` and ``searx_debug`` variables and
+    """Initialize global ``settings`` and ``sxng_debug`` variables and
     ``logger`` from ``SEARXNG_SETTINGS_PATH``.
     """
 
-    global settings, searx_debug  # pylint: disable=global-variable-not-assigned
+    global settings, sxng_debug  # pylint: disable=global-variable-not-assigned
 
     cfg, msg = searx.settings_loader.load_settings(load_user_settings=True)
     cfg = cfg or {}
@@ -42,8 +42,8 @@ def init_settings():
     settings.clear()
     settings.update(cfg)
 
-    searx_debug = settings['general']['debug']
-    if searx_debug:
+    sxng_debug = get_setting("general.debug")
+    if sxng_debug:
         _logging_config_debug()
     else:
         logging.basicConfig(level=LOG_LEVEL_PROD, format=LOG_FORMAT_PROD)

--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -12,7 +12,7 @@ from typing import Dict
 
 import httpx
 
-from searx import logger, searx_debug
+from searx import logger, sxng_debug
 from searx.extended_types import SXNG_Response
 from .client import new_client, get_loop, AsyncHTTPTransportNoHttp
 from .raise_for_httperror import raise_for_httperror
@@ -186,7 +186,7 @@ class Network:
         local_address = next(self._local_addresses_cycle)
         proxies = next(self._proxies_cycle)  # is a tuple so it can be part of the key
         key = (verify, max_redirects, local_address, proxies)
-        hook_log_response = self.log_response if searx_debug else None
+        hook_log_response = self.log_response if sxng_debug else None
         if key not in self._clients or self._clients[key].is_closed:
             client = new_client(
                 self.enable_http,

--- a/searx/search/checker/background.py
+++ b/searx/search/checker/background.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union
 
 import redis.exceptions
 
-from searx import logger, settings, searx_debug
+from searx import logger, settings, sxng_debug
 from searx.redisdb import client as get_redis_client
 from searx.exceptions import SearxSettingsException
 from searx.search.processors import PROCESSORS
@@ -139,7 +139,7 @@ def initialize():
         signal.signal(signal.SIGUSR1, _signal_handler)
 
     # special case when debug is activate
-    if searx_debug and settings['checker']['off_when_debug']:
+    if sxng_debug and settings['checker']['off_when_debug']:
         logger.info('debug mode: checker is disabled')
         return
 

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -9,7 +9,6 @@ import csv
 import hashlib
 import hmac
 import re
-import inspect
 import itertools
 import json
 from datetime import datetime, timedelta
@@ -314,21 +313,6 @@ def searxng_l10n_timespan(dt: datetime) -> str:  # pylint: disable=invalid-name
             return gettext('{minutes} minute(s) ago').format(minutes=minutes)
         return gettext('{hours} hour(s), {minutes} minute(s) ago').format(hours=hours, minutes=minutes)
     return format_date(dt)
-
-
-def is_flask_run_cmdline():
-    """Check if the application was started using "flask run" command line
-
-    Inspect the callstack.
-    See https://github.com/pallets/flask/blob/master/src/flask/__main__.py
-
-    Returns:
-        bool: True if the application was started using "flask run".
-    """
-    frames = inspect.stack()
-    if len(frames) < 2:
-        return False
-    return frames[-2].filename.endswith('flask/cli.py')
 
 
 NO_SUBGROUPING = 'without further subgrouping'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,13 +5,8 @@ import pathlib
 import os
 import aiounittest
 
-# Before import from the searx package, we need to set up the (debug)
-# environment.  The import of the searx package initialize the searx.settings
-# and this in turn takes the defaults from the environment!
 
 os.environ.pop('SEARXNG_SETTINGS_PATH', None)
-os.environ['SEARXNG_DEBUG'] = '1'
-os.environ['SEARXNG_DEBUG_LOG_LEVEL'] = 'WARNING'
 os.environ['SEARXNG_DISABLE_ETC_SETTINGS'] = '1'
 
 

--- a/tests/robot/__main__.py
+++ b/tests/robot/__main__.py
@@ -27,15 +27,6 @@ class SearxRobotLayer:
         webapp = str(tests_path.parent / 'searx' / 'webapp.py')
         exe = 'python'
 
-        # The Flask app is started by Flask.run(...), don't enable Flask's debug
-        # mode, the debugger from Flask will cause wired process model, where
-        # the server never dies.  Further read:
-        #
-        # - debug mode: https://flask.palletsprojects.com/quickstart/#debug-mode
-        # - Flask.run(..): https://flask.palletsprojects.com/api/#flask.Flask.run
-
-        os.environ['SEARXNG_DEBUG'] = '0'
-
         # set robot settings path
         os.environ['SEARXNG_SETTINGS_PATH'] = str(tests_path / 'robot' / 'settings_robot.yml')
 


### PR DESCRIPTION
A local development server can be launched by one of these command lines::

    $ flask --app searx.webapp run
    $ python -m searx.webapp

The different ways of starting the server should lead to the same result, which is generally the case.  However, if the modules are reloaded after code changes (reload option), it must be avoided that the application is initialized twice at startup.  We have already discussed this in 2022 [1][2].

Further information on this topic can be found in [3][4][5].

To test, a bash in the ./local environment was started and the follwing commands had been executed::

    $ ./manage pyenv.cmd bash --norc --noprofile
    (py3) SEARXNG_DEBUG=1 flask --app searx.webapp run --reload
    (py3) SEARXNG_DEBUG=1 python -m searx.webapp

Since the generic parts of the docs also initialize the app to generate doc from it, the build of the docs was also tested::

    $ make docs.clean docs.live

- [1] https://github.com/searxng/searxng/pull/1656#issuecomment-1214198941
- [2] https://github.com/searxng/searxng/pull/1616#issuecomment-1206137468
- [3] https://flask.palletsprojects.com/en/stable/api/#flask.Flask.run
- [4] https://github.com/pallets/flask/issues/5307#issuecomment-1774646119
- [5] https://stackoverflow.com/a/25504196