### PR TITLE
Remove brackets before passing to ip_address

### DIFF
--- a/searx/botdetection/_helpers.py
+++ b/searx/botdetection/_helpers.py
@@ -126,7 +126,15 @@ def get_real_ip(request: SXNG_Request) -> str:
     if real_ip and remote_addr and real_ip != remote_addr:
         logger.warning("IP from WSGI environment (%s) is not equal to IP from X-Real-IP (%s)", remote_addr, real_ip)
 
-    request_ip = ip_address(forwarded_for or real_ip or remote_addr or '0.0.0.0')
+    raw_ip = forwarded_for or real_ip or remote_addr or '0.0.0.0'
+
+    if raw_ip.startswith('['):
+        raw_ip = raw_ip.split(']')[0][1:]
+    elif ':' in raw_ip and raw_ip.count(':') > 1:
+        if raw_ip.rsplit(':', 1)[1].isdigit():
+            raw_ip = raw_ip.rsplit(':', 1)[0]
+
+    request_ip = ip_address(raw_ip)
     if request_ip.version == 6 and request_ip.ipv4_mapped:
         request_ip = request_ip.ipv4_mapped
 


### PR DESCRIPTION
## What does this PR do?

I have added a small condition to remove the brackets from the IPv6 coming from the upstream, [#ip_address](https://docs.python.org/3.13/library/ipaddress.html#ipaddress.ip_address) does not read the brackets (I don't know why). I also removed the port section too, leaving a clean address

## Why is this change important?

Progress on replacing uWSGI

## How to test this PR locally?

This error appears when using Granian as WSGI server (or any server that sends a spec compliant IPv6 structure downstream), needs enabling the `public_instance` param on settings.yml and accessing `/healthz` over IPv6.

## Related issues

Closes https://github.com/inetol-infrastructure/searxng-container/issues/6
