### PR TITLE
Update doku.py

### DIFF
--- a/searx/engines/doku.py
+++ b/searx/engines/doku.py
@@ -4,6 +4,7 @@
 """
 
 from urllib.parse import urlencode
+from urllib.parse import urljoin
 from lxml.html import fromstring
 from searx.utils import extract_text, eval_xpath
 
@@ -63,7 +64,7 @@ def response(resp):
         title = extract_text(eval_xpath(r, './/a[@class="wikilink1"]/@title'))
 
         # append result
-        results.append({'title': title, 'content': "", 'url': base_url + res_url})
+        results.append({'title': title, 'content': "", 'url': urljoin(base_url, res_url)})
 
     # Search results
     for r in eval_xpath(doc, '//dl[@class="search_results"]/*'):
@@ -75,7 +76,7 @@ def response(resp):
                 content = extract_text(eval_xpath(r, '.'))
 
                 # append result
-                results.append({'title': title, 'content': content, 'url': base_url + res_url})
+                results.append({'title': title, 'content': content, 'url': urljoin(base_url, res_url)})
         except:  # pylint: disable=bare-except
             continue
 


### PR DESCRIPTION
## What does this PR do?

Fixes the dual path problem from #4598

Exchanges string concat of URLs with `urljoin` from `urllib.parse`. This eliminates the dual problem, while retaining the old functionality designed to concatenate protocol, hostname and port (as base_url) with path. `urljoin` does the same, but in a more advanced manner that fixes the dual problem.

## Why is this change important?

Dokuwiki searches behind reverse proxy had duplicate base path in the url, creating a wrong url. The change fixes this.

## How to test this PR locally?

Configure searxng's settings.yml like shown in https://github.com/searxng/searxng/issues/4598. Requires that you have a working dokuwiki installed.

## Related issues

Closes #4598
