### PR TITLE
[feat] engine: add Steam engine

### DIFF
--- a/searx/engines/steam.py
+++ b/searx/engines/steam.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Steam (store) for SearXNG."""
+
+from urllib.parse import urlencode
+
+from searx.utils import html_to_text
+from searx.result_types import EngineResults, MainResult
+
+about = {
+    "website": 'https://store.steampowered.com/',
+    "wikidata_id": 'Q337535',
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+categories = []
+
+base_url = "https://store.steampowered.com"
+
+
+def request(query, params):
+    query_params = {"term": query, "cc": "us", "l": "en"}
+    params['url'] = f'{base_url}/api/storesearch/?{urlencode(query_params)}'
+    return params
+
+
+def response(resp) -> EngineResults:
+    results = EngineResults()
+    search_results = resp.json()
+
+    for item in search_results.get('items', []):
+        app_id = item.get('id')
+
+        currency = item.get('price', {}).get('currency', 'USD')
+        price = item.get('price', {}).get('final', 0) / 100
+
+        platforms = ', '.join([platform for platform, supported in item.get('platforms', {}).items() if supported])
+
+        content = [f'Price: {price:.2f} {currency}', f'Platforms: {platforms}']
+
+        results.add(
+            MainResult(
+                title=item.get('name'),
+                content=html_to_text(' | '.join(content)),
+                url=f'{base_url}/app/{app_id}',
+                thumbnail=item.get('tiny_image', ''),
+            )
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1971,6 +1971,11 @@ engines:
     categories: [images, web]
     shortcut: spi
 
+  - name: steam
+    engine: steam
+    shortcut: stm
+    disabled: true
+
   - name: tokyotoshokan
     engine: tokyotoshokan
     shortcut: tt


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

add Steam engine

ref: https://store.steampowered.com/
Wikidata: https://www.wikidata.org/wiki/Q337535

|`steam_app_details`|Screenshot|
|-|-|
|true|![image](https://github.com/user-attachments/assets/fc03b86f-f319-4a23-a92c-d88478daae0e)|
|false|![image](https://github.com/user-attachments/assets/f7fb8759-9dfa-4609-85b9-790765fbda94)|

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

1. search games via `!stm foo`

Note:
set `steam_app_details` to `true`, will fetch the app detail from separate API endpoint.

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
