### PR TITLE
[fix] Result type: remove rstrip "/" from URL normalization

### DIFF
--- a/searx/result_types/_base.py
+++ b/searx/result_types/_base.py
@@ -55,8 +55,7 @@ def _normalize_url_fields(result: Result | LegacyResult):
         result.parsed_url = result.parsed_url._replace(
             # if the result has no scheme, use http as default
             scheme=result.parsed_url.scheme or "http",
-            # normalize ``example.com/path/`` to ``example.com/path``
-            path=result.parsed_url.path.rstrip("/"),
+            path=result.parsed_url.path,
         )
         result.url = result.parsed_url.geturl()
 
@@ -73,7 +72,7 @@ def _normalize_url_fields(result: Result | LegacyResult):
             item["url"] = _url._replace(
                 scheme=_url.scheme or "http",
                 # netloc=_url.netloc.replace("www.", ""),
-                path=_url.path.rstrip("/"),
+                path=_url.path,
             ).geturl()
 
         infobox_id = getattr(result, "id", None)
@@ -82,7 +81,7 @@ def _normalize_url_fields(result: Result | LegacyResult):
             result.id = _url._replace(
                 scheme=_url.scheme or "http",
                 # netloc=_url.netloc.replace("www.", ""),
-                path=_url.path.rstrip("/"),
+                path=_url.path,
             ).geturl()
 
 
@@ -259,9 +258,6 @@ class Result(msgspec.Struct, kw_only=True):
           ``parse_url`` from field ``url``.  The ``url`` field is initialized
           with the resulting value in ``parse_url``, if ``url`` and
           ``parse_url`` are not equal.
-
-        - ``example.com/path/`` and ``example.com/path`` are equivalent and are
-          normalized to ``example.com/path``.
         """
         _normalize_url_fields(self)
 


### PR DESCRIPTION
## What does this PR do?

I removed rstrip("/") for URL normalization steps.
The code passed all tests, and I made a few searched testing the results I had but **I don't know** if there could be deeper implications with this (e.g., this breaks something else), maybe @return42 knows more about this!

## Why is this change important?

This is important since trailing slash behavior is not a standard among webservers and web applications in general. For this reason, example.com/whatever and example.com/whatever/ may bring the user to different pages.
Most of the times the web server redirects the user as needed, but this avoids that redirect as well, which makes for a better request lifecycle.
Also, we should probably present the same URL that we get from the underlying engines.

## How to test this PR locally?

e.g., Search for `artiq manual` by using google, qwant, duckduckgo, brave, as upstream engines.
It will show you results pointing to https://m-labs.hk/artiq/manual/ that is the correct URL for the manual.

## Related issues

Tries to fix #4602 
