### PR TITLE
[mod] include SEARXNG_METHOD environment variable

### DIFF
--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -14,6 +14,7 @@
        limiter: false
        public_instance: false
        image_proxy: false
+       method: "POST"
        default_http_headers:
          X-Content-Type-Options : nosniff
          X-Download-Options : noopen
@@ -49,6 +50,11 @@
 
 ``image_proxy`` : ``$SEARXNG_IMAGE_PROXY``
   Allow your instance of SearXNG of being able to proxy images.  Uses memory space.
+
+.. _method:
+
+``method`` : ``$SEARXNG_METHOD``
+  Whether to use ``GET`` or ``POST`` HTTP method when searching.
 
 .. _HTTP headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -101,7 +101,8 @@ server:
   # 1.0 and 1.1 are supported
   http_protocol_version: "1.0"
   # POST queries are more secure as they don't show up in history but may cause
-  # problems when using Firefox containers
+  # problems when using Firefox containers.
+  # Is overwritten by ${SEARXNG_METHOD}
   method: "POST"
   default_http_headers:
     X-Content-Type-Options: nosniff

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -182,7 +182,7 @@ SCHEMA = {
         'base_url': SettingsValue((False, str), False, 'SEARXNG_BASE_URL'),
         'image_proxy': SettingsValue(bool, False, 'SEARXNG_IMAGE_PROXY'),
         'http_protocol_version': SettingsValue(('1.0', '1.1'), '1.0'),
-        'method': SettingsValue(('POST', 'GET'), 'POST'),
+        'method': SettingsValue(('POST', 'GET'), 'POST', 'SEARXNG_METHOD'),
         'default_http_headers': SettingsValue(dict, {}),
     },
     'redis': {


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR includes `SEARXNG_METHOD` environment variable as a way to change the default HTTP search method.

Documentation is included.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

It might come in handy for people to be able to specify the environment variable to set the setting, just like the other options that are under the server settings section.

There was also a person on Matrix wondering about documentation for this option, and figured it might be nice to include that.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

Run SearXNG with the `SEARXNG_METHOD` set to either `GET` or `POST`. Anything else should result in an error (ValueError: Invalid settings.yml)