### PR TITLE
[fix] fix Quark search calling, change base url from `m.quark.cn` to `quark.sm.cn`

### DIFF
--- a/searx/engines/quark.py
+++ b/searx/engines/quark.py
@@ -11,7 +11,7 @@ from searx.exceptions import SearxEngineAPIException, SearxEngineCaptchaExceptio
 
 # Metadata
 about = {
-    "website": "https://m.quark.cn/",
+    "website": "https://quark.sm.cn/",
     "wikidata_id": "Q48816502",
     "use_official_api": False,
     "require_api_key": False,
@@ -53,7 +53,7 @@ def request(query, params):
 
     category_config = {
         'general': {
-            'endpoint': 'https://m.quark.cn/s',
+            'endpoint': 'https://quark.sm.cn/s',
             'params': {
                 "q": query,
                 "layout": "html",


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

1. Fix Quark search calling, change base url from m.quark.cn to quark.sm.cn

---

Note:

1. `m.quark.cn` now is used to be as an AI search engine from Quark

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

`!qk foo`

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
