### PR TITLE
[fix] is_werkzeug_reload_active is not realted to python -m

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1383,11 +1383,6 @@ def is_werkzeug_reload_active() -> bool:
         if "--reload" in sys.argv or "--debug" in sys.argv:
             return True
 
-    elif frames[0].filename.endswith('searx/webapp.py'):
-        # server was launched by "python -m searx.webapp" / see run()
-        if searx.sxng_debug:
-            return True
-
     return False
 
 


### PR DESCRIPTION
Werkzeug's reloader is not active when was server is launched by::

    python -m searx.webapp

## Related issues

- https://github.com/searxng/searxng/pull/4603

----

BTW: `python -m searx.webapp` starts a instance by `Flask.run`:

[Do not use run() in a production setting. It is not intended to meet security and performance requirements for a production server. Instead see "Deploying to Production" for WSGI server recommendations.](https://flask.palletsprojects.com/en/stable/api/#flask.Flask.run)
