### PR TITLE
[upd] Upgrade to httpx 0.28.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,10 @@ lxml==5.4.0
 pygments==2.19.1
 python-dateutil==2.9.0.post0
 pyyaml==6.0.2
-httpx[http2]==0.24.1
+httpx[http2]==0.28.1
+httpx-socks[asyncio]==0.10.0
 Brotli==1.1.0
 uvloop==0.21.0
-httpx-socks[asyncio]==0.7.7
 setproctitle==1.3.6
 redis==5.2.1
 markdown-it-py==3.0.0


### PR DESCRIPTION
## What does this PR do?

Upgrade httpx to the last version 0.28.1

## Why is this change important?

Use the last version of httpx which is a core dependency of SearXNG

## How to test this PR locally?

* [x] check `enable_http: false` works 
* [x] check `enable_http2: true` works 
* [ ] check `verify: false` works
* [ ] check `verify: "/path/to/ca.pem"` works
* [ ] check `local_addresses` works
* [x] check HTTP proxy
* [x] check HTTPS proxy
* [ ] check SOCKS proxy
* [ ] Cipher list and rotation

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues
