### PR TITLE
[feat] plugins: add new time/timezone search plugin

### DIFF
--- a/docs/dev/plugins/builtins.rst
+++ b/docs/dev/plugins/builtins.rst
@@ -13,3 +13,4 @@ Built-in Plugins
    self_info
    tor_check
    unit_converter
+   time_zone

--- a/docs/dev/plugins/time_zone.rst
+++ b/docs/dev/plugins/time_zone.rst
@@ -1,0 +1,8 @@
+.. _time zone plugin:
+
+=========
+Time Zone
+=========
+
+.. automodule:: searx.plugins.time_zone
+   :members:

--- a/searx/plugins/time_zone.py
+++ b/searx/plugins/time_zone.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring
+
+from __future__ import annotations
+import typing as t
+
+import datetime
+
+from flask_babel import gettext  # type: ignore
+from searx.result_types import EngineResults
+from searx.weather import DateTime, GeoLocation
+
+from . import Plugin, PluginInfo
+
+if t.TYPE_CHECKING:
+    from searx.search import SearchWithPlugins
+    from searx.extended_types import SXNG_Request
+    from searx.plugins import PluginCfg
+
+
+@t.final
+class SXNGPlugin(Plugin):
+    """Plugin to display the current time at different timezones (usually the
+    query city)."""
+
+    id: str = "time_zone"
+    keywords: list[str] = ["time", "timezone", "now", "clock", "timezones"]
+
+    def __init__(self, plg_cfg: "PluginCfg"):
+        super().__init__(plg_cfg)
+
+        self.info = PluginInfo(
+            id=self.id,
+            name=gettext("Timezones plugin"),
+            description=gettext("Display the current time on different time zones."),
+            preference_section="query",
+            examples=["time Berlin", "clock Los Angeles"],
+        )
+
+    def post_search(self, request: "SXNG_Request", search: "SearchWithPlugins") -> EngineResults:
+        """The plugin uses the :py:obj:`searx.weather.GeoLocation` class, which
+        is already implemented in the context of weather forecasts, to determine
+        the time zone. The :py:obj:`searx.weather.DateTime` class is used for
+        the localized display of date and time."""
+
+        results = EngineResults()
+        if search.search_query.pageno > 1:
+            return results
+
+        # remove keywords from the query
+        query = search.search_query.query
+        query_parts = filter(lambda part: part.lower() not in self.keywords, query.split(" "))
+        search_term = " ".join(query_parts).strip()
+
+        if not search_term:
+            date_time = DateTime(time=datetime.datetime.now())
+            results.add(results.types.Answer(answer=date_time.l10n()))
+            return results
+
+        geo = GeoLocation.by_query(search_term=search_term)
+        if geo:
+            date_time = DateTime(time=datetime.datetime.now(tz=geo.zoneinfo))
+            tz_name = geo.timezone.replace('_', ' ')
+            results.add(
+                results.types.Answer(
+                    answer=(f"{tz_name}:" f" {date_time.l10n()} ({date_time.datetime.strftime('%Z')})")
+                )
+            )
+
+        return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -237,6 +237,9 @@ plugins:
   searx.plugins.hostnames.SXNGPlugin:
     active: true
 
+  searx.plugins.time_zone.SXNGPlugin:
+    active: true
+
   searx.plugins.oa_doi_rewrite.SXNGPlugin:
     active: false
 

--- a/searx/weather.py
+++ b/searx/weather.py
@@ -20,6 +20,7 @@ import typing
 import base64
 import datetime
 import dataclasses
+import zoneinfo
 
 from urllib.parse import quote_plus
 
@@ -136,6 +137,10 @@ class GeoLocation:
     elevation: float  # Elevation above mean sea level of this location
     country_code: str  # 2-Character ISO-3166-1 alpha2 country code. E.g. DE for Germany
     timezone: str  # Time zone using time zone database definitions
+
+    @property
+    def zoneinfo(self) -> zoneinfo.ZoneInfo:
+        return zoneinfo.ZoneInfo(self.timezone)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
## What does this PR do?
- this PR adds a new plugin to display the current time at different timezones (usually the query city)

## Why is this change important?
- it allows to quickly lookup the time at other places, e.g. to see if people from other countries you know are awake or at night
- for instance, DuckDuckGo, Google, ... also have similar quick answerers

## How to test this PR locally?
- `time Berlin`
- `now Los Angeles`

## Author's checklist
- The feature could be extended by adding support for countries if we add the [`pytz`](https://pypi.org/project/pytz/) dependency, but I wasn't sure if that dependency is actually considered worth it for such a small plugin

![2025-04-26T22:18:30,897971529+02:00](https://github.com/user-attachments/assets/2bac4525-7a9c-44fc-a651-b9282f7cfd2e)

