### PR TITLE
[fix] engine yahoo: replace fetch_traits by a list of languages

### DIFF
--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -8576,46 +8576,6 @@
       "zh-classical": "zh-classical"
     }
   },
-  "yahoo": {
-    "all_locale": "any",
-    "custom": {},
-    "data_type": "traits_v1",
-    "languages": {
-      "ar": "ar",
-      "bg": "bg",
-      "cs": "cs",
-      "da": "da",
-      "de": "de",
-      "el": "el",
-      "en": "en",
-      "es": "es",
-      "et": "et",
-      "fi": "fi",
-      "fr": "fr",
-      "he": "he",
-      "hr": "hr",
-      "hu": "hu",
-      "it": "it",
-      "ja": "ja",
-      "ko": "ko",
-      "lt": "lt",
-      "lv": "lv",
-      "nl": "nl",
-      "no": "no",
-      "pl": "pl",
-      "pt": "pt",
-      "ro": "ro",
-      "ru": "ru",
-      "sk": "sk",
-      "sl": "sl",
-      "sv": "sv",
-      "th": "th",
-      "tr": "tr",
-      "zh_Hans": "zh_chs",
-      "zh_Hant": "zh_cht"
-    },
-    "regions": {}
-  },
   "z-library": {
     "all_locale": "",
     "custom": {


### PR DESCRIPTION
The Yahoo engine's fetch_traits function has been encountering an error in CI jobs for several months [1], thus aborting the process for all other engines as well.

The language selection dialog (which fetch_traits calls) requires an `EuConsent` cookie. Strangely, the cookie is not needed for searching, which is why the engine itself still works.

Since Yahoo won't be conquering any new marketplaces in the foreseeable future, it should be sufficient to hard-implement the list of currently available languages ​​(`yahoo_languages`).

[1] https://github.com/searxng/searxng/actions/runs/14720458830/job/41313149268

