### PR TITLE
[feat] engine: support source filter for ChinaSo news

### DIFF
--- a/docs/admin/settings/settings_engines.rst
+++ b/docs/admin/settings/settings_engines.rst
@@ -148,6 +148,8 @@ engine is shown.  Most of the options have a default value or even are optional.
 ``display_error_messages`` : default ``true``
   When an engine returns an error, the message is displayed on the user interface.
 
+.. _engine network:
+
 ``network`` : optional
   Use the network configuration from another engine.
   In addition, there are two default networks:
@@ -257,4 +259,3 @@ Example configuration in settings.yml for a German and English speaker:
 
 When searching, the default google engine will return German results and
 "google english" will return English results.
-

--- a/docs/dev/engines/online/chinaso.rst
+++ b/docs/dev/engines/online/chinaso.rst
@@ -1,0 +1,8 @@
+.. _chinaso engine:
+
+=======
+ChinaSo
+=======
+
+.. automodule:: searx.engines.chinaso
+   :members:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -619,23 +619,37 @@ engines:
     # to show premium or plus results too:
     # skip_premium: false
 
+  # WARNING: links from chinaso.com voilate users privacy
+  # Before activate these engines its mandatory to read
+  # - https://github.com/searxng/searxng/issues/4694
+  # - https://docs.searxng.org/dev/engines/online/chinaso.html
+
   - name: chinaso news
-    chinaso_category: news
     engine: chinaso
     shortcut: chinaso
+    categories: [news]
+    chinaso_category: news
+    chinaso_news_source: all
     disabled: true
+    inactive: true
 
   - name: chinaso images
-    chinaso_category: images
     engine: chinaso
+    network: chinaso news
     shortcut: chinasoi
+    categories: [images]
+    chinaso_category: images
     disabled: true
+    inactive: true
 
   - name: chinaso videos
-    chinaso_category: videos
     engine: chinaso
+    network: chinaso news
     shortcut: chinasov
+    categories: [videos]
+    chinaso_category: videos
     disabled: true
+    inactive: true
 
   - name: cloudflareai
     engine: cloudflareai


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This PR introduces a new `chinaso_news_source` config for the ChinaSo engine, allowing filtering news results by source (`CENTRAL`, `LOCAL`, `BUSINESS`, `EPAPER`, or `all`)


## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->
- **Added support for configurable news sources for ChinaSo engine**

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->
I'm a new contributor, please **kindly** point out any issue I might have brought in.

## Related issues
None
<!--
Closes #234
-->