### PR TITLE
[enh] plugins: tor_check: Add more keywords

### DIFF
--- a/searx/plugins/tor_check.py
+++ b/searx/plugins/tor_check.py
@@ -33,7 +33,7 @@ class SXNGPlugin(Plugin):
     """Rewrite hostnames, remove results or prioritize them."""
 
     id = "tor_check"
-    keywords = ["tor-check"]
+    keywords = ["tor-check", "tor_check", "torcheck", "tor", "tor check"]
 
     def __init__(self, plg_cfg: "PluginCfg") -> None:
         super().__init__(plg_cfg)
@@ -53,7 +53,7 @@ class SXNGPlugin(Plugin):
         if search.search_query.pageno > 1:
             return results
 
-        if search.search_query.query.lower() == "tor-check":
+        if search.search_query.query.lower() in self.keywords:
 
             # Request the list of tor exit nodes.
             try:


### PR DESCRIPTION
## What does this PR do?

This PR adds more keywords to the tor_check plugin.

## Why is this change important?

Previously, there was only one usable keyword for the tor_check plugin. Adding more keywords eliminates confusion.

## How to test this PR locally?

Replace tor_check.py in your instance with the updated tor_check.py
