### PR TITLE
[fix] missing dependency for lxml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     # healthcheck
     wget \
+    # lxml (ARMv7)
+    libxslt1.1 \
     # uwsgi
     libpcre3 \
     libxml2 \


### PR DESCRIPTION
I have run the tests under QEMU and it's now working correctly.

I hope this will be the last issue that impacts users running the container image, commit https://github.com/searxng/searxng/pull/4707/commits/fb1429192c0e70cd4073f0a16ef5cb59c4340a0f will prevent future oversights like this.

Closes #4724 