### PR TITLE
[fix] sec-fetch-* blocking infinite scroll

### DIFF
--- a/searx/botdetection/http_sec_fetch.py
+++ b/searx/botdetection/http_sec_fetch.py
@@ -86,7 +86,7 @@ def filter_request(
     user_agent = request.headers.get('User-Agent', '')
     if is_browser_supported(user_agent):
         val = request.headers.get("Sec-Fetch-Mode", "")
-        if val != "navigate":
+        if val not in ('navigate', 'cors'):
             logger.debug("invalid Sec-Fetch-Mode '%s'", val)
             return flask.redirect(flask.url_for('index'), code=302)
 
@@ -96,7 +96,7 @@ def filter_request(
             flask.redirect(flask.url_for('index'), code=302)
 
         val = request.headers.get("Sec-Fetch-Dest", "")
-        if val != "document":
+        if val not in ('document', 'empty'):
             logger.debug("invalid Sec-Fetch-Dest '%s'", val)
             flask.redirect(flask.url_for('index'), code=302)
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->
Immediately fixes the infinite scroll by including 'cors' as allowed for Sec-Fetch-Mode and 'empty' for Sec-Fetch-Dest.

## Why is this change important?

The infinite scroll has been broken by https://github.com/searxng/searxng/commit/fe08bb1d909cb6cef57ce91211c2cbed63300c9e

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

Enable the botdetection and test the infinite scroll. Patch has already been applied on https://priv.au


https://github.com/privau/searxng/commit/4c814a2e798a99d3fa3914a966ef6ad8c5d51a5c


Requesting review by @return42 