### PR TITLE
[fix] missing permission in security.yml workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,9 @@ jobs:
   container:
     name: Container
     runs-on: ubuntu-24.04-arm
+    permissions:
+      security-events: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Uploading SARIFs needs to write into the repository GitHub security tab.

Reported in #4731 