### PR TITLE
[fix] missing PR perm on data-update.yml workflow

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -36,6 +36,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Setup Python
@@ -45,6 +46,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup cache Python
         uses: actions/cache@v4


### PR DESCRIPTION
I thought that already with the contents permission it could handle the PR. I added the last remaining permission and disabled the `persist-credentials` of checkout again.

Reported in https://github.com/searxng/searxng/pull/4736