### PR TITLE
[fix] container not releasing

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -153,13 +153,13 @@ jobs:
       - test
 
     steps:
-      - if: env.DOCKERHUB_USERNAME != ''
+      - if: env.DOCKERHUB_USERNAME != null
         name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: "false"
 
-      - if: env.DOCKERHUB_USERNAME != ''
+      - if: env.DOCKERHUB_USERNAME != null
         name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -167,7 +167,7 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
 
-      - if: env.DOCKERHUB_USERNAME != ''
+      - if: env.DOCKERHUB_USERNAME != null
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -175,7 +175,7 @@ jobs:
           username: "${{ env.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
 
-      - if: env.DOCKERHUB_USERNAME != ''
+      - if: env.DOCKERHUB_USERNAME != null
         name: Release
         env:
           GIT_URL: "${{ needs.build.outputs.git_url }}"


### PR DESCRIPTION
`env.DOCKERHUB_USERNAME` shouldn't be an empty string as it's defined and set (I think, I can't see this), but it's failing the condition. Even if wasn't defined, GitHub Org/Repo wide envs/secrets should return empty strings?

I reverted the change back to use "null" keyword because that's what worked before, just don't understand why now doesn't works.

See https://github.com/searxng/searxng/actions/runs/14957565596/job/42015464191