### PR TITLE
[enh] container: use Wolfi OS as base image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,12 +1,10 @@
-FROM docker.io/library/python:3.13-slim AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest AS builder
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    build-essential \
-    brotli \
-    # uwsgi
-    libpcre3-dev \
- && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    build-base \
+    python-3.13-dev \
+    py3-pip \
+    brotli
 
 WORKDIR /usr/local/searxng/
 
@@ -19,38 +17,40 @@ RUN --mount=type=cache,id=pip,target=/root/.cache/pip python -m venv ./venv \
 
 COPY ./searx/ ./searx/
 
-ARG TIMESTAMP_SETTINGS=0
-ARG TIMESTAMP_UWSGI=0
+ARG TIMESTAMP_SETTINGS="0"
+ARG TIMESTAMP_UWSGI="0"
 
 RUN python -m compileall -q searx \
  && touch -c --date=@$TIMESTAMP_SETTINGS ./searx/settings.yml \
  && touch -c --date=@$TIMESTAMP_UWSGI ./container/uwsgi.ini \
  && find /usr/local/searxng/searx/static \
-    \( -name '*.html' -o -name '*.css' -o -name '*.js' -o -name '*.svg' -o -name '*.ttf' -o -name '*.eot' \) \
+    \( -name "*.html" -o -name "*.css" -o -name "*.js" -o -name "*.svg" -o -name "*.ttf" -o -name "*.eot" \) \
     -type f -exec gzip -9 -k {} + -exec brotli --best {} +
 
-ARG SEARXNG_UID=977
-ARG SEARXNG_GID=977
+ARG SEARXNG_UID="977"
+ARG SEARXNG_GID="977"
 
-RUN grep -m1 root /etc/group > /tmp/.searxng.group \
- && grep -m1 root /etc/passwd > /tmp/.searxng.passwd \
- && echo "searxng:x:$SEARXNG_GID:" >> /tmp/.searxng.group \
- && echo "searxng:x:$SEARXNG_UID:$SEARXNG_GID:searxng:/usr/local/searxng:/bin/bash" >> /tmp/.searxng.passwd
+RUN echo "root:x:0:root" >/tmp/.group \
+ && echo "root:x:0:0:root:/usr/local/searxng:/bin/ash" >/tmp/.passwd \
+ && echo "searxng:x:$SEARXNG_GID:searxng" >>/tmp/.group \
+ && echo "searxng:x:$SEARXNG_UID:$SEARXNG_GID:searxng:/usr/local/searxng:/bin/ash" >>/tmp/.passwd
 
-FROM docker.io/library/python:3.13-slim
+FROM scratch AS dist
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+# Prepare base image
+COPY --from=builder /tmp/.passwd /etc/passwd
+COPY --from=builder /tmp/.group /etc/group
+COPY --chown=root:root --from=cgr.dev/chainguard/wolfi-base:latest / /
+COPY --chown=root:root --from=builder /tmp/.passwd /etc/passwd
+COPY --chown=root:root --from=builder /tmp/.group /etc/group
+RUN rm -rf /root/ /home/
+
+RUN apk add --no-cache \
+    python-3.13 \
     # healthcheck
     wget \
     # uwsgi
-    libpcre3 \
-    libxml2 \
-    mailcap \
- && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=root:root --from=builder /tmp/.searxng.passwd /etc/passwd
-COPY --chown=root:root --from=builder /tmp/.searxng.group /etc/group
+    mailcap
 
 ARG LABEL_DATE="0001-01-01T00:00:00Z"
 ARG GIT_URL="unspecified"
@@ -65,30 +65,37 @@ COPY --chown=searxng:searxng --from=builder /usr/local/searxng/searx/ ./searx/
 COPY --chown=searxng:searxng ./container/ ./container/
 
 LABEL org.opencontainers.image.authors="searxng <$GIT_URL>" \
-      org.opencontainers.image.created=$LABEL_DATE \
+      org.opencontainers.image.created="$LABEL_DATE" \
       org.opencontainers.image.description="A privacy-respecting, hackable metasearch engine" \
       org.opencontainers.image.documentation="https://github.com/searxng/searxng-docker" \
       org.opencontainers.image.licenses="AGPL-3.0-or-later" \
-      org.opencontainers.image.revision=$LABEL_VCS_REF \
-      org.opencontainers.image.source=$LABEL_VCS_URL \
+      org.opencontainers.image.revision="$LABEL_VCS_REF" \
+      org.opencontainers.image.source="$LABEL_VCS_URL" \
       org.opencontainers.image.title="searxng" \
-      org.opencontainers.image.url=$LABEL_VCS_URL \
-      org.opencontainers.image.version=$SEARXNG_GIT_VERSION
+      org.opencontainers.image.url="$LABEL_VCS_URL" \
+      org.opencontainers.image.version="$SEARXNG_GIT_VERSION"
 
-ENV CONFIG_PATH=/etc/searxng \
-    DATA_PATH=/var/cache/searxng
+# Image specific environment variables
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt" \
+    HISTFILE="/dev/null" \
+    CONFIG_PATH="/etc/searxng" \
+    DATA_PATH="/var/cache/searxng"
 
-ENV SEARXNG_VERSION=$SEARXNG_GIT_VERSION \
-    INSTANCE_NAME=searxng \
+# SearXNG specific environment variables
+ENV SEARXNG_VERSION="$SEARXNG_GIT_VERSION" \
+    INSTANCE_NAME="searxng" \
     AUTOCOMPLETE="" \
     BASE_URL="" \
-    BIND_ADDRESS=[::]:8080 \
-    MORTY_KEY="" \
-    MORTY_URL="" \
-    SEARXNG_SETTINGS_PATH=$CONFIG_PATH/settings.yml \
-    UWSGI_SETTINGS_PATH=$CONFIG_PATH/uwsgi.ini \
-    UWSGI_WORKERS=%k \
-    UWSGI_THREADS=4
+    BIND_ADDRESS="[::]:8080" \
+    SEARXNG_SETTINGS_PATH="$CONFIG_PATH/settings.yml" \
+    UWSGI_SETTINGS_PATH="$CONFIG_PATH/uwsgi.ini" \
+    UWSGI_WORKERS="%k" \
+    UWSGI_THREADS="4"
+
+# Volume ownership
+RUN mkdir -p $CONFIG_PATH $DATA_PATH \
+ && chown -R searxng:searxng $CONFIG_PATH $DATA_PATH
 
 VOLUME $CONFIG_PATH
 VOLUME $DATA_PATH

--- a/container/docker-entrypoint.sh
+++ b/container/docker-entrypoint.sh
@@ -71,6 +71,7 @@ patch_searxng_settings() {
         "${CONF}"
 }
 
+# FIXME: Always use "searxng:searxng" ownership
 update_conf() {
     FORCE_CONF_UPDATE=$1
     CONF="$2"


### PR DESCRIPTION
Using a specially designed base image for containers not only reduces maintenance burdens, but improves overall experience for developers (fewer packages we have to track) and end users (smaller images).

```console
REPOSITORY                 TAG                 SIZE
docker.io/searxng/searxng  2025.5.4-19b116f1d  195 MB
localhost/searxng/searxng  wolfi               214 MB
docker.io/searxng/searxng  2025.5.10-1b787ed35 346 MB
```
*(Comparison between the current images and the ones that were based on Alpine under amd64. Ordered from smallest to largest size)*

This change applies to both amd64 and arm64. armv7 device owners are excluded since it is not supported upstream.

CI latest test: https://github.com/inetol/searxng/actions/runs/15054787930

Related https://github.com/searxng/searxng/issues/4753