### PR TITLE
[enh] container: support multiple registries

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -117,10 +117,6 @@ jobs:
             os: ubuntu-24.04-arm
             emulation: true
 
-    permissions:
-      # Organization GHCR
-      packages: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -152,15 +148,17 @@ jobs:
       - build
       - test
 
+    permissions:
+      # Organization GHCR
+      packages: write
+
     steps:
-      - if: env.DOCKERHUB_USERNAME != null
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: "false"
 
-      - if: env.DOCKERHUB_USERNAME != null
-        name: Login to GHCR
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: "ghcr.io"
@@ -175,8 +173,7 @@ jobs:
           username: "${{ env.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
 
-      - if: env.DOCKERHUB_USERNAME != null
-        name: Release
+      - name: Release
         env:
           GIT_URL: "${{ needs.build.outputs.git_url }}"
           DOCKER_TAG: "${{ needs.build.outputs.docker_tag }}"

--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -272,8 +272,7 @@ container.push() {
         done
 
         # Manifest tags
-        release_tags=("latest")
-        release_tags+=("$DOCKER_TAG")
+        release_tags=("latest" "$DOCKER_TAG")
 
         # Create manifests
         for tag in "${release_tags[@]}"; do
@@ -291,13 +290,18 @@ container.push() {
 
         podman image list
 
-        # Push manifests
-        for tag in "${release_tags[@]}"; do
-            build_msg CONTAINER "Pushing manifest with tag: $tag"
+        # Remote registries
+        release_registries=("ghcr.io" "docker.io")
 
-            podman manifest push \
-                "localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:$tag" \
-                "docker://docker.io/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:$tag"
+        # Push manifests
+        for registry in "${release_registries[@]}"; do
+            for tag in "${release_tags[@]}"; do
+                build_msg CONTAINER "Pushing manifest $tag to $registry"
+
+                podman manifest push \
+                    "localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:$tag" \
+                    "docker://$registry/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:$tag"
+            done
         done
     )
     dump_return $?


### PR DESCRIPTION
docker.io applies a ratelimit to unauthenticated users, we should mirror to ghcr.io.

Images will be pushed to both `ghcr.io/searxng/searxng` and `docker.io/searxng/searxng`

Closes? https://github.com/searxng/searxng/issues/4374