### PR TITLE
[fix] CI: handle old cache images from registry

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,34 @@
+---
+name: Cleanup
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "4 4 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  container-cache:
+    name: Container cache
+    runs-on: ubuntu-24.04
+    permissions:
+      # Organization GHCR
+      packages: write
+
+    steps:
+      - name: Prune
+        uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: "${{ github.repository_owner }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          image-names: "cache"
+          image-tags: "!searxng-*"
+          cut-off: "1w"
+          keep-n-most-recent: "100"

--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -112,7 +112,6 @@ container.build() {
 
         if [ "$GITHUB_ACTIONS" = "true" ]; then
             params_build_builder+=" --cache-from=ghcr.io/$CONTAINER_IMAGE_ORGANIZATION/cache --cache-to=ghcr.io/$CONTAINER_IMAGE_ORGANIZATION/cache"
-            params_build+=" --cache-from=ghcr.io/$CONTAINER_IMAGE_ORGANIZATION/cache --cache-to=ghcr.io/$CONTAINER_IMAGE_ORGANIZATION/cache"
 
             # Tags
             params_build+=" --tag=ghcr.io/$CONTAINER_IMAGE_ORGANIZATION/cache:$CONTAINER_IMAGE_NAME-$arch$variant"


### PR DESCRIPTION
Currently, we have 1100~ cache images uploaded to GHCR that weigh more than 300 MB each (most of them are layers from the second phase of the Dockerfile that were uploaded by mistake, read below). To avoid problems, I have set up a new job in a new workflow to be run weekly purging all images older than 1 week, but leaving always the 100 most recent ones.

Only the builder images should be uploaded to cache, the actual behaviour not only slows down the time for building the container, but also wastes lots of space by saving large and useless layers to GHCR that will never be used again.