### PR TITLE
[mod] CI: dependabot group updates by minor & patch and major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     target-branch: "master"
     commit-message:
       prefix: "[upd] pypi:"
+    groups:
+      minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/client/simple"
@@ -20,6 +26,12 @@ updates:
     target-branch: "master"
     commit-message:
       prefix: "[upd] web-client (simple):"
+    groups:
+      minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
By default, Dependabot opens a new pull request to update each dependency and we have a very large number of Dependabot pull requests to review and merge, which can quickly become difficult to manage.

The intention of this patch to dependabot is to have:

- one PR for all minor & patch level updates
- one PR for every dependency with a major update

[1] https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates
[2] https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups
