### PR TITLE
[fix] CI: container workflow env reference

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -153,30 +153,26 @@ jobs:
       - test
 
     steps:
-      - if: env.DOCKERHUB_USERNAME != null
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: "false"
 
-      - if: env.DOCKERHUB_USERNAME != null
-        name: Login to GHCR
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: "ghcr.io"
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
 
-      - if: env.DOCKERHUB_USERNAME != null
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           registry: "docker.io"
-          username: "${{ env.DOCKERHUB_USERNAME }}"
+          username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
 
-      - if: env.DOCKERHUB_USERNAME != null
-        name: Release
+      - name: Release
         env:
           GIT_URL: "${{ needs.build.outputs.git_url }}"
           DOCKER_TAG: "${{ needs.build.outputs.docker_tag }}"


### PR DESCRIPTION
When making the container rework, I unknowingly deleted the section where an env with the same name as the secret was defined on the job scope, making it look like it was originally defined as an organization env.

Since we can't validate the secrets in a condition directly, it's better to let `docker/login-action` take care of failing the entire job if the credentials are invalid.

Thanks @unixfox for noticing this.

Closes https://github.com/searxng/searxng/issues/4777