### PR TITLE
feat: 支持通过环境变量 PROXY_POOL 自动配置代理池

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -16,7 +16,7 @@ Environment variables:
   MORTY_KEY     settings.yml : result_proxy.key
 Volume:
   /etc/searxng  the docker entry point copies settings.yml and uwsgi.ini in
-                this directory (see the -f command line option)
+                this directory (see the -f command line option)"
 EOF
 }
 
@@ -88,8 +88,8 @@ patch_searxng_settings() {
         echo "  proxies:" >> "${CONF}"
         echo "    all://:" >> "${CONF}"
 
-        IFS=',' read -ra PROXY_LIST <<< "$PROXY_POOL"
-        for proxy in "${PROXY_LIST[@]}"; do
+        IFS=',' set -- $PROXY_POOL
+        for proxy in "$@"; do
             echo "      - ${proxy}" >> "${CONF}"
         done
     fi

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -16,7 +16,7 @@ Environment variables:
   MORTY_KEY     settings.yml : result_proxy.key
 Volume:
   /etc/searxng  the docker entry point copies settings.yml and uwsgi.ini in
-                this directory (see the -f command line option)"
+                this directory (see the -f command line option)
 EOF
 }
 


### PR DESCRIPTION
<!-- MANDATORY -->

本次 PR 增加了通过 `PROXY_POOL` 环境变量向 `settings.yml` 注入 `outgoing.proxies` 配置的能力，便于在 Docker 环境中通过外部变量动态配置 HTTP(S) 代理池。

## Why is this change important?

<!-- MANDATORY -->

目前官方默认不支持通过环境变量配置代理，需要手动修改配置文件。这对于云部署（如 Kubernetes、Zeabur）不够灵活。本 PR 使得代理池配置可以通过注入变量实现动态控制，提高部署自动化程度。

## How to test this PR locally?

1. 启动容器前设置环境变量：
   ```bash
   export PROXY_POOL="http://user:pass@host:port"
支持逗号分隔的多代理池格式，例如：http://user1:pwd1@ip1:port1,http://user2:pwd2@ip2:port2