### PR TITLE
[mod] container: build custom base images

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -5,7 +5,7 @@ name: Cleanup
 on:
   workflow_dispatch:
   schedule:
-    - cron: "4 4 * * 0"
+    - cron: "4 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -28,7 +28,7 @@ jobs:
         with:
           account: "${{ github.repository_owner }}"
           token: "${{ secrets.GITHUB_TOKEN }}"
-          image-names: "cache"
-          image-tags: "!searxng-*"
-          cut-off: "1w"
+          image-names: "cache base"
+          image-tags: "!searxng*"
+          cut-off: "1d"
           keep-n-most-recent: "100"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -25,10 +25,80 @@ env:
   PYTHON_VERSION: "3.13"
 
 jobs:
+  build-base:
+    if: |
+      (github.repository_owner == 'searxng' && github.event.workflow_run.conclusion == 'success')
+      || github.event_name == 'workflow_dispatch'
+    name: Build base
+    runs-on: ubuntu-24.04
+    permissions:
+      # Organization GHCR
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
+
+      - name: Get date
+        id: date
+        run: echo "date=$(date +'%Y%m%d')" >>$GITHUB_OUTPUT
+
+      - name: Check cache apko
+        id: cache-apko
+        uses: actions/cache/restore@v4
+        with:
+          # yamllint disable-line rule:line-length
+          key: "apko-${{ steps.date.outputs.date }}-${{ hashFiles('./container/base.yml', './container/base-builder.yml') }}"
+          path: "/tmp/.apko/"
+          lookup-only: true
+
+      - if: steps.cache-apko.outputs.cache-hit != 'true'
+        name: Setup cache apko
+        uses: actions/cache@v4
+        with:
+          # yamllint disable-line rule:line-length
+          key: "apko-${{ steps.date.outputs.date }}-${{ hashFiles('./container/base.yml', './container/base-builder.yml') }}"
+          restore-keys: "apko-${{ steps.date.outputs.date }}-"
+          path: "/tmp/.apko/"
+
+      - if: steps.cache-apko.outputs.cache-hit != 'true'
+        name: Setup apko
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew install apko
+
+      - if: steps.cache-apko.outputs.cache-hit != 'true'
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.repository_owner }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - if: steps.cache-apko.outputs.cache-hit != 'true'
+        name: Build
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
+          apko publish ./container/base.yml ghcr.io/${{ github.repository_owner }}/base:searxng \
+            --cache-dir=/tmp/.apko/ \
+            --sbom=false \
+            --vcs=false \
+            --log-level=debug
+
+          apko publish ./container/base-builder.yml ghcr.io/${{ github.repository_owner }}/base:searxng-builder \
+            --cache-dir=/tmp/.apko/ \
+            --sbom=false \
+            --vcs=false \
+            --log-level=debug
+
   build:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.repository_owner == 'searxng' || github.event_name == 'workflow_dispatch'
     name: Build (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
+    needs: build-base
     strategy:
       fail-fast: false
       matrix:

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,12 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest AS builder
-
-RUN apk add --no-cache \
-    build-base \
-    python-3.13-dev \
-    py3-pip \
-    brotli
-
-WORKDIR /usr/local/searxng/
+FROM ghcr.io/searxng/base:searxng-builder AS builder
 
 COPY ./requirements.txt ./requirements.txt
 
@@ -23,42 +15,17 @@ ARG TIMESTAMP_UWSGI="0"
 RUN python -m compileall -q searx \
  && touch -c --date=@$TIMESTAMP_SETTINGS ./searx/settings.yml \
  && touch -c --date=@$TIMESTAMP_UWSGI ./container/uwsgi.ini \
- && find /usr/local/searxng/searx/static \
+ && find ./searx/static \
     \( -name "*.html" -o -name "*.css" -o -name "*.js" -o -name "*.svg" -o -name "*.ttf" -o -name "*.eot" \) \
     -type f -exec gzip -9 -k {} + -exec brotli --best {} +
 
-ARG SEARXNG_UID="977"
-ARG SEARXNG_GID="977"
-
-RUN echo "root:x:0:root" >/tmp/.group \
- && echo "root:x:0:0:root:/usr/local/searxng:/bin/ash" >/tmp/.passwd \
- && echo "searxng:x:$SEARXNG_GID:searxng" >>/tmp/.group \
- && echo "searxng:x:$SEARXNG_UID:$SEARXNG_GID:searxng:/usr/local/searxng:/bin/ash" >>/tmp/.passwd
-
-FROM scratch AS dist
-
-# Prepare base image
-COPY --from=builder /tmp/.passwd /etc/passwd
-COPY --from=builder /tmp/.group /etc/group
-COPY --chown=root:root --from=cgr.dev/chainguard/wolfi-base:latest / /
-COPY --chown=root:root --from=builder /tmp/.passwd /etc/passwd
-COPY --chown=root:root --from=builder /tmp/.group /etc/group
-RUN rm -rf /root/ /home/
-
-RUN apk add --no-cache \
-    python-3.13 \
-    # healthcheck
-    wget \
-    # uwsgi
-    mailcap
+FROM ghcr.io/searxng/base:searxng AS dist
 
 ARG LABEL_DATE="0001-01-01T00:00:00Z"
 ARG GIT_URL="unspecified"
 ARG SEARXNG_GIT_VERSION="unspecified"
 ARG LABEL_VCS_REF="unspecified"
 ARG LABEL_VCS_URL="unspecified"
-
-WORKDIR /usr/local/searxng/
 
 COPY --chown=searxng:searxng --from=builder /usr/local/searxng/venv/ ./venv/
 COPY --chown=searxng:searxng --from=builder /usr/local/searxng/searx/ ./searx/
@@ -75,16 +42,8 @@ LABEL org.opencontainers.image.authors="searxng <$GIT_URL>" \
       org.opencontainers.image.url="$LABEL_VCS_URL" \
       org.opencontainers.image.version="$SEARXNG_GIT_VERSION"
 
-# Image specific environment variables
-ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-    SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt" \
-    HISTFILE="/dev/null" \
-    CONFIG_PATH="/etc/searxng" \
-    DATA_PATH="/var/cache/searxng"
-
-# SearXNG specific environment variables
 ENV SEARXNG_VERSION="$SEARXNG_GIT_VERSION" \
-    INSTANCE_NAME="searxng" \
+    INSTANCE_NAME="SearXNG" \
     AUTOCOMPLETE="" \
     BASE_URL="" \
     BIND_ADDRESS="[::]:8080" \
@@ -92,10 +51,6 @@ ENV SEARXNG_VERSION="$SEARXNG_GIT_VERSION" \
     UWSGI_SETTINGS_PATH="$CONFIG_PATH/uwsgi.ini" \
     UWSGI_WORKERS="%k" \
     UWSGI_THREADS="4"
-
-# Volume ownership
-RUN mkdir -p $CONFIG_PATH $DATA_PATH \
- && chown -R searxng:searxng $CONFIG_PATH $DATA_PATH
 
 VOLUME $CONFIG_PATH
 VOLUME $DATA_PATH

--- a/container/base-builder.yml
+++ b/container/base-builder.yml
@@ -1,0 +1,27 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - wolfi-baselayout
+    - ca-certificates-bundle
+    - busybox
+    - build-base
+    - python-3.13-dev
+    - py3-pip
+    - brotli
+
+entrypoint:
+  command: /bin/sh -l
+
+work-dir: /usr/local/searxng/
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  HISTFILE: /dev/null
+
+archs:
+  - x86_64
+  - aarch64

--- a/container/base.yml
+++ b/container/base.yml
@@ -1,0 +1,61 @@
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - wolfi-baselayout
+    - ca-certificates-bundle
+    - busybox
+    - python-3.13
+    # healthcheck
+    - wget
+    # uwsgi
+    - mailcap
+
+entrypoint:
+  command: /bin/sh -l
+
+work-dir: /usr/local/searxng/
+
+accounts:
+  groups:
+    - groupname: searxng
+      gid: 977
+  users:
+    - username: searxng
+      uid: 977
+      shell: /bin/ash
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  HISTFILE: /dev/null
+  CONFIG_PATH: /etc/searxng
+  DATA_PATH: /var/cache/searxng
+
+paths:
+  # Workdir
+  - path: /usr/local/searxng/
+    type: directory
+    uid: 977
+    gid: 977
+    permissions: 0o755
+
+  # Config volume
+  - path: /etc/searxng/
+    type: directory
+    uid: 977
+    gid: 977
+    permissions: 0o755
+
+  # Data volume
+  - path: /var/cache/searxng/
+    type: directory
+    uid: 977
+    gid: 977
+    permissions: 0o755
+
+archs:
+  - x86_64
+  - aarch64


### PR DESCRIPTION
Instead of using Wolfi base images from `cgr.dev` and making that mess on the Dockerfile, why don't we build the base images ourselves from Wolfi repos with [`apko`](https://github.com/chainguard-dev/apko)? The intention of this is to simplify the main Dockerfile and avoid having to patch the base image every time, it also simplifies some steps like image ownership management and provides extremely fast builds.

Latest CI: https://github.com/inetol/searxng/actions/runs/15084778493