### PR TITLE
httpx impersonate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ python-dateutil==2.9.0.post0
 pyyaml==6.0.2
 httpx[http2]==0.28.1
 httpx-socks[asyncio]==0.10.0
+httpx_curl_cffi==0.1.3 ; python_version >= "3.10" and (platform_machine == "aarch64" or platform_machine == "arm64"  or platform_machine == "x86_64")
 Brotli==1.1.0
 uvloop==0.21.0
 setproctitle==1.3.6

--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -148,6 +148,12 @@ def request(query, params):
         args['offset'] = (params['pageno'] - 1) * args['count']
 
     params['url'] = url + urlencode(args)
+    params['headers'] = {
+        "Accept": "application/json",
+        "Accept-Language": q_locale.replace("_", "-"),
+        "Referer": "https://www.qwant.com/",
+        "Origin": "https://www.qwant.com",
+    }
 
     return params
 

--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -53,6 +53,7 @@ class Network:
         'max_redirects',
         'retries',
         'retry_on_http_error',
+        'impersonate',
         '_local_addresses_cycle',
         '_proxies_cycle',
         '_clients',
@@ -63,6 +64,7 @@ class Network:
 
     def __init__(
         # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-positional-arguments
         self,
         enable_http=True,
         verify=True,
@@ -77,6 +79,7 @@ class Network:
         retry_on_http_error=None,
         max_redirects=30,
         logger_name=None,
+        impersonate=None,
     ):
 
         self.enable_http = enable_http
@@ -91,6 +94,7 @@ class Network:
         self.retries = retries
         self.retry_on_http_error = retry_on_http_error
         self.max_redirects = max_redirects
+        self.impersonate = impersonate
         self._local_addresses_cycle = self.get_ipaddress_cycle()
         self._proxies_cycle = self.get_proxy_cycles()
         self._clients = {}
@@ -185,10 +189,11 @@ class Network:
         max_redirects = self.max_redirects if max_redirects is None else max_redirects
         local_address = next(self._local_addresses_cycle)
         proxies = next(self._proxies_cycle)  # is a tuple so it can be part of the key
-        key = (verify, max_redirects, local_address, proxies)
+        key = (verify, max_redirects, local_address, proxies, self.impersonate)
         hook_log_response = self.log_response if sxng_debug else None
         if key not in self._clients or self._clients[key].is_closed:
             client = new_client(
+                self.impersonate,
                 self.enable_http,
                 verify,
                 self.enable_http2,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1711,6 +1711,8 @@ engines:
     disabled: true
     additional_tests:
       rosebud: *test_rosebud
+    network:
+      impersonate: chrome
 
   - name: qwant news
     qwant_categ: news


### PR DESCRIPTION
## What does this PR do?

Use [httpx-curl-cffi](https://github.com/vgavro/httpx-curl-cffi) to add a network parameter: `impersonate`.

See https://github.com/lexiforest/curl_cffi/blob/8b4ee6d4db0982a3d93191b698c56936dfdfdcf0/curl_cffi/requests/impersonate.py#L9-L77 for the possible values

## Why is this change important?

See https://github.com/searxng/searxng/issues/3929

## How to test this PR locally?

* [ ] check `enable_http2: true` works 
* [ ] check `enable_http2: false` works 
* [ ] check `verify: false` works
* [ ] check `verify: "/path/to/ca.pem"` works
* [ ] check `local_addresses` works
* [ ] check HTTP proxy
* [ ] check HTTPS proxy
* [ ] check SOCKS proxy
* [ ] check the qwant engine

## Author's checklist

Based on https://github.com/searxng/searxng/pull/4674

curl-cffi requires Python 3.10 or above and ARM64 or AMD64. With curl-cffi, the engines using the impersonate parameter crash with an explanation.



## Related issues

<!--
Closes #234
-->
