### PR TITLE
[fix] container: base-builder should have essentials

### DIFF
--- a/container/base-builder.yml
+++ b/container/base-builder.yml
@@ -4,9 +4,7 @@ contents:
   repositories:
     - https://packages.wolfi.dev/os
   packages:
-    - wolfi-baselayout
-    - ca-certificates-bundle
-    - busybox
+    - wolfi-base
     - build-base
     - python-3.13-dev
     - py3-pip


### PR DESCRIPTION
The wolfi-base metapackage includes busybox, ca-certificates-bundle and the package manager. The change is to make the use of base-builder image more flexible.