### PR TITLE
[fix] Revert "fix: check if the browser supports Sec-Fetch headers (#4696)"

### DIFF
--- a/searx/botdetection/http_sec_fetch.py
+++ b/searx/botdetection/http_sec_fetch.py
@@ -28,7 +28,6 @@ from ipaddress import (
     IPv6Network,
 )
 
-import re
 import flask
 import werkzeug
 
@@ -36,44 +35,6 @@ from searx.extended_types import SXNG_Request
 
 from . import config
 from ._helpers import logger
-
-
-def is_browser_supported(user_agent: str) -> bool:
-    """Check if the browser supports Sec-Fetch headers.
-
-    https://caniuse.com/mdn-http_headers_sec-fetch-dest
-    https://caniuse.com/mdn-http_headers_sec-fetch-mode
-    https://caniuse.com/mdn-http_headers_sec-fetch-site
-
-    Supported browsers:
-    - Chrome >= 80
-    - Firefox >= 90
-    - Safari >= 16.4
-    - Edge (mirrors Chrome)
-    - Opera (mirrors Chrome)
-    """
-    user_agent = user_agent.lower()
-
-    # Chrome/Chromium/Edge/Opera
-    chrome_match = re.search(r'chrome/(\d+)', user_agent)
-    if chrome_match:
-        version = int(chrome_match.group(1))
-        return version >= 80
-
-    # Firefox
-    firefox_match = re.search(r'firefox/(\d+)', user_agent)
-    if firefox_match:
-        version = int(firefox_match.group(1))
-        return version >= 90
-
-    # Safari
-    safari_match = re.search(r'version/(\d+)\.(\d+)', user_agent)
-    if safari_match:
-        major = int(safari_match.group(1))
-        minor = int(safari_match.group(2))
-        return major > 16 or (major == 16 and minor >= 4)
-
-    return False
 
 
 def filter_request(
@@ -88,22 +49,19 @@ def filter_request(
         )
         return None
 
-    # Only check Sec-Fetch headers for supported browsers
-    user_agent = request.headers.get('User-Agent', '')
-    if is_browser_supported(user_agent):
-        val = request.headers.get("Sec-Fetch-Mode", "")
-        if val not in ('navigate', 'cors'):
-            logger.debug("invalid Sec-Fetch-Mode '%s'", val)
-            return flask.redirect(flask.url_for('index'), code=302)
+    val = request.headers.get("Sec-Fetch-Mode", "")
+    if val != "navigate":
+        logger.debug("invalid Sec-Fetch-Mode '%s'", val)
+        return flask.redirect(flask.url_for('index'), code=302)
 
-        val = request.headers.get("Sec-Fetch-Site", "")
-        if val not in ('same-origin', 'same-site', 'none'):
-            logger.debug("invalid Sec-Fetch-Site '%s'", val)
-            flask.redirect(flask.url_for('index'), code=302)
+    val = request.headers.get("Sec-Fetch-Site", "")
+    if val not in ('same-origin', 'same-site', 'none'):
+        logger.debug("invalid Sec-Fetch-Site '%s'", val)
+        flask.redirect(flask.url_for('index'), code=302)
 
-        val = request.headers.get("Sec-Fetch-Dest", "")
-        if val not in ('document', 'empty'):
-            logger.debug("invalid Sec-Fetch-Dest '%s'", val)
-            flask.redirect(flask.url_for('index'), code=302)
+    val = request.headers.get("Sec-Fetch-Dest", "")
+    if val != "document":
+        logger.debug("invalid Sec-Fetch-Dest '%s'", val)
+        flask.redirect(flask.url_for('index'), code=302)
 
     return None


### PR DESCRIPTION
Many bots will probably use other user agents than the common ones (or rotate different ones)[1].

On my instance I can observe how bots with other UA headers are no longer stopped with the patch of PR #4696.

This reverts PR #4696 commit 19b116f1d7aaea2ab2b00868003e9dd852eabbe0.

[1] https://github.com/searxng/searxng/pull/4696#pullrequestreview-2806695481

----

To be clear, I understand the intention of #4696 and think the reasoning is correct.  However, I only see disadvantages for me in practice, which is why I am applying this patch to my instance and making it available to the community with this PR.

The PR is rebased in the event of conflicts with the master branch / it can simply be patched on top of your own instance via cherry picking.



