### PR TITLE
[fix] yahoo: url and title xpath

### DIFF
--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -159,12 +159,12 @@ def response(resp):
 
     # parse results
     for result in eval_xpath_list(dom, '//div[contains(@class,"algo-sr")]'):
-        url = eval_xpath_getindex(result, './/h3/a/@href', 0, default=None)
+        url = eval_xpath_getindex(result, './/div[contains(@class,"compTitle")]/a/@href', 0, default=None)
         if url is None:
             continue
         url = parse_url(url)
 
-        title = eval_xpath_getindex(result, './/h3//a/@aria-label', 0, default='')
+        title = eval_xpath_getindex(result, './/div[contains(@class,"compTitle")]/a/h3/span', 0, default='')
         title: str = extract_text(title)
         content = eval_xpath_getindex(result, './/div[contains(@class, "compText")]', 0, default='')
         content: str = extract_text(content, allow_none=True)


### PR DESCRIPTION
## What does this PR do?
Updates the url and title XPath for the Yahoo engine.

## Why is this change important?
There were no results before because the URL XPath didn't match anything, this fixes it.

## How to test this PR locally?
1. make run
2. !yh test

## Author's checklist
Tested on US IP. I don't have access to IPs from different regions so I would appreciate feedback in case it doesn't work in other regions.

## Related issues
None, as far as I'm aware.
