### PR TITLE
[fix] pinterest: engine broken due to API changes

### DIFF
--- a/searx/engines/pinterest.py
+++ b/searx/engines/pinterest.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Pinterest (images)
-"""
+"""Pinterest (images)"""
 
 from json import dumps
 
@@ -28,6 +27,11 @@ def request(query, params):
         'context': {},
     }
     params['url'] = f"{base_url}/resource/BaseSearchResource/get/?data={dumps(args)}"
+    params['headers'] = {
+        'X-Pinterest-AppState': 'active',
+        'X-Pinterest-Source-Url': '/ideas/',
+        'X-Pinterest-PWS-Handler': 'www/ideas.js',
+    }
 
     return params
 


### PR DESCRIPTION
## What does this PR do?
- apparently the API now requires a `X-Pinterest-PWS-Handler` in order to properly function (extracted from their web UI)
- the other `X-Pinterest` headers here are added in case they become mandatory too

## Related issues
closes #4812