### PR TITLE
[refactor] icon engines: add new icon category

### DIFF
--- a/searx/engines/material_icons.py
+++ b/searx/engines/material_icons.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Material Icons (images)
-
-"""
+"""Material Icons (icons)"""
 
 import re
 from json import loads
@@ -14,6 +12,8 @@ about = {
     "require_api_key": False,
     "results": 'JSON',
 }
+categories = ['images', 'icons']
+
 search_url = "https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true"
 result_url = "https://fonts.google.com/icons?icon.query={query}&selected=Material+Symbols+Outlined:{icon_name}:FILL@0{fill};wght@400;GRAD@0;opsz@24"  # pylint: disable=line-too-long
 img_src_url = "https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/{icon_name}/{svg_type}/24px.svg"
@@ -46,7 +46,7 @@ def response(resp):
             continue
 
         tags = [tag.title() for tag in result["tags"]]
-        categories = [category.title() for category in result["categories"]]
+        icon_categories = [category.title() for category in result["categories"]]
 
         results.append(
             {
@@ -54,7 +54,7 @@ def response(resp):
                 'url': result_url.format(icon_name=result["name"], query=result["name"], fill=0 if outlined else 1),
                 'img_src': img_src_url.format(icon_name=result["name"], svg_type=svg_type),
                 'title': result["name"].replace("_", "").title(),
-                'content': ", ".join(tags) + " / " + ", ".join(categories),
+                'content': ", ".join(tags) + " / " + ", ".join(icon_categories),
             }
         )
 

--- a/searx/engines/selfhst.py
+++ b/searx/engines/selfhst.py
@@ -11,7 +11,7 @@ about = {
     "require_api_key": False,
     "results": 'JSON',
 }
-categories = ['images']
+categories = ['images', 'icons']
 
 
 icons_list_url = 'https://cdn.selfh.st/directory/icons.json'

--- a/searx/engines/svgrepo.py
+++ b/searx/engines/svgrepo.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Svgrepo (images)
+"""Svgrepo (icons)
 """
 
 from lxml import html
@@ -14,7 +14,7 @@ about = {
 }
 
 paging = True
-categories = ['images']
+categories = ['images', 'icons']
 base_url = "https://www.svgrepo.com"
 
 results_xpath = "//div[@class='style_nodeListing__7Nmro']/div"

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1053,7 +1053,6 @@ engines:
 
   - name: material icons
     engine: material_icons
-    categories: images
     shortcut: mi
     disabled: true
 


### PR DESCRIPTION
## Why is this change important?
- I think that this category makes sense because it allows to quickly search for free svg icons to use for websites / other designs with a quick `!icons` query
- they don't seem to fit into the normal images category that well because icons are quite a special type of images

## Author notes
- I probably forgot to add the category at some other places where it's needed