### PR TITLE
[feat] engines: add uxwing engine for icons

### DIFF
--- a/searx/engines/uxwing.py
+++ b/searx/engines/uxwing.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""UXwing (images)"""
+
+from urllib.parse import quote_plus
+from lxml import html
+
+from searx.utils import eval_xpath, eval_xpath_list, extract_text
+
+about = {
+    "website": 'https://uxwing.com',
+    "wikidata_id": None,
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+categories = ['images', 'icons']
+
+base_url = "https://uxwing.com"
+
+
+def request(query, params):
+    params['url'] = f"{base_url}/?s={quote_plus(query)}"
+    return params
+
+
+def response(resp):
+    results = []
+
+    doc = html.fromstring(resp.text)
+    for result in eval_xpath_list(doc, "//article[starts-with(@id, 'post')]"):
+        classes = extract_text(eval_xpath(result, "./@class")).split(" ")
+        tags = []
+        for css_class in classes:
+            for prefix in ("category", "tag"):
+                if css_class.startswith(prefix):
+                    tag = css_class.removeprefix(prefix)
+                    tags.append(tag.replace("-", " ").title())
+
+        results.append(
+            {
+                'template': 'images.html',
+                'url': extract_text(eval_xpath(result, "./a/@href")),
+                'img_src': extract_text(eval_xpath(result, ".//img/@src")),
+                'title': extract_text(eval_xpath(result, ".//img/@alt")),
+                'content': ', '.join(tags),
+            }
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2523,6 +2523,11 @@ engines:
     engine: tootfinder
     shortcut: toot
 
+  - name: uxwing
+    engine: uxwing
+    shortcut: ux
+    disabled: true
+
   - name: voidlinux
     engine: voidlinux
     shortcut: void


### PR DESCRIPTION
## What does this PR do?
- add https://uxwing.com as a new engine

## Why is this change important?
- it provides attribution-free icons to use for design projects
- svgrepo was my go-to before, but it's ratelimiting a lot recently

## How to test this PR locally?
- !ux tree

## Author's checklist
- this should also be added to the icons category if https://github.com/searxng/searxng/pull/4817 is merged