### PR TITLE
[mod] Sogou: resolve the URL using multi_requests

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1836,6 +1836,7 @@ engines:
   - name: sogou
     engine: sogou
     shortcut: sogou
+    timeout: 6.0
     disabled: true
 
   - name: sogou images


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Resolve sogou URL using [multi_requests](https://github.com/searxng/searxng/blob/7420706a5074803a78f3c795cf79427746e504e0/searx/network/__init__.py#L101).

## How to test this PR locally?

locally make some request to sogou.

## Author's checklist

The response time is about 4 seconds.
After few requests with exactly the same query there is an CAPTCHA.
After few minutes, it is possible to send some other queries.

This PR is here for anyone who want to give a try.

TODO: combine this PR with #4801

## Related issues

Related to
* #4811
* #4801