### PR TITLE
[mod] container: remove -e flag

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # shellcheck shell=dash
-set -eu
+set -u
 
 check_file() {
     local target="$1"


### PR DESCRIPTION
Temporarily remove the -e flag from `set` to prevent entrypoint.sh from stopping execution if any command returns a non-zero status. This doesn't solve anything but relaxes the script checks.

Related https://github.com/searxng/searxng/issues/4818