### PR TITLE
[fix] searx.data: fetch-traits - z-library (httpx.ConnectError)

### DIFF
--- a/searx/engines/zlibrary.py
+++ b/searx/engines/zlibrary.py
@@ -180,6 +180,8 @@ def fetch_traits(engine_traits: EngineTraits) -> None:
     # pylint: disable=import-outside-toplevel, too-many-branches
 
     import babel
+    import httpx
+
     from searx.network import get  # see https://github.com/searxng/searxng/issues/762
     from searx.locales import language_tag
 
@@ -191,7 +193,7 @@ def fetch_traits(engine_traits: EngineTraits) -> None:
 
     try:
         resp = get(base_url, verify=False)
-    except SearxException as exc:
+    except (SearxException, httpx.ConnectError) as exc:
         print(f"ERROR: zlibrary domain '{base_url}' is seized?")
         print(f"  --> {exc}")
         _use_old_values()


### PR DESCRIPTION
There is currently no known z-library, and all known URLs are dead [1]. To avoid interrupting automated updates, a connection error to a z-library is treated as a *known error*, and the old properties of the z-library are retained.

- [1] https://github.com/searxng/searxng/issues/3610
