### PR TITLE
[fix] ddg engine: IndexError exception is raised on empty contend

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -372,8 +372,9 @@ def response(resp) -> EngineResults:
             continue
         item["title"] = extract_text(title)
         item["url"] = eval_xpath(div_result, './/h2/a/@href')[0]
-        item["content"] = extract_text(eval_xpath(div_result, './/a[contains(@class, "result__snippet")]')[0])
-
+        item["content"] = extract_text(
+            eval_xpath_getindex(div_result, './/a[contains(@class, "result__snippet")]', 0, [])
+        )
         results.append(item)
 
     zero_click_info_xpath = '//div[@id="zero_click_abstract"]'


### PR DESCRIPTION
Sometimes (e.g. when ddg does not have a result item) there is no content and the engine will fail with an IndexError:

  * Error: IndexError
  * Percentage: 10
  * Parameters: `()`
  * File name: `searx/engines/duckduckgo.py:375`
  * Function: `response`
  * Code: `item["content"] = extract_text(eval_xpath(div_result, './/a[contains(@class, "result__snippet")]')[0])`
