### PR TITLE
[fix] preferences: description not localized for all UI languages

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -106,6 +106,7 @@ from searx.metrics import get_engines_stats, get_engine_errors, get_reliabilitie
 from searx.flaskfix import patch_application
 
 from searx.locales import (
+    LOCALE_BEST_MATCH,
     LOCALE_NAMES,
     RTL_LOCALES,
     localeselector,
@@ -1059,10 +1060,12 @@ def image_proxy():
 
 @app.route('/engine_descriptions.json', methods=['GET'])
 def engine_descriptions():
-    locale = get_locale().split('_')[0]
+    sxng_ui_lang_tag = get_locale().replace("_", "-")
+    sxng_ui_lang_tag = LOCALE_BEST_MATCH.get(sxng_ui_lang_tag, sxng_ui_lang_tag)
+
     result = ENGINE_DESCRIPTIONS['en'].copy()
-    if locale != 'en':
-        for engine, description in ENGINE_DESCRIPTIONS.get(locale, {}).items():
+    if sxng_ui_lang_tag != 'en':
+        for engine, description in ENGINE_DESCRIPTIONS.get(sxng_ui_lang_tag, {}).items():
             result[engine] = description
     for engine, description in result.items():
         if len(description) == 2 and description[1] == 'ref':


### PR DESCRIPTION
The previous implementation for determining the description of an engine did not take into account that the UI languages ​​can also have a region tag and/or a script tag:

    el-GR:      Ελληνικά, Ελλάδα (Greek, Greece)
    fa-IR:      فارسی, ایران (Persian, Iran)
    nb-NO:      Norsk bokmål, Norge (Norwegian bokmål, Norway)
    nl-BE:      Nederlands, België (Dutch, Belgium)
    pt-BR:      Português, Brasil (Portuguese, Brazil)
    zh-HK:      中文, 中國香港特別行政區 (Chinese, Hong Kong SAR China)
    zh-Hans-CN: 中文, 中国 (Chinese, China)
    zh-Hant-TW: 中文, 台灣 (Chinese, Taiwan)

Closes: https://github.com/searxng/searxng/issues/4842