### PR TITLE
[fix] searx.network: don't trigger DeprecationWarning

### DIFF
--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -180,7 +180,7 @@ class Network:
         Network._TOR_CHECK_RESULT[proxies] = result
         return result
 
-    async def get_client(self, verify=None, max_redirects=None):
+    async def get_client(self, verify=None, max_redirects=None) -> httpx.AsyncClient:
         verify = self.verify if verify is None else verify
         max_redirects = self.max_redirects if max_redirects is None else max_redirects
         local_address = next(self._local_addresses_cycle)
@@ -269,6 +269,8 @@ class Network:
         kwargs_clients = Network.extract_kwargs_clients(kwargs)
         while retries >= 0:  # pragma: no cover
             client = await self.get_client(**kwargs_clients)
+            cookies = kwargs.pop("cookies", None)
+            client.cookies = httpx.Cookies(cookies)
             try:
                 if stream:
                     response = client.stream(method, url, **kwargs)


### PR DESCRIPTION
## What does this PR do?

See #4833

Code based on httpx unit test:
https://github.com/encode/httpx/blob/6a99f6f2b3a638719f70200de9983f80d618ee1c/tests/client/test_cookies.py#L123-L137

## Why is this change important?

Avoid a confusing warning.

## How to test this PR locally?

Use the duckduckgo engine for example.

Debug SearXNG or hack duckduckgo.py:

```python
def response(resp: Response) -> EngineResults:
   print(resp.request.headers)  # add this line and see the cookie was set on the request
```

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

Close #4833
