### PR TITLE
[chore] il post: disable by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1116,6 +1116,7 @@ engines:
   - name: il post
     engine: il_post
     shortcut: pst
+    disabled: true
 
   - name: huggingface
     engine: huggingface


### PR DESCRIPTION
## Why is this change important?
- the engine only provides italian results and thus shouldn't be part of the news tab by default
