### PR TITLE
[fix] searx.network: cookies being reset when more than one requests

### DIFF
--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -270,7 +270,8 @@ class Network:
         while retries >= 0:  # pragma: no cover
             client = await self.get_client(**kwargs_clients)
             cookies = kwargs.pop("cookies", None)
-            client.cookies = httpx.Cookies(cookies)
+            if cookies:
+                client.cookies = httpx.Cookies(cookies)
             try:
                 if stream:
                     response = client.stream(method, url, **kwargs)


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This PR fixes an issue where cookies would be reset when an engine does more than 1 requests.

Implementation-wise, it checks if the cookie is not None, and only then sets the httpx cookie.

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Search engines such like Presearch requires 2 requests to do a search, and also requires cookies from request 1 to be present during the 2nd request. Otherwise it gets blocked by Amazon WAF.

## Related issues

Closes #4854
