### PR TITLE
[mod] CI: exclude SearXNG checker and build & deploy of online docs

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   search:
+    if: github.repository_owner == 'searxng' || github.event_name == 'workflow_dispatch'
     name: Search
     runs-on: ubuntu-24.04-arm
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   release:
+    if: github.repository_owner == 'searxng' || github.event_name == 'workflow_dispatch'
     name: Release
     runs-on: ubuntu-24.04-arm
     permissions:


### PR DESCRIPTION
checker.yml

1. The checker is not yet of sufficient quality to allow the results of the check to be evaluated / we do not evaluate them ourselves.

2. The checker sends hundreds of requests to the search engines and causes problems there / we either overload small providers or we train their bot defenses to use the SearXNG signature.

documentation.yml

Building the documentation and deploying it on GH-docs of a clones (GH forks) is generally not desirable either --> We have >2k clones, but we only need one up-to-date documentation and that is the one from the master branch of the searxng/searxng repo.

If search engines like Google start linking to the documentation in the clones, SearXNG users may no longer find the original documentation or be lost in the flood of options.

Related:

- https://github.com/searxng/searxng/issues/4847

-------

About checker: 

I like the idea of ​​an automated engine check, but the current implementation and framework still raise questions that need to be clarified:

1. There is currently no reasonable evaluation of the tests.

2. It needs to be examined whether the GH-CI network is suitable for such checks: many service providers block requests from the GH-CI network, which would make the test results unrepresentative.

--> So it would be worth considering whether we should deactivate this checker on our repo as well until these questions/problems are resolved

.. meanings?