### PR TITLE
[chore] engine preferences: fix grammar mistakes

### DIFF
--- a/searx/templates/simple/preferences/engines.html
+++ b/searx/templates/simple/preferences/engines.html
@@ -6,7 +6,7 @@
   {%- set ns.checked = false -%}
   {%- if categ == DEFAULT_CATEGORY -%}
     <p>
-      {{- _('This tab does not exists in the user interface, but you can search in these engines by its !bangs.') -}}
+      {{- _('This tab does not exist in the user interface, but you can search with these engines via !bangs.') -}}
       {{- ' ' -}}<a href="{{ url_for('info', pagename='search-syntax') }}">&#9432;</a>
     </p>
   {%- endif -%}


### PR DESCRIPTION
## What does this PR do?

This PR fixes grammatical errors in the "Engines" tab of the preferences page.

## Why is this change important?

Previously, the grammar in this tab was incorrect.

## How to test this PR locally?

Replace engines.html in your instance with the updated file.

