### PR TITLE
[doc] fix typo and add missing help of the docker entrypoint script

### DIFF
--- a/docs/dev/result_types/main_result.rst
+++ b/docs/dev/result_types/main_result.rst
@@ -20,7 +20,7 @@ The :ref:`LegacyResult <LegacyResult>` is used internally for the results that
 have not yet been typed.  The templates can be used as orientation until the
 final typing is complete.
 
-- :ref:`template default` / :py:obj:`Result`
+- :ref:`template default` / :py:obj:`MainResult`
 - :ref:`template images`
 - :ref:`template videos`
 - :ref:`template torrent`


### PR DESCRIPTION
### container/entrypoint.sh

before https://github.com/searxng/searxng/pull/4793 there was a -h option which is used to generate documentation from ..

https://github.com/searxng/searxng/blob/d63bdcd773b05d3a119cc0c710ba424d87172f93/docs/admin/installation-docker.rst?plain=1#L188-L190

### docs/dev/result_types/main_result.rst

Fix typo: MainResult is the type for the default.html template
