### PR TITLE
[fix] .editorconfig: correction of the settings from the realities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,10 +11,13 @@ end_of_line = lf
 charset = utf-8
 
 [*.py]
-max_line_length = 119
+# code formatter accepts length of 120, but editor should prefer 80
+max_line_length = 80
 
 [*.html]
-indent_size = 4
+# in the jinja templates we use indent size of 2 and we do not use tabs
+indent_size = 2
+indent_style = space
 
 [*.css]
 indent_size = 2


### PR DESCRIPTION
The code formatter allows up to 120 characters per line, but for better readability the editor should prefer 80 characters per line

In the HTML templates (jinja) we usually use an indentation of two and no tabs.
