### PR TITLE
[feat] Add ability to display a message of the day

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -29,6 +29,8 @@ brand:
   #   links:
   #     Uptime: https://uptime.searxng.org/history/darmarit-org
   #     About: "https://searxng.org"
+  # Display a message of the day (MOTD) below the search bar
+  motd: ""
 
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict

--- a/searx/templates/simple/simple_search.html
+++ b/searx/templates/simple/simple_search.html
@@ -18,3 +18,5 @@
   <input type="hidden" name="theme" value="{{ theme }}" >
   {% if timeout_limit %}<input type="hidden" name="timeout_limit" value="{{ timeout_limit|e }}" >{% endif %}
 </form>
+<br>
+{{ get_setting('brand.motd') }}


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to display a message of the day (MOTD) below the search bar on the homepage. 

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Instance maintainers can use a MOTD to notify users about important information such as upcoming maintenance or new features. 

## How to test this PR locally?

* Replace simple_search.html with the updated file
* Add `motd: ""` to the `brand` section of settings.yml
* Write your desired MOTD inside the quotation marks

