### PR TITLE
[feat] Engines: Add Minecraft Wiki

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2677,6 +2677,18 @@ engines:
     timeout: 4.0
     disabled: true
 
+  - name: minecraft wiki
+    engine: mediawiki
+    shortcut: mcw
+    categories: ["software wikis"]
+    base_url: https://minecraft.wiki/
+    api_path: "api.php"
+    search_type: text
+    disabled: true
+    about:
+      website: https://minecraft.wiki/
+      wikidata_id: Q105533483
+
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.
 #  - name: ubuntuwiki


### PR DESCRIPTION
## What does this PR do?

This PR adds the Minecraft Wiki as an engine

## Why is this change important?

Being able to quickly search the Minecraft wiki via SearXNG can be useful for Minecraft players.

## How to test this PR locally?

Add the new lines to settings.yml
