### PR TITLE
[chore] Preferences: Make autocomplete description sound less casual

### DIFF
--- a/searx/templates/simple/preferences/autocomplete.html
+++ b/searx/templates/simple/preferences/autocomplete.html
@@ -12,6 +12,6 @@
     </select>{{- '' -}}
   </div>{{- '' -}}
   <div class="description">
-    {{- _('Find stuff as you type') -}}
+    {{- _('Show possible queries as you type') -}}
   </div>{{- '' -}}
 </fieldset>{{- '' -}}


### PR DESCRIPTION
## What does this PR do?

This PR makes the description of autocomplete in the preferences menu use more formal language

## Why is this change important?

The previous description was too casual and felt out of place compared to the descriptions of the other options. Using "stuff" to mean search queries is also a little vague. 

## How to test this PR locally?

Replace autocomplete.html in your instance with the updated file.
