### PR TITLE
[mod] Hash plugin: List the available hash functions in the description

### DIFF
--- a/searx/plugins/hash_plugin.py
+++ b/searx/plugins/hash_plugin.py
@@ -32,7 +32,9 @@ class SXNGPlugin(Plugin):
         self.info = PluginInfo(
             id=self.id,
             name=gettext("Hash plugin"),
-            description=gettext("Converts strings to different hash digests."),
+            description=gettext(
+                "Converts strings to different hash digests. Available functions: md5, sha1, sha224, sha256, sha384, sha512."  # pylint:disable=line-too-long
+            ),
             examples=["sha512 The quick brown fox jumps over the lazy dog"],
             preference_section="query",
         )


### PR DESCRIPTION
## What does this PR do?

This PR lists the available hash functions/algorithms in the description of the hash plugin

## Why is this change important?

Previously, it was not clear which hash functions are available.

## How to test this PR locally?

Replace hash_plugin.py in your instance with the updated file.