### PR TITLE
[feat] add docker-compose configuration for SearXNG service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.7'
+
+services:
+  searxng:
+    image: ghcr.io/searxng/searxng
+    container_name: searxng
+    ports:
+      - "8080:8080"
+    volumes:
+      - searxng-data:/usr/local/searxng/data
+      - searxng-config:/usr/local/searxng/config
+    environment:
+      - INSTANCE_NAME=SearXNG
+      - BASE_URL=http://localhost:8080/
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+      - DAC_OVERRIDE
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "1"
+
+volumes:
+  searxng-data:
+  searxng-config:


### PR DESCRIPTION
## What does this PR do?

Adds a `docker-compose.yml` file to simplify running SearXNG in a container.

## Why is this change important?

Makes it easier to run SearXNG locally with a single `docker-compose up` command instead of using raw Docker commands.

## How to test this PR locally?

```bash
docker-compose up -d
```
Then visit http://localhost:8080

## Author's checklist

- [x] Added `docker-compose.yml` to the project root

## Related issues

<!-- No related issues to close -->