### PR TITLE
remove dissem.in due to its closure

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2771,7 +2771,6 @@ engines:
 doi_resolvers:
   oadoi.org: 'https://oadoi.org/'
   doi.org: 'https://doi.org/'
-  doai.io: 'https://dissem.in/'
   sci-hub.se: 'https://sci-hub.se/'
   sci-hub.st: 'https://sci-hub.st/'
   sci-hub.ru: 'https://sci-hub.ru/'

--- a/tests/robot/settings_robot.yml
+++ b/tests/robot/settings_robot.yml
@@ -51,7 +51,6 @@ engines:
 doi_resolvers:
   oadoi.org: 'https://oadoi.org/'
   doi.org: 'https://doi.org/'
-  doai.io: 'https://dissem.in/'
   sci-hub.se: 'https://sci-hub.se/'
   sci-hub.st: 'https://sci-hub.st/'
   sci-hub.ru: 'https://sci-hub.ru/'


### PR DESCRIPTION
## What does this PR do?

remove dissem.in as an option as it has shut down
https://association.dissem.in/dissemin-closure.html
https://web.archive.org/web/20250621200318/https://association.dissem.in/dissemin-closure.html

## Why is this change important?

dissem.in is shut down and to avoid confusion it should be removed as an option.