### PR TITLE
[fix] restore startpage autocompleter

### DIFF
--- a/docs/admin/settings/settings_search.rst
+++ b/docs/admin/settings/settings_search.rst
@@ -46,6 +46,7 @@
   - ``qwant``
   - ``seznam``
   - ``sogou``
+  - ``startpage``
   - ``stract``
   - ``swisscows``
   - ``wikipedia``

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -34,7 +34,7 @@ search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
   # Existing autocomplete backends: "360search", "baidu", "brave", "dbpedia", "duckduckgo", "google", "yandex",
-  # "mwmbl", "naver", "seznam", "sogou", "stract", "swisscows", "quark", "qwant", "wikipedia" -
+  # "mwmbl", "naver", "seznam", "sogou", "startpage", "stract", "swisscows", "quark", "qwant", "wikipedia" -
   # leave blank to turn it off by default.
   autocomplete: ""
   # minimun characters to type before autocompleter starts


### PR DESCRIPTION
## What does this PR do?
Restores the deleted Startpage autocompleter.

Changes:
- Undo deletions of the autocompleter in settings and logic
- Add fixed autocomplete function in autocomplete.py

## Why is this change important?
We can have Startpage autocomplete results again.

## How to test this PR locally?
1. make run
2. Set autocomplete to **startpage**
3. Test supported languages (and check that request params match the proper **lui**)
4. Test unsupported language (and check that **lui=english**)

## Author's checklist
Uses languages from the supported languages found in the Firefox extension's files.

## Related issues
- https://github.com/searxng/searxng/issues/4334

