### PR TITLE
[fix] debian: install apt package python-is-python3

### DIFF
--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -57,7 +57,7 @@ NGINX_SEARXNG_SITE="searxng.conf"
 # apt packages
 
 SEARXNG_PACKAGES_debian="\
-python3-dev python3-babel python3-venv
+python3-dev python3-babel python3-venv python-is-python3
 uwsgi uwsgi-plugin-python3
 git build-essential libxslt-dev zlib1g-dev libffi-dev libssl-dev"
 


### PR DESCRIPTION
On debian the 'python-is-python3' packages restores an appropriate '/usr/bin/python' symlink for third-party scripts ..

- https://github.com/searxng/searxng/issues/3235#issuecomment-1954459081

