### PR TITLE
[docs] Docker's entrypoint.sh does no longer have an help option -h

### DIFF
--- a/docs/admin/installation-docker.rst
+++ b/docs/admin/installation-docker.rst
@@ -186,5 +186,3 @@ In the :origin:`Dockerfile` the ENTRYPOINT_ is defined as
 .. code:: sh
 
     docker run --rm -it searxng/searxng -h
-
-.. program-output:: ../container/entrypoint.sh -h


### PR DESCRIPTION
The new Docker entrypoint.sh script implemented in PR:

- https://github.com/searxng/searxng/pull/4793

does no longer have a `-h` option [1].  When building the `make docs` a warning is shown::

    WARNING: Unexpected return code 2 from command Command(command=('../container/entrypoint.sh', '-h') \
    .. (output='../container/entrypoint.sh: 152: SEARXNG_VERSION: parameter not set')

[1] https://github.com/searxng/searxng/pull/4793/files#diff-694a402a03e8de5aa227b1c0294ffdc072b6bac09b4dcbe144dc7d97d4e07159L35
