### PR TITLE
[fix] container: remove HEALTHCHECK

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -60,6 +60,4 @@ VOLUME $DATA_PATH
 
 EXPOSE 8080
 
-HEALTHCHECK CMD wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
-
 ENTRYPOINT ["/usr/local/searxng/entrypoint.sh"]

--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -93,8 +93,8 @@ container.build() {
         info_msg "Set \$GIT_BRANCH: $GIT_BRANCH"
 
         if [ "$container_engine" = "podman" ]; then
-            params_build_builder="build --format=docker --platform=$platform --target=builder --layers --identity-label=false"
-            params_build="build --format=docker --platform=$platform --layers --squash-all --omit-history --identity-label=false"
+            params_build_builder="build --format=oci --platform=$platform --target=builder --layers --identity-label=false"
+            params_build="build --format=oci --platform=$platform --layers --squash-all --omit-history --identity-label=false"
         else
             params_build_builder="build --platform=$platform --target=builder"
             params_build="build --platform=$platform --squash"


### PR DESCRIPTION
This is a poorly designed instruction, which is hardcoded and cannot be easily modified or maintained on a rolling release sw like ours. This *should* be set in the SearXNG Docker Compose template, not in the image itself.

The OCI format is now used since we no longer have the [`HEALTHCHECK`](https://docs.docker.com/reference/dockerfile/#healthcheck) on the Dockerfile.

Closes https://github.com/searxng/searxng/issues/4906
Closes https://github.com/searxng/searxng/issues/4722

---

Latest CI https://github.com/inetol/searxng/actions/runs/15900692051