### PR TITLE
[fix] leftover from PR #4947 - ./manage vite.simple.build

### DIFF
--- a/client/simple/generated/pygments.less
+++ b/client/simple/generated/pygments.less
@@ -1,6 +1,6 @@
 /*
    this file is generated automatically by searxng_extra/update/update_pygments.py
-   using pygments version 2.19.1
+   using pygments version 2.19.2
 */
 
 


### PR DESCRIPTION
PR #4947 upgraded the pygment, but forgot to apply the change to the static files::

    $ ./manage vite.simple.build

Related:

- https://github.com/searxng/searxng/pull/4947
