### PR TITLE
[fix] calculator plugin: crash when trying to evaluate non-math query

### DIFF
--- a/searx/plugins/calculator.py
+++ b/searx/plugins/calculator.py
@@ -170,8 +170,8 @@ def _eval_expr(expr):
         root_expr = ast.parse(expr, mode='eval').body
         return _eval(root_expr), isinstance(root_expr, ast.Compare)
 
-    except ZeroDivisionError:
-        # This is undefined
+    except (SyntaxError, TypeError, ZeroDivisionError):
+        # Expression that can't be evaluated (i.e. not a math expression)
         return "", False
 
 


### PR DESCRIPTION
It's possible that `SyntaxError` or `TypeError` instances are thrown when we can't evaluate a query, simply because it's not a math expression. In this case, it should just be skipped, i.e. the calculator plugin doesn't return any result instead of forwarding the exception.
