### PR TITLE
[mod] wordnik: convert to answerer

### DIFF
--- a/searx/engines/wordnik.py
+++ b/searx/engines/wordnik.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Wordnik (general)
-
-"""
+"""Wordnik (general)"""
 
 from lxml.html import fromstring
 from searx.utils import extract_text
-from searx.network import raise_for_httperror
+
+from searx.result_types import EngineResults
 
 # about
 about = {
@@ -17,7 +16,7 @@ about = {
     "results": 'HTML',
 }
 
-categories = ['general']
+categories = ['dictionaries', 'define']
 paging = False
 
 
@@ -27,46 +26,23 @@ def request(query, params):
 
 
 def response(resp):
-    results = []
+    results = EngineResults()
 
-    raise_for_httperror(resp)
     dom = fromstring(resp.text)
-    word = extract_text(dom.xpath('//*[@id="headword"]/text()'))
 
-    definitions = []
     for src in dom.xpath('//*[@id="define"]//h3[@class="source"]'):
-        src_text = extract_text(src).strip()
-        if src_text.startswith('from '):
-            src_text = src_text[5:]
-
-        src_defs = []
+        item = results.types.Translations.Item(text="")
         for def_item in src.xpath('following-sibling::ul[1]/li'):
             def_abbr = extract_text(def_item.xpath('.//abbr')).strip()
             def_text = extract_text(def_item).strip()
             if def_abbr:
                 def_text = def_text[len(def_abbr) :].strip()
-            src_defs.append((def_abbr, def_text))
 
-        definitions.append((src_text, src_defs))
+            # use first result as summary
+            if not item.text:
+                item.text = def_text
+            item.definitions.append(def_text)
 
-    if not definitions:
-        return results
-
-    infobox = ''
-    for src_text, src_defs in definitions:
-        infobox += f"<small>{src_text}</small>"
-        infobox += "<ul>"
-        for def_abbr, def_text in src_defs:
-            if def_abbr:
-                def_abbr += ": "
-            infobox += f"<li><i>{def_abbr}</i> {def_text}</li>"
-        infobox += "</ul>"
-
-    results.append(
-        {
-            'infobox': word,
-            'content': infobox,
-        }
-    )
+        results.add(results.types.Translations(translations=[item], url=resp.search_params["url"]))
 
     return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2481,8 +2481,7 @@ engines:
 
   - name: wordnik
     engine: wordnik
-    shortcut: def
-    categories: [dictionaries]
+    shortcut: wnik
     timeout: 5.0
 
   - name: woxikon.de synonyme


### PR DESCRIPTION
## What's changed?
- Wordnik is now an answerer and not in the infobox anymore: it uses the translations answerer, because it provides all the features needed
- by default, only its first results is shown
- additionally a new "define" category is added - I know, it's the same as the "dictionaries" category, but I don't think we can alias categories
- this allows to search e.g. for `!define tree`

## Author notes
- the idea is to allow easy searches for definitions of words

## Related issues
- related: https://github.com/searxng/searxng/issues/4111
