### PR TITLE
[fix] granian: enabling debug on searxng-docker causes server crash

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1350,9 +1350,9 @@ def is_werkzeug_reload_active() -> bool:
     .. _werkzeug.serving:
        https://werkzeug.palletsprojects.com/en/stable/serving/#werkzeug.serving.run_simple
     """
-
-    if "uwsgi" in sys.argv:
-        # server was launched by uWSGI
+    logger.debug("sys.argv: %s", sys.argv)
+    if "uwsgi" in sys.argv[0] or "granian" in sys.argv[0]:
+        # server was launched by granian (or uWSGI)
         return False
 
     # https://github.com/searxng/searxng/pull/1656#issuecomment-1214198941


### PR DESCRIPTION
When debugging is enabled, the context in which the process is running (uWSGI or `Flask.run` server) was previously checked [1]. This check has not yet taken the granian server into account.

----

The check is actually only required for the developer environment (`make run`) [2] and is intended to prevent double loading of modules when initializing a Flask server [3].

In the long term, we should find a more robust solution that explicitly enables the specific features of a development environment via switches. Further information on this problematic code can be found in [4][5][6].

[1] https://github.com/searxng/searxng/issues/4973#issuecomment-3047890957
[2] https://flask.palletsprojects.com/en/stable/api/#flask.Flask.run
[3] https://github.com/pallets/flask/issues/5307#issuecomment-1774646119
[4] https://github.com/searxng/searxng/pull/1656#issuecomment-1214198941
[5] https://github.com/searxng/searxng/pull/1616#issuecomment-1206137468
[6] https://stackoverflow.com/a/25504196

- closes: https://github.com/searxng/searxng/issues/4973