### PR TITLE
[fix] devcontainers: missing Valkey package

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,22 @@
-FROM mcr.microsoft.com/devcontainers/base:debian
+ARG DEBIAN_CODENAME="bookworm"
+
+FROM mcr.microsoft.com/devcontainers/base:$DEBIAN_CODENAME
+
+ARG DEBIAN_CODENAME="bookworm"
+
+RUN cat <<EOF > /etc/apt/sources.list.d/debian.sources
+Types: deb
+URIs: http://deb.debian.org/debian
+Suites: $DEBIAN_CODENAME $DEBIAN_CODENAME-updates $DEBIAN_CODENAME-backports
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://security.debian.org/debian-security
+Suites: $DEBIAN_CODENAME-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
 
 RUN apt-get update && \
-    apt-get -y install python3 python3-venv valkey firefox-esr graphviz imagemagick librsvg2-bin fonts-dejavu shellcheck
+    apt-get -y install python3 python3-venv valkey-server firefox-esr graphviz imagemagick librsvg2-bin fonts-dejavu shellcheck

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
   "build": {
+    "args": {
+      "DEBIAN_CODENAME": "bookworm",
+    },
     "dockerfile": "Dockerfile"
   },
   "features": {


### PR DESCRIPTION
[`mcr.microsoft.com/devcontainers/base:debian`](https://github.com/devcontainers/templates/tree/main/src/debian) still on bullseye branch, so no `valkey-server` package available even in backports. We still have to use `redis-server` on devcontainers until they update their images.

Reported https://github.com/searxng/searxng/discussions/4995
Closes https://github.com/searxng/searxng/issues/4996

---

https://packages.debian.org/search?keywords=valkey-server