### PR TITLE
[mod] remove option ui.static_use_hash (cache busting)

### DIFF
--- a/docs/admin/architecture.rst
+++ b/docs/admin/architecture.rst
@@ -29,8 +29,8 @@ up and maintained by the scripts from our :ref:`toolboxing`.
 
    Reference architecture of a public SearXNG setup.
 
-The reference installation activates ``server.limiter``, ``server.image_proxy``
-and ``ui.static_use_hash`` (:origin:`/etc/searxng/settings.yml
+The reference installation activates ``server.limiter`` and
+``server.image_proxy`` (:origin:`/etc/searxng/settings.yml
 <utils/templates/etc/searxng/settings.yml>`)
 
 .. literalinclude:: ../../utils/templates/etc/searxng/settings.yml

--- a/docs/admin/installation-searxng.rst
+++ b/docs/admin/installation-searxng.rst
@@ -86,7 +86,6 @@ below. This setup:
 
 - enables :ref:`limiter <limiter>` to protect against bots
 - enables :ref:`image proxy <image_proxy>` for better privacy
-- enables :ref:`cache busting <static_use_hash>` to save bandwidth
 
 Modify the ``/etc/searxng/settings.yml`` to your needs:
 
@@ -129,4 +128,3 @@ configuration file.
 If everything works fine, hit ``[CTRL-C]`` to stop the *webapp* and disable the
 debug option in ``settings.yml``. You can now exit SearXNG user bash session (enter exit
 command twice).  At this point SearXNG is not demonized; uwsgi allows this.
-

--- a/docs/admin/installation-uwsgi.rst
+++ b/docs/admin/installation-uwsgi.rst
@@ -181,10 +181,7 @@ uWSGI setup
 
 Create the configuration ini-file according to your distribution and restart the
 uwsgi application.  As shown below, the :ref:`installation scripts` installs by
-default:
-
-- a uWSGI setup that listens on a socket and
-- enables :ref:`cache busting <static_use_hash>`.
+default a uWSGI setup that listens on a socket.
 
 .. tabs::
 

--- a/docs/admin/settings/settings_ui.rst
+++ b/docs/admin/settings/settings_ui.rst
@@ -10,7 +10,6 @@
 .. code:: yaml
 
    ui:
-     static_use_hash: false
      default_locale: ""
      query_in_title: false
      infinite_scroll: false
@@ -22,11 +21,6 @@
      search_on_category_select: true
      hotkeys: default
      url_formatting: pretty
-
-.. _static_use_hash:
-
-``static_use_hash`` : ``$SEARXNG_STATIC_USE_HASH``
-  Enables `cache busting`_ of static files.
 
 ``default_locale`` :
   SearXNG interface language.  If blank, the locale is detected by using the

--- a/docs/admin/update-searxng.rst
+++ b/docs/admin/update-searxng.rst
@@ -58,10 +58,6 @@ and then, to name just a few:
 - Bot protection has been switched from filtron to SearXNG's :ref:`limiter
   <limiter>`, this requires a :ref:`Valkey <settings valkey>` database.
 
-- To save bandwidth :ref:`cache busting <static_use_hash>` has been implemented.
-  To get in use, the ``static-expires`` needs to be set in the :ref:`uwsgi
-  setup`.
-
 To stay tuned and get in use of the new features, instance maintainers have to
 update the SearXNG code regularly (see :ref:`update searxng`).  As the above
 examples show, this is not always enough, sometimes services have to be set up

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -119,8 +119,6 @@ valkey:
 ui:
   # Custom static path - leave it blank if you didn't change
   static_path: ""
-  # Is overwritten by ${SEARXNG_STATIC_USE_HASH}.
-  static_use_hash: false
   # Custom templates path - leave it blank if you didn't change
   templates_path: ""
   # query_in_title: When true, the result page's titles contains the query

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -194,7 +194,6 @@ SCHEMA = {
     },
     'ui': {
         'static_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'static')),
-        'static_use_hash': SettingsValue(bool, False, 'SEARXNG_STATIC_USE_HASH'),
         'templates_path': SettingsDirectoryValue(str, os.path.join(searx_dir, 'templates')),
         'default_theme': SettingsValue(str, 'simple'),
         'default_locale': SettingsValue(str, ''),

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -25,9 +25,6 @@ class ViewsTestCase(SearxTestCase):  # pylint: disable=too-many-public-methods
             pass
 
         self.setattr4test(searx.search.processors, 'initialize_processor', dummy)
-        # remove sha for the static file so the tests don't have to care about
-        # the changing URLs
-        self.setattr4test(searx.webapp, 'static_files', {})
 
         # set some defaults
         test_results = [

--- a/utils/templates/etc/httpd/sites-available/searxng.conf
+++ b/utils/templates/etc/httpd/sites-available/searxng.conf
@@ -33,9 +33,6 @@ LoadModule proxy_http_module    ${APACHE_MODULES}/mod_proxy_http.so
 
 </Location>
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
+# To serve the static files via the HTTP server
 #
 # Alias ${SEARXNG_URL_PATH}/static/ ${SEARXNG_STATIC}/

--- a/utils/templates/etc/httpd/sites-available/searxng.conf:socket
+++ b/utils/templates/etc/httpd/sites-available/searxng.conf:socket
@@ -33,9 +33,6 @@ LoadModule proxy_uwsgi_module   ${APACHE_MODULES}/mod_proxy_uwsgi.so
 
 </Location>
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
+# To serve the static files via the HTTP server
 #
 # Alias ${SEARXNG_URL_PATH}/static/ ${SEARXNG_STATIC}/

--- a/utils/templates/etc/nginx/default.apps-available/searxng.conf
+++ b/utils/templates/etc/nginx/default.apps-available/searxng.conf
@@ -19,10 +19,7 @@ location ${SEARXNG_URL_PATH} {
 
 }
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
+# To serve the static files via the HTTP server
 #
 # location ${SEARXNG_URL_PATH}/static/ {
 #     alias ${SEARXNG_STATIC}/;

--- a/utils/templates/etc/nginx/default.apps-available/searxng.conf:socket
+++ b/utils/templates/etc/nginx/default.apps-available/searxng.conf:socket
@@ -16,10 +16,7 @@ location ${SEARXNG_URL_PATH} {
     uwsgi_param    HTTP_X_FORWARDED_FOR  \$proxy_add_x_forwarded_for;
 }
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
+# To serve the static files via the HTTP server
 #
 # location ${SEARXNG_URL_PATH}/static/ {
 #     alias ${SEARXNG_STATIC}/;

--- a/utils/templates/etc/searxng/settings.yml
+++ b/utils/templates/etc/searxng/settings.yml
@@ -25,9 +25,6 @@ valkey:
   # URL to connect valkey database. Is overwritten by ${SEARXNG_VALKEY_URL}.
   url: valkey://localhost:6379/0
 
-ui:
-  static_use_hash: true
-
 # preferences:
 #   lock:
 #     - autocomplete

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
@@ -75,11 +75,7 @@ pythonpath = ${SEARXNG_SRC}
 http = ${SEARXNG_INTERNAL_HTTP}
 buffer-size = 8192
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
-#
+# To serve the static files via the WSGI server
 static-map = /static=${SEARXNG_STATIC}
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
@@ -72,11 +72,7 @@ pythonpath = ${SEARXNG_SRC}
 socket = ${SEARXNG_UWSGI_SOCKET}
 buffer-size = 8192
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
-#
+# To serve the static files via the WSGI server
 static-map = /static=${SEARXNG_STATIC}
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini
@@ -78,11 +78,7 @@ pythonpath = ${SEARXNG_SRC}
 http = ${SEARXNG_INTERNAL_HTTP}
 buffer-size = 8192
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
-#
+# To serve the static files via the WSGI server
 static-map = /static=${SEARXNG_STATIC}
 static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
@@ -75,11 +75,7 @@ pythonpath = ${SEARXNG_SRC}
 socket = ${SEARXNG_UWSGI_SOCKET}
 buffer-size = 8192
 
-# uWSGI serves the static files and in settings.yml we use::
-#
-#   ui:
-#     static_use_hash: true
-#
+# To serve the static files via the WSGI server
 static-map = /static=${SEARXNG_STATIC}
 static-gzip-all = True
 offload-threads = %k


### PR DESCRIPTION
Cache busting has caused serious problems for end users in the past, here are two examples:

- https://github.com/searxng/searxng/issues/4419
- https://github.com/searxng/searxng/issues/4481

And it makes development and deployment significantly more complex because it binds the client side to the server side:

- https://github.com/searxng/searxng/pull/4466

In the light of a decoupled development of the WEB clients from the server side:

- https://github.com/searxng/searxng/pull/4988

is it appropriate to abandon this feature. In fact,  it has been ineffective since #4436 anyway.

However, the benefit has always been questionable, since at best only a few kB of data are saved (at least in the context of an image_proxy, the effect is below the detection limit). Ultimately, the client is responsible for caching.

Related: https://github.com/searxng/searxng/issues?q=label%3A%22clear%20browser%20cache%22

Closes: 

- https://github.com/searxng/searxng/pull/4466
- https://github.com/searxng/searxng/issues/1326
- https://github.com/searxng/searxng/issues/964