### PR TITLE
[fix] custom `plugins:` settings must not be merged.

### DIFF
--- a/docs/admin/settings/settings_plugins.rst
+++ b/docs/admin/settings/settings_plugins.rst
@@ -25,6 +25,38 @@ transferred to the plugin, e.g. to activate it by default / *opt-in* or
 Please note that some plugins, such as the :ref:`hostnames plugin` plugin,
 require further configuration before they can be made available for selection.
 
+By default the :ref:`settings built in plugins` are loaded.  To change the list
+of plugins to be loaded, the value for ``plugins:`` in
+``/etc/searxng/settings.yml`` must be overwritten.
+
+Following is an example that uses :ref:`settings use_default_settings` and only
+two plugins are registered: the calculator can be activated by the user and the
+unit converter is active by default.
+
+
+.. code:: yaml
+
+    use_default_settings: true
+
+    plugins:
+
+      searx.plugins.calculator.SXNGPlugin:
+        active: false
+
+      searx.plugins.unit_converter.SXNGPlugin:
+        active: true
+
+To prevent any plugins from loading, the following setting can be used:
+
+.. code:: yaml
+
+    use_default_settings: true
+
+    plugins: {}
+
+
+.. _settings built in plugins:
+
 built-in plugins
 ================
 

--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -137,6 +137,10 @@ def update_settings(default_settings: dict, user_settings: dict):
     if categories_as_tabs:
         default_settings['categories_as_tabs'] = categories_as_tabs
 
+    plugins = user_settings.get('plugins')
+    if plugins is not None:
+        default_settings['plugins'] = plugins
+
     # parse the engines
     remove_engines = None
     keep_only_engines = None


### PR DESCRIPTION
In customizing it should be decided which plugin modules should be loaded and which should not.

Related:

- https://github.com/searxng/searxng/pull/4678#issuecomment-3079109035