### PR TITLE
[enh] py: whitenoise for static handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tomli==2.2.1; python_version < '3.11'
 msgspec==0.19.0
 typer-slim==0.16.0
 isodate==0.7.2
+whitenoise==6.9.0

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini
@@ -75,7 +75,4 @@ pythonpath = ${SEARXNG_SRC}
 http = ${SEARXNG_INTERNAL_HTTP}
 buffer-size = 8192
 
-# To serve the static files via the WSGI server
-static-map = /static=${SEARXNG_STATIC}
-static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-archlinux/searxng.ini:socket
@@ -72,7 +72,4 @@ pythonpath = ${SEARXNG_SRC}
 socket = ${SEARXNG_UWSGI_SOCKET}
 buffer-size = 8192
 
-# To serve the static files via the WSGI server
-static-map = /static=${SEARXNG_STATIC}
-static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini
@@ -78,7 +78,4 @@ pythonpath = ${SEARXNG_SRC}
 http = ${SEARXNG_INTERNAL_HTTP}
 buffer-size = 8192
 
-# To serve the static files via the WSGI server
-static-map = /static=${SEARXNG_STATIC}
-static-gzip-all = True
 offload-threads = %k

--- a/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
+++ b/utils/templates/etc/uwsgi/apps-available/searxng.ini:socket
@@ -75,7 +75,4 @@ pythonpath = ${SEARXNG_SRC}
 socket = ${SEARXNG_UWSGI_SOCKET}
 buffer-size = 8192
 
-# To serve the static files via the WSGI server
-static-map = /static=${SEARXNG_STATIC}
-static-gzip-all = True
 offload-threads = %k


### PR DESCRIPTION
While looking at ways to better handle static files, I saw a package that replaces Flask `static_folder` functionality. Not only it's considerably faster, but already includes the capability to serve sidecars without having to intercept. This also replaces the uWSGI folder mapping functionality.

Closes https://github.com/searxng/searxng/issues/4977

---

<details>
<summary>Flask</summary>

<img width="500" height="655" alt="Image" src="https://github.com/user-attachments/assets/8702b20a-fc38-4c9e-834a-89b9245a7d8f" />

</details>

<details>
<summary>WhiteNoise</summary>

<img width="500" height="655" alt="Image" src="https://github.com/user-attachments/assets/1bf519df-b5e7-4379-9c33-53d1db12582f" />

</details>