### PR TITLE
[fix] tracker url remover + external bangs: use standard network config

### DIFF
--- a/searx/data/tracker_patterns.py
+++ b/searx/data/tracker_patterns.py
@@ -10,9 +10,8 @@ import re
 from collections.abc import Iterator
 from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 
-import httpx
-
 from searx.data.core import get_cache, log
+from searx.network import get as http_get
 
 RuleType = tuple[str, list[str], list[str]]
 
@@ -44,7 +43,7 @@ class TrackerPatternsDB:
             self.cache.properties.set("tracker_patterns loaded", "OK")
             self.load()
         # F I X M E:
-        #     do we need a maintenance .. rember: database is stored
+        #     do we need a maintenance .. remember: database is stored
         #     in /tmp and will be rebuild during the reboot anyway
 
     def load(self):
@@ -71,7 +70,7 @@ class TrackerPatternsDB:
     def iter_clear_list(self) -> Iterator[RuleType]:
         resp = None
         for url in self.CLEAR_LIST_URL:
-            resp = httpx.get(url, timeout=3)
+            resp = http_get(url, timeout=3)
             if resp.status_code == 200:
                 break
             log.warning(f"TRACKER_PATTERNS: ClearURL ignore HTTP {resp.status_code} {url}")

--- a/searxng_extra/update/update_external_bangs.py
+++ b/searxng_extra/update/update_external_bangs.py
@@ -8,10 +8,10 @@ from :py:obj:`BANGS_URL`.
 """
 
 import json
-import httpx
 
 from searx.external_bang import LEAF_KEY
 from searx.data import data_dir
+from searx.network import get as http_get
 
 DATA_FILE = data_dir / 'external_bangs.json'
 
@@ -24,7 +24,7 @@ HTTP_COLON = 'http:'
 
 def main():
     print(f'fetch bangs from {BANGS_URL}')
-    response = httpx.get(BANGS_URL)
+    response = http_get(BANGS_URL)
     response.raise_for_status()
     ddg_bangs = json.loads(response.content.decode())
     trie = parse_ddg_bangs(ddg_bangs)


### PR DESCRIPTION
Using plain `httpx` directly doesn't use SearXNG's additional network config, including proxies, http2 config, ...

Related issues:
- closes https://github.com/searxng/searxng/issues/5027
