### PR TITLE
[fix]Baidu: json error caused by baidu captcha

### DIFF
--- a/searx/engines/baidu.py
+++ b/searx/engines/baidu.py
@@ -98,7 +98,10 @@ def response(resp):
     if baidu_category == 'images':
         # baidu's JSON encoder wrongly quotes / and ' characters by \\ and \'
         text = text.replace(r"\/", "/").replace(r"\'", "'")
-    data = json.loads(text, strict=False)
+    try:
+        data = json.loads(text, strict=False)
+    except json.JSONDecodeError:
+        return []
     parsers = {'general': parse_general, 'images': parse_images, 'it': parse_it}
 
     return parsers[baidu_category](data)


### PR DESCRIPTION
## What does this PR do?

When I use the searXNG api in Dify workflow, the repsonse will show error because of baidu captcha.

## Why is this change important?

<img width="627" height="188" alt="image" src="https://github.com/user-attachments/assets/bf04a372-0728-4c92-a7f1-368b8103e1c6" />


The captcha response will raise JSON parse error.
As the Chinese engine 360 so, it just extract useful info from text.
I think it should return [] when there is JSON parse error.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
