### PR TITLE
[fix] py: restore `application` for uWSGI

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1447,6 +1447,10 @@ app.wsgi_app = WhiteNoise(
 )
 
 patch_application(app)
+
+# remove when we drop support for uwsgi
+application = app
+
 init()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Was removed on https://github.com/searxng/searxng/pull/5032

---

Closes #5039 