### PR TITLE
[fix] py: absolute static path

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -265,7 +265,7 @@ def custom_url_for(endpoint: str, **values):
             if theme_filename in _STATIC_FILES:
                 values["filename"] = theme_filename
 
-        return f"/static/{values['filename']}"
+        return f"static/{values['filename']}"
 
     if endpoint == "info" and "locale" not in values:
 


### PR DESCRIPTION
The path to static should be relative (If sxng is served under "/sxng", the static route passed to the client won't be "/sxng/static/..." as expected but "/static/...")

Closes https://github.com/searxng/searxng/issues/5042