### PR TITLE
Correct comment in settings.yml for value to disable scheduling

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -277,7 +277,7 @@ checker:
   # disable checker when in debug mode
   off_when_debug: true
 
-  # use "scheduling: false" to disable scheduling
+  # use "scheduling:" to disable scheduling
   # scheduling: interval or int
 
   # to activate the scheduler:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -277,7 +277,7 @@ checker:
   # disable checker when in debug mode
   off_when_debug: true
 
-  # use "scheduling:" to disable scheduling
+  # use "scheduling: {}" to disable scheduling
   # scheduling: interval or int
 
   # to activate the scheduler:


### PR DESCRIPTION
Updates settings.yml comment for checker.scheduling with the required value to disable scheduling. 

The current comment implies the following will disable scheduling but ./utils/searxng_check.py displays `ERROR   searx                         : checker.scheduling: The value has to be one of these types/values: None, dict`
```
checker:
  scheduling: false
```

A working setting value is:
```
checker:
  scheduling:
```

Run `./utils/searxng_check.py`  with a path argument to an otherwise valid settings.yml but configure `scheduling: false` to see the error and `scheduling:` for it to succeed. I also verified with python logging that this does disable Checker scheduler.

I'm unsure if a better approach would be to modify `settings_defaults.py` to accept the current comment's recommendation of an explicit valid `STR_TO_BOOL` value however that may make it more complex if it were to only accept false.

I'm not sure if line 281 is correct either as it accepts only `(None, dict)`, but I don't understand scheduling well enough to say definitivly.