### PR TITLE
[fix] duckduckgo engine: logger.error / missing argument

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -129,7 +129,7 @@ def get_vqd(query: str, region: str, force_request: bool = False) -> str:
     if value:
         cache.set(key=key, value=value)
     else:
-        logger.error("vqd value from duckduckgo.com ", resp.status_code)
+        logger.error("none vqd value from duckduckgo.com: HTTP %s", resp.status_code)
     return value
 
 


### PR DESCRIPTION
The error message in case the vqd value could not be determined was incorrect and triggered an exception::

     File "/usr/local/searxng/searxng-src/searx/engines/duckduckgo.py", line 132, in get_vqd
       logger.error("vqd value from duckduckgo.com ", resp.status_code)
     Message: 'vqd value from duckduckgo.com '
     Arguments: (202,)
