### PR TITLE
[fix] NotImplementedError raised by ResultContainer

### DIFF
--- a/searx/results.py
+++ b/searx/results.py
@@ -88,10 +88,12 @@ class ResultContainer:
             if isinstance(result, Result):
                 result.engine = result.engine or engine_name
                 result.normalize_result_fields()
+                if not self.on_result(result):
+                    continue
 
-                if isinstance(result, BaseAnswer) and self.on_result(result):
+                if isinstance(result, BaseAnswer):
                     self.answers.add(result)
-                elif isinstance(result, MainResult) and self.on_result(result):
+                elif isinstance(result, MainResult):
                     main_count += 1
                     self._merge_main_result(result, main_count)
                 else:


### PR DESCRIPTION
If the ``on_result`` handle returns False, then the ``else`` was always jumped to, which throws the NotImplementedError exception::

    File "/usr/local/searxng/searxng-src/searx/results.py", line 99, in extend
      raise NotImplementedError(f"no handler implemented to process the result of type {result}")
    NotImplementedError: no handler implemented to process the result of type MainResult(title=...
