### PR TITLE
[fix] CI task "update_engine_traits.py" fails

### DIFF
--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -1720,7 +1720,7 @@
         "sk": "sk",
         "sl": "sl",
         "sq-AL": "sq-al",
-        "sr_Cyrl": "sr-cyrl",
+        "sr": "sr",
         "sr_Latn": "sr-latn",
         "sv": "sv",
         "sw-KE": "sw-ke",
@@ -1728,8 +1728,8 @@
         "tr": "tr",
         "uk": "uk",
         "vi": "vi",
-        "zh_Hans": "zh-hans",
-        "zh_Hant": "zh-hant"
+        "zh": "zh",
+        "zh-TW": "zh-tw"
       }
     },
     "data_type": "traits_v1",
@@ -1826,7 +1826,7 @@
         "sk": "sk",
         "sl": "sl",
         "sq-AL": "sq-al",
-        "sr_Cyrl": "sr-cyrl",
+        "sr": "sr",
         "sr_Latn": "sr-latn",
         "sv": "sv",
         "sw-KE": "sw-ke",
@@ -1834,8 +1834,8 @@
         "tr": "tr",
         "uk": "uk",
         "vi": "vi",
-        "zh_Hans": "zh-hans",
-        "zh_Hant": "zh-hant"
+        "zh": "zh",
+        "zh-TW": "zh-tw"
       }
     },
     "data_type": "traits_v1",
@@ -1932,7 +1932,7 @@
         "sk": "sk",
         "sl": "sl",
         "sq-AL": "sq-al",
-        "sr_Cyrl": "sr-cyrl",
+        "sr": "sr",
         "sr_Latn": "sr-latn",
         "sv": "sv",
         "sw-KE": "sw-ke",
@@ -1940,8 +1940,8 @@
         "tr": "tr",
         "uk": "uk",
         "vi": "vi",
-        "zh_Hans": "zh-hans",
-        "zh_Hant": "zh-hant"
+        "zh": "zh",
+        "zh-TW": "zh-tw"
       }
     },
     "data_type": "traits_v1",
@@ -2038,7 +2038,7 @@
         "sk": "sk",
         "sl": "sl",
         "sq-AL": "sq-al",
-        "sr_Cyrl": "sr-cyrl",
+        "sr": "sr",
         "sr_Latn": "sr-latn",
         "sv": "sv",
         "sw-KE": "sw-ke",
@@ -2046,8 +2046,8 @@
         "tr": "tr",
         "uk": "uk",
         "vi": "vi",
-        "zh_Hans": "zh-hans",
-        "zh_Hant": "zh-hant"
+        "zh": "zh",
+        "zh-TW": "zh-tw"
       }
     },
     "data_type": "traits_v1",

--- a/searx/engines/zlibrary.py
+++ b/searx/engines/zlibrary.py
@@ -193,7 +193,7 @@ def fetch_traits(engine_traits: EngineTraits) -> None:
 
     try:
         resp = get(base_url, verify=False)
-    except (SearxException, httpx.ConnectError) as exc:
+    except (SearxException, httpx.HTTPError) as exc:
         print(f"ERROR: zlibrary domain '{base_url}' is seized?")
         print(f"  --> {exc}")
         _use_old_values()


### PR DESCRIPTION
To catch all problems with an HTTP request, the more general class ``httpx.HTTPError`` must be caught, for your test use::

    $ ./manage dev.env
    (dev.env)$ python ./searxng_extra/update/update_engine_traits.py

Closes: 
- https://github.com/searxng/searxng/issues/5068
