### PR TITLE
[feat] statistics answerer: add the ability to calculate range

### DIFF
--- a/searx/answerers/statistics.py
+++ b/searx/answerers/statistics.py
@@ -21,6 +21,7 @@ kw2func = [
     ("avg", lambda args: sum(args) / len(args)),
     ("sum", sum),
     ("prod", lambda args: reduce(mul, args, 1)),
+    ("range", lambda args: max(args) - min(args)),
 ]
 
 


### PR DESCRIPTION
## What does this PR do?

This adds to the statistics answerer the ability to calculate the range of a given set by subtracting the minimum from the maximum.

## Why is this change important?

Quickly showing the range of a set can be useful.

## How to test this PR locally?

Replace statistics.py in your instance with the updated file.