### PR TITLE
[feat] engines: add Github Code Search engine

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -178,3 +178,4 @@ features or generally made SearXNG better:
 - `Bearz314 <https://github.com/bearz314>`_
 - Tommaso Colella `<https://github.com/gioleppe>`
 - @AgentScrubbles
+- Filip Mikina `<https://github.com/fiffek>`

--- a/docs/dev/engines/online/github_code.rst
+++ b/docs/dev/engines/online/github_code.rst
@@ -1,0 +1,8 @@
+.. _github code engine:
+
+===========
+Github Code
+===========
+
+.. automodule:: searx.engines.github_code
+   :members:

--- a/searx/engines/github_code.py
+++ b/searx/engines/github_code.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: AGPL-3.0-or-lat_er
+"""GitHub code search with `search syntax`_ as described in `Constructing a
+search query`_ in the documentation of GitHub's REST API.
+
+.. _search syntax:
+    https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax
+.. _Constructing a search query:
+    https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#constructing-a-search-query
+.. _Github REST API for code search:
+    https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-code
+.. _Github REST API auth for code search:
+    https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-code--fine-grained-access-tokens
+
+Configuration
+=============
+
+The engine has the following mandatory setting:
+
+- :py:obj:`ghc_auth`
+  Change the authentication method used when using the API, defaults to none.
+
+Optional settings are:
+
+- :py:obj:`ghc_highlight_matching_lines`
+   Control the highlighting of the matched text (turns off/on).
+- :py:obj:`ghc_strip_new_lines`
+   Strip new lines at the start or end of each code fragment.
+- :py:obj:`ghc_strip_whitespace`
+   Strip any whitespace at the start or end of each code fragment.
+- :py:obj:`ghc_insert_block_separator`
+   Add a `...` between each code fragment before merging them.
+
+.. code:: yaml
+
+  - name: github code
+    engine: github_code
+    shortcut: ghc
+    ghc_auth:
+      type: "none"
+
+  - name: github code
+    engine: github_code
+    shortcut: ghc
+    ghc_auth:
+      type: "personal_access_token"
+      token: "<token>"
+    ghc_highlight_matching_lines: true
+    ghc_strip_whitespace: true
+    ghc_strip_new_lines: true
+
+
+  - name: github code
+    engine: github_code
+    shortcut: ghc
+    ghc_auth:
+      type: "bearer"
+      token: "<token>"
+
+Implementation
+===============
+
+GitHub does not return the code line indices alongside the code fragment in the
+search API. Since these are not super important for the user experience all the
+code lines are just relabeled (starting from 1) and appended (a disjoint set of
+code blocks in a single file might be returned from the API).
+"""
+
+from __future__ import annotations
+
+import typing as t
+from urllib.parse import urlencode, urlparse
+
+from pygments.lexers import guess_lexer_for_filename
+from pygments.util import ClassNotFound
+from searx.result_types import EngineResults
+from searx.extended_types import SXNG_Response
+from searx.network import raise_for_httperror
+
+# about
+about = {
+    "website": 'https://github.com/',
+    "wikidata_id": 'Q364',
+    "official_api_documentation": 'https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-code',
+    "use_official_api": True,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+# engine dependent config
+categories = ['code']
+
+
+search_url = 'https://api.github.com/search/code?sort=indexed&{query}&{page}'
+# https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#text-match-metadata
+accept_header = 'application/vnd.github.text-match+json'
+paging = True
+
+ghc_auth = {
+    "type": "none",
+    "token": "",
+}
+"""Change the method of authenticating to the github API.
+
+``type`` needs to be one of ``none``, ``personal_access_token``, or ``bearer``.
+When type is not `none` a token is expected to be passed as well in
+``auth.token``.
+
+If there is any privacy concerns about generating a token, one can use the API
+without authentication.  The calls will be heavily rate limited, this is what the
+API returns on such calls::
+
+    API rate limit exceeded for <redacted ip>.
+    (But here's the good news: Authenticated requests get a higher rate limit)
+
+The personal access token or a bearer for an org or a group can be generated [in
+the `GitHub settings`_.
+
+.. _GitHub settings:
+   https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-code--fine-grained-access-tokens
+"""
+
+ghc_highlight_matching_lines = True
+"""Highlight the matching code lines."""
+
+ghc_strip_new_lines = True
+"""Strip leading and trailing newlines for each returned fragment.
+Single file might return multiple code fragments.
+"""
+
+ghc_strip_whitespace = False
+"""Strip all leading and trailing whitespace for each returned fragment.
+Single file might return multiple code fragments. Enabling this might break
+code indentation.
+"""
+
+ghc_api_version = "2022-11-28"
+"""The version of the GitHub REST API.
+"""
+
+ghc_insert_block_separator = False
+"""Each file possibly consists of more than one code block that matches the
+search, if this is set to true, the blocks will be separated with ``...`` line.
+This might break the lexer and thus result in the lack of code highlighting.
+"""
+
+
+def request(query: str, params: dict[str, t.Any]) -> None:
+
+    params['url'] = search_url.format(query=urlencode({'q': query}), page=urlencode({'page': params['pageno']}))
+    params['headers']['Accept'] = accept_header
+    params['headers']['X-GitHub-Api-Version'] = ghc_api_version
+
+    if ghc_auth['type'] == "none":
+        # Without the auth header the query fails, so add a dummy instead.
+        # Queries without auth are heavily rate limited.
+        params['headers']['Authorization'] = "placeholder"
+    if ghc_auth['type'] == "personal_access_token":
+        params['headers']['Authorization'] = f"token {ghc_auth['token']}"
+    if ghc_auth['type'] == "bearer":
+        params['headers']['Authorization'] = f"Bearer {ghc_auth['token']}"
+
+    params['raise_for_httperror'] = False
+
+
+def get_code_language_name(filename: str, code_snippet: str) -> str | None:
+    """Returns a code language name by pulling information from the filename if
+    possible otherwise by scanning the passed code snippet. In case there is any
+    parsing error just default to no syntax highlighting."""
+    try:
+        lexer = guess_lexer_for_filename(filename, _text=code_snippet)
+        if lexer is None:
+            return None
+        code_name_aliases = lexer.aliases
+        if len(code_name_aliases) == 0:
+            return None
+        return code_name_aliases[0]
+    except ClassNotFound:
+        return None
+
+
+def extract_code(code_matches: list[dict[str, t.Any]]) -> tuple[list[str], set[int]]:
+    """
+    Iterate over multiple possible matches, for each extract a code fragment.
+    GitHub additionally sends context for _word_ highlights; pygments supports
+    highlighting lines, as such we calculate which lines to highlight while
+    traversing the text.
+    """
+    lines: list[str] = []
+    highlighted_lines_index: set[int] = set()
+
+    for i, match in enumerate(code_matches):
+        if i > 0 and ghc_insert_block_separator:
+            lines.append("...")
+        buffer: list[str] = []
+        highlight_groups = [highlight_group['indices'] for highlight_group in match['matches']]
+
+        code: str = match['fragment']
+        original_code_lenght = len(code)
+
+        if ghc_strip_whitespace:
+            code = code.lstrip()
+        if ghc_strip_new_lines:
+            code = code.lstrip("\n")
+
+        offset = original_code_lenght - len(code)
+
+        if ghc_strip_whitespace:
+            code = code.rstrip()
+        if ghc_strip_new_lines:
+            code = code.rstrip("\n")
+
+        for i, letter in enumerate(code):
+            if len(highlight_groups) > 0:
+                # the API ensures these are sorted already, and we have a
+                # guaranteed match in the code (all indices are in the range 0
+                # and len(fragment)), so only check the first highlight group
+                [after, before] = highlight_groups[0]
+                if after <= (i + offset) < before:
+                    # pygments enumerates lines from 1, highlight the next line
+                    highlighted_lines_index.add(len(lines) + 1)
+                    highlight_groups.pop(0)
+
+            if letter == "\n":
+                lines.append("".join(buffer))
+                buffer = []
+                continue
+
+            buffer.append(letter)
+        lines.append("".join(buffer))
+    return lines, highlighted_lines_index
+
+
+def response(resp: SXNG_Response) -> EngineResults:
+    results = EngineResults()
+
+    if resp.status_code == 422:
+        # on a invalid search term the status code 422 "Unprocessable Content"
+        # is returned / e.g. search term is "user: foo" instead "user:foo"
+        return results
+    # raise for other errors
+    raise_for_httperror(resp)
+
+    for item in resp.json().get('items', []):
+        repo = item['repository']
+        text_matches = item['text_matches']
+        # ensure picking only the code contents in the blob
+        code_matches = [
+            match for match in text_matches if match["object_type"] == "FileContent" and match["property"] == "content"
+        ]
+        lines, highlighted_lines_index = extract_code(code_matches)
+        if not ghc_highlight_matching_lines:
+            highlighted_lines_index: set[int] = set()
+
+        code_snippet = "\n".join(lines)
+
+        kwargs: dict[str, t.Any] = {
+            'template': 'code.html',
+            'url': item['html_url'],
+            'title': f"{repo['full_name']} · {item['path']}",
+            'content': repo['description'],
+            'repository': repo['html_url'],
+            'codelines': [(i + 1, line) for (i, line) in enumerate(lines)],
+            'hl_lines': highlighted_lines_index,
+            'code_language': get_code_language_name(filename=item['name'], code_snippet=code_snippet),
+            # important to set for highlighing
+            'strip_whitespace': ghc_strip_whitespace,
+            'strip_new_lines': ghc_strip_new_lines,
+            'parsed_url': urlparse(item['html_url']),
+        }
+        results.add(results.types.LegacyResult(**kwargs))
+
+    return results

--- a/searx/engines/searchcode_code.py
+++ b/searx/engines/searchcode_code.py
@@ -70,6 +70,8 @@ def response(resp):
                 'codelines': sorted(lines.items()),
                 'code_language': code_language,
                 'template': 'code.html',
+                'strip_whitespace': True,
+                'strip_new_lines': True,
             }
         )
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -983,6 +983,24 @@ engines:
     engine: github
     shortcut: gh
 
+  - name: github code
+    engine: github_code
+    shortcut: ghc
+    disabled: true
+    ghc_auth:
+      # type is one of:
+      # * none
+      # * personal_access_token
+      # * bearer
+      # When none is passed, the token is not requried.
+      type: "none"
+      token: "token"
+    # specify whether to highlight the matching lines to the query
+    ghc_highlight_matching_lines: true
+    ghc_strip_new_lines: true
+    ghc_strip_whitespace: false
+    timeout: 10.0
+
   - name: codeberg
     # https://docs.searxng.org/dev/engines/online/gitea.html
     engine: gitea

--- a/searx/templates/simple/result_templates/code.html
+++ b/searx/templates/simple/result_templates/code.html
@@ -25,7 +25,7 @@
 {%- endif -%}
 
 <div dir="ltr" class="codelines">
-    {{- result.codelines|code_highlighter(result.code_language)|safe -}}
+    {{- result.codelines|code_highlighter(result.code_language, result.hl_lines, result.strip_whitespace, result.strip_new_lines)|safe -}}
 </div>
 
 {{- result_sub_footer(result) -}}

--- a/tests/unit/settings/test_github_code.yml
+++ b/tests/unit/settings/test_github_code.yml
@@ -1,0 +1,13 @@
+# This SearXNG setup is used in unit tests
+
+use_default_settings:
+
+  engines:
+    keep_only: []
+
+engines:
+
+  - name: github code
+    engine: github_code
+    shortcut: "ghc"
+    disabled: true

--- a/tests/unit/test_engine_github_code.py
+++ b/tests/unit/test_engine_github_code.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,disable=missing-class-docstring
+
+import logging
+from unittest.mock import Mock
+from urllib.parse import urlparse
+from parameterized import parameterized
+
+import searx.engines
+from tests import SearxTestCase
+from searx.result_types import EngineResults
+
+
+class GithubCodeTests(SearxTestCase):
+
+    TEST_SETTINGS = "test_github_code.yml"
+
+    def setUp(self):
+        super().setUp()
+        self.ghc = searx.engines.engines['github code']
+        self.ghc.logger.setLevel(logging.INFO)
+
+    def tearDown(self):
+        searx.search.load_engines([])
+
+    @parameterized.expand(
+        [
+            [
+                [
+                    {
+                        "fragment": "    - [Tab management](#tab-management)\n    - [Buffer/window management]"
+                        "(#bufferwindow-management)\n- [🎨 Highlights](#-highlights)",
+                        "matches": [{"indices": [47, 53], "text": "Buffer"}, {"indices": [74, 80], "text": "buffer"}],
+                    },
+                    {
+                        "fragment": "To conditionally activate plugins, the best solution is to use the\n"
+                        "[LazyVim VSCode extra](https://www.lazyvim.org/extras/vscode). However, "
+                        "`packer.nvim` and `lazy.nvim` have built-in\nsupport for "
+                        "`cond = vim.g.vscode` and `vim-plug` has a",
+                        "matches": [
+                            {"indices": [68, 75], "text": "LazyVim"},
+                            {"indices": [102, 109], "text": "lazyvim"},
+                        ],
+                    },
+                ],
+                [
+                    "    - [Tab management](#tab-management)",
+                    "    - [Buffer/window management](#bufferwindow-management)",
+                    "- [🎨 Highlights](#-highlights)",
+                    "To conditionally activate plugins, the best solution is to use the",
+                    "[LazyVim VSCode extra](https://www.lazyvim.org/extras/vscode)."
+                    " However, `packer.nvim` and `lazy.nvim` have built-in",
+                    "support for `cond = vim.g.vscode` and `vim-plug` has a",
+                ],
+                {2, 5},
+            ],
+            [
+                [
+                    {
+                        "fragment": "\n| `<leader>uf` | Toggle format (global) |\n"
+                        "| `<leader>uF` | Toggle format (buffer) |\n"
+                        "| `<leader>us` | Toggle spelling |\n",
+                        "matches": [{"indices": [74, 80], "text": "buffer"}],
+                    },
+                ],
+                [
+                    "| `<leader>uf` | Toggle format (global) |",
+                    "| `<leader>uF` | Toggle format (buffer) |",
+                    "| `<leader>us` | Toggle spelling |",
+                ],
+                {2},
+            ],
+            [
+                [
+                    {
+                        "fragment": "\n\n\n1\n2\n3\n4",
+                        "matches": [{"indices": [3, 4], "text": "1"}],
+                    },
+                ],
+                [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                ],
+                {1},
+            ],
+            [
+                [
+                    {
+                        "fragment": "placeholder",
+                        "matches": [],
+                    },
+                ],
+                [
+                    "placeholder",
+                ],
+                set(),
+            ],
+        ]
+    )
+    def test_code_extraction(self, code_matches, expected_code, expected_highlighted_lines):
+        code, highlights = self.ghc.extract_code(code_matches=code_matches)
+        self.assertEqual(code, expected_code)
+        self.assertEqual(highlights, expected_highlighted_lines)
+
+    def test_transforms_response(self):
+        response = Mock()
+        response.json.return_value = {
+            "items": [
+                {
+                    "name": "TODO.md",
+                    "path": "TODO.md",
+                    "html_url": "https://github.com/folke/dot/blob/3140f4f5720c3cc6b5034c624eb7706f8533a82c/TODO.md",
+                    "repository": {
+                        "full_name": "folke/dot",
+                        "html_url": "https://github.com/folke/dot",
+                        "description": "☕️   My Dot Files",
+                    },
+                    "text_matches": [
+                        {
+                            "object_type": "FileContent",
+                            "property": "content",
+                            "fragment": "- [x] windows picker\n"
+                            "- [x] toggle cwd / root (LazyVim)\n"
+                            "- [x] dynamic workspace symbol",
+                            "matches": [{"indices": [46, 53], "text": "LazyVim"}],
+                        },
+                        {
+                            "object_type": "FileContent",
+                            "property": "content",
+                            "fragment": "- [x] smart stops working after custom\n"
+                            "- [x] edit in empty buffer\n"
+                            "- [x] support toggling line nr for preview",
+                            "matches": [{"indices": [59, 65], "text": "buffer"}, {"indices": [89, 93], "text": "line"}],
+                        },
+                    ],
+                }
+            ]
+        }
+        response.status_code = 200
+        results = self.ghc.response(response)
+        expected_results = EngineResults()
+        expected_results.add(
+            expected_results.types.LegacyResult(
+                **{
+                    'url': "https://github.com/folke/dot/blob/3140f4f5720c3cc6b5034c624eb7706f8533a82c/TODO.md",
+                    'title': "folke/dot · TODO.md",
+                    'content': "☕️   My Dot Files",
+                    'repository': "https://github.com/folke/dot",
+                    'codelines': [
+                        (1, "- [x] windows picker"),
+                        (2, "- [x] toggle cwd / root (LazyVim)"),
+                        (3, "- [x] dynamic workspace symbol"),
+                        (4, "- [x] smart stops working after custom"),
+                        (5, "- [x] edit in empty buffer"),
+                        (6, "- [x] support toggling line nr for preview"),
+                    ],
+                    'hl_lines': {2, 5, 6},
+                    'code_language': "markdown",
+                    'template': 'code.html',
+                    'strip_whitespace': False,
+                    'strip_new_lines': True,
+                    'parsed_url': urlparse(
+                        "https://github.com/folke/dot/blob/3140f4f5720c3cc6b5034c624eb7706f8533a82c/TODO.md"
+                    ),
+                }
+            )
+        )
+        self.assertEqual(results, expected_results)


### PR DESCRIPTION
 ## What does this PR do?

Adds an engine to query Github repositories using the [Github Code Search API](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-code).  For motivation see `Why is this change important?`.

Since the security is important for the project I tried to make sure to adhere to the standards:

1. Auth Token

The API can be used without authenticating:
<img width="482" height="216" alt="image" src="https://github.com/user-attachments/assets/d5b20d87-d5de-47b3-be91-2ce8a222aeb6" />

and the defaults in this implementation is not to require a token, however, github heavily limits such API calls (I've never managed to properly query it this way, it seems to depend on the public IP that the API is presented with):
```json
{
  "message": "API rate limit exceeded for REDACTED. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) If you reach out to GitHub Support for help, please include the request ID REDACTED and timestamp REDACTED UTC.",
  "documentation_url": "https://docs.github.com/rest/overview/rate-limits-for-the-rest-api",
  "status": "403"
}
``` 

[So realistically one needs to either generate a personal token, or an app bearer token](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28).


2. The engine is disabled by default.

### Screenshots

A few examples:
<img width="528" height="1046" alt="image" src="https://github.com/user-attachments/assets/28cd6eee-fd54-4470-9951-354319bcb63f" />
<img width="523" height="1215" alt="image" src="https://github.com/user-attachments/assets/b4520eaa-58c4-42c1-9516-b2ec3e84f3ce" />



## Why is this change important?

I use searxng as a single pane for multiple search results, as a coder, I spend considerable amount of time searching through Github repos to find a better solution or just poke around peoples' ideas how to accomplish something specific. In most cases the returned context doesn't matter that much for me, I just want to be able to type a query and get significant matching results, then I skim through the visible context of the file and decide to open the repo or not. IMO it would be fantastic to have github code search natively in searxng so that the context switching is minimized. 

I feel like there is a lot of non-public smaller searxng instances that would benefit from the ability to simply surface github's code search (myself and my household included). 

## How to test this PR locally?

More than likely you need a personal token since unauth queries are too heavily throttled.

1. Generate a token in [developer settings](https://github.com/settings/tokens/new), the easiest way is to generate the classic token, the only scope needed really is the public repos read access:
<img width="685" height="336" alt="image" src="https://github.com/user-attachments/assets/d6a60ba9-caaf-4566-b7b5-ba4e5c854487" />
2. Adjust the searxng `settings.yaml`, e.g.:

```diff
diff --git a/searx/settings.yml b/searx/settings.yml
index c03e3fa67..1d4aae5c4 100644
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -986,15 +986,15 @@ engines:
   - name: github code
     engine: github_code
     shortcut: ghc
-    disabled: true
+    disabled: false
     ghc_auth:
       # type is one of:
       # * none
       # * personal_access_token
       # * bearer
       # When none is passed, the token is not requried.
-      type: "none"
-      token: "token"
+      type: "personal_access_token"
+      token: "your token here"
     # specify whether to highlight the matching lines to the query
     ghc_highlight_matching_lines: true
     ghc_strip_new_lines: true
```
3. `make run` then open searxng and type your query with `ghc` bang, e.g. `!ghc lazyvim`, you can use github's query language and that will be passthrough'd, e.g. `!ghc lazyvim language:Lua`

unit tests are added for parsing and highlighting logic, can be run in isolation:
```bash
source local/py3/bin/activate
python -m nose2 -vvvv tests.unit.test_engine_github_code
```



## Author's checklist


#### Limitations

The API does not return the line numbers alongside the response, it sends the matching code fragments and tells you what words can be highlighted on the ui, e.g. query for `lazivim` returns (this is stripped to showcase the payloads):

```json
    {
      "name": "TODO.md",
      "path": "TODO.md",
      "sha": "e9a138103a10ab2be63f5e1d155bc4e55415feb6",
      "url": "https://api.github.com/repositories/214174020/contents/TODO.md?ref=3140f4f5720c3cc6b5034c624eb7706f8533a82c",
      "git_url": "https://api.github.com/repositories/214174020/git/blobs/e9a138103a10ab2be63f5e1d155bc4e55415feb6",
      "html_url": "https://github.com/folke/dot/blob/3140f4f5720c3cc6b5034c624eb7706f8533a82c/TODO.md",
      "repository": {
        "id": 214174020,
        "node_id": "MDEwOlJlcG9zaXRvcnkyMTQxNzQwMjA=",
        "name": "dot",
        "full_name": "folke/dot",
        }
        "text_matches": [
        {
          "object_url": "https://api.github.com/repositories/214174020/contents/TODO.md?ref=3140f4f5720c3cc6b5034c624eb7706f8533a82c",
          "object_type": "FileContent",
          "property": "content",
          "fragment": "- [x] windows picker\n- [x] toggle cwd / root (LazyVim)\n- [x] dynamic workspace symbol",
          "matches": [
            {
              "indices": [
                46,
                53
              ],
              "text": "LazyVim"
            }
          ]
        },
        {
          "object_url": "https://api.github.com/repositories/214174020/contents/TODO.md?ref=3140f4f5720c3cc6b5034c624eb7706f8533a82c",
          "object_type": "FileContent",
          "property": "content",
          "fragment": "- [x] smart stops working after custom\n- [x] edit in empty buffer\n- [x] support toggling line nr for preview",
          "matches": [
            {
              "indices": [
                59,
                65
              ],
              "text": "buffer"
            },
            {
              "indices": [
                89,
                93
              ],
              "text": "line"
            }
          ]
        }
      ]
```

And this is how github  shows this match:
<img width="991" height="213" alt="image" src="https://github.com/user-attachments/assets/61755495-e2d9-4768-8c8c-1ce8ee8c35f5" />

Whereas, this is how searxng implementation looks like:

<img width="495" height="207" alt="image" src="https://github.com/user-attachments/assets/7e438f2d-fa8b-42b8-b126-6593e70d9f29" />

The following decisions were made:
* since there is no line indices, just relabel them starting from 1 (pygments "0")
* concatenate the fragments of code one after another
* allow for line (instead of word) highlighting (as far as I can see pygments just does not natively support word highlights, I can work on that later if it would be of use?)

An alternative would be to query for each file contents in the search result and then locate the text, I did not go into that direction (yet?) to see whether there is any interest first, since this approach does not really play well in the searx framework and more importantly generates loads of query calls that are just (IMO) unnecessary.

**Another option is to hide the line numbers altogether but still display highlighting, I'd imagine it's just some css change, I'd like to hear the maintainers opinions on this.**

### Minor implementation details

#### code.html and webapp changes

The method used previously to highlight code in searchcode relied on file extensions and was mapping them heuristically (+ pygments internal logic), this can be simplified by just the other pygments method:
```python
from pygments.lexers import get_lexer_for_filename
````
no need to do the work if pygments does it for us, the callers have been adjusted.

I've exposed stripping arguments from pygments parsers to the user, I think it should be a choice whether they want to keep the leading and trailing whitespace/newlines. Particularly, the previous implementation in searchcode explicitly relies on stripping the whitespace which just breaks the first line of code indentation (this behavior is left intact) and the engine works as expected:
<img width="619" height="1137" alt="image" src="https://github.com/user-attachments/assets/d9b230c9-31f6-411c-bc1a-6ffaee58a09c" />

#### EngineResults

Since the types for `Code` are not implemented yet I used the legacy typing, I can output the type addition and change it in another PR if it's of value.


## Related issues

If it's of interest, I'd be down to implement something similar for Gitlab, although a token is definitely required to code search (let me know, since I'll be implementing this for myself anyway, just depends whether I'd output the PR in the end). Open to discussing this in an issue as well.
