### PR TITLE
[enh] container: latest tag should be last

### DIFF
--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -254,8 +254,8 @@ container.push() {
             podman pull "ghcr.io/$CONTAINER_IMAGE_ORGANIZATION/cache:$CONTAINER_IMAGE_NAME-${archs[$i]}${variants[$i]}"
         done
 
-        # Manifest tags
-        release_tags=("latest" "$DOCKER_TAG")
+        # Manifest tags ("latest" should be the last manifest)
+        release_tags=("$DOCKER_TAG" "latest")
 
         # Create manifests
         for tag in "${release_tags[@]}"; do


### PR DESCRIPTION
With this change, the "latest" tag will be visually higher. Right now, it appears under the "DOCKER_TAG" manifest tag, which can be confusing.

<img width="805" height="622" alt="sh20250801130636" src="https://github.com/user-attachments/assets/4ca62c8d-451e-450c-8e6b-7f73a8f1cca1" />

(same on GHCR)