### PR TITLE
[fix] tagesschau: crash if there's no video stream available

### DIFF
--- a/searx/engines/tagesschau.py
+++ b/searx/engines/tagesschau.py
@@ -101,6 +101,9 @@ def _video(item):
         title = title.replace("_vapp.mxf", "")
         title = re.sub(r"APP\d+ (FC-)?", "", title, count=1)
 
+    # sometimes, only adaptive m3u8 streams are available, so video_url is None
+    url = video_url or f"{base_url}/multimedia/video/{item['sophoraId']}.html"
+
     return {
         'template': 'videos.html',
         'title': title,
@@ -108,5 +111,5 @@ def _video(item):
         'publishedDate': datetime.strptime(item['date'][:19], '%Y-%m-%dT%H:%M:%S'),
         'content': item.get('firstSentence', ''),
         'iframe_src': video_url,
-        'url': video_url,
+        'url': url,
     }


### PR DESCRIPTION
Sometimes, there's only an `adaptivestreaming` field in `streams`, which
is usually an m3u8 file. That's however not supported by the video player
of any browser, so we can't use and must build a different url instead.