### PR TITLE
[fix] legacy results: published date missing

### DIFF
--- a/searx/result_types/_base.py
+++ b/searx/result_types/_base.py
@@ -446,7 +446,7 @@ class LegacyResult(dict):
     positions: list[int]
     score: float
     category: str
-    publishedDate: datetime.datetime | None = None
+    publishedDate: datetime.datetime | None
     pubdate: str = ""
 
     # infobox result
@@ -476,6 +476,7 @@ class LegacyResult(dict):
         self["positions"] = self.get("positions", "")
         self["score"] = self.get("score", 0)
         self["category"] = self.get("category", "")
+        self["publishedDate"] = self.get("publishedDate")
 
         if "infobox" in self:
             self["urls"] = self.get("urls", [])


### PR DESCRIPTION
The `publishedDate` has always been `None` before that change, which
causes that there are no `publishedDate`s visible for any result.
