### PR TITLE
[fix] webapp.py: default_http_headers not parsed as strings

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1387,7 +1387,8 @@ def static_headers(headers: Headers, _path: str, _url: str) -> None:
     headers['Cache-Control'] = 'public, max-age=30, stale-while-revalidate=60'
 
     for header, value in settings['server']['default_http_headers'].items():
-        headers[header] = value
+        # cast value to string, as WhiteNoise requires header values to be strings
+        headers[header] = str(value)
 
 
 app.wsgi_app = WhiteNoise(


### PR DESCRIPTION
WhiteNoise requires all headers to be strings, however it's common to use
other primitive types (e.g. numbers) in the header, e.g. `X-XSS-Protection: 0`.
Thus, we must convert all types of values (i.e. numbers) to strings.

- closes https://github.com/searxng/searxng/issues/5091
