### PR TITLE
[mod] ci: docker task unused

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,15 +65,6 @@ updates:
           - "minor"
           - "patch"
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "friday"
-    target-branch: "master"
-    commit-message:
-      prefix: "[upd] docker:"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We always use the latest versions of our base images, so this dependabot task is unneeded.