### PR TITLE
[fix] use X-Forwarded-Proto header if the URL scheme is unknown

### DIFF
--- a/searx/flaskfix.py
+++ b/searx/flaskfix.py
@@ -59,7 +59,7 @@ class ReverseProxyPathFix:
             if path_info.startswith(script_name):
                 environ['PATH_INFO'] = path_info[len(script_name) :]
 
-        scheme = self.scheme or environ.get('HTTP_X_SCHEME', '')
+        scheme = self.scheme or environ.get('HTTP_X_SCHEME') or environ.get('HTTP_X_FORWARDED_PROTO')
         if scheme:
             environ['wsgi.url_scheme'] = scheme
 


### PR DESCRIPTION
The HTTP X-Forwarded-Proto (XFP) request header is a de-facto standard header for identifying the protocol (HTTP or HTTPS) that a client used to connect to a proxy or load balancer.[1]

In our documentation[2] we recommend to set the `X-Scheme` header. This header is not required if the `server.base_url` is set correctly.[3]

If none of these URL scheme details exist, then the header X-Forwarded-Proto is evaluated as a third alternative.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto
[2] https://docs.searxng.org/admin/installation-apache.html#apache-s-searxng-site
[3] https://docs.searxng.org/admin/settings/settings_server.html

Closes: https://github.com/searxng/searxng/issues/5105