### PR TITLE
[fix] replace ``X-Scheme`` by ``X-Forwarded-Proto`` header

### DIFF
--- a/searx/flaskfix.py
+++ b/searx/flaskfix.py
@@ -21,7 +21,7 @@ class ReverseProxyPathFix:
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Script-Name /myprefix;
         }
 

--- a/utils/templates/etc/httpd/sites-available/searxng.conf
+++ b/utils/templates/etc/httpd/sites-available/searxng.conf
@@ -24,10 +24,10 @@ LoadModule proxy_http_module    ${APACHE_MODULES}/mod_proxy_http.so
     ProxyPass http://${SEARXNG_INTERNAL_HTTP}
 
     # see flaskfix.py
-    RequestHeader set X-Scheme %{REQUEST_SCHEME}s
+    RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
     RequestHeader set X-Script-Name ${SEARXNG_URL_PATH}
 
-    # see limiter.py
+    # see botdetection/trusted_proxies.py
     RequestHeader set X-Real-IP %{REMOTE_ADDR}s
     RequestHeader append X-Forwarded-For %{REMOTE_ADDR}s
 

--- a/utils/templates/etc/httpd/sites-available/searxng.conf:socket
+++ b/utils/templates/etc/httpd/sites-available/searxng.conf:socket
@@ -24,10 +24,10 @@ LoadModule proxy_uwsgi_module   ${APACHE_MODULES}/mod_proxy_uwsgi.so
     ProxyPass unix:${SEARXNG_UWSGI_SOCKET}|uwsgi://uwsgi-uds-searxng/
 
     # see flaskfix.py
-    RequestHeader set X-Scheme %{REQUEST_SCHEME}s
+    RequestHeader set X-Forwarded-Proto %{REQUEST_SCHEME}s
     RequestHeader set X-Script-Name ${SEARXNG_URL_PATH}
 
-    # see limiter.py
+    # see botdetection/trusted_proxies.py
     RequestHeader set X-Real-IP %{REMOTE_ADDR}s
     RequestHeader append X-Forwarded-For %{REMOTE_ADDR}s
 

--- a/utils/templates/etc/nginx/default.apps-available/searxng.conf
+++ b/utils/templates/etc/nginx/default.apps-available/searxng.conf
@@ -6,10 +6,10 @@ location ${SEARXNG_URL_PATH} {
     proxy_set_header   Connection       \$http_connection;
 
     # see flaskfix.py
-    proxy_set_header   X-Scheme         \$scheme;
+    proxy_set_header   X-Forwarded-Proto \$scheme;
     proxy_set_header   X-Script-Name    ${SEARXNG_URL_PATH};
 
-    # see limiter.py
+    # see botdetection/trusted_proxies.py
     proxy_set_header   X-Real-IP        \$remote_addr;
     proxy_set_header   X-Forwarded-For  \$proxy_add_x_forwarded_for;
 

--- a/utils/templates/etc/nginx/default.apps-available/searxng.conf:socket
+++ b/utils/templates/etc/nginx/default.apps-available/searxng.conf:socket
@@ -8,10 +8,10 @@ location ${SEARXNG_URL_PATH} {
     uwsgi_param    HTTP_CONNECTION       \$http_connection;
 
     # see flaskfix.py
-    uwsgi_param    HTTP_X_SCHEME         \$scheme;
+    uwsgi_param    HTTP_X_FORWARDED_PROTO  \$scheme;
     uwsgi_param    HTTP_X_SCRIPT_NAME    ${SEARXNG_URL_PATH};
 
-    # see limiter.py
+    # see botdetection/trusted_proxies.py
     uwsgi_param    HTTP_X_REAL_IP        \$remote_addr;
     uwsgi_param    HTTP_X_FORWARDED_FOR  \$proxy_add_x_forwarded_for;
 }


### PR DESCRIPTION
The HTTP X-Forwarded-Proto (XFP) request header is a *de-facto* standard header for identifying the protocol (HTTP or HTTPS) that a client used to connect to a proxy or load balancer.[1]

The ``X-Scheme`` header was added 10 years ago, why ``X-Scheme`` was used back then and not ``X-Forwarded-Proto``, nobody knows today / possibly because ``X-Forwarded-Proto`` wasn't a *de-facto* standard back then.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto
[2] https://github.com/searx/searx/commit/6ef7c3276

----

Related: https://github.com/searxng/searxng/issues/5105#issuecomment-3172447170