### PR TITLE
Fix publishedDate format in reuters engine

### DIFF
--- a/searx/engines/reuters.py
+++ b/searx/engines/reuters.py
@@ -84,7 +84,7 @@ def response(resp) -> EngineResults:
                 content=result["description"],
                 thumbnail=result.get("thumbnail", {}).get("url", ""),
                 metadata=result.get("kicker", {}).get("name"),
-                publishedDate=datetime.strptime(result["display_time"], "%Y-%m-%dT%H:%M:%SZ"),
+                publishedDate=datetime.fromisoformat(result["display_time"]),
             )
         )
     return res


### PR DESCRIPTION
## What does this PR do?

FIxes publishedDate format in reuters engine to encompass ISO 8601 times both with and without milliseconds.

## Why is this change important?

Previously, the engine would sometimes fail saying:

```
2025-08-12 21:13:23,091 ERROR:searx.engines.reuters: exception : time data '2024-04-15T19:08:30.833Z' does not match format '%Y-%m-%dT%H:%M:%SZ'

Traceback (most recent call last):

...
  File "/usr/local/searxng/searx/engines/reuters.py", line 87, in response

    publishedDate=datetime.strptime(result["display_time"], "%Y-%m-%dT%H:%M:%SZ"),

                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...

```

Note that most queries seem to work with Reuters, but there are some results that have the additional milliseconds and fail. Regardless, the change is backwards compatible as both the formats (with and without the ms) should now parse correctly.

## Author's checklist

I tested this locally and search results have entries from Reuters.
