### PR TITLE
[fix] container: change mirror

### DIFF
--- a/container/base-builder.yml
+++ b/container/base-builder.yml
@@ -1,7 +1,7 @@
 contents:
   repositories:
-    - https://mirrors.edge.kernel.org/alpine/edge/main
-    - https://mirrors.edge.kernel.org/alpine/edge/community
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/community
   packages:
     - alpine-base
     - build-base

--- a/container/base.yml
+++ b/container/base.yml
@@ -1,6 +1,6 @@
 contents:
   repositories:
-    - https://mirrors.edge.kernel.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
   packages:
     - alpine-baselayout
     - ca-certificates-bundle


### PR DESCRIPTION
`mirrors.edge.kernel.org` has weird issues, use the official mirror and avoid future issues.

---

https://github.com/searxng/searxng/actions/runs/17048590749/job/48330524814
https://github.com/searxng/searxng/actions/runs/16776555681/job/47503866517