### PR TITLE
[fix] selfhst icons: icon list url invalid, set to active

### DIFF
--- a/searx/engines/selfhst.py
+++ b/searx/engines/selfhst.py
@@ -14,12 +14,11 @@ about = {
 categories = ['images', 'icons']
 
 
-icons_list_url = 'https://cdn.selfh.st/directory/icons.json'
-icons_cdn_base_url = 'https://cdn.jsdelivr.net'
+cdn_base_url = 'https://cdn.jsdelivr.net/gh/selfhst/icons'
 
 
 def request(query, params):
-    params['url'] = icons_list_url
+    params['url'] = f"{cdn_base_url}/index.json"
     params['query'] = query
     return params
 
@@ -39,7 +38,7 @@ def response(resp):
                 img_format = format_name.lower()
                 break
 
-        img_src = f'{icons_cdn_base_url}/gh/selfhst/icons/{img_format}/{item["Reference"]}.{img_format}'
+        img_src = f'{cdn_base_url}/{img_format}/{item["Reference"]}.{img_format}'
         result = {
             'template': 'images.html',
             'url': img_src,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1869,7 +1869,6 @@ engines:
   - name: selfhst icons
     engine: selfhst
     shortcut: si
-    inactive: true
     disabled: true
 
   - name: sepiasearch


### PR DESCRIPTION
- the previous CDN icon list url no longer works
- a list of all icons is mirrored to the JSDelivr CDN however
- there's no reason to set the engine to inactive now that we use public CDNs