### PR TITLE
[mod] py3.9 EOL

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"


### PR DESCRIPTION
[End of Python 3.9 support in SearXNG](https://github.com/searxng/searxng/pull/5148)

[1] https://devguide.python.org/versions/
[2] https://peps.python.org/pep-0596/