### PR TITLE
[mod] optimize Baidu Captcha suspended time

### DIFF
--- a/searx/engines/baidu.py
+++ b/searx/engines/baidu.py
@@ -96,7 +96,7 @@ def request(query, params):
 def response(resp):
     # Detect Baidu Captcha, it will redirect to wappass.baidu.com
     if 'wappass.baidu.com/static/captcha' in resp.headers.get('Location', ''):
-        raise SearxEngineCaptchaException()
+        raise SearxEngineCaptchaException(suspended_time=300, message="Baidu CAPTCHA detected. Please try again later.")
 
     text = resp.text
     if baidu_category == 'images':


### PR DESCRIPTION
## What does this PR do?

Set custom suspended time for Baidu Captcha.

---

Note:
1. As far as investigating, seems the suspended time is around 5min. 

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Current behavior is follow the default `SearxEngineCaptcha: 86400`.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

`!baidu test`

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
