### PR TITLE
[fix] typo in the docs about HTML method POST versus GET

### DIFF
--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -56,17 +56,18 @@
 .. _method:
 
 ``method`` : ``GET`` | ``POST``
+
   HTTP method.  By defaults ``POST`` is used / The ``POST`` method has the
   advantage with some WEB browsers that the history is not easy to read, but
   there are also various disadvantages that sometimes **severely restrict the
   ease of use for the end user** (e.g. back button to jump back to the previous
   search page and drag & drop of search term to new tabs do not work as
-  expected .. and several more).  We had a lot of long discussions about the
-  *pros v2 cons*:
+  expected .. and several more).  We had some discussions about the *pros
+  versus cons*:
 
-  - `set HTTP GET method by default
+  - `[doc] adds the missing documentation of the server.method settings
     <https://github.com/searxng/searxng/pull/3619>`__
-  - `http methods GET & POST
+  - look out for `label:"http methods GET & POST"
     <https://github.com/search?q=repo%3Asearxng%2Fsearxng+label%3A%22http+methods+GET+%26+POST%22>`__
 
 .. _HTTP headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers


### PR DESCRIPTION
the error comes from

- https://github.com/searxng/searxng/pull/3619