### PR TITLE
[fix] engine: searchcode.com is offline (inactive)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1955,6 +1955,7 @@ engines:
     engine: searchcode_code
     shortcut: scc
     disabled: true
+    inactive: true
 
   # - name: searx
   #   engine: searx_engine


### PR DESCRIPTION
Searchcode.com is offline, and its future is still uncertain [1], so the engine will be deactivated for the time being. If Searchcode.com doesn't come back online soon, we can remove the engine entirely.

- [1] https://boyter.org/posts/searchcode-is-being-rebooted/
- [2] https://github.com/searxng/searxng/pull/5131#issuecomment-3239156555
