### PR TITLE
[fix] chinaoso: add random `uid` to cookie

### DIFF
--- a/searx/engines/chinaso.py
+++ b/searx/engines/chinaso.py
@@ -54,7 +54,9 @@ Implementations
 
 """
 
+import base64
 import typing
+import secrets
 
 from urllib.parse import urlencode
 from datetime import datetime
@@ -140,6 +142,10 @@ def request(query, params):
     query_params.update(category_config[chinaso_category]['params'])
 
     params["url"] = f"{base_url}{category_config[chinaso_category]['endpoint']}?{urlencode(query_params)}"
+    cookie = {
+        "uid": base64.b64encode(secrets.token_bytes(16)).decode("utf-8"),
+    }
+    params["cookies"] = cookie
 
     return params
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

add random uid to cookie

## Why is this change important?

without this cookie setting, chinaso do not return the search results.

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
