### PR TITLE
fix(tubearchivist engine): Update tubearchivist.py

### DIFF
--- a/searx/engines/tubearchivist.py
+++ b/searx/engines/tubearchivist.py
@@ -126,6 +126,10 @@ def request(query, params):
     if not query:
         return False
 
+    params.setdefault('headers', {})  # ensure the dict exists
+    params.setdefault('max_redirects', 3)
+    params.setdefault('soft_max_redirects', 3)
+    params['allow_redirects'] = True
     args = {'query': query}
     params['url'] = f"{base_url.rstrip('/')}/api/search?{urlencode(args)}"
     params['headers']['Authorization'] = f'Token {ta_token}'


### PR DESCRIPTION

## What does this PR do?

Set max_redirects / soft_max_redirects, allow_redirects params 


## Why is this change important?

This enables tubearchivist instances behind a proxy to be accessible to searxng

## How to test this PR locally?

add a proxy between a tubearchivist instance and searxng :) 

## Author's checklist

This seems to work for me. 

(( but I'll admit to not having done extensive testing  ))

... I could see the argument that allow_redirects aughtn't be set if max_redirects == 0; 
... I could see the argument that soft_max_redirects aughtn't exceed  max_redirects; 

implementing either of these however required a bigger change set and I figured that smaller was better ;)

## Related issues

Closes #5188 
