### PR TITLE
[upd] disable public domain image archive engine by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1733,6 +1733,7 @@ engines:
   - name: public domain image archive
     engine: public_domain_image_archive
     shortcut: pdia
+    disabled: true
 
   - name: pubmed
     engine: pubmed


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

Disables the Public Domain Image Archive engine by default. 

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

Will massively reduce the amount of bot and spam traffic directed toward the PDIA engine.
