### PR TITLE
[fix] explicitly require `tzdata` module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ typer-slim==0.17.3
 isodate==0.7.2
 whitenoise==6.9.0
 typing-extensions==4.14.1
+tzdata==2025.2


### PR DESCRIPTION
## What does this PR do?

Explicitly require the `tzdata` module.

## Why is this change important?

Currently the timezone plugin only works partially on (self build) docker images.

Looking up `time` works and returns the correct time.
Looking up `time Berlin` for example returns nothing.
The logs show this error:

```
searxng  | 2025-09-01 14:45:19,602 ERROR:searx.plugins.time_zone: Exception while calling post_search
searxng  | Traceback (most recent call last):
searxng  |   File "/usr/lib/python3.12/zoneinfo/_common.py", line 12, in load_tzdata
searxng  |     return resources.files(package_name).joinpath(resource_name).open("rb")
searxng  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/lib/python3.12/importlib/resources/_common.py", line 46, in wrapper
searxng  |     return func(anchor)
searxng  |            ^^^^^^^^^^^^
searxng  |   File "/usr/lib/python3.12/importlib/resources/_common.py", line 56, in files
searxng  |     return from_package(resolve(anchor))
searxng  |                         ^^^^^^^^^^^^^^^
searxng  |   File "/usr/lib/python3.12/functools.py", line 912, in wrapper
searxng  |     return dispatch(args[0].__class__)(*args, **kw)
searxng  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/lib/python3.12/importlib/resources/_common.py", line 82, in _
searxng  |     return importlib.import_module(cand)
searxng  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
searxng  |     return _bootstrap._gcd_import(name[level:], package, level)
searxng  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
searxng  |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
searxng  |   File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
searxng  |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
searxng  |   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
searxng  |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
searxng  |   File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
searxng  |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
searxng  |   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
searxng  |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
searxng  |   File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
searxng  | ModuleNotFoundError: No module named 'tzdata'
searxng  | 
searxng  | During handling of the above exception, another exception occurred:
searxng  | 
searxng  | Traceback (most recent call last):
searxng  |   File "/usr/local/searxng/searx/plugins/_core.py", line 298, in post_search
searxng  |     results = plugin.post_search(request=request, search=search) or []
searxng  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/plugins/time_zone.py", line 62, in post_search
searxng  |     date_time = DateTime(time=datetime.datetime.now(tz=geo.zoneinfo))
searxng  |                                                        ^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/weather.py", line 143, in zoneinfo
searxng  |     return zoneinfo.ZoneInfo(self.timezone)
searxng  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/lib/python3.12/zoneinfo/_common.py", line 24, in load_tzdata
searxng  |     raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
searxng  | zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Europe/Berlin'
```

## How to test this PR locally?

1. Include this commit
2. run `make container`
3. start the docker container
4. search `time Berlin`

Check the following instances which are vanilla docker instances with the timezone plugin enabled:

https://s.mble.dk/search?q=time
https://search.system51.co.uk/search?q=time

https://s.mble.dk/search?q=time+Berlin
https://search.system51.co.uk/search?q=time+Berlin

Check my instance with the fix implemented:

https://searx.tiekoetter.com/search?q=time
https://searx.tiekoetter.com/search?q=time+Berlin


