### PR TITLE
Fix base_url conflict with YaCy engines

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -179,3 +179,4 @@ features or generally made SearXNG better:
 - Tommaso Colella `<https://github.com/gioleppe>`
 - @AgentScrubbles
 - Filip Mikina `<https://github.com/fiffek>`
+- Daniel Vinci (xylobol) `<https://danielvinci.com>`

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -100,8 +100,11 @@ base_url: list | str = 'https://yacy.searchlab.eu'
 selected randomly.
 """
 
+# store the current engine's name so we can access it while getting the base_url
+_current_engine_name = None
 
-def init(_):
+def init(engine_settings):
+    global _current_engine_name
     valid_types = [
         'text',
         'image',
@@ -109,12 +112,14 @@ def init(_):
     ]
     if search_type not in valid_types:
         raise ValueError('search_type "%s" is  not one of %s' % (search_type, valid_types))
+    
+    _current_engine_name = engine_settings.get('name')
 
 
 def _base_url() -> str:
     from searx.engines import engines  # pylint: disable=import-outside-toplevel
 
-    url = engines['yacy'].base_url  # type: ignore
+    url = engines[_current_engine_name].base_url  # type: ignore
     if isinstance(url, list):
         url = random.choice(url)
     if url.endswith("/"):


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This is a quick bugfix for an issue where you cannot have multiple YaCy engines with different base_urls. See #4869 for more details.

## Why is this change important?

<!-- MANDATORY -->

This allows administrators to add multiple YaCy engines. Personally, I use this to keep an index of web results and an index of results from my intranet separate.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

Run searxng with multiple YaCy engines configured, each with a different `base_url`, and with none named `yacy`. 

## Author's checklist

<!-- additional notes for reviewers -->
I don't know what to put in this section. I've tested it locally after building in Docker, and I'm running it in my homelab right now. I've also made sure the default configuration works. 

## Related issues

<!--
Closes #234
-->

Would help with #4869 and #3953.