### PR TITLE
[feat] engines yacy & piped: enable individual configuration of URLs

### DIFF
--- a/searx/engines/piped.py
+++ b/searx/engines/piped.py
@@ -12,7 +12,9 @@ Configuration
 =============
 
 The :py:obj:`backend_url` and :py:obj:`frontend_url` has to be set in the engine
-named `piped` and are used by all piped engines
+named `piped` and are used by all ``piped`` engines (unless an individual values
+for ``backend_url`` and ``frontend_url`` are configured for the engine).
+
 
 .. code:: yaml
 
@@ -43,6 +45,7 @@ fit into SearXNG's UI to select a page by number.
 
 Implementations
 ===============
+
 """
 
 
@@ -69,7 +72,7 @@ categories = []
 paging = True
 
 # search-url
-backend_url: list | str = "https://pipedapi.kavin.rocks"
+backend_url: list[str] | str | None = None
 """Piped-Backend_: The core component behind Piped.  The value is an URL or a
 list of URLs.  In the latter case instance will be selected randomly.  For a
 complete list of official instances see Piped-Instances (`JSON
@@ -80,7 +83,7 @@ complete list of official instances see Piped-Instances (`JSON
 
 """
 
-frontend_url: str = "https://piped.video"
+frontend_url: str | None = None
 """Piped-Frontend_: URL to use as link and for embeds.
 
 .. _Piped-Frontend: https://github.com/TeamPiped/Piped
@@ -93,7 +96,7 @@ piped_filter = 'all'
 def _backend_url() -> str:
     from searx.engines import engines  # pylint: disable=import-outside-toplevel
 
-    url = engines['piped'].backend_url  # type: ignore
+    url: list[str] | str = backend_url or engines["piped"].backend_url  # type: ignore
     if isinstance(url, list):
         url = random.choice(url)
     return url
@@ -102,7 +105,7 @@ def _backend_url() -> str:
 def _frontend_url() -> str:
     from searx.engines import engines  # pylint: disable=import-outside-toplevel
 
-    return engines['piped'].frontend_url  # type: ignore
+    return frontend_url or engines["piped"].frontend_url  # type: ignore
 
 
 def request(query, params):

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -23,7 +23,8 @@ The engine has the following (additional) settings:
 - :py:obj:`search_type`
 
 The :py:obj:`base_url` has to be set in the engine named `yacy` and is used by
-all yacy engines.
+all yacy engines (unless an individual value for ``base_url`` is configured for
+the engine).
 
 .. code:: yaml
 
@@ -95,7 +96,7 @@ search_type = 'text'
 ``video`` are not yet implemented (Pull-Requests are welcome).
 """
 
-base_url: list | str = 'https://yacy.searchlab.eu'
+base_url: list[str] | str | None = None
 """The value is an URL or a list of URLs.  In the latter case instance will be
 selected randomly.
 """
@@ -114,7 +115,7 @@ def init(_):
 def _base_url() -> str:
     from searx.engines import engines  # pylint: disable=import-outside-toplevel
 
-    url = engines['yacy'].base_url  # type: ignore
+    url: list[str] | str = base_url or engines["yacy"].base_url  # type: ignore
     if isinstance(url, list):
         url = random.choice(url)
     if url.endswith("/"):

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1594,17 +1594,14 @@ engines:
     categories: videos
     piped_filter: videos
     timeout: 3.0
+    inactive: true
 
     # URL to use as link and for embeds
     frontend_url: https://srv.piped.video
     # Instance will be selected randomly, for more see https://piped-instances.kavin.rocks/
     backend_url:
-      - https://pipedapi.adminforge.de
-      - https://pipedapi.nosebs.ru
       - https://pipedapi.ducks.party
-      - https://pipedapi.reallyaweso.me
       - https://api.piped.private.coffee
-      - https://pipedapi.darkness.services
 
   - name: piped.music
     engine: piped
@@ -1613,6 +1610,7 @@ engines:
     categories: music
     piped_filter: music_songs
     timeout: 3.0
+    inactive: true
 
   - name: piratebay
     engine: piratebay
@@ -2492,14 +2490,9 @@ engines:
     engine: yacy
     categories: general
     search_type: text
+    # see https://github.com/searxng/searxng/pull/3631#issuecomment-2240903027
     base_url:
       - https://yacy.searchlab.eu
-      # see https://github.com/searxng/searxng/pull/3631#issuecomment-2240903027
-      # - https://search.kyun.li
-      # - https://yacy.securecomcorp.eu
-      # - https://yacy.myserv.ca
-      # - https://yacy.nsupdate.info
-      # - https://yacy.electroncash.de
     shortcut: ya
     disabled: true
     # if you aren't using HTTPS for your local yacy instance disable https


### PR DESCRIPTION
With this change it is possible with individual engines (yacy & piped) to configure individual URLs.

BTW: obsolete URLs have been removed from the `settings.yml`.

Related:

- https://github.com/searxng/searxng/issues/4869#issuecomment-327335928
- https://github.com/searxng/searxng/pull/3472/files#r1595586019
- https://github.com/searxng/searxng/issues/3428#issuecomment-2102142530