### PR TITLE
[fix] container: missing potential packages

### DIFF
--- a/container/base.yml
+++ b/container/base.yml
@@ -4,6 +4,8 @@ contents:
   packages:
     - alpine-baselayout
     - ca-certificates-bundle
+    - musl-locales
+    - musl-locales-lang
     - tzdata
     - busybox
     - python3

--- a/container/base.yml
+++ b/container/base.yml
@@ -4,9 +4,9 @@ contents:
   packages:
     - alpine-baselayout
     - ca-certificates-bundle
+    - tzdata
     - busybox
     - python3
-    # healthcheck
     - wget
 
 entrypoint:


### PR DESCRIPTION
We add 3 additional packages to the base image as a potential requirement to some Python modules. All packages come from main repo.

- [`tzdata`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/tzdata): [zoneinfo](https://docs.python.org/3/library/zoneinfo.html)
- [`musl-locales*`](https://pkgs.alpinelinux.org/packages?name=musl-locales*&branch=edge&arch=x86_64): [locale](https://docs.python.org/3/library/locale.html)

Supersedes https://github.com/searxng/searxng/pull/5192