### PR TITLE
[fix] image proxy: object has no attribute 'status_code'

### DIFF
--- a/searx/network/network.py
+++ b/searx/network/network.py
@@ -280,9 +280,9 @@ class Network:
             client.cookies = httpx.Cookies(cookies)
             try:
                 if stream:
-                    response = client.stream(method, url, **kwargs)
-                else:
-                    response = await client.request(method, url, **kwargs)
+                    return client.stream(method, url, **kwargs)
+
+                response = await client.request(method, url, **kwargs)
                 if self.is_valid_response(response) or retries <= 0:
                     return self.patch_response(response, do_raise_for_httperror)
             except httpx.RemoteProtocolError as e:


### PR DESCRIPTION
## What does this PR do?

https://github.com/searxng/searxng/commit/8f8343dc0d78bb57215afc3e99fd9000fce6e0cf introduced a bug in the network logic of SearXNG where `stream` requests (such as the one from the image proxy) would fail because a wrapper was returned instead of a response object with the correct attribute.

```
searxng  | 2025-09-19 00:05:25,932 ERROR:searx.webapp: Exception on /image_proxy [GET]
searxng  | Traceback (most recent call last):
searxng  |   File "/usr/local/searxng/.venv/lib/python3.12/site-packages/flask/app.py", line 1511, in wsgi_app
searxng  |     response = self.full_dispatch_request()
searxng  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/.venv/lib/python3.12/site-packages/flask/app.py", line 919, in full_dispatch_request
searxng  |     rv = self.handle_user_exception(e)
searxng  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
searxng  |     rv = self.dispatch_request()
searxng  |          ^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
searxng  |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
searxng  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/webapp.py", line 1040, in image_proxy
searxng  |     resp, stream = http_stream(method='GET', url=url, headers=request_headers, allow_redirects=True)
searxng  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/network/__init__.py", line 269, in stream
searxng  |     response = next(generator)  # pylint: disable=stop-iteration-return
searxng  |                ^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/network/__init__.py", line 239, in _stream_generator
searxng  |     raise obj_or_exception
searxng  |   File "/usr/local/searxng/searx/network/__init__.py", line 206, in stream_chunk_to_queue
searxng  |     async with await network.stream(method, url, **kwargs) as response:
searxng  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/network/network.py", line 307, in stream
searxng  |     return await self.call_client(True, method, url, **kwargs)
searxng  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/network/network.py", line 286, in call_client
searxng  |     if self.is_valid_response(response) or retries <= 0:
searxng  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
searxng  |   File "/usr/local/searxng/searx/network/network.py", line 267, in is_valid_response
searxng  |     or (isinstance(self.retry_on_http_error, int) and response.status_code == self.retry_on_http_error)
searxng  |                                                       ^^^^^^^^^^^^^^^^^^^^
searxng  | AttributeError: '_AsyncGeneratorContextManager' object has no attribute 'status_code'
```

## Author's checklist

This is just a quick in place fix I implemented to get it working again. It would be better to implement corresponding logic to give stream requests the correct object.

