### PR TITLE
[mod] ci: add cp3.14

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,12 +25,14 @@ jobs:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14-dev"
 
     steps:
       - name: Setup Python
@@ -54,6 +56,7 @@ jobs:
         run: make V=1 install
 
       - name: Run tests
+        continue-on-error: ${{ matrix.python-version == '3.14-dev' }}
         run: make V=1 ci.test
 
   theme:


### PR DESCRIPTION
CI tests on Python 3.14.

`3.14-dev` will be switched to `3.14` in another PR when 3.14 is released and CI tests passes.

FYI, the `3.14-dev` matrix job will return OK even if fails, always look the logs.