### PR TITLE
[enh] container: reproducible layers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -134,6 +134,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: "false"
+          fetch-depth: "0"
 
       - name: Setup cache Python
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4

--- a/container/builder.dockerfile
+++ b/container/builder.dockerfile
@@ -9,8 +9,7 @@ RUN --mount=type=cache,id=uv,target=/root/.cache/uv set -eux -o pipefail; \
     uv venv; \
     uv pip install --no-managed-python --compile-bytecode --requirements ./requirements.txt --requirements ./requirements-server.txt; \
     uv cache prune --ci; \
-    find ./.venv/lib/python*/site-packages/*.dist-info/ -type f -name "RECORD" -print0 | \
-    xargs -0 -n1 -I{} sort -t, -k1,1 -o {} {}; \
+    find ./.venv/lib/python*/site-packages/*.dist-info/ -type f -name "RECORD" -exec sort -t, -k1,1 -o {} {} \;; \
     find ./.venv/ -exec touch -h --date="@$TIMESTAMP_VENV" {} +; \
     unset SOURCE_DATE_EPOCH
 

--- a/container/builder.dockerfile
+++ b/container/builder.dockerfile
@@ -1,27 +1,29 @@
 FROM ghcr.io/searxng/base:searxng-builder AS builder
 
-COPY ./requirements*.txt ./
+ARG TIMESTAMP_VENV="0"
 
-ARG TIMESTAMP="0"
+COPY ./requirements.txt ./requirements-server.txt ./
 
-RUN --mount=type=cache,id=uv,target=/root/.cache/uv set -eux; \
+RUN --mount=type=cache,id=uv,target=/root/.cache/uv set -eux -o pipefail; \
+    export SOURCE_DATE_EPOCH="$TIMESTAMP_VENV"; \
     uv venv; \
     uv pip install --no-managed-python --compile-bytecode --requirements ./requirements.txt --requirements ./requirements-server.txt; \
     uv cache prune --ci; \
-    find ./.venv/ -exec touch -h -t $TIMESTAMP {} +
+    find ./.venv/lib/python*/site-packages/*.dist-info/ -type f -name "RECORD" -print0 | \
+    xargs -0 -n1 -I{} sort -t, -k1,1 -o {} {}; \
+    find ./.venv/ -exec touch -h --date="@$TIMESTAMP_VENV" {} +; \
+    unset SOURCE_DATE_EPOCH
 
 COPY ./searx/ ./searx/
 
 ARG TIMESTAMP_SETTINGS="0"
 
-RUN set -eux; \
+RUN set -eux -o pipefail; \
     python -m compileall -q ./searx/; \
-    touch -c -t $TIMESTAMP_SETTINGS ./searx/settings.yml; \
     find ./searx/static/ -type f \
     \( -name "*.html" -o -name "*.css" -o -name "*.js" -o -name "*.svg" \) \
     -exec gzip -9 -k {} + \
     -exec brotli -9 -k {} + \
     -exec gzip --test {}.gz + \
     -exec brotli --test {}.br +; \
-    # Move always changing files to /usr/local/searxng/
-    mv ./searx/version_frozen.py ./
+    touch -c --date="@$TIMESTAMP_SETTINGS" ./searx/settings.yml

--- a/container/builder.dockerfile
+++ b/container/builder.dockerfile
@@ -13,6 +13,7 @@ RUN --mount=type=cache,id=uv,target=/root/.cache/uv set -eux -o pipefail; \
     find ./.venv/ -exec touch -h --date="@$TIMESTAMP_VENV" {} +; \
     unset SOURCE_DATE_EPOCH
 
+# use "--exclude=./searx/version_frozen.py" when actions/runner-images updates to Podman 5.0+
 COPY ./searx/ ./searx/
 
 ARG TIMESTAMP_SETTINGS="0"

--- a/container/dist.dockerfile
+++ b/container/dist.dockerfile
@@ -6,7 +6,7 @@ ARG CONTAINER_IMAGE_NAME="searxng"
 COPY --chown=searxng:searxng --from=localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder /usr/local/searxng/.venv/ ./.venv/
 COPY --chown=searxng:searxng --from=localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder /usr/local/searxng/searx/ ./searx/
 COPY --chown=searxng:searxng ./container/ ./
-COPY --chown=searxng:searxng ./searx/version_frozen.py ./searx/
+#COPY --chown=searxng:searxng ./searx/version_frozen.py ./searx/
 
 ARG CREATED="0001-01-01T00:00:00Z"
 ARG VERSION="unknown"

--- a/container/dist.dockerfile
+++ b/container/dist.dockerfile
@@ -6,7 +6,7 @@ ARG CONTAINER_IMAGE_NAME="searxng"
 COPY --chown=searxng:searxng --from=localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder /usr/local/searxng/.venv/ ./.venv/
 COPY --chown=searxng:searxng --from=localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder /usr/local/searxng/searx/ ./searx/
 COPY --chown=searxng:searxng ./container/ ./
-COPY --chown=searxng:searxng --from=localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder /usr/local/searxng/version_frozen.py ./searx/
+COPY --chown=searxng:searxng ./searx/version_frozen.py ./searx/
 
 ARG CREATED="0001-01-01T00:00:00Z"
 ARG VERSION="unknown"

--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -85,9 +85,22 @@ container.build() {
         info_msg "Set \$DOCKER_TAG: $DOCKER_TAG"
         info_msg "Set \$GIT_URL: $GIT_URL"
 
+        timestamp_git=$(git log -1 --format='%ct')
+
+        # change cmp to lockfile when available
+        timestamp_requirements_main=$(git log -1 --format='%ct' ./requirements.txt)
+        timestamp_requirements_server=$(git log -1 --format='%ct' ./requirements-server.txt)
+        if [[ "$timestamp_requirements_main" -lt "$timestamp_requirements_server" ]]; then
+            timestamp_venv="$timestamp_requirements_server"
+        else
+            timestamp_venv="$timestamp_requirements_main"
+        fi
+
+        timestamp_searx_settings=$(git log -1 --format='%ct' ./searx/settings.yml)
+
         if [ "$container_engine" = "podman" ]; then
-            params_build_builder="build --format=oci --platform=$platform --layers --identity-label=false"
-            params_build=$params_build_builder
+            params_build_builder="build --format=oci --platform=$platform --layers --identity-label=false --timestamp=$timestamp_venv"
+            params_build="build --format=oci --platform=$platform --layers --identity-label=false"
         else
             params_build_builder="build --platform=$platform"
             params_build=$params_build_builder
@@ -102,8 +115,8 @@ container.build() {
 
         # shellcheck disable=SC2086
         "$container_engine" $params_build_builder \
-            --build-arg="TIMESTAMP=$(git log -1 --date=format:'%Y%m%d%H%M.%S' --format='%ad')" \
-            --build-arg="TIMESTAMP_SETTINGS=$(git log -1 --date=format:'%Y%m%d%H%M.%S' --format='%ad' ./searx/settings.yml)" \
+            --build-arg="TIMESTAMP_VENV=$timestamp_venv" \
+            --build-arg="TIMESTAMP_SETTINGS=$timestamp_searx_settings" \
             --tag="localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder" \
             --file="./container/builder.dockerfile" \
             .

--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -85,15 +85,13 @@ container.build() {
         info_msg "Set \$DOCKER_TAG: $DOCKER_TAG"
         info_msg "Set \$GIT_URL: $GIT_URL"
 
-        timestamp_git=$(git log -1 --format='%ct')
-
         # change cmp to lockfile when available
         timestamp_requirements_main=$(git log -1 --format='%ct' ./requirements.txt)
         timestamp_requirements_server=$(git log -1 --format='%ct' ./requirements-server.txt)
-        if [[ "$timestamp_requirements_main" -lt "$timestamp_requirements_server" ]]; then
-            timestamp_venv="$timestamp_requirements_server"
-        else
+        if [[ "$timestamp_requirements_main" -ge "$timestamp_requirements_server" ]]; then
             timestamp_venv="$timestamp_requirements_main"
+        else
+            timestamp_venv="$timestamp_requirements_server"
         fi
 
         timestamp_searx_settings=$(git log -1 --format='%ct' ./searx/settings.yml)


### PR DESCRIPTION
We are not aiming for reproducibility compliance, but we look to make most builder layers reproducible without caching at least for a short period of time (until the builder's base image changes or the child dependencies of a requirements.txt package are updated).

This feature is only ~available~ (applicable) on Podman.

This targets https://github.com/searxng/searxng/pull/5086 main goal.