### PR TITLE
[enh] container: compact venv

### DIFF
--- a/container/builder.dockerfile
+++ b/container/builder.dockerfile
@@ -1,17 +1,23 @@
 FROM ghcr.io/searxng/base:searxng-builder AS builder
 
-ARG TIMESTAMP_VENV="0"
-
 COPY ./requirements.txt ./requirements-server.txt ./
+
+ENV UV_NO_MANAGED_PYTHON="true"
+ENV UV_NATIVE_TLS="true"
+
+ARG TIMESTAMP_VENV="0"
 
 RUN --mount=type=cache,id=uv,target=/root/.cache/uv set -eux -o pipefail; \
     export SOURCE_DATE_EPOCH="$TIMESTAMP_VENV"; \
     uv venv; \
-    uv pip install --no-managed-python --compile-bytecode --requirements ./requirements.txt --requirements ./requirements-server.txt; \
+    uv pip install --requirements ./requirements.txt --requirements ./requirements-server.txt; \
     uv cache prune --ci; \
+    find ./.venv/lib/ -type f -exec strip --strip-unneeded {} + || true; \
+    find ./.venv/lib/ -type d -name "__pycache__" -exec rm -rf {} +; \
+    find ./.venv/lib/ -type f -name "*.pyc" -delete; \
+    python -m compileall -q -f -j 0 --invalidation-mode=unchecked-hash ./.venv/lib/; \
     find ./.venv/lib/python*/site-packages/*.dist-info/ -type f -name "RECORD" -exec sort -t, -k1,1 -o {} {} \;; \
-    find ./.venv/ -exec touch -h --date="@$TIMESTAMP_VENV" {} +; \
-    unset SOURCE_DATE_EPOCH
+    find ./.venv/ -exec touch -h --date="@$TIMESTAMP_VENV" {} +
 
 # use "--exclude=./searx/version_frozen.py" when actions/runner-images updates to Podman 5.0+
 COPY ./searx/ ./searx/
@@ -19,7 +25,7 @@ COPY ./searx/ ./searx/
 ARG TIMESTAMP_SETTINGS="0"
 
 RUN set -eux -o pipefail; \
-    python -m compileall -q ./searx/; \
+    python -m compileall -q -f -j 0 --invalidation-mode=unchecked-hash ./searx/; \
     find ./searx/static/ -type f \
     \( -name "*.html" -o -name "*.css" -o -name "*.js" -o -name "*.svg" \) \
     -exec gzip -9 -k {} + \


### PR DESCRIPTION
We can leverage the immutable nature of containers to add additional optimizations.

No debugging or tinkering inside containers, so stripping all unused symbols inside `venv` should be fine. We are also going to compile the bytecode ourselves to modify some parameters related to reproducibility and optimizations.

With these small changes, we have reduced the `venv` layer size by 10MB~