### PR TITLE
[fix] utils: variable expansion

### DIFF
--- a/container/dist.dockerfile
+++ b/container/dist.dockerfile
@@ -1,10 +1,11 @@
-FROM ghcr.io/searxng/base:searxng AS dist
-
 ARG CONTAINER_IMAGE_ORGANIZATION="searxng"
 ARG CONTAINER_IMAGE_NAME="searxng"
 
-COPY --chown=searxng:searxng --from=localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder /usr/local/searxng/.venv/ ./.venv/
-COPY --chown=searxng:searxng --from=localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder /usr/local/searxng/searx/ ./searx/
+FROM localhost/$CONTAINER_IMAGE_ORGANIZATION/$CONTAINER_IMAGE_NAME:builder AS builder
+FROM ghcr.io/searxng/base:searxng AS dist
+
+COPY --chown=searxng:searxng --from=builder /usr/local/searxng/.venv/ ./.venv/
+COPY --chown=searxng:searxng --from=builder /usr/local/searxng/searx/ ./searx/
 COPY --chown=searxng:searxng ./container/ ./
 #COPY --chown=searxng:searxng ./searx/version_frozen.py ./searx/
 

--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -62,6 +62,10 @@ container.build() {
     esac
     info_msg "Selected platform: $platform"
 
+    if [ "$container_engine" = "docker" ] && ! docker buildx version &>/dev/null; then
+        die 42 "docker buildx is not installed: https://docs.docker.com/go/buildx/"
+    fi
+
     pyenv.install
 
     (


### PR DESCRIPTION
Docker buildx outputs the following error:

```
variable expansion is not supported for --from, define a new stage with FROM using ARG from global scope as a workaround.
```

Also force BuildKit extension to be installed, legacy build is no longer supported.

Closes https://github.com/searxng/searxng/issues/5219