### PR TITLE
[fix] ProcessorMap: fix error log, not enough arguments for format string

### DIFF
--- a/searx/search/processors/__init__.py
+++ b/searx/search/processors/__init__.py
@@ -84,7 +84,7 @@ class ProcessorMap(dict[str, EngineProcessor]):
             self[eng_proc.engine.name] = eng_proc
             # logger.debug("registered engine processor: %s", eng_proc.engine.name)
         else:
-            logger.error("init method of engine %s failed (%s).", eng_proc.engine.name)
+            logger.error("can't register engine processor: %s (init failed)", eng_proc.engine.name)
 
         return eng_proc_ok
 


### PR DESCRIPTION
Issue was introduced by PR-5204:

- https://github.com/searxng/searxng/pull/5204


reported issue::

    logger.error("init method of engine %s failed (%s).", eng_proc.engine.name)
    TypeError: not enough arguments for format string
