### PR TITLE
[upd] pypi: Bump black from 24.3.0 to 25.9.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 mock==5.2.0
 nose2[coverage_plugin]==0.15.1
 cov-core==1.15.0
-black==24.3.0
+black==25.9.0
 pylint==3.3.8
 splinter==0.21.0
 selenium==4.35.0

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""This module implements functions needed for the autocompleter.
-
-"""
+"""This module implements functions needed for the autocompleter."""
 # pylint: disable=use-dict-literal
 
 import json

--- a/searx/data/__init__.py
+++ b/searx/data/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """This module holds the *data* created by::
 
-  make data.all
+make data.all
 
 """
 # pylint: disable=invalid-name

--- a/searx/engines/1337x.py
+++ b/searx/engines/1337x.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=invalid-name
-"""1337x
-
-"""
+"""1337x"""
 
 from urllib.parse import quote, urljoin
 from lxml import html

--- a/searx/engines/ahmia.py
+++ b/searx/engines/ahmia.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Ahmia (Onions)
+Ahmia (Onions)
 """
 
 from urllib.parse import urlencode, urlparse, parse_qs

--- a/searx/engines/apkmirror.py
+++ b/searx/engines/apkmirror.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""APKMirror
-"""
+"""APKMirror"""
 
 # pylint: disable=invalid-name
 

--- a/searx/engines/apple_app_store.py
+++ b/searx/engines/apple_app_store.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Apple App Store
-
-"""
+"""Apple App Store"""
 
 from json import loads
 from urllib.parse import urlencode

--- a/searx/engines/base.py
+++ b/searx/engines/base.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""BASE (Scholar publications)
-
-"""
+"""BASE (Scholar publications)"""
 from datetime import datetime
 import re
 

--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Bing-Images: description see :py:obj:`searx.engines.bing`.
-"""
+"""Bing-Images: description see :py:obj:`searx.engines.bing`."""
 # pylint: disable=invalid-name
 import json
 from urllib.parse import urlencode

--- a/searx/engines/bing_videos.py
+++ b/searx/engines/bing_videos.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=invalid-name
-"""Bing-Videos: description see :py:obj:`searx.engines.bing`.
-"""
+"""Bing-Videos: description see :py:obj:`searx.engines.bing`."""
 
 import json
 from urllib.parse import urlencode

--- a/searx/engines/btdigg.py
+++ b/searx/engines/btdigg.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- BTDigg (Videos, Music, Files)
+BTDigg (Videos, Music, Files)
 """
 
 from urllib.parse import quote, urljoin

--- a/searx/engines/chefkoch.py
+++ b/searx/engines/chefkoch.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Chefkoch is a German database of recipes.
-"""
+"""Chefkoch is a German database of recipes."""
 
 from datetime import datetime
 from urllib.parse import urlencode

--- a/searx/engines/cppreference.py
+++ b/searx/engines/cppreference.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Cppreference
-"""
+"""Cppreference"""
 from lxml import html
 from searx.utils import eval_xpath
 

--- a/searx/engines/deezer.py
+++ b/searx/engines/deezer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Deezer (Music)
+Deezer (Music)
 """
 
 from json import loads

--- a/searx/engines/destatis.py
+++ b/searx/engines/destatis.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""DeStatis
-"""
+"""DeStatis"""
 
 from urllib.parse import urlencode
 from lxml import html

--- a/searx/engines/deviantart.py
+++ b/searx/engines/deviantart.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Deviantart (Images)
-
-"""
+"""Deviantart (Images)"""
 
 import urllib.parse
 from lxml import html

--- a/searx/engines/dictzone.py
+++ b/searx/engines/dictzone.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Dictzone
+Dictzone
 """
 
 import urllib.parse

--- a/searx/engines/digbt.py
+++ b/searx/engines/digbt.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- DigBT (Videos, Music, Files)
+DigBT (Videos, Music, Files)
 """
 
 from urllib.parse import urljoin

--- a/searx/engines/docker_hub.py
+++ b/searx/engines/docker_hub.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Docker Hub (IT)
-
-"""
+"""Docker Hub (IT)"""
 # pylint: disable=use-dict-literal
 
 from urllib.parse import urlencode

--- a/searx/engines/doku.py
+++ b/searx/engines/doku.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Doku Wiki
+Doku Wiki
 """
 
 from urllib.parse import urlencode

--- a/searx/engines/duden.py
+++ b/searx/engines/duden.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Duden
-
-"""
+"""Duden"""
 
 import re
 from urllib.parse import quote, urljoin

--- a/searx/engines/dummy-offline.py
+++ b/searx/engines/dummy-offline.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=invalid-name
-"""Dummy Offline
-
-"""
+"""Dummy Offline"""
 
 
 # about

--- a/searx/engines/dummy.py
+++ b/searx/engines/dummy.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Dummy
-
-"""
+"""Dummy"""
 
 # about
 about = {

--- a/searx/engines/ebay.py
+++ b/searx/engines/ebay.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Ebay (Videos, Music, Files)
+Ebay (Videos, Music, Files)
 """
 
 from urllib.parse import quote

--- a/searx/engines/fdroid.py
+++ b/searx/engines/fdroid.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- F-Droid (a repository of FOSS applications for Android)
+F-Droid (a repository of FOSS applications for Android)
 """
 
 from urllib.parse import urlencode

--- a/searx/engines/flickr.py
+++ b/searx/engines/flickr.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Flickr (Images)
+Flickr (Images)
 
- More info on api-key : https://www.flickr.com/services/apps/create/
+More info on api-key : https://www.flickr.com/services/apps/create/
 """
 
 from json import loads

--- a/searx/engines/flickr_noapi.py
+++ b/searx/engines/flickr_noapi.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Flickr (Images)
-
-"""
+"""Flickr (Images)"""
 
 import json
 from time import time

--- a/searx/engines/frinkiac.py
+++ b/searx/engines/frinkiac.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Frinkiac (Images)
+Frinkiac (Images)
 """
 
 from json import loads

--- a/searx/engines/fyyd.py
+++ b/searx/engines/fyyd.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Fyyd (podcasts)
-"""
+"""Fyyd (podcasts)"""
 
 from datetime import datetime
 from urllib.parse import urlencode

--- a/searx/engines/genius.py
+++ b/searx/engines/genius.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=invalid-name
-"""Genius
-
-"""
+"""Genius"""
 
 from urllib.parse import urlencode
 from datetime import datetime

--- a/searx/engines/github.py
+++ b/searx/engines/github.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Github (IT)
-
-"""
+"""Github (IT)"""
 
 from urllib.parse import urlencode
 from dateutil import parser

--- a/searx/engines/goodreads.py
+++ b/searx/engines/goodreads.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Goodreads (books)
-"""
+"""Goodreads (books)"""
 
 from urllib.parse import urlencode
 

--- a/searx/engines/google_play.py
+++ b/searx/engines/google_play.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Google Play Apps & Google Play Movies
-"""
+"""Google Play Apps & Google Play Movies"""
 
 from urllib.parse import urlencode
 from lxml import html

--- a/searx/engines/hackernews.py
+++ b/searx/engines/hackernews.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Hackernews
-"""
+"""Hackernews"""
 
 from datetime import datetime
 from urllib.parse import urlencode

--- a/searx/engines/imgur.py
+++ b/searx/engines/imgur.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Imgur (images)
-"""
+"""Imgur (images)"""
 
 from urllib.parse import urlencode
 from lxml import html

--- a/searx/engines/ina.py
+++ b/searx/engines/ina.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- INA (Videos)
+INA (Videos)
 """
 
 from html import unescape

--- a/searx/engines/mediathekviewweb.py
+++ b/searx/engines/mediathekviewweb.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""MediathekViewWeb (API)
-
-"""
+"""MediathekViewWeb (API)"""
 
 import datetime
 from json import loads, dumps

--- a/searx/engines/metacpan.py
+++ b/searx/engines/metacpan.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""metacpan
-"""
+"""metacpan"""
 
 from urllib.parse import urlunparse
 

--- a/searx/engines/mixcloud.py
+++ b/searx/engines/mixcloud.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Mixcloud (Music)
-
-"""
+"""Mixcloud (Music)"""
 
 from urllib.parse import urlencode
 from dateutil import parser

--- a/searx/engines/npm.py
+++ b/searx/engines/npm.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""npms.io
-
-"""
+"""npms.io"""
 
 from urllib.parse import urlencode
 from dateutil import parser

--- a/searx/engines/nyaa.py
+++ b/searx/engines/nyaa.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Nyaa.si (Anime Bittorrent tracker)
-
-"""
+"""Nyaa.si (Anime Bittorrent tracker)"""
 
 from urllib.parse import urlencode
 

--- a/searx/engines/opensemantic.py
+++ b/searx/engines/opensemantic.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Open Semantic Search
-
-"""
+"""Open Semantic Search"""
 
 from json import loads
 from urllib.parse import quote

--- a/searx/engines/openstreetmap.py
+++ b/searx/engines/openstreetmap.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""OpenStreetMap (Map)
-
-"""
+"""OpenStreetMap (Map)"""
 
 import re
 import urllib.parse

--- a/searx/engines/openverse.py
+++ b/searx/engines/openverse.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
 
- Openverse (formerly known as: Creative Commons search engine) [Images]
+Openverse (formerly known as: Creative Commons search engine) [Images]
 
 """
 

--- a/searx/engines/pdbe.py
+++ b/searx/engines/pdbe.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- PDBe (Protein Data Bank in Europe)
+PDBe (Protein Data Bank in Europe)
 """
 
 from json import loads

--- a/searx/engines/photon.py
+++ b/searx/engines/photon.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Photon (Map)
+Photon (Map)
 """
 
 from json import loads

--- a/searx/engines/piratebay.py
+++ b/searx/engines/piratebay.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Piratebay (Videos, Music, Files)
+Piratebay (Videos, Music, Files)
 """
 
 from json import loads

--- a/searx/engines/podcastindex.py
+++ b/searx/engines/podcastindex.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Podcast Index
-"""
+"""Podcast Index"""
 
 from urllib.parse import quote_plus
 from datetime import datetime

--- a/searx/engines/pypi.py
+++ b/searx/engines/pypi.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""pypi.org
-
-"""
+"""pypi.org"""
 
 from urllib.parse import urlencode
 from dateutil import parser

--- a/searx/engines/reddit.py
+++ b/searx/engines/reddit.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Reddit
-
-"""
+"""Reddit"""
 
 import json
 from datetime import datetime

--- a/searx/engines/rottentomatoes.py
+++ b/searx/engines/rottentomatoes.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""RottenTomatoes (movies)
-"""
+"""RottenTomatoes (movies)"""
 
 from urllib.parse import quote_plus
 from lxml import html

--- a/searx/engines/rumble.py
+++ b/searx/engines/rumble.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Rumble (Videos)
-
-"""
+"""Rumble (Videos)"""
 
 from datetime import datetime
 

--- a/searx/engines/scanr_structures.py
+++ b/searx/engines/scanr_structures.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- ScanR Structures (Science)
+ScanR Structures (Science)
 """
 
 from json import loads, dumps

--- a/searx/engines/searx_engine.py
+++ b/searx/engines/searx_engine.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Searx (all)
+Searx (all)
 """
 
 from json import loads

--- a/searx/engines/senscritique.py
+++ b/searx/engines/senscritique.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""SensCritique (movies)
-"""
+"""SensCritique (movies)"""
 
 import typing as t
 

--- a/searx/engines/seznam.py
+++ b/searx/engines/seznam.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Seznam
-
-"""
+"""Seznam"""
 
 from urllib.parse import urlencode
 from lxml import html

--- a/searx/engines/solidtorrents.py
+++ b/searx/engines/solidtorrents.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""SolidTorrents
-
-"""
+"""SolidTorrents"""
 
 from datetime import datetime
 from urllib.parse import urlencode

--- a/searx/engines/spotify.py
+++ b/searx/engines/spotify.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Spotify (Music)
-
-"""
+"""Spotify (Music)"""
 
 from json import loads
 from urllib.parse import urlencode

--- a/searx/engines/svgrepo.py
+++ b/searx/engines/svgrepo.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Svgrepo (icons)
-"""
+"""Svgrepo (icons)"""
 
 from lxml import html
 from searx.utils import extract_text, eval_xpath, eval_xpath_list

--- a/searx/engines/tokyotoshokan.py
+++ b/searx/engines/tokyotoshokan.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Tokyo Toshokan (A BitTorrent Library for Japanese Media)
-
-"""
+"""Tokyo Toshokan (A BitTorrent Library for Japanese Media)"""
 
 import re
 from datetime import datetime

--- a/searx/engines/tootfinder.py
+++ b/searx/engines/tootfinder.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Tootfinder (social media)
-"""
+"""Tootfinder (social media)"""
 
 from datetime import datetime
 from json import loads

--- a/searx/engines/translated.py
+++ b/searx/engines/translated.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""MyMemory Translated
-
-"""
+"""MyMemory Translated"""
 
 import urllib.parse
 

--- a/searx/engines/unsplash.py
+++ b/searx/engines/unsplash.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Unsplash
-
-"""
+"""Unsplash"""
 
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
 from json import loads

--- a/searx/engines/vimeo.py
+++ b/searx/engines/vimeo.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Wikipedia (Web
+Wikipedia (Web
 """
 
 from urllib.parse import urlencode

--- a/searx/engines/wikicommons.py
+++ b/searx/engines/wikicommons.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Wikimedia Commons (images)
-
-"""
+"""Wikimedia Commons (images)"""
 
 import datetime
 

--- a/searx/engines/wolframalpha_api.py
+++ b/searx/engines/wolframalpha_api.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Wolfram|Alpha (Science)
-
-"""
+"""Wolfram|Alpha (Science)"""
 
 from urllib.parse import urlencode
 

--- a/searx/engines/wolframalpha_noapi.py
+++ b/searx/engines/wolframalpha_noapi.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Wolfram|Alpha (Science)
+Wolfram|Alpha (Science)
 """
 
 

--- a/searx/engines/www1x.py
+++ b/searx/engines/www1x.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""1x (Images)
-
-"""
+"""1x (Images)"""
 
 from urllib.parse import urlencode, urljoin
 from lxml import html, etree

--- a/searx/engines/yep.py
+++ b/searx/engines/yep.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Yep (general, images, news)
-"""
+"""Yep (general, images, news)"""
 
 from datetime import datetime
 from urllib.parse import urlencode

--- a/searx/engines/youtube_api.py
+++ b/searx/engines/youtube_api.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
- Youtube (Videos)
+Youtube (Videos)
 """
 
 from json import loads

--- a/searx/engines/youtube_noapi.py
+++ b/searx/engines/youtube_noapi.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Youtube (Videos)
-
-"""
+"""Youtube (Videos)"""
 
 from functools import reduce
 from json import loads, dumps

--- a/searx/exceptions.py
+++ b/searx/exceptions.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Exception types raised by SearXNG modules.
-"""
+"""Exception types raised by SearXNG modules."""
 
 import typing as t
 from lxml.etree import XPath

--- a/searx/network/raise_for_httperror.py
+++ b/searx/network/raise_for_httperror.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Raise exception for an HTTP response is an error.
-
-"""
+"""Raise exception for an HTTP response is an error."""
 
 import typing as t
 from searx.exceptions import (

--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Searx preferences implementation.
-"""
+"""Searx preferences implementation."""
 
 # pylint: disable=useless-object-inheritance
 

--- a/searx/searxng.msg
+++ b/searx/searxng.msg
@@ -1,7 +1,6 @@
 # -*- mode: python -*-
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""A SearXNG message file, see :py:obj:`searx.babel`
-"""
+"""A SearXNG message file, see :py:obj:`searx.babel`"""
 
 import typing
 

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Implementation of the default settings.
-
-"""
+"""Implementation of the default settings."""
 from __future__ import annotations
 
 import typing as t

--- a/searxng_extra/update/update_engine_traits.py
+++ b/searxng_extra/update/update_engine_traits.py
@@ -50,7 +50,7 @@ A list of five-digit tuples:
    Empty string for language tags.
 3. English language name (from :py:obj:`babel.core.Locale.english_name`)
 4. Unicode flag (emoji) that fits to SearXNG's internal region tag. Languages
-   are represented by a globe (\U0001F310)
+   are represented by a globe (\U0001f310)
 
 .. code:: python
 
@@ -68,11 +68,11 @@ A list of five-digit tuples:
 
 
 lang2emoji = {
-    'ha': '\U0001F1F3\U0001F1EA',  # Hausa / Niger
-    'bs': '\U0001F1E7\U0001F1E6',  # Bosnian / Bosnia & Herzegovina
-    'jp': '\U0001F1EF\U0001F1F5',  # Japanese
-    'ua': '\U0001F1FA\U0001F1E6',  # Ukrainian
-    'he': '\U0001F1EE\U0001F1F1',  # Hebrew
+    'ha': '\U0001f1f3\U0001f1ea',  # Hausa / Niger
+    'bs': '\U0001f1e7\U0001f1e6',  # Bosnian / Bosnia & Herzegovina
+    'jp': '\U0001f1ef\U0001f1f5',  # Japanese
+    'ua': '\U0001f1fa\U0001f1e6',  # Ukrainian
+    'he': '\U0001f1ee\U0001f1f1',  # Hebrew
 }
 
 
@@ -178,7 +178,7 @@ def get_unicode_flag(locale: babel.Locale):
         return emoji
 
     if not locale.territory:
-        return '\U0001F310'
+        return '\U0001f310'
 
     emoji = lang2emoji.get(locale.territory.lower())
     if emoji:


### PR DESCRIPTION
In 25.1.0 [2] an old bug has been fixed: "Docstring formatting does not apply to module docstrings" [3].

[1] https://github.com/psf/black/blob/main/CHANGES.md#2590
[2] https://github.com/psf/black/blob/main/CHANGES.md#2510
[3] https://github.com/psf/black/issues/4094
