### PR TITLE
[upd] pypi: Bump sphinx from 7.4.7 to 8.2.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,12 +6,14 @@ pylint==3.3.8
 splinter==0.21.0
 selenium==4.35.0
 Pallets-Sphinx-Themes==2.3.0
-Sphinx==7.4.7
+Sphinx==8.2.3 ; python_version >= '3.11'
+Sphinx==8.1.3 ; python_version < '3.11'
 sphinx-issues==5.0.1
 sphinx-jinja==2.0.2
 sphinx-tabs==3.4.7
 sphinxcontrib-programoutput==0.18
-sphinx-autobuild==2024.10.3
+sphinx-autobuild==2025.8.25 ; python_version >= '3.11'
+sphinx-autobuild==2024.10.3 ; python_version < '3.11'
 sphinx-notfound-page==1.1.0
 myst-parser==4.0.1
 linuxdoc==20240924


### PR DESCRIPTION
- supersede: https://github.com/searxng/searxng/pull/4377

Sphinx 8.2 dropped Python 3.10 support, last versions supporting Python 3.10:

- Sphinx==8.1.3
- sphinx-autobuild==2024.10.3