### PR TITLE
[mod] pin external developer tools (mise en place)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,0 @@
-nodejs     24.3.0
-python     3.10.18
-shellcheck 0.10.0
-sqlite     3.47.2

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+[tools]
+# minimal version we support
+python = "3.10"
+node = "24.3.0"
+go = "1.24.5"
+shellcheck = "0.11.0"
+# python 3.10 uses 3.40.1 (on mac and win)
+sqlite = "3.40.1"

--- a/utils/lib_sxng_node.sh
+++ b/utils/lib_sxng_node.sh
@@ -4,7 +4,7 @@
 declare _Blue
 declare _creset
 
-export NODE_MINIMUM_VERSION="23.6.0"
+export NODE_MINIMUM_VERSION="24.3.0"
 
 node.help() {
     cat <<EOF


### PR DESCRIPTION
Mise en place config [1] does no longer support ``.tool-versions`` compatibility syntax, migrate to TOML ``mise.toml``.

In ``utils/lib_sxng_node.sh`` the node version was not updated, update to 24.3.0 (compare ``mise.toml``).

[1] https://mise.jdx.dev/configuration.html