### PR TITLE
[fix] ModuleNotFoundError: No module named 'lxml'

### DIFF
--- a/searx/exceptions.py
+++ b/searx/exceptions.py
@@ -2,7 +2,9 @@
 """Exception types raised by SearXNG modules."""
 
 import typing as t
-from lxml.etree import XPath
+
+if t.TYPE_CHECKING:
+    from lxml.etree import XPath
 
 
 class SearxException(Exception):
@@ -40,7 +42,7 @@ class SearxEngineException(SearxException):
 class SearxXPathSyntaxException(SearxEngineException):
     """Syntax error in a XPATH"""
 
-    def __init__(self, xpath_spec: str | XPath, message: str):
+    def __init__(self, xpath_spec: "str | XPath", message: str):
         super().__init__(str(xpath_spec) + " " + message)
         self.message: str = message
         # str(xpath_spec) to deal with str and XPath instance
@@ -111,7 +113,7 @@ class SearxEngineTooManyRequestsException(SearxEngineAccessDeniedException):
 class SearxEngineXPathException(SearxEngineResponseException):
     """Error while getting the result of an XPath expression"""
 
-    def __init__(self, xpath_spec: str | XPath, message: str):
+    def __init__(self, xpath_spec: "str | XPath", message: str):
         super().__init__(str(xpath_spec) + " " + message)
         self.message: str = message
         # str(xpath_spec) to deal with str and XPath instance


### PR DESCRIPTION
When installing SearXNG (e.g.):

    pip install --use-pep517 --no-build-isolation -e .

An import exception is raised:

    ModuleNotFoundError: No module named 'lxml'

The ``setup.py`` file imports ``searx``, which in turn triggers various other imports.  However, the name XPath is only needed for type checking.

Closes: https://github.com/searxng/searxng/issues/5177