### PR TITLE
[fix] JSON format: serialization of the result-types

### DIFF
--- a/searx/engines/duckduckgo_weather.py
+++ b/searx/engines/duckduckgo_weather.py
@@ -76,12 +76,12 @@ def _weather_data(location: weather.GeoLocation, data: dict[str, t.Any]):
 
     return EngineResults.types.WeatherAnswer.Item(
         location=location,
-        temperature=weather.Temperature(unit="°C", value=data['temperature']),
+        temperature=weather.Temperature(val=data['temperature'], unit="°C"),
         condition=WEATHERKIT_TO_CONDITION[data["conditionCode"]],
-        feels_like=weather.Temperature(unit="°C", value=data['temperatureApparent']),
+        feels_like=weather.Temperature(val=data['temperatureApparent'], unit="°C"),
         wind_from=weather.Compass(data["windDirection"]),
-        wind_speed=weather.WindSpeed(data["windSpeed"], unit="mi/h"),
-        pressure=weather.Pressure(data["pressure"], unit="hPa"),
+        wind_speed=weather.WindSpeed(val=data["windSpeed"], unit="mi/h"),
+        pressure=weather.Pressure(val=data["pressure"], unit="hPa"),
         humidity=weather.RelativeHumidity(data["humidity"] * 100),
         cloud_cover=data["cloudCover"] * 100,
     )

--- a/searx/engines/open_meteo.py
+++ b/searx/engines/open_meteo.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Open Meteo (weather)"""
 
+import typing as t
+
 from urllib.parse import urlencode
 from datetime import datetime
 
@@ -106,16 +108,16 @@ WMO_TO_CONDITION: dict[int, weather.WeatherConditionType] = {
 }
 
 
-def _weather_data(location: weather.GeoLocation, data: dict):
+def _weather_data(location: weather.GeoLocation, data: dict[str, t.Any]):
 
     return WeatherAnswer.Item(
         location=location,
-        temperature=weather.Temperature(unit="°C", value=data["temperature_2m"]),
+        temperature=weather.Temperature(val=data["temperature_2m"], unit="°C"),
         condition=WMO_TO_CONDITION[data["weather_code"]],
-        feels_like=weather.Temperature(unit="°C", value=data["apparent_temperature"]),
+        feels_like=weather.Temperature(val=data["apparent_temperature"], unit="°C"),
         wind_from=weather.Compass(data["wind_direction_10m"]),
-        wind_speed=weather.WindSpeed(data["wind_speed_10m"], unit="km/h"),
-        pressure=weather.Pressure(data["pressure_msl"], unit="hPa"),
+        wind_speed=weather.WindSpeed(val=data["wind_speed_10m"], unit="km/h"),
+        pressure=weather.Pressure(val=data["pressure_msl"], unit="hPa"),
         humidity=weather.RelativeHumidity(data["relative_humidity_2m"]),
         cloud_cover=data["cloud_cover"],
     )

--- a/searx/engines/pdbe.py
+++ b/searx/engines/pdbe.py
@@ -67,7 +67,7 @@ def construct_body(result):
             )
         thumbnail = pdbe_preview_url.format(pdb_id=result['pdb_id'])
     except KeyError:
-        content = None
+        content = ""
         thumbnail = None
 
     # construct url for preview image

--- a/searx/engines/wttr.py
+++ b/searx/engines/wttr.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """wttr.in (weather forecast service)"""
 
+import typing as t
+
 from urllib.parse import quote
 from datetime import datetime
 
@@ -80,19 +82,19 @@ def request(query, params):
     return params
 
 
-def _weather_data(location: weather.GeoLocation, data: dict):
+def _weather_data(location: weather.GeoLocation, data: dict[str, t.Any]):
     # the naming between different data objects is inconsitent, thus temp_C and
     # tempC are possible
     tempC: float = data.get("temp_C") or data.get("tempC")  # type: ignore
 
     return WeatherAnswer.Item(
         location=location,
-        temperature=weather.Temperature(unit="°C", value=tempC),
+        temperature=weather.Temperature(val=tempC, unit="°C"),
         condition=WWO_TO_CONDITION[data["weatherCode"]],
-        feels_like=weather.Temperature(unit="°C", value=data["FeelsLikeC"]),
+        feels_like=weather.Temperature(val=data["FeelsLikeC"], unit="°C"),
         wind_from=weather.Compass(int(data["winddirDegree"])),
-        wind_speed=weather.WindSpeed(data["windspeedKmph"], unit="km/h"),
-        pressure=weather.Pressure(data["pressure"], unit="hPa"),
+        wind_speed=weather.WindSpeed(val=data["windspeedKmph"], unit="km/h"),
+        pressure=weather.Pressure(val=data["pressure"], unit="hPa"),
         humidity=weather.RelativeHumidity(data["humidity"]),
         cloud_cover=data["cloudcover"],
     )

--- a/searx/plugins/_core.py
+++ b/searx/plugins/_core.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=too-few-public-methods,missing-module-docstring
 
-
 __all__ = ["PluginInfo", "Plugin", "PluginCfg", "PluginStorage"]
 
 import abc
@@ -9,16 +8,17 @@ import importlib
 import inspect
 import logging
 import re
-import typing
-from collections.abc import Sequence
+
+import typing as t
+from collections.abc import Generator
 
 from dataclasses import dataclass, field
 
 from searx.extended_types import SXNG_Request
-from searx.result_types import Result
 
-if typing.TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from searx.search import SearchWithPlugins
+    from searx.result_types import Result, EngineResults, LegacyResult  # pyright: ignore[reportPrivateLocalImportUsage]
     import flask
 
 log: logging.Logger = logging.getLogger("searx.plugins")
@@ -42,7 +42,7 @@ class PluginInfo:
     description: str
     """Short description of the *answerer*."""
 
-    preference_section: typing.Literal["general", "ui", "privacy", "query"] | None = "general"
+    preference_section: t.Literal["general", "ui", "privacy", "query"] | None = "general"
     """Section (tab/group) in the preferences where this plugin is shown to the
     user.
 
@@ -71,7 +71,7 @@ class Plugin(abc.ABC):
     id: str = ""
     """The ID (suffix) in the HTML form."""
 
-    active: typing.ClassVar[bool]
+    active: t.ClassVar[bool]
     """Plugin is enabled/disabled by default (:py:obj:`PluginCfg.active`)."""
 
     keywords: list[str] = []
@@ -109,7 +109,7 @@ class Plugin(abc.ABC):
             raise ValueError(f"plugin ID {self.id} contains invalid character (use lowercase ASCII)")
 
         if not getattr(self, "log", None):
-            pkg_name = inspect.getmodule(self.__class__).__package__  # type: ignore
+            pkg_name = inspect.getmodule(self.__class__).__package__  # pyright: ignore[reportOptionalMemberAccess]
             self.log = logging.getLogger(f"{pkg_name}.{self.id}")
 
     def __hash__(self) -> int:
@@ -120,7 +120,7 @@ class Plugin(abc.ABC):
 
         return id(self)
 
-    def __eq__(self, other: typing.Any):
+    def __eq__(self, other: t.Any):
         """py:obj:`Plugin` objects are equal if the hash values of the two
         objects are equal."""
 
@@ -146,7 +146,7 @@ class Plugin(abc.ABC):
         """
         return True
 
-    def on_result(self, request: SXNG_Request, search: "SearchWithPlugins", result: Result) -> bool:
+    def on_result(self, request: SXNG_Request, search: "SearchWithPlugins", result: "Result") -> bool:
         """Runs for each result of each engine and returns a boolean:
 
         - ``True`` to keep the result
@@ -166,7 +166,9 @@ class Plugin(abc.ABC):
         """
         return True
 
-    def post_search(self, request: SXNG_Request, search: "SearchWithPlugins") -> None | Sequence[Result]:
+    def post_search(
+        self, request: SXNG_Request, search: "SearchWithPlugins"
+    ) -> "None | list[Result | LegacyResult] | EngineResults":
         """Runs AFTER the search request.  Can return a list of
         :py:obj:`Result <searx.result_types._base.Result>` objects to be added to the
         final result list."""
@@ -196,7 +198,7 @@ class PluginStorage:
     def __init__(self):
         self.plugin_list = set()
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[Plugin]:
         yield from self.plugin_list
 
     def __len__(self):
@@ -207,7 +209,7 @@ class PluginStorage:
 
         return [p.info for p in self.plugin_list]
 
-    def load_settings(self, cfg: dict[str, dict[str, typing.Any]]):
+    def load_settings(self, cfg: dict[str, dict[str, t.Any]]):
         """Load plugins configured in SearXNG's settings :ref:`settings
         plugins`."""
 
@@ -262,7 +264,7 @@ class PluginStorage:
                 break
         return ret
 
-    def on_result(self, request: SXNG_Request, search: "SearchWithPlugins", result: Result) -> bool:
+    def on_result(self, request: SXNG_Request, search: "SearchWithPlugins", result: "Result") -> bool:
 
         ret = True
         for plugin in [p for p in self.plugin_list if p.id in search.user_plugins]:

--- a/searx/plugins/time_zone.py
+++ b/searx/plugins/time_zone.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=missing-module-docstring
 
-from __future__ import annotations
 import typing as t
 
 import datetime
 
-from flask_babel import gettext  # type: ignore
+from flask_babel import gettext
 from searx.result_types import EngineResults
 from searx.weather import DateTime, GeoLocation
 
@@ -53,13 +52,13 @@ class SXNGPlugin(Plugin):
         search_term = " ".join(query_parts).strip()
 
         if not search_term:
-            date_time = DateTime(time=datetime.datetime.now())
+            date_time = DateTime(datetime.datetime.now())
             results.add(results.types.Answer(answer=date_time.l10n()))
             return results
 
         geo = GeoLocation.by_query(search_term=search_term)
         if geo:
-            date_time = DateTime(time=datetime.datetime.now(tz=geo.zoneinfo))
+            date_time = DateTime(datetime.datetime.now(tz=geo.zoneinfo))
             tz_name = geo.timezone.replace('_', ' ')
             results.add(
                 results.types.Answer(

--- a/searx/results.py
+++ b/searx/results.py
@@ -357,12 +357,12 @@ def merge_two_infoboxes(origin: LegacyResult, other: LegacyResult):
 def merge_two_main_results(origin: MainResult | LegacyResult, other: MainResult | LegacyResult):
     """Merges the values from ``other`` into ``origin``."""
 
-    if len(other.content) > len(origin.content):
+    if len(other.content or "") > len(origin.content or ""):
         # use content with more text
         origin.content = other.content
 
     # use title with more text
-    if len(other.title) > len(origin.title):
+    if len(other.title or "") > len(origin.title or ""):
         origin.title = other.title
 
     # merge all result's parameters not found in origin

--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -16,6 +16,7 @@ from typing import Iterable, List, Tuple, TYPE_CHECKING
 from io import StringIO
 from codecs import getincrementalencoder
 
+import msgspec
 from flask_babel import gettext, format_date  # type: ignore
 
 from searx import logger, get_setting
@@ -147,6 +148,8 @@ def write_csv_response(csv: CSVWriter, rc: "ResultContainer") -> None:  # pylint
 
 class JSONEncoder(json.JSONEncoder):  # pylint: disable=missing-class-docstring
     def default(self, o):
+        if isinstance(o, msgspec.Struct):
+            return msgspec.to_builtins(o)
         if isinstance(o, datetime):
             return o.isoformat()
         if isinstance(o, timedelta):


### PR DESCRIPTION
The ``JSONEncoder`` (`format="json"`) must perform a conversion to the built-in types for the ``msgspec.Struct``::

    if isinstance(o, msgspec.Struct):
        return msgspec.to_builtins(o)

The result types are already of type ``msgspec.Struct``, so they can be converted into built-in types.

The field types (in the result type) that were not yet of type ``msgspec.Struct`` have been converted to::

    searx.weather.GeoLocation@dataclass -> msgspec.Struct
    searx.weather.DateTime              -> msgspec.Struct
    searx.weather.Temperature           -> msgspec.Struct
    searx.weather.PressureUnits         -> msgspec.Struct
    searx.weather.WindSpeed             -> msgspec.Struct
    searx.weather.RelativeHumidity      -> msgspec.Struct
    searx.weather.Compass               -> msgspec.Struct

BTW: Wherever it seemed sensible, the typing was also modernized in the modified files.

- Closes: https://github.com/searxng/searxng/issues/5250