### PR TITLE
[mod] brand - partial migration of settings to msgspec.Struct

### DIFF
--- a/docs/admin/settings/settings_brand.rst
+++ b/docs/admin/settings/settings_brand.rst
@@ -4,22 +4,5 @@
 ``brand:``
 ==========
 
-.. code:: yaml
-
-   brand:
-     issue_url: https://github.com/searxng/searxng/issues
-     docs_url: https://docs.searxng.org
-     public_instances: https://searx.space
-     wiki_url: https://github.com/searxng/searxng/wiki
-
-``issue_url`` :
-  If you host your own issue tracker change this URL.
-
-``docs_url`` :
-  If you host your own documentation change this URL.
-
-``public_instances`` :
-  If you host your own https://searx.space change this URL.
-
-``wiki_url`` :
-  Link to your wiki (or ``false``)
+.. autoclass:: searx.brand.SettingsBrand
+   :members:

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -9,6 +9,7 @@ from os.path import dirname, abspath
 
 import logging
 
+import msgspec
 import searx.unixthreadname  # pylint: disable=unused-import
 
 # Debug
@@ -76,20 +77,22 @@ def get_setting(name: str, default: t.Any = _unset) -> t.Any:
     settings and the ``default`` is unset, a :py:obj:`KeyError` is raised.
 
     """
-    value: dict[str, t.Any] = settings
+    value = settings
     for a in name.split('.'):
-        if isinstance(value, dict):
-            value = value.get(a, _unset)
+        if isinstance(value, msgspec.Struct):
+            value = getattr(value, a, _unset)
+        elif isinstance(value, dict):
+            value = value.get(a, _unset)  # pyright: ignore
         else:
-            value = _unset  # type: ignore
+            value = _unset
 
         if value is _unset:
             if default is _unset:
                 raise KeyError(name)
-            value = default  # type: ignore
+            value = default
             break
 
-    return value
+    return value  # pyright: ignore
 
 
 def _is_color_terminal():

--- a/searx/brand.py
+++ b/searx/brand.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Implementations needed for a branding of SearXNG."""
+# pylint: disable=too-few-public-methods
+
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
+
+__all__ = ["SettingsBrand"]
+
+import msgspec
+
+
+class BrandCustom(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):
+    """Custom settings in the brand section."""
+
+    links: dict[str, str] = {}
+    """Custom entries in the footer of the WEB page: ``[title]: [link]``"""
+
+
+class SettingsBrand(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):
+    """Options for configuring brand properties.
+
+    .. code:: yaml
+
+       brand:
+         issue_url: https://github.com/searxng/searxng/issues
+         docs_url: https://docs.searxng.org
+         public_instances: https://searx.space
+         wiki_url: https://github.com/searxng/searxng/wiki
+
+         custom:
+           links:
+             Uptime: https://uptime.searxng.org/history/example-org
+             About: https://example.org/user/about.html
+    """
+
+    issue_url: str = "https://github.com/searxng/searxng/issues"
+    """If you host your own issue tracker change this URL."""
+
+    docs_url: str = "https://docs.searxng.org"
+    """If you host your own documentation change this URL."""
+
+    public_instances: str = "https://searx.space"
+    """If you host your own https://searx.space change this URL."""
+
+    wiki_url: str = "https://github.com/searxng/searxng/wiki"
+    """Link to your wiki (or ``false``)"""
+
+    custom: BrandCustom = msgspec.field(default_factory=BrandCustom)
+    """Optional customizing.
+
+    .. autoclass:: searx.brand.BrandCustom
+       :members:
+    """
+
+    # new_issue_url is a hackish solution tailored for only one hoster (GH).  As
+    # long as we don't have a more general solution, we should support it in the
+    # given function, but it should not be expanded further.
+
+    new_issue_url: str = "https://github.com/searxng/searxng/issues/new"
+    """If you host your own issue tracker not on GitHub, then unset this URL.
+
+    Note: This URL will create a pre-filled GitHub bug report form for an
+    engine.  Since this feature is implemented only for GH (and limited to
+    engines), it will probably be replaced by another solution in the near
+    future.
+    """

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -24,7 +24,6 @@ brand:
   wiki_url: https://github.com/searxng/searxng/wiki
   issue_url: https://github.com/searxng/searxng/issues
   # custom:
-  #   maintainer: "Jon Doe"
   #   # Custom entries in the footer: [title]: [link]
   #   links:
   #     Uptime: https://uptime.searxng.org/history/darmarit-org

--- a/tests/robot/settings_robot.yml
+++ b/tests/robot/settings_robot.yml
@@ -3,8 +3,6 @@ general:
   instance_name: "searx_test"
 
 brand:
-  git_url: https://github.com/searxng/searxng
-  git_branch: master
   issue_url: https://github.com/searxng/searxng/issues
   new_issue_url: https://github.com/searxng/searxng/issues/new
   docs_url: https://docs.searxng.org


### PR DESCRIPTION
The settings are currently an untyped key/value structure, whose types are dynamically built at runtime.  The construction process of this structure is *hand-crafted*.

In the long term, we want a static typing of this structure, based on a standard tool. The ``msgspec.Struct`` structures are suitable as a standard tool.

This patch makes a first step towards static typing and implements the "brand" section using ``msgspec.Struct`` structures.

BTW: searx/settings_defaults.py - ``git_url`` and ``git_branch`` had been removed in aee613d256, this is a leftover.