### PR TITLE
fix bugs that first appear with Python 3.14

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,14 +25,13 @@ jobs:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
       matrix:
         python-version:
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14-dev"
+          - "3.14"
 
     steps:
       - name: Setup Python
@@ -56,7 +55,6 @@ jobs:
         run: make V=1 install
 
       - name: Run tests
-        continue-on-error: ${{ matrix.python-version == '3.14-dev' }}
         run: make V=1 ci.test
 
   theme:

--- a/searx/cache.py
+++ b/searx/cache.py
@@ -5,6 +5,10 @@
 ----
 """
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
+
 __all__ = ["ExpireCacheCfg", "ExpireCacheStats", "ExpireCache", "ExpireCacheSQLite"]
 
 import abc

--- a/searx/favicons/cache.py
+++ b/searx/favicons/cache.py
@@ -17,6 +17,10 @@
 
 """
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
+
 import typing as t
 
 import os

--- a/searx/favicons/config.py
+++ b/searx/favicons/config.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=missing-module-docstring
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
 
 import pathlib
 import msgspec

--- a/searx/favicons/proxy.py
+++ b/searx/favicons/proxy.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Implementations for a favicon proxy"""
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
 
 from typing import Callable
 

--- a/searx/result_types/_base.py
+++ b/searx/result_types/_base.py
@@ -16,6 +16,10 @@
    :members:
 """
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
+
 __all__ = ["Result"]
 
 import typing as t

--- a/searx/result_types/answer.py
+++ b/searx/result_types/answer.py
@@ -28,6 +28,9 @@ template.
 """
 # pylint: disable=too-few-public-methods
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
 
 __all__ = ["AnswerSet", "Answer", "Translations", "WeatherAnswer"]
 

--- a/searx/result_types/code.py
+++ b/searx/result_types/code.py
@@ -14,6 +14,8 @@ template.  For highlighting the code passages, Pygments_ is used.
 """
 # pylint: disable=too-few-public-methods, disable=invalid-name
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
 from __future__ import annotations
 
 __all__ = ["Code"]

--- a/searx/result_types/keyvalue.py
+++ b/searx/result_types/keyvalue.py
@@ -13,6 +13,9 @@ template.
 """
 # pylint: disable=too-few-public-methods
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
 
 __all__ = ["KeyValue"]
 

--- a/searx/result_types/paper.py
+++ b/searx/result_types/paper.py
@@ -21,6 +21,8 @@ Related topics:
 """
 # pylint: disable=too-few-public-methods, disable=invalid-name
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
 from __future__ import annotations
 
 __all__ = ["Paper"]

--- a/searx/weather.py
+++ b/searx/weather.py
@@ -255,7 +255,8 @@ class DateTime(msgspec.Struct):
         return babel.dates.format_date(self.datetime, format=fmt, locale=locale)
 
 
-TemperatureUnits: t.TypeAlias = t.Literal["°C", "°F", "K"]
+TemperatureUnit: t.TypeAlias = t.Literal["°C", "°F", "K"]
+TEMPERATURE_UNITS: t.Final[tuple[TemperatureUnit]] = t.get_args(TemperatureUnit)
 
 
 class Temperature(msgspec.Struct, kw_only=True):
@@ -263,19 +264,19 @@ class Temperature(msgspec.Struct, kw_only=True):
     measured values."""
 
     val: float
-    unit: TemperatureUnits
+    unit: TemperatureUnit
 
     si_name: t.ClassVar[str] = "Q11579"
-    units: t.ClassVar[list[str]] = list(t.get_args(TemperatureUnits))
+    UNITS: t.ClassVar[tuple[TemperatureUnit]] = TEMPERATURE_UNITS
 
     def __post_init__(self):
-        if self.unit not in self.units:
+        if self.unit not in self.UNITS:
             raise ValueError(f"invalid unit: {self.unit}")
 
     def __str__(self):
         return self.l10n()
 
-    def value(self, unit: TemperatureUnits) -> float:
+    def value(self, unit: TemperatureUnit) -> float:
         if unit == self.unit:
             return self.val
         si_val = convert_to_si(si_name=self.si_name, symbol=self.unit, value=self.val)
@@ -283,7 +284,7 @@ class Temperature(msgspec.Struct, kw_only=True):
 
     def l10n(
         self,
-        unit: TemperatureUnits | None = None,
+        unit: TemperatureUnit | None = None,
         locale: babel.Locale | GeoLocation | None = None,
         template: str = "{value} {unit}",
         num_pattern: str = "#,##0",
@@ -322,7 +323,8 @@ class Temperature(msgspec.Struct, kw_only=True):
         return template.format(value=val_str, unit=unit)
 
 
-PressureUnits: t.TypeAlias = t.Literal["Pa", "hPa", "cm Hg", "bar"]
+PressureUnit: t.TypeAlias = t.Literal["Pa", "hPa", "cm Hg", "bar"]
+PRESSURE_UNITS: t.Final[tuple[PressureUnit]] = t.get_args(PressureUnit)
 
 
 class Pressure(msgspec.Struct, kw_only=True):
@@ -330,19 +332,19 @@ class Pressure(msgspec.Struct, kw_only=True):
     measured values."""
 
     val: float
-    unit: PressureUnits
+    unit: PressureUnit
 
     si_name: t.ClassVar[str] = "Q44395"
-    units: t.ClassVar[list[str]] = list(t.get_args(PressureUnits))
+    UNITS: t.ClassVar[tuple[PressureUnit]] = PRESSURE_UNITS
 
     def __post_init__(self):
-        if self.unit not in self.units:
+        if self.unit not in self.UNITS:
             raise ValueError(f"invalid unit: {self.unit}")
 
     def __str__(self):
         return self.l10n()
 
-    def value(self, unit: PressureUnits) -> float:
+    def value(self, unit: PressureUnit) -> float:
         if unit == self.unit:
             return self.val
         si_val = convert_to_si(si_name=self.si_name, symbol=self.unit, value=self.val)
@@ -350,7 +352,7 @@ class Pressure(msgspec.Struct, kw_only=True):
 
     def l10n(
         self,
-        unit: PressureUnits | None = None,
+        unit: PressureUnit | None = None,
         locale: babel.Locale | GeoLocation | None = None,
         template: str = "{value} {unit}",
         num_pattern: str = "#,##0",
@@ -367,7 +369,8 @@ class Pressure(msgspec.Struct, kw_only=True):
         return template.format(value=val_str, unit=unit)
 
 
-WindSpeedUnits: t.TypeAlias = t.Literal["m/s", "km/h", "kn", "mph", "mi/h", "Bft"]
+WindSpeedUnit: t.TypeAlias = t.Literal["m/s", "km/h", "kn", "mph", "mi/h", "Bft"]
+WIND_SPEED_UNITS: t.Final[tuple[WindSpeedUnit]] = t.get_args(WindSpeedUnit)
 
 
 class WindSpeed(msgspec.Struct, kw_only=True):
@@ -382,19 +385,19 @@ class WindSpeed(msgspec.Struct, kw_only=True):
     """
 
     val: float
-    unit: WindSpeedUnits
+    unit: WindSpeedUnit
 
     si_name: t.ClassVar[str] = "Q182429"
-    units: t.ClassVar[list[str]] = list(t.get_args(WindSpeedUnits))
+    UNITS: t.ClassVar[tuple[WindSpeedUnit]] = WIND_SPEED_UNITS
 
     def __post_init__(self):
-        if self.unit not in self.units:
+        if self.unit not in self.UNITS:
             raise ValueError(f"invalid unit: {self.unit}")
 
     def __str__(self):
         return self.l10n()
 
-    def value(self, unit: WindSpeedUnits) -> float:
+    def value(self, unit: WindSpeedUnit) -> float:
         if unit == self.unit:
             return self.val
         si_val = convert_to_si(si_name=self.si_name, symbol=self.unit, value=self.val)
@@ -402,7 +405,7 @@ class WindSpeed(msgspec.Struct, kw_only=True):
 
     def l10n(
         self,
-        unit: WindSpeedUnits | None = None,
+        unit: WindSpeedUnit | None = None,
         locale: babel.Locale | GeoLocation | None = None,
         template: str = "{value} {unit}",
         num_pattern: str = "#,##0",
@@ -419,7 +422,8 @@ class WindSpeed(msgspec.Struct, kw_only=True):
         return template.format(value=val_str, unit=unit)
 
 
-RelativeHumidityUnits: t.TypeAlias = t.Literal["%"]
+RelativeHumidityUnit: t.TypeAlias = t.Literal["%"]
+RELATIVE_HUMIDITY_UNITS: t.Final[tuple[RelativeHumidityUnit]] = t.get_args(RelativeHumidityUnit)
 
 
 class RelativeHumidity(msgspec.Struct):
@@ -428,8 +432,12 @@ class RelativeHumidity(msgspec.Struct):
     val: float
 
     # there exists only one unit (%) --> set "%" as the final value (constant)
-    unit: t.ClassVar["t.Final[RelativeHumidityUnits]"] = "%"
-    units: t.ClassVar[list[str]] = list(t.get_args(RelativeHumidityUnits))
+    unit: t.ClassVar[RelativeHumidityUnit] = "%"
+    UNITS: t.ClassVar[tuple[RelativeHumidityUnit]] = RELATIVE_HUMIDITY_UNITS
+
+    def __post_init__(self):
+        if self.unit not in self.UNITS:
+            raise ValueError(f"invalid unit: {self.unit}")
 
     def __str__(self):
         return self.l10n()
@@ -457,20 +465,23 @@ CompassPoint: t.TypeAlias = t.Literal[
     "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"
 ]
 """Compass point type definition"""
+COMPASS_POINTS: t.Final[tuple[CompassPoint]] = t.get_args(CompassPoint)
 
-CompassUnits: t.TypeAlias = t.Literal["°", "Point"]
+CompassUnit: t.TypeAlias = t.Literal["°", "Point"]
+COMPASS_UNITS: t.Final[tuple[CompassUnit]] = t.get_args(CompassUnit)
 
 
 class Compass(msgspec.Struct):
     """Class for converting compass points and azimuth values (360°)"""
 
     val: "float | int | CompassPoint"
-    unit: CompassUnits = "°"
+    unit: CompassUnit = "°"
+    UNITS: t.ClassVar[tuple[CompassUnit]] = COMPASS_UNITS
 
     TURN: t.ClassVar[float] = 360.0
     """Full turn (360°)"""
 
-    POINTS: t.ClassVar[list[CompassPoint]] = list(t.get_args(CompassPoint))
+    POINTS: t.ClassVar[tuple[CompassPoint]] = COMPASS_POINTS
     """Compass points."""
 
     RANGE: t.ClassVar[float] = TURN / len(POINTS)
@@ -488,7 +499,7 @@ class Compass(msgspec.Struct):
     def __str__(self):
         return self.l10n()
 
-    def value(self, unit: CompassUnits):
+    def value(self, unit: CompassUnit):
         if unit == "Point" and isinstance(self.val, float):
             return self.point(self.val)
         if unit == "°":
@@ -507,7 +518,7 @@ class Compass(msgspec.Struct):
 
     def l10n(
         self,
-        unit: CompassUnits = "Point",
+        unit: CompassUnit = "Point",
         locale: babel.Locale | GeoLocation | None = None,
         template: str = "{value}{unit}",
         num_pattern: str = "#,##0",

--- a/searx/weather.py
+++ b/searx/weather.py
@@ -2,6 +2,10 @@
 """Implementations used for weather conditions and forecast."""
 # pylint: disable=too-few-public-methods
 
+# Struct fields aren't discovered in Python 3.14
+# - https://github.com/searxng/searxng/issues/5284
+from __future__ import annotations
+
 __all__ = [
     "symbol_url",
     "Temperature",


### PR DESCRIPTION
- In Python 3.14, incompatible changes were made to the type introspection API. This affects type annotations and tools like pydantic or msgspec (which we use).

----

for more details read the commit messages ..

----

Here is how I build my developer environment (debian) ..

```bash

$ apt install zlib1g zlib1g-dev libssl-dev libbz2-dev libsqlite3-dev liblzma-dev libncurses-dev libffi-dev libreadline-dev python3-tk tk-dev

$ cd searxng/
$ mise settings set python.compile true
$ mise use python@3.14.0rc3
$ mise install -f python@3.14.0rc3
```







