### PR TITLE
Remove unsupported `--replace` flag from Docker run command

### DIFF
--- a/docs/admin/installation-docker.rst
+++ b/docs/admin/installation-docker.rst
@@ -100,7 +100,7 @@ Basic container instancing example:
    $ cd ./searxng/
 
    # Run the container
-   $ docker run --name searxng --replace -d \
+   $ docker run --name searxng -d \
        -p 8888:8080 \
        -v "./config/:/etc/searxng/" \
        -v "./data/:/var/cache/searxng/" \


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

Removes the unsupported --replace flag from the Docker command in the documentation.


## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

This flag is not recognized by the standard Docker CLI and causes the command to fail, and result:
`unknown flag: --replace
`


<!--
Closes #234
-->
