### PR TITLE
[fix] startpage engine - SafeSearch works in reverse

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -128,7 +128,7 @@ time_range_support = True
 safesearch = True
 
 time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
-safesearch_dict = {0: '0', 1: '1', 2: '1'}
+safesearch_dict = {0: '1', 1: '0', 2: '0'}
 
 # search-url
 base_url = 'https://www.startpage.com'


### PR DESCRIPTION
The Name of the option is *disable_family_filter* ->  we have to reverse the meaning of the ascending safe-search filter level.

- https://github.com/searxng/searxng/issues/5287