### PR TITLE
[enh] ci: bump to cp3.14

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   search:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,7 +22,7 @@ permissions:
   packages: read
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   build-base:

--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   data:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   release:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   test:

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   update:


### PR DESCRIPTION
Bumps default runner Python version to 3.14 for every workflow.