### PR TITLE
 Naming consistency and no spaces for mullvadleta Google and Brave

### DIFF
--- a/searx/data/engine_descriptions.json
+++ b/searx/data/engine_descriptions.json
@@ -251,8 +251,8 @@
    "mojeek:ar",
    "ref"
   ],
-  "mullvadleta":"مولفاد هو مزود شبكة خاصة افتراضية ومقره السويد. إنه يلتزم بسياسة صارمة لعدم الاحتفاظ بالسجلات وسياسة خصوصية شاملة للغاية. لا تجمع مولفاد أي معلومات منك عند التسجيل. بدلاً من ذلك ، يتم إنشاء رقم عشوائي واستخدامه كمعرف خاص بك. تدعم اوبن في بي إن و وايرجارد. ويدعم أيضًا قفزات خادم متعددة مع ميزة التجسير. تقدم مولفاد خدمة جيدة للغاية مع تركيز قوي على الخصوصية.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"مولفاد هو مزود شبكة خاصة افتراضية ومقره السويد. إنه يلتزم بسياسة صارمة لعدم الاحتفاظ بالسجلات وسياسة خصوصية شاملة للغاية. لا تجمع مولفاد أي معلومات منك عند التسجيل. بدلاً من ذلك ، يتم إنشاء رقم عشوائي واستخدامه كمعرف خاص بك. تدعم اوبن في بي إن و وايرجارد. ويدعم أيضًا قفزات خادم متعددة مع ميزة التجسير. تقدم مولفاد خدمة جيدة للغاية مع تركيز قوي على الخصوصية.",
+  "mullvadleta-brave":[
    "mullvadleta:ar",
    "ref"
   ],
@@ -2298,8 +2298,8 @@
    "mozhi - Mozhi is an alternative-frontend for many translation engines.",
    "https://codeberg.org/aryak/mozhi"
   ],
-  "mullvadleta":"Mullvad is a commercial VPN service based in Sweden. The name \"Mullvad\" is the word for \"mole\" in the Swedish language. Mullvad operates using the WireGuard and OpenVPN protocols. It also supports Shadowsocks as a bridge protocol for censorship circumvention. Mullvad's VPN client software is publicly available under the GPLv3, a free and open-source software license.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad is a commercial VPN service based in Sweden. The name \"Mullvad\" is the word for \"mole\" in the Swedish language. Mullvad operates using the WireGuard and OpenVPN protocols. It also supports Shadowsocks as a bridge protocol for censorship circumvention. Mullvad's VPN client software is publicly available under the GPLv3, a free and open-source software license.",
+  "mullvadleta-brave":[
    "mullvadleta:en",
    "ref"
   ],
@@ -2916,8 +2916,8 @@
    "mojeek:es",
    "ref"
   ],
-  "mullvadleta":"Mullvad es una red privada virtual comercial de código abierto con sede en Suecia. Lanzado en marzo de 2009, Mullvad opera utilizando los protocolos WireGuard y OpenVPN. Mullvad acepta Bitcoin, Bitcoin Cash y Monero para el pago además de los métodos de pago convencionales.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad es una red privada virtual comercial de código abierto con sede en Suecia. Lanzado en marzo de 2009, Mullvad opera utilizando los protocolos WireGuard y OpenVPN. Mullvad acepta Bitcoin, Bitcoin Cash y Monero para el pago además de los métodos de pago convencionales.",
+  "mullvadleta-brave":[
    "mullvadleta:es",
    "ref"
   ],
@@ -3498,8 +3498,8 @@
    "پلتفرم پخش جاری صوتی بریتانیایی",
    "wikidata"
   ],
-  "mullvadleta":"مولواد یک برنامه شبکه خصوصی مجازی (VPN) شخصی است که در مارس ۲۰۰۹ بوجود آمد.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"مولواد یک برنامه شبکه خصوصی مجازی (VPN) شخصی است که در مارس ۲۰۰۹ بوجود آمد.",
+  "mullvadleta-brave":[
    "mullvadleta:fa-IR",
    "ref"
   ],
@@ -3731,8 +3731,8 @@
    "Opettele vuorovaikutteisten oppituntien ja teknisen dokumentaation avulla, ansaitse työtunteja ja sertifiointeja ja muodosta yhteys yhteisöön.",
    "https://learn.microsoft.com"
   ],
-  "mullvadleta":"Mullvad VPN AB on ruotsalainen VPN-palveluntarjoaja, joka keskittyy yksityisyyden takaamiseen käyttäjilleen. Fredrik Strömberg ja Daniel Berntsson perustivat Mullvadin maaliskuussa 2009 emoyhtiö Amagicom AB:n alle. Useiden riippumattomien tarkastusten mukaan Mullvad suoriutuu hyvin käyttäjien turvallisuuden ja yksityisyyden suojaamisessa.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad VPN AB on ruotsalainen VPN-palveluntarjoaja, joka keskittyy yksityisyyden takaamiseen käyttäjilleen. Fredrik Strömberg ja Daniel Berntsson perustivat Mullvadin maaliskuussa 2009 emoyhtiö Amagicom AB:n alle. Useiden riippumattomien tarkastusten mukaan Mullvad suoriutuu hyvin käyttäjien turvallisuuden ja yksityisyyden suojaamisessa.",
+  "mullvadleta-brave":[
    "mullvadleta:fi",
    "ref"
   ],
@@ -4083,8 +4083,8 @@
    "mojeek:fr",
    "ref"
   ],
-  "mullvadleta":"Mullvad est un service de réseau privé virtuel crée en 2009 et basé en Suède. Mullvad utilise les protocoles de communication WireGuard et OpenVPN.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad est un service de réseau privé virtuel crée en 2009 et basé en Suède. Mullvad utilise les protocoles de communication WireGuard et OpenVPN.",
+  "mullvadleta-brave":[
    "mullvadleta:fr",
    "ref"
   ],
@@ -4918,8 +4918,8 @@
    "https://learn.microsoft.com"
   ],
   "mixcloud":"A Mixcloud egy freemium zenemegosztó streamingszolgáltató weboldal, ami rádióműsorok, zenei mixek és podcastok megosztását teszi lehetővé. Az oldal crowdsourcing alapján működik, a regisztrált felhasználók által feltöltött munkák biztosítják a tartalmat. A felhasználók korlátlanul tölthetnek fel az oldalra, de a feltöltött munkákat letölteni nem lehet, csak streamelni. A Mixcloud alkalmazása megjelent Androidra és iOS-re.",
-  "mullvadleta":"A Mullvad előfizetés-alapú virtuális magánhálózat-szolgáltató (VPN), melyet a göteborgi székhelyű Amagicom AB Mullvad VPN AB nevű leányvállalata üzemeltet. A vállalatnak Android, iOS, Linux, macOS és Windows platformokra van nyílt forráskódú natív alkalmazása, de több OpenVPN és WireGuard protokollt támogató eszközhöz nyújt automatizált konfigurációs fájlokat.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"A Mullvad előfizetés-alapú virtuális magánhálózat-szolgáltató (VPN), melyet a göteborgi székhelyű Amagicom AB Mullvad VPN AB nevű leányvállalata üzemeltet. A vállalatnak Android, iOS, Linux, macOS és Windows platformokra van nyílt forráskódú natív alkalmazása, de több OpenVPN és WireGuard protokollt támogató eszközhöz nyújt automatizált konfigurációs fájlokat.",
+  "mullvadleta-brave":[
    "mullvadleta:hu",
    "ref"
   ],
@@ -5917,8 +5917,8 @@
    "대화형 수업과 기술 설명서를 통해 학습하고, 전문 개발 시간과 인증을 취득하고, 커뮤니티에서 소통합니다.",
    "https://learn.microsoft.com"
   ],
-  "mullvadleta":"Mullvad는 2009년 3월에 출시한 스웨덴에 기반을 둔 오픈 소스 상용 VPN 서비스이다. Mullvad는 WireGuard 와 OpenVPN 프로토콜를 지원한다. Mullvad는 기존의 결제 방법 외에도 비트코인, 비트코인 캐시, 모네로로 결제할 수 있다.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad는 2009년 3월에 출시한 스웨덴에 기반을 둔 오픈 소스 상용 VPN 서비스이다. Mullvad는 WireGuard 와 OpenVPN 프로토콜를 지원한다. Mullvad는 기존의 결제 방법 외에도 비트코인, 비트코인 캐시, 모네로로 결제할 수 있다.",
+  "mullvadleta-brave":[
    "mullvadleta:ko",
    "ref"
   ],
@@ -6898,11 +6898,11 @@
    "https://learn.microsoft.com"
   ],
   "mixcloud":"Mixcloud is een online audioplatform voor het streamen van muziek. Met behulp van Mixcloud kunnen radioprogramma's, mixen van dj's en podcasts gedistribueerd en beluisterd worden.",
-  "mullvadleta":[
+  "mullvadleta-google":[
    "aanbieder van VPN-diensten",
    "wikidata"
   ],
-  "mullvadleta brave":[
+  "mullvadleta-brave":[
    "mullvadleta:nl",
    "ref"
   ],
@@ -7255,11 +7255,11 @@
    "mixcloud:nl",
    "ref"
   ],
-  "mullvadleta":[
+  "mullvadleta-google":[
    "mullvadleta:nl",
    "ref"
   ],
-  "mullvadleta brave":[
+  "mullvadleta-brave":[
    "mullvadleta:nl",
    "ref"
   ],
@@ -8998,8 +8998,8 @@
    "wikidata"
   ],
   "mixcloud":"Mixcloud — британская онлайн-платформа для распространения звуковой информации. Платформа позволяет размещать радиошоу, диджейские миксы и подкасты.",
-  "mullvadleta":"Mullvad — сервис по поставке услуг виртуальной частной сети (VPN) с открытым исходным кодом, базирующийся в Швеции. Mullvad работает с использованием протоколов WireGuard и OpenVPN. В дополнение к стандартным способам оплаты подписки на Mullvad, сервис принимает криптовалюту, такую как Bitcoin, Bitcoin Cash и Monero.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad — сервис по поставке услуг виртуальной частной сети (VPN) с открытым исходным кодом, базирующийся в Швеции. Mullvad работает с использованием протоколов WireGuard и OpenVPN. В дополнение к стандартным способам оплаты подписки на Mullvad, сервис принимает криптовалюту, такую как Bitcoin, Bitcoin Cash и Monero.",
+  "mullvadleta-brave":[
    "mullvadleta:ru",
    "ref"
   ],
@@ -9906,8 +9906,8 @@
    "Lär dig med interaktiva lektioner och teknisk dokumentation, få professionella utvecklingstimmar och certifieringar och få kontakt med communityn.",
    "https://learn.microsoft.com"
   ],
-  "mullvadleta":"Mullvad är en kommersiell VPN-tjänst baserad i Sverige. Mullvad lanserades i mars 2009 och använder protokollen WireGuard och OpenVPN. Det stöder också ShadowSocks som ett bryggprotokoll för att kunna kringgå censur.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad är en kommersiell VPN-tjänst baserad i Sverige. Mullvad lanserades i mars 2009 och använder protokollen WireGuard och OpenVPN. Det stöder också ShadowSocks som ett bryggprotokoll för att kunna kringgå censur.",
+  "mullvadleta-brave":[
    "mullvadleta:sv",
    "ref"
   ],
@@ -10489,8 +10489,8 @@
    "mojeek:tr",
    "ref"
   ],
-  "mullvadleta":"Mullvad, İsveç merkezli açık kaynaklı bir ticari VPN hizmetidir. Mart 2009'da başlatılan Mullvad, WireGuard ve OpenVPN protokollerini kullanarak çalışır. Mullvad, geleneksel ödeme yöntemlerine ek olarak abonelikler için Bitcoin ve Bitcoin Cash'i kabul eder.",
-  "mullvadleta brave":[
+  "mullvadleta-google":"Mullvad, İsveç merkezli açık kaynaklı bir ticari VPN hizmetidir. Mart 2009'da başlatılan Mullvad, WireGuard ve OpenVPN protokollerini kullanarak çalışır. Mullvad, geleneksel ödeme yöntemlerine ek olarak abonelikler için Bitcoin ve Bitcoin Cash'i kabul eder.",
+  "mullvadleta-brave":[
    "mullvadleta:tr",
    "ref"
   ],

--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -6628,7 +6628,7 @@
       "to-TO": "to"
     }
   },
-  "mullvadleta": {
+  "mullvadleta-google": {
     "all_locale": null,
     "custom": {},
     "data_type": "traits_v1",

--- a/searx/engines/mullvad_leta.py
+++ b/searx/engines/mullvad_leta.py
@@ -28,7 +28,7 @@ You can configure one Leta engine for Google and one for Brave:
 
   - name: mullvadleta-brave
     engine: mullvad_leta
-    network: mullvadleta  # use network from engine "mullvadleta" configured above
+    network: mullvadleta-google  # use network from engine "mullvadleta-google" configured above
     leta_engine: brave
     shortcut: mlb
 

--- a/searx/engines/mullvad_leta.py
+++ b/searx/engines/mullvad_leta.py
@@ -21,12 +21,12 @@ You can configure one Leta engine for Google and one for Brave:
 
 .. code:: yaml
 
-  - name: mullvadleta
+  - name: mullvadleta-google
     engine: mullvad_leta
     leta_engine: google
     shortcut: ml
 
-  - name: mullvadleta brave
+  - name: mullvadleta-brave
     engine: mullvad_leta
     network: mullvadleta  # use network from engine "mullvadleta" configured above
     leta_engine: brave

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1426,14 +1426,14 @@ engines:
       results: JSON
 
   # https://docs.searxng.org/dev/engines/online/mullvad_leta.html
-  - name: mullvadleta
+  - name: mullvadleta-google
     engine: mullvad_leta
     disabled: true
     leta_engine: google
     categories: [general, web]
     shortcut: ml
 
-  - name: mullvadleta brave
+  - name: mullvadleta-brave
     engine: mullvad_leta
     network: mullvadleta
     disabled: true


### PR DESCRIPTION
It was confusing to name the Google version as just "mullvadleta", and also confusing for the Brave version to be called "mullvadleta brave" with a space, because there is a separate engine also named "brave". For example:

<img width="859" height="511" alt="image" src="https://github.com/user-attachments/assets/1c2317f8-8ad1-497e-bed4-ecb922637608" />
