### PR TITLE
[mod] bing engine: follow redirects

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -108,6 +108,10 @@ def request(query, params):
         time_ranges = {'day': '1', 'week': '2', 'month': '3', 'year': f'5_{unix_day-365}_{unix_day}'}
         params['url'] += f'&filters=ex1:"ez{time_ranges[params["time_range"]]}"'
 
+    # in some regions where geoblocking is employed (e.g. China),
+    # www.bing.com redirects to the regional version of Bing
+    params['allow_redirects'] = True
+
     return params
 
 


### PR DESCRIPTION
Apparently, in China, Bing redirects from `www.bing.com` to `cn.bing.com`. So in order to make Bing work for chinese users by default, we have to follow that redirect.

related: https://github.com/searxng/searxng/issues/5243
