### PR TITLE
[chore] Mention the black theme style in settings.yml

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -138,7 +138,7 @@ ui:
   # Open result links in a new tab by default
   # results_on_new_tab: false
   theme_args:
-    # style of simple theme: auto, light, dark
+    # style of simple theme: auto, light, dark, black
     simple_style: auto
   # Perform search immediately if a category selected.
   # Disable to select multiple categories at once and start the search manually.


### PR DESCRIPTION
## What does this PR do?

This PR mentions the "Black" style for the Simple theme in the comment in settings.yml that lists the other styles.

## Why is this change important?

The "Black" style was not previously mentioned, so instance maintainers may not know about it.

## How to test this PR locally?

Replace line 141 in your settings.yml with the changed line.