### PR TITLE
Update settings_loader to handle missing settings path

### DIFF
--- a/searx/settings_loader.py
+++ b/searx/settings_loader.py
@@ -104,13 +104,18 @@ def get_user_cfg_folder() -> Path | None:
         elif settings_path.is_file():
             folder = settings_path.parent
         else:
-            raise EnvironmentError(1, f"{settings_path} not exists!", settings_path)
+            # MODIFIED: Don't raise error, try fallback instead
+            folder = None
 
     if not folder and not disable_etc:
         # default: rule 3.
         folder = Path("/etc/searxng")
         if not folder.is_dir():
             folder = None
+    
+    # ADDED: Final fallback to project root if nothing else works
+    if not folder:
+        folder = Path("/opt/render/project/src")
 
     return folder
 


### PR DESCRIPTION
Modified settings_loader to use fallback folder paths instead of raising an error when settings_path does not exist. Added a final fallback to the project root if no other folder is found.

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
