### PR TITLE
[upd] themes/simple: Bump rolldown-vite from 7.1.17 to 7.1.19

### DIFF
--- a/client/simple/package-lock.json
+++ b/client/simple/package-lock.json
@@ -29,7 +29,7 @@
         "stylelint-prettier": "~5.0.3",
         "svgo": "~4.0.0",
         "typescript": "~5.9.3",
-        "vite": "npm:rolldown-vite@7.1.17",
+        "vite": "npm:rolldown-vite@7.1.19",
         "vite-bundle-analyzer": "~1.2.3"
       }
     },
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
+      "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -843,16 +843,19 @@
       }
     },
     "node_modules/@keyv/bigmap": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.0.3.tgz",
-      "integrity": "sha512-jUEkNlnE9tYzX2AIBeoSe1gVUvSOfIOQ5EFPL5Un8cFHGvjD9L/fxpxlS1tEivRLHgapO2RZJ3D93HYAa049pg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.1.0.tgz",
+      "integrity": "sha512-MX7XIUNwVRK+hjZcAbNJ0Z8DREo+Weu9vinBOjGU1thEi9F6vPhICzBbk4CCf3eEefKRz7n6TfZXwUFZTSgj8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.12.1"
+        "hookified": "^1.12.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.5.3"
       }
     },
     "node_modules/@keyv/serialize": {
@@ -924,9 +927,9 @@
       }
     },
     "node_modules/@oxc-project/runtime": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.92.0.tgz",
-      "integrity": "sha512-Z7x2dZOmznihvdvCvLKMl+nswtOSVxS2H2ocar+U9xx6iMfTp0VGIrX6a4xB1v80IwOPC7dT1LXIJrY70Xu3Jw==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.95.0.tgz",
+      "integrity": "sha512-qJS5pNepwMGnafO9ayKGz7rfPQgUBuunHpnP1//9Qa0zK3oT3t1EhT+I+pV9MUA+ZKez//OFqxCxf1vijCKb2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -934,9 +937,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.94.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.94.0.tgz",
-      "integrity": "sha512-+UgQT/4o59cZfH6Cp7G0hwmqEQ0wE+AdIwhikdwnhWI9Dp8CgSY081+Q3O67/wq3VJu8mgUEB93J9EHHn70fOw==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.95.0.tgz",
+      "integrity": "sha512-vACy7vhpMPhjEJhULNxrdR0D943TkA/MigMpJCHmBHvMXxRStRi/dPtTlfQ3uDwWSzRpT8z+7ImjZVf8JWBocQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1019,9 +1022,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.43.tgz",
-      "integrity": "sha512-TP8bcPOb1s6UmY5syhXrDn9k0XkYcw+XaoylTN4cJxf0JOVS2j682I3aTcpfT51hOFGr2bRwNKN9RZ19XxeQbA==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.44.tgz",
+      "integrity": "sha512-g9ejDOehJFhxC1DIXQuZQ9bKv4lRDioOTL42cJjFjqKPl1L7DVb9QQQE1FxokGEIMr6FezLipxwnzOXWe7DNPg==",
       "cpu": [
         "arm64"
       ],
@@ -1036,9 +1039,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.43.tgz",
-      "integrity": "sha512-kuVWnZsE4vEjMF/10SbSUyzucIW2zmdsqFghYMqy+fsjXnRHg0luTU6qWF8IqJf4Cbpm9NEZRnjIEPpAbdiSNQ==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.44.tgz",
+      "integrity": "sha512-PxAW1PXLPmCzfhfKIS53kwpjLGTUdIfX4Ht+l9mj05C3lYCGaGowcNsYi2rdxWH24vSTmeK+ajDNRmmmrK0M7g==",
       "cpu": [
         "arm64"
       ],
@@ -1053,9 +1056,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.43.tgz",
-      "integrity": "sha512-u9Ps4sh6lcmJ3vgLtyEg/x4jlhI64U0mM93Ew+tlfFdLDe7yKyA+Fe80cpr2n1mNCeZXrvTSbZluKpXQ0GxLjw==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.44.tgz",
+      "integrity": "sha512-/CtQqs1oO9uSb5Ju60rZvsdjE7Pzn8EK2ISAdl2jedjMzeD/4neNyCbwyJOAPzU+GIQTZVyrFZJX+t7HXR1R/g==",
       "cpu": [
         "x64"
       ],
@@ -1070,9 +1073,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.43.tgz",
-      "integrity": "sha512-h9lUtVtXgfbk/tnicMpbFfZ3DJvk5Zn2IvmlC1/e0+nUfwoc/TFqpfrRRqcNBXk/e+xiWMSKv6b0MF8N+Rtvlg==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.44.tgz",
+      "integrity": "sha512-V5Q5W9c4+2GJ4QabmjmVV6alY97zhC/MZBaLkDtHwGy3qwzbM4DYgXUbun/0a8AH5hGhuU27tUIlYz6ZBlvgOA==",
       "cpu": [
         "x64"
       ],
@@ -1087,9 +1090,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.43.tgz",
-      "integrity": "sha512-IX2C6bA6wM2rX/RvD75ko+ix9yxPKjKGGq7pOhB8wGI4Z4fqX5B1nDHga/qMDmAdCAR1m9ymzxkmqhm/AFYf7A==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.44.tgz",
+      "integrity": "sha512-X6adjkHeFqKsTU0FXdNN9HY4LDozPqIfHcnXovE5RkYLWIjMWuc489mIZ6iyhrMbCqMUla9IOsh5dvXSGT9o9A==",
       "cpu": [
         "arm"
       ],
@@ -1104,9 +1107,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.43.tgz",
-      "integrity": "sha512-mcjd57vEj+CEQbZAzUiaxNzNgwwgOpFtZBWcINm8DNscvkXl5b/s622Z1dqGNWSdrZmdjdC6LWMvu8iHM6v9sQ==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.44.tgz",
+      "integrity": "sha512-kRRKGZI4DXWa6ANFr3dLA85aSVkwPdgXaRjfanwY84tfc3LncDiIjyWCb042e3ckPzYhHSZ3LmisO+cdOIYL6Q==",
       "cpu": [
         "arm64"
       ],
@@ -1121,9 +1124,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.43.tgz",
-      "integrity": "sha512-Pa8QMwlkrztTo/1mVjZmPIQ44tCSci10TBqxzVBvXVA5CFh5EpiEi99fPSll2dHG2uT4dCOMeC6fIhyDdb0zXA==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.44.tgz",
+      "integrity": "sha512-hMtiN9xX1NhxXBa2U3Up4XkVcsVp2h73yYtMDY59z9CDLEZLrik9RVLhBL5QtoX4zZKJ8HZKJtWuGYvtmkCbIQ==",
       "cpu": [
         "arm64"
       ],
@@ -1138,9 +1141,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.43.tgz",
-      "integrity": "sha512-BgynXKMjeaX4AfWLARhOKDetBOOghnSiVRjAHVvhiAaDXgdQN8e65mSmXRiVoVtD3cHXx/cfU8Gw0p0K+qYKVQ==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.44.tgz",
+      "integrity": "sha512-rd1LzbpXQuR8MTG43JB9VyXDjG7ogSJbIkBpZEHJ8oMKzL6j47kQT5BpIXrg3b5UVygW9QCI2fpFdMocT5Kudg==",
       "cpu": [
         "x64"
       ],
@@ -1155,9 +1158,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.43.tgz",
-      "integrity": "sha512-VIsoPlOB/tDSAw9CySckBYysoIBqLeps1/umNSYUD8pMtalJyzMTneAVI1HrUdf4ceFmQ5vARoLIXSsPwVFxNg==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.44.tgz",
+      "integrity": "sha512-qI2IiPqmPRW25exXkuQr3TlweCDc05YvvbSDRPCuPsWkwb70dTiSoXn8iFxT4PWqTi71wWHg1Wyta9PlVhX5VA==",
       "cpu": [
         "x64"
       ],
@@ -1172,9 +1175,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.43.tgz",
-      "integrity": "sha512-YDXTxVJG67PqTQMKyjVJSddoPbSWJ4yRz/E3xzTLHqNrTDGY0UuhG8EMr8zsYnfH/0cPFJ3wjQd/hJWHuR6nkA==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.44.tgz",
+      "integrity": "sha512-+vHvEc1pL5iJRFlldLC8mjm6P4Qciyfh2bh5ZI6yxDQKbYhCHRKNURaKz1mFcwxhVL5YMYsLyaqM3qizVif9MQ==",
       "cpu": [
         "arm64"
       ],
@@ -1189,9 +1192,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.43.tgz",
-      "integrity": "sha512-3M+2DmorXvDuAIGYQ9Z93Oy1G9ETkejLwdXXb1uRTgKN9pMcu7N+KG2zDrJwqyxeeLIFE22AZGtSJm3PJbNu9Q==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.44.tgz",
+      "integrity": "sha512-XSgLxRrtFj6RpTeMYmmQDAwHjKseYGKUn5LPiIdW4Cq+f5SBSStL2ToBDxkbdxKPEbCZptnLPQ/nfKcAxrC8Xg==",
       "cpu": [
         "wasm32"
       ],
@@ -1206,9 +1209,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.43.tgz",
-      "integrity": "sha512-/B1j1pJs33y9ywtslOMxryUPHq8zIGu/OGEc2gyed0slimJ8fX2uR/SaJVhB4+NEgCFIeYDR4CX6jynAkeRuCA==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.44.tgz",
+      "integrity": "sha512-cF1LJdDIX02cJrFrX3wwQ6IzFM7I74BYeKFkzdcIA4QZ0+2WA7/NsKIgjvrunupepWb1Y6PFWdRlHSaz5AW1Wg==",
       "cpu": [
         "arm64"
       ],
@@ -1223,9 +1226,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-ia32-msvc": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.43.tgz",
-      "integrity": "sha512-29oG1swCz7hNP+CQYrsM4EtylsKwuYzM8ljqbqC5TsQwmKat7P8ouDpImsqg/GZxFSXcPP9ezQm0Q0wQwGM3JA==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.44.tgz",
+      "integrity": "sha512-5uaJonDafhHiMn+iEh7qUp3QQ4Gihv3lEOxKfN8Vwadpy0e+5o28DWI42DpJ9YBYMrVy4JOWJ/3etB/sptpUwA==",
       "cpu": [
         "ia32"
       ],
@@ -1240,9 +1243,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.43.tgz",
-      "integrity": "sha512-eWBV1Ef3gfGNehxVGCyXs7wLayRIgCmyItuCZwYYXW5bsk4EvR4n2GP5m3ohjnx7wdiY3nLmwQfH2Knb5gbNZw==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.44.tgz",
+      "integrity": "sha512-vsqhWAFJkkmgfBN/lkLCWTXF1PuPhMjfnAyru48KvF7mVh2+K7WkKYHezF3Fjz4X/mPScOcIv+g6cf6wnI6eWg==",
       "cpu": [
         "x64"
       ],
@@ -1257,9 +1260,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.43.tgz",
-      "integrity": "sha512-5Uxg7fQUCmfhax7FJke2+8B6cqgeUJUD9o2uXIKXhD+mG0mL6NObmVoi9wXEU1tY89mZKgAYA6fTbftx3q2ZPQ==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.44.tgz",
+      "integrity": "sha512-g6eW7Zwnr2c5RADIoqziHoVs6b3W5QTQ4+qbpfjbkMJ9x+8Og211VW/oot2dj9dVwaK/UyC6Yo+02gV+wWQVNg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1368,9 +1371,9 @@
       ]
     },
     "node_modules/@stencil/core": {
-      "version": "4.38.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.38.1.tgz",
-      "integrity": "sha512-qImplYLSp2wSZJo3oMZ3HrTaI+uULcRB4Knrua7UT9VjN/va+TDfk4JAKwDyDfTDkD2laDPcy6QJP2S3hVxZFQ==",
+      "version": "4.38.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.38.2.tgz",
+      "integrity": "sha512-opyjA+DYAtaKmaSnuC8Bb/PH7nuO+1GhVn6amsN8XT+TlT9biptlcpz4YWETwYZ+XxtX+nLdxWbW0TVafrqsvQ==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -1488,16 +1491,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1543,9 +1536,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.17.tgz",
-      "integrity": "sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==",
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.19.tgz",
+      "integrity": "sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1637,16 +1630,16 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.0.tgz",
-      "integrity": "sha512-zzL1BxdnqwD69JRT0dihnawAcLkBMwAH+hZSKjUzeBbPedVhk3qYPjRw9VOMYWwt5xRih5xd8S+3kEdGohZm/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.1.tgz",
+      "integrity": "sha512-LmF4AXiSNdiRbI2UjH8pAp9NIXxeQsTotpEaegPiDcnN0YPygDJDV3l/Urc0mL72JWdATEorKqIHEx55nDlONg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/memoize": "^2.0.3",
         "@cacheable/memory": "^2.0.3",
         "@cacheable/utils": "^2.1.0",
-        "hookified": "^1.12.1",
+        "hookified": "^1.12.2",
         "keyv": "^5.5.3",
         "qified": "^0.5.0"
       }
@@ -2685,6 +2678,7 @@
       "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -3144,9 +3138,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.25.tgz",
-      "integrity": "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
+      "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3468,13 +3462,13 @@
       "optional": true
     },
     "node_modules/qified": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.0.tgz",
-      "integrity": "sha512-Zj6Q/Vc/SQ+Fzc87N90jJUzBzxD7MVQ2ZvGyMmYtnl2u1a07CejAhvtk4ZwASos+SiHKCAIylyGHJKIek75QBw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.1.tgz",
+      "integrity": "sha512-+BtFN3dCP+IaFA6IYNOu/f/uK1B8xD2QWyOeCse0rjtAebBmkzgd2d1OAXi3ikAzJMIBSdzZDNZ3wZKEUDQs5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.12.1"
+        "hookified": "^1.12.2"
       },
       "engines": {
         "node": ">=20"
@@ -3569,15 +3563,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-beta.43",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.43.tgz",
-      "integrity": "sha512-6RcqyRx0tY1MlRLnjXPp/849Rl/CPFhzpGGwNPEPjKwqBMqPq/Rbbkxasa8s0x+IkUk46ty4jazb5skZ/Vgdhw==",
+      "version": "1.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.44.tgz",
+      "integrity": "sha512-gcqgyCi3g93Fhr49PKvymE8PoaGS0sf6ajQrsYaQ8o5de6aUEbD6rJZiJbhOfpcqOnycgsAsUNPYri1h25NgsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.94.0",
-        "@rolldown/pluginutils": "1.0.0-beta.43",
-        "ansis": "=4.2.0"
+        "@oxc-project/types": "=0.95.0",
+        "@rolldown/pluginutils": "1.0.0-beta.44"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3586,20 +3579,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-beta.43",
-        "@rolldown/binding-darwin-arm64": "1.0.0-beta.43",
-        "@rolldown/binding-darwin-x64": "1.0.0-beta.43",
-        "@rolldown/binding-freebsd-x64": "1.0.0-beta.43",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.43",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.43",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.43",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.43",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.43",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.43",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.43",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.43",
-        "@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.43",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.43"
+        "@rolldown/binding-android-arm64": "1.0.0-beta.44",
+        "@rolldown/binding-darwin-arm64": "1.0.0-beta.44",
+        "@rolldown/binding-darwin-x64": "1.0.0-beta.44",
+        "@rolldown/binding-freebsd-x64": "1.0.0-beta.44",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.44",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.44",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.44",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.44",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.44",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.44",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.44",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.44",
+        "@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.44",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.44"
       }
     },
     "node_modules/run-parallel": {
@@ -4292,18 +4285,18 @@
     },
     "node_modules/vite": {
       "name": "rolldown-vite",
-      "version": "7.1.17",
-      "resolved": "https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.1.17.tgz",
-      "integrity": "sha512-bNUI0r4RuZxLeip7sOcZK3y4eYUcMAMM6ys68tbU/KWDH8lqaPFYE03Doc04Dz94jHmVg1OWyeBqlDOYntsLsA==",
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.1.19.tgz",
+      "integrity": "sha512-4TRFlbv0F8zE0EbaSAuzHEGlBRRTSaMd3QP8Qz0VTeSb6Z+kpCXSAw2k2QimTuDCJSxdYItcjZjWXtn0j6ksTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.92.0",
+        "@oxc-project/runtime": "0.95.0",
         "fdir": "^6.5.0",
         "lightningcss": "^1.30.2",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
-        "rolldown": "1.0.0-beta.43",
+        "rolldown": "1.0.0-beta.44",
         "tinyglobby": "^0.2.15"
       },
       "bin": {

--- a/client/simple/package.json
+++ b/client/simple/package.json
@@ -45,7 +45,7 @@
     "stylelint-prettier": "~5.0.3",
     "svgo": "~4.0.0",
     "typescript": "~5.9.3",
-    "vite": "npm:rolldown-vite@7.1.17",
+    "vite": "npm:rolldown-vite@7.1.19",
     "vite-bundle-analyzer": "~1.2.3"
   }
 }


### PR DESCRIPTION
This security update does nothing but creating a new commit to build a container with the new `base` image.