### PR TITLE
[fix] Installation Script install fails (msgspec)

### DIFF
--- a/docs/build-templates/searxng.rst
+++ b/docs/build-templates/searxng.rst
@@ -120,6 +120,7 @@ ${fedora_build}
        pip install -U setuptools
        pip install -U wheel
        pip install -U pyyaml
+       pip install -U msgspec
 
        # jump to SearXNG's working tree and install SearXNG into virtualenv
        (${SERVICE_USER})$ cd \"$SEARXNG_SRC\"


### PR DESCRIPTION
Since #5280 has been merged, msgspec, like yaml, is a fixed part of the SearXNG *settings framework* and therefore, like yaml, must be installed in the virtual environment before installing SearXNG (``searx``).

The actual reason is that in SearXNG we store settings in the configuration that are required for the installation of the ``searx`` package.  This means that these settings (from settings.yml) are read in during the installation, and all the necessary tools for this (pyyaml, msgspec, setuptools, etc.) must be installed beforehand (chicken or the egg dilemma).

Related:

- https://github.com/searxng/searxng/pull/5346
- https://github.com/searxng/searxng/pull/5280
- https://github.com/searxng/searxng/pull/5254

Closes: https://github.com/searxng/searxng/issues/5352

