### PR TITLE
[fix] Installation Script install fails (msgspec)

### DIFF
--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -553,6 +553,7 @@ pip install -U pip
 pip install -U setuptools
 pip install -U wheel
 pip install -U pyyaml
+pip install -U msgspec
 pip install -U --use-pep517 --no-build-isolation -e .
 EOF
     rst_para "update instance's settings.yml from ${SEARXNG_SETTINGS_PATH}"


### PR DESCRIPTION
Since #5280 has been merged, msgspec, like yaml, is a fixed part of the SearXNG *settings framework* and therefore, like yaml, must be installed in the virtual environment before installing SearXNG (``searx``).

The actual reason is that in SearXNG we store settings in the configuration that are required for the installation of the ``searx`` package.  This means that these settings (from settings.yml) are read in during the installation, and all the necessary tools for this (pyyaml, msgspec, setuptools, etc.) must be installed beforehand (chicken or the egg dilemma).

Related:

- https://github.com/searxng/searxng/pull/5353
- https://github.com/searxng/searxng/pull/5346
- https://github.com/searxng/searxng/pull/5280
- https://github.com/searxng/searxng/pull/5254

Closes: https://github.com/searxng/searxng/issues/5357