### PR TITLE
[feat] plugins: Add "define <term>" Plugin to Show Definitions in Searches

### DIFF
--- a/searx/plugins/define.py
+++ b/searx/plugins/define.py
@@ -47,7 +47,7 @@ if typing.TYPE_CHECKING:
 
 # ---------------------------------------  Definition Provider Functionality  ------------------------------------------
 
-
+# Internal dataclass for provider results storage
 @dataclass(eq=True, frozen=False)
 class Definition:
     """
@@ -324,7 +324,7 @@ class DefineHandler:
 
             items.append(
                 Translations.Item(
-                    text=word,  # now just "liquid"
+                    text=word,
                     transliteration=f"({pos})" if pos != "unknown" else "",
                     definitions=definitions_text,
                     examples=examples,

--- a/searx/plugins/define.py
+++ b/searx/plugins/define.py
@@ -124,7 +124,7 @@ class Definition:
 class DefinitionProvider:
     """
     Root class for handling web IO and exposing a common interface.
-    Subclasses should implement `.definitions(word, lang="en") -> list[Definition]`.
+    Subclasses should implement `.lookup(word, lang="en") -> list[Definition]`.
     """
 
     # Override this

--- a/searx/plugins/define.py
+++ b/searx/plugins/define.py
@@ -1,0 +1,370 @@
+from searx.result_types import Answer, Translations
+from searx.answerers import Answerer, AnswererInfo
+from searx.result_types.answer import BaseAnswer
+from searx.extended_types import SXNG_Response
+from flask_babel import gettext as _
+from flask_babel import get_locale
+from searx.network import get
+
+from searx.result_types import EngineResults
+from . import Plugin, PluginInfo
+
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+from html import unescape
+from urllib import parse
+import typing
+import re
+
+if typing.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Request
+    from searx.search import SearchWithPlugins
+    from . import PluginCfg
+
+
+
+# ---------------------------------------  Definition Provider Functionality  ------------------------------------------
+
+@dataclass(eq=True, frozen=False)
+class Definition:
+    """
+    Root data model for a single definition entry
+    """
+
+    word:           str
+    part_of_speech: Optional[str]
+    definition:     str
+    examples:       List[str] = field(default_factory=list)
+    lang:           str = "unknown"
+    provider:       str = "unknown"
+    source_url:     Optional[str] = None
+
+
+    # Part-of-speech normalization
+    pos_normalized = {
+        "noun":         "noun",
+        "verb":         "verb",
+        "adjective":    "adjective",
+        "adverb":       "adverb",
+        "pronoun":      "pronoun",
+        "preposition":  "preposition",
+        "conjunction":  "conjunction",
+        "interjection": "interjection",
+        "proper noun":  "proper noun",
+        "proper_noun":  "proper noun",
+        "determiner":   "determiner",
+        "article":      "article",
+    }
+
+    # Normalize fields & dedupe examples when created
+    def __post_init__(self):
+        self.word       = self._clean_text(self.word)
+        self.definition = self._clean_text(self.definition)
+        self.examples   = self._dedupe(self.examples)
+
+        pos = (self.part_of_speech or "").strip().lower()
+        self.part_of_speech = self.pos_normalized.get(pos, pos or "unknown")
+
+    def _clean_text(self, s: str) -> str:
+        s = unescape(s or "")
+        return " ".join(s.split())
+
+    def _dedupe(self, seq: List[str]) -> List[str]:
+        seen, out = set(), []
+        for x in seq:
+            k = self._clean_text(x)
+            if k and k not in seen:
+                seen.add(k)
+                out.append(k)
+        return out
+
+    @property
+    def normalized_pos(self) -> str:
+        return self.part_of_speech or "unknown"
+
+    @property
+    def title(self) -> str:
+        return f"{self.word} ({self.normalized_pos})" if self.normalized_pos != "unknown" else self.word
+
+    @property
+    def dedupe_key(self) -> tuple:
+        return (self.normalized_pos, self.definition)
+
+    def short_example(self, limit: int = 140) -> Optional[str]:
+        if not self.examples:
+            return None
+
+        ex = self.examples[0]
+        return (ex if len(ex) <= limit else ex[: max(0, limit - 1)] + "…")
+
+
+class DefinitionProvider():
+    """
+    Root class for handling web IO and exposing a common interface.
+    Subclasses should implement `.definitions(word, lang="en") -> List[Definition]`.
+    """
+
+    # Override this
+    name: str
+
+
+    def _get(self, url: str) -> SXNG_Response:
+        return get(url)
+
+    def lookup(self, term: str, lang: str = "en") -> List[Definition]:
+        """
+        Return a list of Definition objects for `word`
+        Must be implemented by subclasses
+        """
+        raise NotImplementedError
+
+
+class WiktionaryProvider(DefinitionProvider):
+    """
+    Wiktionary implementation using the official REST API:
+    https://en.wiktionary.org/api/rest_v1/
+    """
+
+    name:          str = 'wiktionary'
+    api_template:  str = "https://en.wiktionary.org/api/rest_v1/page/definition/{title}"
+    page_template: str = "https://en.wiktionary.org/wiki/{title}"
+
+    # Matches href="/wiki/term#POS"
+    _wiki_href_re = re.compile(r'href="(?P<href>/wiki/[^"]+)"')
+
+    def _rewrite_wiki_links(self, html: str) -> str:
+        """
+        Rewrites <a href="/wiki/term[#Section][:Index]"> -> /search?q=define+term
+        - strips #Part-of-speech fragment
+        - strips namespace/index after first colon
+        """
+
+        if not html:
+            return html
+
+        keyword = DefineHandler.keyword
+
+        def _normalize(href: str) -> str:
+            path = href.split('#', 1)[0]
+            if path.startswith('/wiki/'):
+                path = path[len('/wiki/'):]
+            path = path.split(':', 1)[0]
+
+            term = parse.unquote(path).replace('_', ' ').strip()
+            return term
+
+        def _repl(m: re.Match) -> str:
+            term = _normalize(m.group('href'))
+            if not term:
+                return 'href="#"'
+            q = parse.quote_plus(f'{keyword} {term}').lower()
+            return f'href="/search?q={q}"'
+
+        return self._wiki_href_re.sub(_repl, html)
+
+
+    def lookup(self, term: str, lang: str = "en") -> List[Definition]:
+        url  = self.api_template.format(title=term)
+        resp = None
+
+        try:
+            resp = self._get(url)
+            success = resp.status_code == 200
+        except:
+            success = False
+
+        if not (success and resp):
+            return []
+
+        payload = resp.json()
+        entries = payload.get(lang, [])
+        results: List[Definition] = []
+
+        for entry in entries:
+            pos = entry.get("partOfSpeech")
+            for d in entry.get("definitions", []):
+                def_html = self._rewrite_wiki_links(d.get("definition", ""))
+                ex_list  = [self._rewrite_wiki_links(x) for x in d.get("examples", [])]
+                results.append(
+
+                    Definition(
+                        word           = term,
+                        part_of_speech = pos,
+                        definition     = def_html,
+                        examples       = ex_list,
+                        lang           = lang,
+                        provider       = "wiktionary",
+                        source_url     = self.page_template.format(title=term),
+                    )
+
+                )
+
+        return results
+
+
+
+# ----------------------------------------------  SearXNG Integration  -------------------------------------------------
+
+class DefineHandler():
+    """
+    Links a definition provider and provides a public API to the answerer
+    """
+
+    keyword:  str = "define"
+    provider: DefinitionProvider = WiktionaryProvider()
+
+    default_answer: Answer = Answer(answer=_("No definitions were found."))
+    max_definitions:   int = 5
+    max_examples:      int = 3
+
+
+    def _get_locale(self) -> str:
+        """
+        Prefer the user's selected search language if available
+        otherwise fall back to the UI locale, finally 'en'
+        Returns a ISO code like 'en', 'fr', 'de'
+        """
+
+        loc = get_locale()
+        if loc:
+            return str(loc).split('_')[0].lower()
+
+        return 'en'
+
+
+    # Expects a full query, including 'self.keyword'
+    def _extract_term(self, query: str) -> str | None:
+        extracted = None
+        term_key  = self.keyword + ' '
+
+        if query.startswith(term_key):
+            extracted = query[len(term_key):].strip()
+
+        return extracted
+
+
+    def _make_definitions_answer(self, definitions: list[Translations.Item], url: str | None) -> Translations:
+        if not self.provider.name:
+            raise NotImplementedError('no real provider was specified')
+
+        return Translations(
+            translations = definitions,
+            url          = url,
+            engine       = self.provider.name,
+            template     = 'answer/define.html'
+        )
+
+
+    def _build_translations_answer(self, definitions: List[Definition]) -> Translations | None:
+        """
+        Turn a list[Definition] into a single Translations answer
+        - One item per part-of-speech
+        - Each item carries multiple definitions & a few examples
+        """
+
+        if not definitions:
+            return None
+
+        by_pos: dict[str, List[Definition]] = {}
+        for d in definitions:
+            by_pos.setdefault(d.normalized_pos, []).append(d)
+
+        url = next((d.source_url for d in definitions if d.source_url), None)
+        items: List[Translations.Item] = []
+
+
+        # Dedupe identical senses
+        for pos, entries in by_pos.items():
+            seen = set()
+            definitions_text: List[str] = []
+            examples: List[str] = []
+
+            for d in entries:
+                if d.dedupe_key in seen:
+                    continue
+
+                seen.add(d.dedupe_key)
+                if len(definitions_text) < self.max_definitions:
+                    definitions_text.append(d.definition)
+
+                for ex in d.examples:
+                    if len(examples) >= self.max_examples:
+                        break
+
+                    if ex not in examples:
+                        examples.append(ex)
+
+
+            # Title of the card uses the first definition's word
+            word = entries[0].word if entries else ""
+            pos  = entries[0].normalized_pos if entries else "unknown"
+
+            items.append(
+                Translations.Item(
+                    text            = word,             # now just "liquid"
+                    transliteration = f"({pos})" if pos != "unknown" else "",
+                    definitions     = definitions_text,
+                    examples        = examples,
+                    synonyms        = [],
+                )
+            )
+
+        return self._make_definitions_answer(definitions=items, url=url)
+
+
+    # Expects a full query, including 'self.keyword'
+    def find_results(self, query: str) -> list[BaseAnswer]:
+        results = []
+        term = self._extract_term(query)
+        if not term:
+            return results
+
+        lang = self._get_locale()
+        definitions: list[Definition] = self.provider.lookup(term, lang=lang)
+        if not definitions:
+            results.append(self.default_answer)
+            return results
+
+        translations_answer = self._build_translations_answer(definitions)
+        if translations_answer: results.append(translations_answer)
+        else:            results.append(self.default_answer)
+
+        return results
+
+
+class SXNGPlugin(Plugin, DefineHandler):
+    """Adds a 'define <term>' special query that returns a Translations answer."""
+
+    id = DefineHandler.keyword
+    keywords = [ id ]
+
+    def __init__(self, plg_cfg: "PluginCfg"):
+        Plugin.__init__(self, plg_cfg)
+
+        self.info = PluginInfo(
+            id                 = self.id,
+            name               = _(self.id.title()),
+            description        = f'{_("Displays definitions to a search term")} ({_("Source")}: {self.provider.name})',
+            examples           = [ f"{self.id} <{_('term')}>", f"{self.id} effervescence" ],
+            preference_section = "query",
+        )
+
+    def post_search(self, request: "SXNG_Request", search: "SearchWithPlugins") -> EngineResults:
+        """Returns answers only for the first page"""
+        
+        results = EngineResults()
+
+        if search.search_query.pageno > 1:
+            return results
+
+        q = (search.search_query.query or "").strip()
+        term = self._extract_term(q)
+        if not term:
+            return results
+
+        # Pull functionality from 'DefineHandler'
+        for ans in self.find_results(q):
+            results.add(ans)
+
+        return results

--- a/searx/plugins/define.py
+++ b/searx/plugins/define.py
@@ -1,21 +1,43 @@
-from searx.result_types import Answer, Translations
-from searx.answerers import Answerer, AnswererInfo
-from searx.result_types.answer import BaseAnswer
-from searx.extended_types import SXNG_Response
-from flask_babel import gettext as _
-from flask_babel import get_locale
-from searx.network import get
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=too-many-branches, unused-argument, too-few-public-methods
+"""
+Add a special query ``define <term>`` that returns a compact, inline
+definition card powered by Wiktionary.
 
-from searx.result_types import EngineResults
-from . import Plugin, PluginInfo
+This plugin parses the query string for the keyword ``define`` (first token),
+fetches definitions from the Wiktionary REST API, and renders them using
+SearXNG's ``Translations`` answer type and a custom template
+(``answer/define.html``). Internal links like ``/wiki/term#Section`` are
+rewritten to local SearXNG searches (e.g. ``/search?q=define+term``).
+
+Notes:
+- The plugin only returns an answer on the first page of results.
+- If the query does not start with ``define ``, the plugin does nothing.
+- If no definitions are found, it returns a short 'No definitions were found.'
+  answer instead of a Translations card.
+- Network calls are made with SearXNG's internal HTTP client.
+- ``Translations`` items carry HTML snippets and may need sanitization with other providers.
+"""
 
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import ClassVar
 from html import unescape
 from urllib import parse
 import typing
 import re
+
+from flask_babel import get_locale, gettext  # pyright: ignore[reportUnknownVariableType]
+
+from httpx import HTTPError
+
+from searx.result_types import Answer, Translations
+from searx.result_types.answer import BaseAnswer
+from searx.extended_types import SXNG_Response
+from searx.network import get
+
+from searx.result_types import EngineResults
+from . import Plugin, PluginInfo
 
 if typing.TYPE_CHECKING:
     from searx.extended_types import SXNG_Request
@@ -23,8 +45,8 @@ if typing.TYPE_CHECKING:
     from . import PluginCfg
 
 
-
 # ---------------------------------------  Definition Provider Functionality  ------------------------------------------
+
 
 @dataclass(eq=True, frozen=False)
 class Definition:
@@ -32,46 +54,46 @@ class Definition:
     Root data model for a single definition entry
     """
 
-    word:           str
-    part_of_speech: Optional[str]
-    definition:     str
-    examples:       List[str] = field(default_factory=list)
-    lang:           str = "unknown"
-    provider:       str = "unknown"
-    source_url:     Optional[str] = None
-
+    word: str
+    part_of_speech: str | None
+    definition: str
+    examples: list[str] = field(default_factory=list)
+    lang: str = "unknown"
+    provider: str = "unknown"
+    source_url: str | None = None
 
     # Part-of-speech normalization
-    pos_normalized = {
-        "noun":         "noun",
-        "verb":         "verb",
-        "adjective":    "adjective",
-        "adverb":       "adverb",
-        "pronoun":      "pronoun",
-        "preposition":  "preposition",
-        "conjunction":  "conjunction",
+    pos_normalized: ClassVar[dict[str, str]] = {
+        "noun": "noun",
+        "verb": "verb",
+        "adjective": "adjective",
+        "adverb": "adverb",
+        "pronoun": "pronoun",
+        "preposition": "preposition",
+        "conjunction": "conjunction",
         "interjection": "interjection",
-        "proper noun":  "proper noun",
-        "proper_noun":  "proper noun",
-        "determiner":   "determiner",
-        "article":      "article",
+        "proper noun": "proper noun",
+        "proper_noun": "proper noun",
+        "determiner": "determiner",
+        "article": "article",
     }
 
     # Normalize fields & dedupe examples when created
     def __post_init__(self):
-        self.word       = self._clean_text(self.word)
+        self.word = self._clean_text(self.word)
         self.definition = self._clean_text(self.definition)
-        self.examples   = self._dedupe(self.examples)
+        self.examples = self._dedupe(self.examples)
 
         pos = (self.part_of_speech or "").strip().lower()
         self.part_of_speech = self.pos_normalized.get(pos, pos or "unknown")
 
-    def _clean_text(self, s: str) -> str:
-        s = unescape(s or "")
-        return " ".join(s.split())
+    def _clean_text(self, string: str) -> str:
+        string = unescape(string or "")
+        return " ".join(string.split())
 
-    def _dedupe(self, seq: List[str]) -> List[str]:
-        seen, out = set(), []
+    def _dedupe(self, seq: list[str]) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
         for x in seq:
             k = self._clean_text(x)
             if k and k not in seen:
@@ -88,36 +110,36 @@ class Definition:
         return f"{self.word} ({self.normalized_pos})" if self.normalized_pos != "unknown" else self.word
 
     @property
-    def dedupe_key(self) -> tuple:
+    def dedupe_key(self) -> tuple[str, str]:
         return (self.normalized_pos, self.definition)
 
-    def short_example(self, limit: int = 140) -> Optional[str]:
+    def short_example(self, limit: int = 140) -> str | None:
         if not self.examples:
             return None
 
         ex = self.examples[0]
-        return (ex if len(ex) <= limit else ex[: max(0, limit - 1)] + "…")
+        return ex if len(ex) <= limit else ex[: max(0, limit - 1)] + "…"
 
 
-class DefinitionProvider():
+class DefinitionProvider:
     """
     Root class for handling web IO and exposing a common interface.
-    Subclasses should implement `.definitions(word, lang="en") -> List[Definition]`.
+    Subclasses should implement `.definitions(word, lang="en") -> list[Definition]`.
     """
 
     # Override this
-    name: str
-
+    name: str = ""
 
     def _get(self, url: str) -> SXNG_Response:
         return get(url)
 
-    def lookup(self, term: str, lang: str = "en") -> List[Definition]:
+    def lookup(self, term: str, lang: str = "en") -> list[Definition]:
         """
         Return a list of Definition objects for `word`
         Must be implemented by subclasses
         """
-        raise NotImplementedError
+        why: str = (' ' + term + lang)[0].strip()
+        raise NotImplementedError(why)
 
 
 class WiktionaryProvider(DefinitionProvider):
@@ -126,12 +148,12 @@ class WiktionaryProvider(DefinitionProvider):
     https://en.wiktionary.org/api/rest_v1/
     """
 
-    name:          str = 'wiktionary'
-    api_template:  str = "https://en.wiktionary.org/api/rest_v1/page/definition/{title}"
+    name: str = "wiktionary"
+    api_template: str = "https://en.wiktionary.org/api/rest_v1/page/definition/{title}"
     page_template: str = "https://en.wiktionary.org/wiki/{title}"
 
     # Matches href="/wiki/term#POS"
-    _wiki_href_re = re.compile(r'href="(?P<href>/wiki/[^"]+)"')
+    _wiki_href_re: re.Pattern[str] = re.compile(r'href="(?P<href>/wiki/[^"]+)"')
 
     def _rewrite_wiki_links(self, html: str) -> str:
         """
@@ -146,32 +168,31 @@ class WiktionaryProvider(DefinitionProvider):
         keyword = DefineHandler.keyword
 
         def _normalize(href: str) -> str:
-            path = href.split('#', 1)[0]
-            if path.startswith('/wiki/'):
-                path = path[len('/wiki/'):]
-            path = path.split(':', 1)[0]
+            path = href.split("#", 1)[0]
+            if path.startswith("/wiki/"):
+                path = path[len("/wiki/") :]
+            path = path.split(":", 1)[0]
 
-            term = parse.unquote(path).replace('_', ' ').strip()
+            term = parse.unquote(path).replace("_", " ").strip()
             return term
 
-        def _repl(m: re.Match) -> str:
-            term = _normalize(m.group('href'))
+        def _repl(match: re.Match[str]) -> str:
+            term = _normalize(match.group("href"))
             if not term:
                 return 'href="#"'
-            q = parse.quote_plus(f'{keyword} {term}').lower()
+            q = parse.quote_plus(f"{keyword} {term}").lower()
             return f'href="/search?q={q}"'
 
         return self._wiki_href_re.sub(_repl, html)
 
-
-    def lookup(self, term: str, lang: str = "en") -> List[Definition]:
-        url  = self.api_template.format(title=term)
+    def lookup(self, term: str, lang: str = "en") -> list[Definition]:
+        url = self.api_template.format(title=term)
         resp = None
 
         try:
             resp = self._get(url)
             success = resp.status_code == 200
-        except:
+        except HTTPError:
             success = False
 
         if not (success and resp):
@@ -179,45 +200,51 @@ class WiktionaryProvider(DefinitionProvider):
 
         payload = resp.json()
         entries = payload.get(lang, [])
-        results: List[Definition] = []
+        results: list[Definition] = []
 
         for entry in entries:
             pos = entry.get("partOfSpeech")
             for d in entry.get("definitions", []):
-                def_html = self._rewrite_wiki_links(d.get("definition", ""))
-                ex_list  = [self._rewrite_wiki_links(x) for x in d.get("examples", [])]
+
+                raw_def = d.get("definition", "")
+                if not raw_def or not raw_def.strip():
+                    continue
+
+                def_html = self._rewrite_wiki_links(raw_def)
+                ex_list = [self._rewrite_wiki_links(x) for x in d.get("examples", [])]
+
+                if not def_html.strip():
+                    continue
+
                 results.append(
-
                     Definition(
-                        word           = term,
-                        part_of_speech = pos,
-                        definition     = def_html,
-                        examples       = ex_list,
-                        lang           = lang,
-                        provider       = "wiktionary",
-                        source_url     = self.page_template.format(title=term),
+                        word=term,
+                        part_of_speech=pos,
+                        definition=def_html,
+                        examples=ex_list,
+                        lang=lang,
+                        provider="wiktionary",
+                        source_url=self.page_template.format(title=term),
                     )
-
                 )
 
         return results
 
 
-
 # ----------------------------------------------  SearXNG Integration  -------------------------------------------------
 
-class DefineHandler():
+
+class DefineHandler:
     """
     Links a definition provider and provides a public API to the answerer
     """
 
-    keyword:  str = "define"
+    keyword: str = "define"
     provider: DefinitionProvider = WiktionaryProvider()
 
-    default_answer: Answer = Answer(answer=_("No definitions were found."))
-    max_definitions:   int = 5
-    max_examples:      int = 3
-
+    default_answer: Answer = Answer(answer=gettext("No definitions were found."))
+    max_definitions: int = 5
+    max_examples: int = 3
 
     def _get_locale(self) -> str:
         """
@@ -228,35 +255,32 @@ class DefineHandler():
 
         loc = get_locale()
         if loc:
-            return str(loc).split('_')[0].lower()
+            return str(loc).split('_', maxsplit=1)[0].lower()
 
-        return 'en'
-
+        return "en"
 
     # Expects a full query, including 'self.keyword'
     def _extract_term(self, query: str) -> str | None:
         extracted = None
-        term_key  = self.keyword + ' '
+        term_key = self.keyword + " "
 
         if query.startswith(term_key):
-            extracted = query[len(term_key):].strip()
+            extracted = query[len(term_key) :].strip()
 
         return extracted
 
-
     def _make_definitions_answer(self, definitions: list[Translations.Item], url: str | None) -> Translations:
         if not self.provider.name:
-            raise NotImplementedError('no real provider was specified')
+            raise NotImplementedError("no real provider was specified")
 
         return Translations(
-            translations = definitions,
-            url          = url,
-            engine       = self.provider.name,
-            template     = 'answer/define.html'
+            translations=definitions,
+            url=url,
+            engine=self.provider.name,
+            template="answer/define.html",
         )
 
-
-    def _build_translations_answer(self, definitions: List[Definition]) -> Translations | None:
+    def _build_translations_answer(self, definitions: list[Definition]) -> Translations | None:
         """
         Turn a list[Definition] into a single Translations answer
         - One item per part-of-speech
@@ -266,19 +290,18 @@ class DefineHandler():
         if not definitions:
             return None
 
-        by_pos: dict[str, List[Definition]] = {}
+        by_pos: dict[str, list[Definition]] = {}
         for d in definitions:
             by_pos.setdefault(d.normalized_pos, []).append(d)
 
         url = next((d.source_url for d in definitions if d.source_url), None)
-        items: List[Translations.Item] = []
-
+        items: list[Translations.Item] = []
 
         # Dedupe identical senses
         for pos, entries in by_pos.items():
-            seen = set()
-            definitions_text: List[str] = []
-            examples: List[str] = []
+            seen: set[tuple[str, str]] = set()
+            definitions_text: list[str] = []
+            examples: list[str] = []
 
             for d in entries:
                 if d.dedupe_key in seen:
@@ -295,28 +318,26 @@ class DefineHandler():
                     if ex not in examples:
                         examples.append(ex)
 
-
             # Title of the card uses the first definition's word
             word = entries[0].word if entries else ""
-            pos  = entries[0].normalized_pos if entries else "unknown"
+            pos = entries[0].normalized_pos if entries else "unknown"
 
             items.append(
                 Translations.Item(
-                    text            = word,             # now just "liquid"
-                    transliteration = f"({pos})" if pos != "unknown" else "",
-                    definitions     = definitions_text,
-                    examples        = examples,
-                    synonyms        = [],
+                    text=word,  # now just "liquid"
+                    transliteration=f"({pos})" if pos != "unknown" else "",
+                    definitions=definitions_text,
+                    examples=examples,
+                    synonyms=[],
                 )
             )
 
         return self._make_definitions_answer(definitions=items, url=url)
 
-
     # Expects a full query, including 'self.keyword'
     def find_results(self, query: str) -> list[BaseAnswer]:
-        results = []
-        term = self._extract_term(query)
+        results: list[BaseAnswer] = []
+        term: str | None = self._extract_term(query)
         if not term:
             return results
 
@@ -326,9 +347,11 @@ class DefineHandler():
             results.append(self.default_answer)
             return results
 
-        translations_answer = self._build_translations_answer(definitions)
-        if translations_answer: results.append(translations_answer)
-        else:            results.append(self.default_answer)
+        translations_answer: Translations | None = self._build_translations_answer(definitions)
+        if translations_answer:
+            results.append(translations_answer)
+        else:
+            results.append(self.default_answer)
 
         return results
 
@@ -336,35 +359,37 @@ class DefineHandler():
 class SXNGPlugin(Plugin, DefineHandler):
     """Adds a 'define <term>' special query that returns a Translations answer."""
 
-    id = DefineHandler.keyword
-    keywords = [ id ]
+    id: str = DefineHandler.keyword
+    keywords: list[str] = [id]
+    info: PluginInfo
+    description: str = "Displays definitions to a search term"
 
     def __init__(self, plg_cfg: "PluginCfg"):
         Plugin.__init__(self, plg_cfg)
 
         self.info = PluginInfo(
-            id                 = self.id,
-            name               = _(self.id.title()),
-            description        = f'{_("Displays definitions to a search term")} ({_("Source")}: {self.provider.name})',
-            examples           = [ f"{self.id} <{_('term')}>", f"{self.id} effervescence" ],
-            preference_section = "query",
+            id=self.id,
+            name=gettext(self.id.title()),
+            description=f'{gettext(self.description)} ({gettext("Source")}: {self.provider.name})',
+            examples=[f"{self.id} <{gettext('term')}>", f"{self.id} effervescence"],
+            preference_section="query",
         )
 
     def post_search(self, request: "SXNG_Request", search: "SearchWithPlugins") -> EngineResults:
         """Returns answers only for the first page"""
-        
+
         results = EngineResults()
 
         if search.search_query.pageno > 1:
             return results
 
-        q = (search.search_query.query or "").strip()
-        term = self._extract_term(q)
+        query = (search.search_query.query or "").strip()
+        term = self._extract_term(query)
         if not term:
             return results
 
         # Pull functionality from 'DefineHandler'
-        for ans in self.find_results(q):
-            results.add(ans)
+        for answer in self.find_results(query):
+            results.add(answer)
 
         return results

--- a/searx/plugins/define.py
+++ b/searx/plugins/define.py
@@ -47,6 +47,7 @@ if typing.TYPE_CHECKING:
 
 # ---------------------------------------  Definition Provider Functionality  ------------------------------------------
 
+
 # Internal dataclass for provider results storage
 @dataclass(eq=True, frozen=False)
 class Definition:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -249,6 +249,9 @@ plugins:
   searx.plugins.tracker_url_remover.SXNGPlugin:
     active: true
 
+  searx.plugins.define.SXNGPlugin:
+    active: true
+
 
 # Configuration of the "Hostnames plugin":
 #

--- a/searx/templates/simple/answer/define.html
+++ b/searx/templates/simple/answer/define.html
@@ -24,6 +24,16 @@
         </dt>
       </div>
       <dd>
+        {%- if item.definitions -%}
+          <br>
+          <div class="section-title"><b>{{ _('Definitions') }}</b></div>
+          <ol class="definitions">
+            {%- for d in item.definitions -%}
+              <li>{{ d|safe }}</li>
+            {%- endfor -%}
+          </ol>
+        {%- endif -%}
+
         {%- if item.examples -%}
           <br>
           <div class="section-title"><b>{{ _('Examples') }}</b></div>
@@ -31,16 +41,6 @@
             {%- for ex in item.examples -%}
               {# ex is expected to be sanitized HTML #}
               <li>{{ ex|safe }}</li>
-            {%- endfor -%}
-          </ul>
-        {%- endif -%}
-
-        {%- if item.definitions -%}
-          <br>
-          <div class="section-title"><b>{{ _('Definitions') }}</b></div>
-          <ul class="definitions">
-            {%- for d in item.definitions -%}
-              <li>{{ d|safe }}</li>
             {%- endfor -%}
           </ul>
         {%- endif -%}
@@ -76,6 +76,25 @@
 </div>
 
 <style>
+  .answer ol,
+  .answer ul {
+    margin: 0.35em 0 0.6em 1.2em;
+    padding-left: 20px;
+    line-height: 1.55;
+  }
+
+  .answer li + li {
+    margin-top: 0.3em;
+  }
+
+  .answer li::marker {
+    font-size: 0.9em;
+  }
+
+  .answer li {
+    padding-left: 0.15em;  /* increases gap between bullet and text */
+  }
+
   .define-source-btn {
     display: inline-block;
     background: rgba(255, 255, 255, 0.08);

--- a/searx/templates/simple/answer/define.html
+++ b/searx/templates/simple/answer/define.html
@@ -1,0 +1,100 @@
+{# Translations-like answer, but expanded by default & renders HTML #}
+<details class="answer-translations" open>
+  <summary>
+    {%- if answer.translations -%}
+      {{ _('definition of ' + (answer.translations and answer.translations[0].text)).strip() }}
+    {%- else -%}
+      {{ _('no definition') }}
+    {%- endif -%}
+  </summary>
+
+  <dl>
+    {%- for item in answer.translations -%}
+      <br>
+      {%- if not loop.first -%}
+        <br>
+      {%- endif -%}
+      
+      <div class="pos-label">
+        <dt>
+          <b>{{ item.text }}</b>
+          {%- if item.transliteration -%}
+            <i style="opacity:0.7;">  {{ item.transliteration }}</i>
+          {%- endif -%}
+        </dt>
+      </div>
+      <dd>
+        {%- if item.examples -%}
+          <br>
+          <div class="section-title"><b>{{ _('Examples') }}</b></div>
+          <ul class="examples">
+            {%- for ex in item.examples -%}
+              {# ex is expected to be sanitized HTML #}
+              <li>{{ ex|safe }}</li>
+            {%- endfor -%}
+          </ul>
+        {%- endif -%}
+
+        {%- if item.definitions -%}
+          <br>
+          <div class="section-title"><b>{{ _('Definitions') }}</b></div>
+          <ul class="definitions">
+            {%- for d in item.definitions -%}
+              <li>{{ d|safe }}</li>
+            {%- endfor -%}
+          </ul>
+        {%- endif -%}
+
+        {%- if item.synonyms -%}
+          <br>
+          <div class="section-title"><b>{{ _('Synonyms') }}</b></div>
+          <ul class="synonyms">
+            {%- for s in item.synonyms -%}
+              <li>{{ s }}</li>
+            {%- endfor -%}
+          </ul>
+        {%- endif -%}
+      </dd>
+    {%- endfor -%}
+  </dl>
+</details>
+
+<div style="text-align:right;margin-top:25px;">
+  {%- if answer.url -%}
+    <a href="{{ answer.url }}"
+       class="define-source-btn"
+       {% if results_on_new_tab %}
+         target="_blank" rel="noopener noreferrer"
+       {% else %}
+         rel="noreferrer"
+       {% endif %}>
+      {{ _('Source:') }} {{ answer.engine }}
+    </a>
+  {%- else -%}
+    <span class="define-source-btn disabled">{{ answer.engine }}</span>
+  {%- endif -%}
+</div>
+
+<style>
+  .define-source-btn {
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.08);
+    color: #bbb;
+    font-size: 0.9em;
+    padding: 3px 10px;
+    border-radius: 9999px;
+    text-decoration: none;
+    opacity: 0.7;
+    transition: opacity 0.15s ease, background 0.15s ease;
+  }
+
+  .define-source-btn:hover {
+    opacity: 0.8;
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  .define-source-btn.disabled {
+    pointer-events: none;
+    opacity: 0.4;
+  }
+</style>


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR adds a new plugin: **`define`**, which provides inline dictionary definitions to search results, powered by Wiktionary. I use this feature a lot with search engines, and added this feature to my own instance for that reason. I also thought it would be beneficial to share with the community!

<img width="742" height="520" alt="image" src="https://github.com/user-attachments/assets/698eab0c-9b23-4fdb-a5ab-01947a82d723" />

<br><br>

When a user searches for a query beginning with

```
define <term>
```

the plugin fetches definitions via the official Wiktionary REST API and renders them as a answer card using a modified `Translations` type.

The plugin:

* Displays definitions grouped by part of speech (noun, verb, adjective, etc.)
* Includes a few example usages from Wiktionary
* Rewrites internal `/wiki/...` links to equivalent local searches (e.g. `/search?q=define+term`)
* Returns results only on the first page of a search
* Adds a button in the botton right corner to view the Wiktionary entry directly
* Falls back gracefully with a short "No definitions were found." message

Implementation notes:

* Fully type-annotated and follows the required code style
* At least from what I can tell, safe HTML rewriting and de-duplication
* Uses SearXNG’s native HTTP client (`searx.network.get`) for requests
* An extensible provider framework to add new sources in the future with `DefinitionProvider`
* Adds a Jinja template for rendering embedded HTML from the Wiktionary REST API `answer/define.html`

---

## Why is this change important?

<!-- MANDATORY -->

This plugin gives users quick, inline dictionary definitions without opening another tab or engine result. This is similar to what major search engines provide.
It enhances the SearXNG user experience by:

* Adding native dictionary-style answers directly at the top of search results when triggered
* Leveraging Wiktionary, a free and open data source
* Integrating seamlessly with SearXNG’s existing answerer and translations infrastructure
* Recursive searches with hyperlinks to browse multiple definitions easily
* Providing multilingual results when available (unfortunately it's not in my wheelhouse and still needs work)

This makes "define" queries faster, privacy-friendly, and self-contained in the UI.

---

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

1. Make sure the plugin is enabled in your SearXNG configuration (`settings.yml`):
  > Note: I've enabled it by default in this PR

   ```yaml
   plugins:
     - searx.plugins.define.SXNGPlugin
   ```

2. Rebuild or reload your dev environment:

   ```bash
   make run
   ```

3. Open SearXNG in your browser and verify that "Define" is enabled in Special Queries > Plugins:

<img width="1266" height="537" alt="image" src="https://github.com/user-attachments/assets/bf248515-c169-425d-beec-2b34e6d6e039" />


4. From the home page, try queries such as:

   * `define effervescence`
   * `define network`
   * `define chicken tender`

5. You should see a compact definition card rendered at the top of the results:

<img width="726" height="622" alt="image" src="https://github.com/user-attachments/assets/82398275-9be2-420f-a629-68de13fd4a0a" />

<br><br>

To run automated tests:

```bash
make test
```

Expected:
  - `pyright`: no errors
  - `pylint`: 10.00/10
  - `pytest`: all tests pass
> Note that I've tested this in GitHub Codespaces, and on my personal server from a manual installation in Ubuntu Server (minimal) 24.02
<details>
  <summary>view my results</summary>

   ```
   (.venv) @macarooni-man ➜ /workspaces/searxng-define (master) $ make test
   TEST      [yamllint] .github/ISSUE_TEMPLATE/config.yml
   TEST      [black] --exclude
   All done! ✨ 🍰 ✨
   366 files would be left unchanged.
   TEST      [basedpyright] static type check of local modified files
   0 errors, 0 warnings, 0 notes
   TEST      [pylint] ./searx/engines

   --------------------------------------------------------------------
   Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

   TEST      [pylint] ./searx ./searxng_extra ./tests

   --------------------------------------------------------------------
   Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

   TEST      tests/unit
   ...................................................................................................................................................................................................................................................................................................
   ----------------------------------------------------------------------
   Ran 291 tests in 50.368s

   OK
   TEST      robot
   INSTALL   gecko.driver
   INSTALL   geckodriver already installed
   2025-10-24 04:16:49,725 WARNING:searx.botdetection.config: missing config file: /workspaces/searxng-define/tests/robot/limiter.toml

   Running 7 tests
   /workspaces/searxng-define/local/py3/bin/geckodriver
   /usr/bin/firefox
   TEST      [reST markup] README.rst
   TEST      test.shell OK
   TEST      [shfmt] ./manage ./container ./utils
   INSTALL   [pkg.go.dev] ./go.mod: developer and CI tools
   go: downloading mvdan.cc/sh/v3 v3.12.0
   go: downloading github.com/google/renameio/v2 v2.0.0
   go: downloading github.com/rogpeppe/go-internal v1.14.1
   go: downloading golang.org/x/term v0.32.0
   go: downloading mvdan.cc/editorconfig v0.3.0
   go: downloading golang.org/x/sys v0.33.0
   go: downloading github.com/go-quicktest/qt v1.101.0
   go: downloading github.com/google/go-cmp v0.7.0
   go: downloading golang.org/x/tools v0.31.0
   go: downloading github.com/kr/pretty v0.3.1
   go: downloading github.com/kr/text v0.2.0
   ```

</details>


---

## Author's checklist

<!-- additional notes for reviewers -->

* [x] Fully typed, tests are clean
* [x] `pylint` score: 10.00/10
* [x] All unit tests pass
* [x] Verified rendering of definitions and examples
* [x] Confirmed proper escaping and link rewriting

Future ideas:

* Add support for multiple dictionary providers
* Add support for more locales
* Add local result caching

I'm open to any feedback, and I also can't wait to see how else this project evolves. I've been really happy with this tool in my network!