### PR TITLE
[fix] engine qwant - return forbidden instead of showing parsing error

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -53,6 +53,7 @@ from searx.exceptions import (
     SearxEngineAPIException,
     SearxEngineTooManyRequestsException,
     SearxEngineCaptchaException,
+    SearxEngineAccessDeniedException,
 )
 from searx.network import raise_for_httperror
 from searx.enginelib.traits import EngineTraits
@@ -184,8 +185,12 @@ def parse_web_api(resp):
 
     results = []
 
-    # load JSON result
-    search_results = loads(resp.text)
+    # Try to load JSON result
+    try:
+        search_results = loads(resp.text)
+    except ValueError:
+        search_results = {}
+
     data = search_results.get('data', {})
 
     # check for an API error
@@ -195,6 +200,8 @@ def parse_web_api(resp):
             raise SearxEngineTooManyRequestsException()
         if search_results.get("data", {}).get("error_data", {}).get("captchaUrl") is not None:
             raise SearxEngineCaptchaException()
+        if resp.status_code == 403:
+            raise SearxEngineAccessDeniedException()
         msg = ",".join(data.get('message', ['unknown']))
         raise SearxEngineAPIException(f"{msg} ({error_code})")
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This PR fixes an issue where Qwant engine would display Parsing error (`json.decoder.JSONDecodeError`) when trying to display CAPTCHA. It is currently returning this:

```html
<html lang="en"><head><title>qwant.com</title><style>#cmsg{animation: A 1.5s;}@keyframes A{0%{opacity:0;}99%{opacity:0;}100%{opacity:1;}}</style></head><body style="margin:0"><p id="cmsg">Please enable JS and disable any ad blocker</p><script data-cfasync="false">var dd={'rt':'c','cid':'AHrlqAAAAAMAYq-l64OFaQAAX1vU0A==','hsh':'78B13B7513D180B7AB6D6FF9EB0A51','t':'fe','qp':'','s':57088,'e':'3be42de1f9a91df3a784b7a1e97d3068561680be72b258b158b29cdfbbb806c67c2a8587d7ec5f9e18f0da48d5b26114','host':'geo.captcha-delivery.com','cookie':'hjfBhwYuJRjQR3krk4XDbhjiyfVH6i1YeklWSUmUPKLY7OIeRDuf6js7oIRimKcEVg2HKcaCAfxV~Yyr~VBj02wUefYKdWqjno0p1T5Zm_eGosPR~z79_VsIq28UM2P_'}</script><script data-cfasync="false" src="https://ct.captcha-delivery.com/c.js"></script></body></html>
```

I made the implementation a bit generic, returning `access denied` since scanning through the HTML output might make it more complicated than it needs to.

## Why is this change important?

<!-- MANDATORY -->

Displaying parsing error is confusing for the user.