### PR TITLE
feat(plugins): add spellcheck plugin for query correction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ typer-slim==0.20.0
 isodate==0.7.2
 whitenoise==6.11.0
 typing-extensions==4.15.0
+pyspellchecker==0.8.1

--- a/searx/plugins/_core.py
+++ b/searx/plugins/_core.py
@@ -188,6 +188,9 @@ class PluginCfg:
     active: bool = False
     """Plugin is active by default and the user can *opt-out* in the preferences."""
 
+    parameters: dict[str, t.Any] = field(default_factory=dict)
+    """Arbitrary plugin parameters from settings.yml (plugin-specific)."""
+
 
 class PluginStorage:
     """A storage for managing the *plugins* of SearXNG."""

--- a/searx/plugins/spellcheck.py
+++ b/searx/plugins/spellcheck.py
@@ -1,0 +1,491 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Spell checking plugin providing "Did you mean?" corrections.
+
+This plugin suggests a single corrected variant of the current query
+and exposes an on/off toggle in Preferences.
+
+The plugin uses lazy-loaded dictionaries from ``pyspellchecker`` and
+supports a limited set of languages. If the UI/search language is not
+supported or the query is unchanged, no results are produced.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from flask_babel import gettext
+
+from searx.plugins import Plugin, PluginInfo
+from searx.result_types import EngineResults
+
+if TYPE_CHECKING:  # import only for typing
+    from collections.abc import Iterable
+
+    from searx.extended_types import SXNG_Request
+    from searx.plugins import PluginCfg
+    from searx.search import SearchWithPlugins
+
+
+log: logging.Logger = logging.getLogger("searx.plugins.spellcheck")
+
+
+@runtime_checkable
+class WordCorrectionProvider(Protocol):
+    """Provider for per-word spell correction."""
+
+    def find_misspellings(self, candidates: Iterable[str]) -> Iterable[str]:
+        """Return misspelled tokens among candidates.
+
+        Parameters
+        ----------
+        candidates : Iterable[str]
+            Candidate tokens to evaluate.
+
+        Returns
+        -------
+        Iterable[str]
+            Tokens detected as misspellings.
+        """
+        ...
+
+    def correction(self, word: str) -> str | None:
+        """Return the best correction for a single word.
+
+        Parameters
+        ----------
+        word : str
+            Input token to correct.
+
+        Returns
+        -------
+        str or None
+            Suggested correction or ``None`` if unknown.
+        """
+        ...
+
+
+@runtime_checkable
+class QuerySuggestionProvider(Protocol):
+    """Provider for whole-query correction."""
+
+    def correct_query(self, query: str, sxng_locale: str) -> str | None:
+        """Return a whole-query suggestion.
+
+        Parameters
+        ----------
+        query : str
+            Original query text.
+        sxng_locale : str
+            SearXNG locale tag.
+
+        Returns
+        -------
+        str or None
+            Suggested query replacement, or ``None`` if not applicable.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class _SupportedLanguage:
+    code: str
+    spellchecker_code: str
+
+
+SUPPORTED_LANGUAGES: tuple[_SupportedLanguage, ...] = (
+    _SupportedLanguage("en", "en"),
+    _SupportedLanguage("es", "es"),
+    _SupportedLanguage("fr", "fr"),
+    _SupportedLanguage("pt", "pt"),
+    _SupportedLanguage("de", "de"),
+    _SupportedLanguage("it", "it"),
+    _SupportedLanguage("ru", "ru"),
+    _SupportedLanguage("ar", "ar"),
+    _SupportedLanguage("eu", "eu"),  # Basque
+    _SupportedLanguage("lv", "lv"),
+    _SupportedLanguage("nl", "nl"),
+)
+
+
+_LANG_MAP: dict[str, str] = {
+    lang.code: lang.spellchecker_code for lang in SUPPORTED_LANGUAGES
+}
+
+
+@lru_cache(maxsize=16)
+def _load_spellchecker(lang_code: str):
+    """Lazily load a ``SpellChecker`` for the given language.
+
+    Parameters
+    ----------
+    lang_code : str
+        Language code as expected by ``pyspellchecker``.
+
+    Returns
+    -------
+    object | None
+        The SpellChecker instance or None if unavailable.
+    """
+    try:
+        from spellchecker import SpellChecker  # type: ignore[unresolved-import]
+    except ImportError as exc:
+        log.warning("pyspellchecker is not installed: %s", exc)
+        return None
+
+    try:
+        return SpellChecker(language=lang_code)
+    except (OSError, ValueError, LookupError) as exc:
+        log.warning(
+            "pyspellchecker failed to initialize for language %s: %s", lang_code, exc
+        )
+        return None
+
+
+class PySpellcheckerProvider:
+    """Spellcheck provider using ``pyspellchecker``.
+
+    Parameters
+    ----------
+    lang_code : str
+        Language code for the underlying dictionary.
+    """
+
+    def __init__(self, lang_code: str):
+        self._sc = _load_spellchecker(lang_code)
+
+    def find_misspellings(self, candidates: Iterable[str]) -> Iterable[str]:  # type: ignore[override]
+        """Return misspelled items from candidates.
+
+        Parameters
+        ----------
+        candidates : Iterable[str]
+            Candidate tokens to evaluate.
+
+        Returns
+        -------
+        Iterable[str]
+            Misspelled tokens among ``candidates``. Returns an empty
+            iterable if the backend is unavailable.
+        """
+        if not self._sc:
+            return []
+        func = getattr(self._sc, "unknown", None)
+        if not callable(func):
+            return []
+        return func(candidates)
+
+    def correction(self, word: str) -> str | None:  # type: ignore[override]
+        """Return the best correction for ``word``.
+
+        Parameters
+        ----------
+        word : str
+            Input token to correct.
+
+        Returns
+        -------
+        str or None
+            Suggested correction or ``None`` when no improvement is found
+            or the backend is unavailable.
+        """
+        if not self._sc:
+            return None
+        func = getattr(self._sc, "correction", None)
+        if not callable(func):
+            return None
+        return func(word)
+
+
+class GoogleAutocompleteProvider:
+    """Spellcheck provider backed by Google Autocomplete.
+
+    Implements optional ``correct_query``; word-level methods are no-ops.
+    """
+
+    def find_misspellings(self, candidates: Iterable[str]) -> Iterable[str]:
+        """Return an empty iterable; Google provider does not check words.
+
+        Parameters
+        ----------
+        candidates : Iterable[str]
+            Ignored.
+
+        Returns
+        -------
+        Iterable[str]
+            Always returns an empty iterable.
+        """
+        return []
+
+    def correction(self, word: str) -> str | None:
+        """Return ``None``; Google provider does not correct single words.
+
+        Parameters
+        ----------
+        word : str
+            Ignored.
+
+        Returns
+        -------
+        str or None
+            Always returns ``None``.
+        """
+        return None
+
+    def correct_query(self, query: str, sxng_locale: str) -> str | None:
+        """Return a whole-query suggestion from Google Autocomplete.
+
+        Parameters
+        ----------
+        query : str
+            Original query text.
+        sxng_locale : str
+            SearXNG locale tag (influences Google subdomain/language).
+
+        Returns
+        -------
+        str or None
+            Suggested query if sufficiently similar and different;
+            otherwise ``None``.
+        """
+        from difflib import SequenceMatcher
+
+        from searx.autocomplete import search_autocomplete
+
+        suggestions = search_autocomplete("google", query, sxng_locale) or []
+        if not suggestions:
+            return None
+
+        # Pick the suggestion with the best combined score:
+        # similarity minus a small penalty for length difference, with
+        # an additional bonus for permutations of the same letters
+        # (common transposition errors like "teh" -> "the").
+        best: tuple[float, str] | None = None
+        for s in suggestions:
+            similarity = SequenceMatcher(None, query, s).ratio()
+            penalty = 0.1 * abs(len(s) - len(query))
+            score = similarity - penalty
+            if sorted(s) == sorted(query):
+                score += 0.1
+            if best is None or score > best[0]:
+                best = (score, s)
+
+        # Conservative acceptance threshold
+        if not best or best[0] < 0.5:
+            return None
+        candidate = best[1]
+        if candidate.strip() == query.strip():
+            return None
+        return candidate
+
+
+def _tokenize(text: str) -> list[tuple[str, bool]]:
+    """Tokenize text into a sequence of (token, is_word) keeping delimiters.
+
+    Parameters
+    ----------
+    text : str
+        Original query text.
+
+    Returns
+    -------
+    list[tuple[str, bool]]
+        Sequence of (segment, is_word) preserving whitespace segments.
+    """
+    # Use a simple split that preserves delimiters; avoid heavy NLP here.
+    # Split on whitespace while capturing separators.
+    parts: list[str] = re.split(r"(\s+)", text)
+    tokens: list[tuple[str, bool]] = []
+    for p in parts:
+        if not p:
+            continue
+        tokens.append((p, p.strip() != "" and not p.isspace()))
+    return tokens
+
+
+def _is_supported_lang(pref_lang: str | None) -> str | None:
+    """Map preference language to spellchecker language code if supported.
+
+    Parameters
+    ----------
+    pref_lang : str or None
+        Preference language (e.g., 'en', 'de', 'all', 'auto', '').
+
+    Returns
+    -------
+    str or None
+        Spellchecker language code or ``None`` if unsupported.
+    """
+    if not pref_lang:
+        return None
+    pref = pref_lang.lower()
+    if pref in ("all", "auto"):
+        return None
+    # Normalize regional variants like en-US -> en
+    base = pref.split("-")[0]
+    return _LANG_MAP.get(base)
+
+
+class SXNGPlugin(Plugin):
+    """Spell checking plugin.
+
+    Suggests a corrected query ("Did you mean?") on page 1 when the
+    language is supported by the underlying dictionary.
+    """
+
+    id = "spellcheck"
+
+    def __init__(self, plg_cfg: PluginCfg) -> None:
+        """Initialize the plugin.
+
+        Parameters
+        ----------
+        plg_cfg : PluginCfg
+            The plugin configuration passed from settings.
+        """
+        super().__init__(plg_cfg)
+        self.info = PluginInfo(
+            id=self.id,
+            name=gettext("Spell Check"),
+            description=gettext("Suggest corrected queries when typos are detected"),
+            preference_section="general",
+        )
+        # provider selection via settings (PluginCfg.parameters)
+        params = getattr(plg_cfg, "parameters", {}) or {}
+        provider = params.get("provider", "pyspellchecker")
+        self.provider_name: str = str(provider)
+
+    def post_search(
+        self, request: SXNG_Request, search: SearchWithPlugins
+    ) -> EngineResults:
+        """Compute spelling correction suggestions.
+
+        Parameters
+        ----------
+        request : SXNG_Request
+            The current HTTP request with preferences.
+        search : SearchWithPlugins
+            The running search execution context.
+
+        Returns
+        -------
+        EngineResults
+            Result list containing at most one legacy correction item.
+        """
+        results = EngineResults()
+
+        # Only check on first page
+        if search.search_query.pageno > 1:
+            return results
+
+        query: str = search.search_query.query or ""
+        if not query or len(query) < 2:
+            return results
+
+        lang_pref: str | None = request.preferences.get_value("language")
+        sc_lang: str | None = _is_supported_lang(lang_pref)
+        if sc_lang is None:
+            # Fallback: use UI locale if search language is auto/all/unsupported
+            ui_locale: str | None = request.preferences.get_value("locale")
+            if ui_locale:
+                sc_lang = _LANG_MAP.get(ui_locale.split("-")[0].lower())
+        if sc_lang is None and self.provider_name != "google":
+            return results
+
+        provider = self._select_provider(sc_lang)
+        if provider is None:
+            return results
+
+        # Avoid touching bang-prefixed queries at the beginning (!yt ...)
+        if query.lstrip().startswith("!"):
+            return results
+
+        if isinstance(provider, GoogleAutocompleteProvider):
+            corrected = provider.correct_query(
+                query, request.preferences.get_value("locale") or ""
+            )
+        else:
+            corrected = self._correct_query(query, provider)  # type: ignore[arg-type]
+        if corrected is None or corrected == query:
+            return results
+
+        # Use legacy correction dict via EngineResults.types.LegacyResult
+        results.add(results.types.LegacyResult({"correction": corrected}))
+        return results
+
+    # --- helpers -----------------------------------------------------------------
+
+    def _correct_query(
+        self, query: str, spellchecker: WordCorrectionProvider
+    ) -> str | None:
+        """Return a single corrected variant of the query or ``None``.
+
+        Parameters
+        ----------
+        query : str
+            Original query text.
+        spellchecker : SpellcheckProvider
+            Provider implementing per-word correction.
+
+        Returns
+        -------
+        str or None
+            Corrected query if different and meaningful; otherwise ``None``.
+        """
+        # We operate token-wise, only alphabetic words. Keep delimiters.
+        tokens: list[tuple[str, bool]] = _tokenize(query)
+        words: list[str] = [t for t, is_word in tokens if is_word]
+        if not words:
+            return None
+
+        # Determine misspelled words first to avoid unnecessary corrections.
+        misspelled: set[str] = set(spellchecker.find_misspellings(words))
+        if not misspelled:
+            return None
+
+        corrected_parts: list[str] = []
+        for part, is_word in tokens:
+            if not is_word:
+                corrected_parts.append(part)
+                continue
+            w = part
+            # Preserve casing of the first letter when applying correction.
+            lower_w = w.lower()
+            if lower_w in misspelled:
+                suggestion = spellchecker.correction(lower_w)
+                if suggestion and suggestion != lower_w:
+                    if w[0].isupper():
+                        suggestion = suggestion.capitalize()
+                    w = suggestion
+            corrected_parts.append(w)
+
+        corrected_query = "".join(corrected_parts)
+        # Avoid trivial/no-op changes
+        if corrected_query.strip() == query.strip():
+            return None
+        return corrected_query
+
+    def _select_provider(self, sc_lang: str | None) -> object | None:
+        """Select and initialize a provider based on configuration.
+
+        Parameters
+        ----------
+        sc_lang : str or None
+            Spellchecker language code for dictionary-backed providers.
+
+        Returns
+        -------
+        SpellcheckProvider or None
+            A provider instance or ``None`` when it cannot be constructed.
+        """
+        name = (self.provider_name or "pyspellchecker").lower()
+        if name == "google":
+            return GoogleAutocompleteProvider()
+        # default: pyspellchecker requires language
+        if sc_lang is None:
+            return None
+        return PySpellcheckerProvider(sc_lang)

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -249,6 +249,15 @@ plugins:
   searx.plugins.tracker_url_remover.SXNGPlugin:
     active: true
 
+  # Spelling / Did you mean? plugin (disabled by default)
+  searx.plugins.spellcheck.SXNGPlugin:
+    active: false
+    # Spell check provider. 'google' uses Google Autocomplete for corrections.
+    # If Google is unavailable or undesired (privacy, disabled, network),
+    # remove this 'parameters' block or set provider: pyspellchecker.
+    parameters:
+      provider: google
+
 
 # Configuration of the "Hostnames plugin":
 #

--- a/tests/unit/test_spellcheck_plugin.py
+++ b/tests/unit/test_spellcheck_plugin.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from searx.plugins.spellcheck import (
+    GoogleAutocompleteProvider,
+    PySpellcheckerProvider,
+    SXNGPlugin,
+    _is_supported_lang,
+    _tokenize,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# ---- helpers -------------------------------------------------------------------
+
+
+@dataclass
+class _FakePreferences:
+    language: str | None = None
+    locale: str | None = "en-US"
+
+    def get_value(self, key: str) -> str | None:  # noqa: D401
+        """Return stored preference value by key."""
+
+        if key == "language":
+            return self.language
+        if key == "locale":
+            return self.locale
+        return None
+
+
+@dataclass
+class _FakeRequest:
+    preferences: _FakePreferences
+
+
+def _make_request(language: str | None = None, locale: str | None = "en-US") -> _FakeRequest:
+    return _FakeRequest(preferences=_FakePreferences(language=language, locale=locale))
+
+
+def _make_search(query: str, pageno: int = 1):
+    return SimpleNamespace(search_query=SimpleNamespace(query=query, pageno=pageno))
+
+
+class _FakeWordProvider:
+    """Simple provider for per-word testing."""
+
+    def __init__(self, misspelled: set[str], mapping: dict[str, str]):
+        self._misspelled = misspelled
+        self._mapping = mapping
+
+    def find_misspellings(self, candidates: Iterable[str]) -> Iterable[str]:
+        return [w for w in candidates if w.lower() in self._misspelled]
+
+    def correction(self, word: str) -> str | None:
+        return self._mapping.get(word.lower())
+
+
+# ---- unit tests ----------------------------------------------------------------
+
+
+@parameterized.expand(
+    [
+        ("en", "en"),
+        ("en-US", "en"),
+        ("de", "de"),
+        ("auto", None),
+        ("all", None),
+        ("", None),
+        (None, None),
+        ("xx", None),
+    ]
+)
+def test_is_supported_lang(pref: str | None, expected: str | None):
+    assert _is_supported_lang(pref) == expected
+
+
+@parameterized.expand(
+    [
+        ("hello, world", [("hello,", True), (" ", False), ("world", True)]),
+        (" one  two ", [(" ", False), ("one", True), ("  ", False), ("two", True), (" ", False)]),
+        ("a", [("a", True)]),
+        ("", []),
+    ]
+)
+def test_tokenize(text: str, expected: list[tuple[str, bool]]):
+    assert _tokenize(text) == expected
+
+
+def test_google_provider_correct_query_returns_none_on_no_suggestions():
+    provider = GoogleAutocompleteProvider()
+    with patch("searx.autocomplete.search_autocomplete", return_value=[]):
+        assert provider.correct_query("teh", "en-US") is None
+
+
+def test_google_provider_correct_query_prefers_close_match():
+    provider = GoogleAutocompleteProvider()
+    with patch(
+        "searx.autocomplete.search_autocomplete",
+        return_value=["the", "tech", "ten"],
+    ):
+        # get_close_matches prefers the closest suggestion
+        assert provider.correct_query("teh", "en-US") == "the"
+
+
+def test_pyspell_provider_uses_backend_methods():
+    fake = _FakeWordProvider(misspelled={"recieve"}, mapping={"recieve": "receive"})
+    with patch.object(PySpellcheckerProvider, "__init__", return_value=None):
+        p = PySpellcheckerProvider.__new__(PySpellcheckerProvider)  # type: ignore[misc]
+        # Inject fake backend object
+        object.__setattr__(p, "_sc", type("_B", (), {"unknown": fake.find_misspellings, "correction": fake.correction})())
+        # unknown path
+        assert list(p.find_misspellings(["recieve", "x"])) == ["recieve"]
+        # correction path
+        assert p.correction("recieve") == "receive"
+
+
+def test_plugin_google_provider_flow():
+    cfg = SimpleNamespace(parameters={"provider": "google"})
+    plugin = SXNGPlugin(cfg)
+
+    # Suggestion available from provider
+    with patch.object(GoogleAutocompleteProvider, "correct_query", return_value="vacuum cleaners"):
+        results = plugin.post_search(
+            request=_make_request(language=None, locale="en-US"),
+            search=_make_search("vacum cleaners", 1),
+        )
+        assert len(results) == 1
+        item = results[0]
+        assert isinstance(item, dict)
+        assert item.get("correction") == "vacuum cleaners"
+
+
+def test_plugin_pyspell_provider_flow_with_fallback_ui_locale():
+    cfg = SimpleNamespace(parameters={"provider": "pyspellchecker"})
+    plugin = SXNGPlugin(cfg)
+
+    # Force provider selection to our fake provider with fallback language from UI locale
+    fake_provider = _FakeWordProvider(misspelled={"recieve"}, mapping={"recieve": "receive"})
+    with patch("searx.plugins.spellcheck.PySpellcheckerProvider", return_value=fake_provider):
+        results = plugin.post_search(
+            request=_make_request(language="auto", locale="en-US"),
+            search=_make_search("how to recieve email", 1),
+        )
+        assert len(results) == 1
+        assert results[0]["correction"].startswith("how to receive")
+
+
+@parameterized.expand(
+    [
+        (2, "teh"),  # not first page
+        (1, ""),     # empty
+        (1, "!")     # bang query
+    ]
+)
+def test_plugin_early_exits(pageno: int, query: str):
+    cfg = SimpleNamespace(parameters={"provider": "google"})
+    plugin = SXNGPlugin(cfg)
+
+    with patch.object(GoogleAutocompleteProvider, "correct_query", return_value="the"):
+        results = plugin.post_search(
+            request=_make_request(locale="en-US"),
+            search=_make_search(query, pageno),
+        )
+        assert len(results) == 0
+
+

--- a/tests/unit/test_spellcheck_plugin.py
+++ b/tests/unit/test_spellcheck_plugin.py
@@ -100,13 +100,13 @@ def test_tokenize(text: str, expected: list[tuple[str, bool]]):
     assert _tokenize(text) == expected
 
 
-def test_google_provider_correct_query_returns_none_on_no_suggestions():
+def test_google_no_suggestions():
     provider = GoogleAutocompleteProvider()
     with patch("searx.plugins.spellcheck.search_autocomplete", return_value=[]):
         assert provider.correct_query("teh", "en-US") is None
 
 
-def test_google_provider_correct_query_prefers_close_match():
+def test_google_close_match():
     provider = GoogleAutocompleteProvider()
     with patch(
         "searx.plugins.spellcheck.search_autocomplete",
@@ -116,7 +116,7 @@ def test_google_provider_correct_query_prefers_close_match():
         assert provider.correct_query("teh", "en-US") == "the"
 
 
-def test_pyspell_provider_uses_backend_methods():
+def test_pyspell_provider_backend():
     fake = _FakeWordProvider(misspelled={"recieve"}, mapping={"recieve": "receive"})
     with patch.object(PySpellcheckerProvider, "__init__", return_value=None):
         p = PySpellcheckerProvider.__new__(PySpellcheckerProvider)  # type: ignore[misc]
@@ -136,7 +136,7 @@ def test_pyspell_provider_uses_backend_methods():
         assert p.correction("recieve") == "receive"
 
 
-def test_plugin_google_provider_flow():
+def test_plugin_google_flow():
     cfg = SimpleNamespace(parameters={"provider": "google"})
     plugin = SXNGPlugin(cfg)
 
@@ -152,7 +152,7 @@ def test_plugin_google_provider_flow():
         assert item.get("correction") == "vacuum cleaners"
 
 
-def test_plugin_pyspell_provider_flow_with_fallback_ui_locale():
+def test_plugin_pyspell_fallback():
     cfg = SimpleNamespace(parameters={"provider": "pyspellchecker"})
     plugin = SXNGPlugin(cfg)
 


### PR DESCRIPTION
This PR closes: #3837

## What does this PR do?

Implements a modern spellcheck plugin that provides "Try searching for:" suggestions for misspelled search queries. The plugin supports two providers:
- **pyspellchecker**: Local spell checking (privacy-friendly)
- **google**: Google Autocomplete API (default, requires internet)

The plugin follows modern SearXNG plugin architecture with SOLID principles, protocol-based design, and comprehensive unit testing.

## Why is this change important?

- SearXNG currently lacks built-in spell checking functionality for search queries
- Users often misspell search terms without getting helpful corrections
- Provides a configurable solution that respects user privacy preferences
- Supports both local (privacy-friendly) and cloud-based spell checking options

## How to test this PR locally?

1. Enable the plugin in :
   ```yaml
   searx.plugins.spellcheck.SXNGPlugin:
     active: true
     parameters:
       provider: pyspellchecker  # or 'google'
   ```

2. Install dependencies:
   ```bash
   uv pip install -r ./requirements.txt
   ```

3. Test with misspelled queries:
   - Try "vaccum cleaner" (should suggest "vacuum cleaner")
   - If using `google` provider; it supports langauges `pyspellchecker ` doesn't support:
     - (Vietnamese) Try "lich phat song vtv3 hom nay" (should suggest "lịch phát sóng vtv3 hôm nay")
     - (Czech) Try "pocasi praha zitra" (should suggest "počasí Praha zítra")

4. Run unit tests:
   ```bash
   uv run nose2 -v tests.unit.test_spellcheck_plugin
   ```

## Related issues

- Closes #3837

## Screenshots

<img width="703" height="210" alt="image" src="https://github.com/user-attachments/assets/82d0cfb8-7259-44bc-9a22-27991515789d" />

<img width="713" height="215" alt="image" src="https://github.com/user-attachments/assets/0b832399-fc39-4e0d-ba93-1f2b1ad6cbd2" />