### PR TITLE
[fix] startpage engine: properly display CAPTCHA if CAPTCHA redirect page is seen

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -404,6 +404,10 @@ def _get_image_result(result) -> dict[str, t.Any] | None:
 def response(resp):
     categ = startpage_categ.capitalize()
     results_raw = '{' + extr(resp.text, f"React.createElement(UIStartpage.AppSerp{categ}, {{", '}})') + '}}'
+
+    if resp.headers.get('Location', '').startswith("https://www.startpage.com/sp/captcha"):
+        raise SearxEngineCaptchaException()
+
     results_json = loads(results_raw)
     results_obj = results_json.get('render', {}).get('presenter', {}).get('regions', {})
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR fixes an issue where startpage engine would display Parsing error (`json.decoder.JSONDecodeError`) when returning CAPTCHA redirect page.

Currently, it tries to get the JSON content inside the javascript in the response like this: https://github.com/searxng/searxng/blob/954f0f62b40b3c38c232c5ec51af12416b8cb2db/searx/engines/startpage.py#L406

But it will evaluate to `{}}` if the match was not found.

If startpage wants to respond with a CAPTCHA, a typical HTML output would look something like this:

```html
<!doctype html>
<html lang=en>
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to the target URL: <a href="https://www.startpage.com/sp/captcha-block#?bc=DE&amp;bi=Vodafone+Germany&amp;be=81c81ca661dfa88ac3e9af35798ef385&amp;bds_t=1761452235T5df926ba61528e867537b2b0734effa324b36353cb9e76a52f58b353cb16e8bd&amp;bds_s=24e6eedd3cca48a0b5650f99dc9152f8&amp;bds_cq=&amp;query=test&amp;sc=mtyn4jDADBbk20&amp;cat=web&amp;language=english&amp;lui=english&amp;t=device&amp;cmd=gen_page">https://www.startpage.com/sp/captcha-block#?bc=DE&amp;bi=Vodafone+Germany&amp;be=81c81ca661dfa88ac3e9af35798ef385&amp;bds_t=1761452235T5df926ba61528e867537b2b0734effa324b36353cb9e76a52f58b353cb16e8bd&amp;bds_s=24e6eedd3cca48a0b5650f99dc9152f8&amp;bds_cq=&amp;query=test&amp;sc=mtyn4jDADBbk20&amp;cat=web&amp;language=english&amp;lui=english&amp;t=device&amp;cmd=gen_page</a>. If not, click the link.
```

Unlike the issue with Qwant (https://github.com/searxng/searxng/pull/5377), startpage returns a 307 with location set to `https://www.startpage.com/sp/captcha-block#?bc=DE&bi=etcetc`.

<!-- explain the changes in your PR, algorithms, design, architecture -->

The fix simply checks if response header has Location, and if it starts with `https://www.startpage.com/sp/captcha`, it will raise a CAPTCHA exception before trying to parse the data.

Alternatively, you could check if `results_raw` evaluates to a valid JSON with try except, or maybe try to extract the data a bit differently.

## Why is this change important?

<!-- MANDATORY -->

Displaying parsing error is confusing for the user.