### PR TITLE
[fix] qwant engine: setting accept-language to bypass bot detection

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -82,6 +82,9 @@ max_page = 5
 """5 pages maximum (``&p=5``): Trying to do more just results in an improper
 redirect"""
 
+# Otherwise Qwant will return 403 if not set
+send_accept_language_header = True
+
 qwant_categ = None
 """One of ``web-lite`` (or ``web``), ``news``, ``images`` or ``videos``"""
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR sets accept language for the Qwant engine. During testing, it seems like setting the accept language gives more success for bypassing bot detection. Tested with a few ~20 searches.

It doesn't seem like Qwant cares what the accept language is, just that it is set to something. Since we are already getting the locale for the query string, I felt it was convenient to just put that as the accept language.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

Qwant does not seem to work on any SearXNG instance right now, and this is a fix for this issue.

<!-- explain the motivation behind your PR -->
