### PR TITLE
[fix] deviantart engine: pagination match change

### DIFF
--- a/searx/engines/deviantart.py
+++ b/searx/engines/deviantart.py
@@ -30,7 +30,7 @@ img_src_xpath = './div/img/@srcset'
 title_xpath = './@aria-label'
 premium_xpath = '../div/div/div/text()'
 premium_keytext = 'Watch the artist to view this deviation'
-cursor_xpath = '(//a[@class="_1OGeq"]/@href)[last()]'
+cursor_xpath = '(//a[@class="vQ2brP"]/@href)[last()]'
 
 
 def request(query, params):


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR fixes pagination for Deviantart. With the change of class ids seen from https://github.com/searxng/searxng/pull/5383, I forgot to test pagination.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

Pagination currently does not work for deviantart, resulting in the same page being shown when going to the next page in SearXNG.

<!-- explain the motivation behind your PR -->

## Related issues

#5383 
