### PR TITLE
[mod] Engines: Temporarily disable Google

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1027,6 +1027,7 @@ engines:
   - name: google
     engine: google
     shortcut: go
+    disabled: true
     # additional_tests:
     #   android: *test_android
 
@@ -1045,6 +1046,7 @@ engines:
   - name: google news
     engine: google_news
     shortcut: gon
+    disabled: true
     # additional_tests:
     #   android: *test_android
 
@@ -1437,7 +1439,6 @@ engines:
   # https://docs.searxng.org/dev/engines/online/mullvad_leta.html
   - name: mullvadleta
     engine: mullvad_leta
-    disabled: true
     leta_engine: google
     categories: [general, web]
     shortcut: ml


### PR DESCRIPTION
## What does this PR do?

This pull request disables the Google and Google News engines for now, which do not return any results. They should be re-enabled once the Google issue is fixed. It also enables Mullvad Leta by default, which uses Google as a backend and works right now.

## Why is this change important?

Google is the most popular search engine and is enabled by default in SearXNG, but there is an issue with it right now that causes it to not return any results. Replacing it with Mullvad Leta until the engine is resolved should improve result quality.

## How to test this PR locally?

Disable Google and Google News in your instance and enable Mullvad Leta.

## Related issues
#5286 