### PR TITLE
[feat] engine: add grokipedia

### DIFF
--- a/searx/engines/grokipedia.py
+++ b/searx/engines/grokipedia.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Grokipedia (general)"""
+
+from urllib.parse import urlencode
+from searx.utils import html_to_text
+from searx.result_types import EngineResults
+
+about = {
+    "website": 'https://grokipedia.com',
+    "wikidata_id": "Q136410803",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+base_url = "https://grokipedia.com/api/full-text-search"
+categories = ['general']
+paging = True
+results_per_page = 10
+
+
+def request(query, params):
+
+    start_index = (params["pageno"] - 1) * results_per_page
+
+    query_params = {
+        "query": query,
+        "limit": results_per_page,
+        "offset": start_index,
+    }
+
+    params["url"] = f"{base_url}?{urlencode(query_params)}"
+
+    return params
+
+
+def response(resp) -> EngineResults:
+    results = EngineResults()
+    search_res = resp.json()
+
+    for item in search_res["results"]:
+
+        results.add(
+            results.types.MainResult(
+                url='https://grokipedia.com/page/' + item["slug"],
+                title=item["title"],
+                content=html_to_text(item["snippet"]),
+            )
+        )
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1072,6 +1072,12 @@ engines:
     play_categ: movies
     disabled: true
 
+  - name: grokipedia
+    engine: grokipedia
+    shortcut: gp
+    disabled: true
+    inactive: true
+
   - name: material icons
     engine: material_icons
     shortcut: mi


### PR DESCRIPTION
## What does this PR do?

adds grokipedia engine

## Why is this change important?

Grokipedia is a Wikipedia alternative that was largely created using AI. Was requested.

## How to test this PR locally?

make run
!gp test

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

closes https://github.com/searxng/searxng/issues/5393
