### PR TITLE
[fix] ./manage dev.env - nvm is not installed by nvm.env

### DIFF
--- a/manage
+++ b/manage
@@ -117,7 +117,7 @@ EOF
 
 dev.env() {
     go.env.dev
-    nvm.env
+    nvm.ensure
     node.env.dev
 
     export GOENV


### PR DESCRIPTION
To complete a SearXNG developer environment, nvm needs to be installed (ensured).  Without this patch::

    $ LANG=C ./manage dev.env
    ...
    ./utils/lib_nvm.sh: line 27: .nvm/nvm.sh: No such file or directory
    ./utils/lib_nvm.sh: line 28: .nvm/bash_completion: No such file or directory
    ...
    (dev.env)$
