### PR TITLE
Docs macos installation guide

### DIFF
--- a/docs/admin/installation-macos-telugu.rst
+++ b/docs/admin/installation-macos-telugu.rst
@@ -1,0 +1,173 @@
+.. _installation macos telugu:
+
+=========================
+macOS లో సేర్చ్‌ఎన్‌జి ఇన్‌స్టాలేషన్
+=========================
+
+macOS సిస్టమ్స్ కోసం SearXNG ఇన్‌స్టాలేషన్ గైడ్ (Apple Silicon M1/M2/M3 మరియు Intel Mac లు)
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+ముందు అవసరమైనవి
+=================
+
+సిస్టమ్ అవసరాలు
+-----------------
+
+* macOS 11 (Big Sur) లేదా తరువాతి వెర్షన్
+* macOS 15.7.1 (Sequoia) పరీక్షించబడింది మరియు పనిచేస్తుంది
+* కనీసం 4GB RAM
+* 2GB ఖాళీ డిస్క్ స్థలం
+
+అవసరమైన సాఫ్ట్‌వేర్
+--------------------
+
+Homebrew Package Manager
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+మీకు Homebrew ఇన్‌స్టాల్ చేయబడలేదంటే::
+
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+ఇన్‌స్టాలేషన్ తర్వాత, మీ PATH కు Homebrew జోడించడానికి సూచనలను అనుసరించండి.
+
+Mac కోసం Docker Desktop
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Docker Desktop ఇన్‌స్టాల్ చేయండి::
+
+    brew install --cask docker
+
+లేదా నేరుగా డౌన్‌లోడ్ చేయండి: https://www.docker.com/products/docker-desktop
+
+**Apple Silicon వాడుకరులకు ముఖ్యం**: మీరు Docker Desktop యొక్క Apple Silicon వెర్షన్‌ను డౌన్‌లోడ్ చేసుకోవాలి.
+
+ఇన్‌స్టాలేషన్ తర్వాత:
+
+1. Applications నుండి Docker Desktop ప్రారంభించండి
+2. Docker ప్రారంభం కావడం వరకు వేచి ఉండండి
+3. Docker రన్నింగ్ అవుతుందో తనిఖీ చేయండి::
+
+    docker --version
+    docker compose version
+
+ఇన్‌స్టాలేషన్ పద్ధతులు
+=======================
+
+పద్ధతి 1: Docker ఇన్‌స్టాలేషన్ (సిఫార్సు చేయబడింది)
+--------------------------------------------------
+
+ఇది macOS వాడుకరులకు సులభమైన పద్ధతి.
+
+దశ 1: Docker Repository క్లోన్ చేయండి
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    cd ~/Documents
+    git clone https://github.com/searxng/searxng-docker.git
+    cd searxng-docker
+
+దశ 2: మీ Instance ను కాన్ఫిగర్ చేయండి
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``.env`` ఫైల్‌ను సవరించండి::
+
+    nano .env
+
+మీ instance పేరు మరియు ఇతర ప్రాధాన్యతలను సెట్ చేయండి.
+
+దశ 3: SearXNG ప్రారంభించండి
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    docker compose up -d
+
+దశ 4: మీ Instance యాక్సెస్ చేయండి
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+మీ బ్రౌజర్ తెరిచి వెళ్ళండి: http://localhost:8080
+
+macOS-నిర్దిష్ట పరిగణనలు
+===========================
+
+Apple Silicon (M1/M2/M3) గమనికలు
+---------------------------------
+
+Mac కోసం Docker Desktop ఆర్కిటెక్చర్ తేడాలను స్వయంచాలకంగా నిర్వహిస్తుంది. ARM64 ఆర్కిటెక్చర్ కోసం ప్రత్యేక కాన్ఫిగరేషన్ అవసరం లేదు.
+
+ఫైల్ అనుమతులు
+---------------
+
+మీకు అనుమతి లోపాలు ఎదురైతే::
+
+    sudo chown -R $(whoami) ~/Documents/searxng-docker/
+
+Port సంఘర్షణలు
+---------------
+
+సాధారణ macOS సేవలు డిఫాల్ట్ ports తో సంఘర్షించవచ్చు:
+
+Port 8080 సంఘర్షణ తనిఖీ::
+
+    lsof -i :8080
+
+Port ఉపయోగంలో ఉంటే, ఒకటి:
+
+1. సంఘర్షించే ప్రక్రియను ముగించండి::
+
+    kill -9 <PID>
+
+2. లేదా ``docker-compose.yml`` లో port మార్చండి
+
+సమస్య పరిష్కారం
+==================
+
+Docker ప్రారంభం కావడం లేదు
+---------------------------
+
+Docker ప్రారంభం కాకపోతే:
+
+1. Docker Desktop పూర్తిగా నిష్క్రమించండి
+2. మళ్లీ Docker Desktop ప్రారంభించండి
+
+SearXNG యాక్సెస్ చేయలేకపోవడం
+----------------------------
+
+మీరు localhost:8080 వద్ద SearXNG యాక్సెస్ చేయలేకపోతే:
+
+1. Docker containers రన్నింగ్ అవుతున్నాయో తనిఖీ చేయండి::
+
+    docker ps
+
+2. లాగ్‌లను తనిఖీ చేయండి::
+
+    docker compose logs searxng
+
+తదుపరి దశలు
+=============
+
+* :ref:`searxng settings`
+* :ref:`buildhosts`
+* engines కాన్ఫిగర్ చేయండి
+* nginx లేదా Apache తో HTTPS సెటప్ చేయండి
+
+అదనపు వనరులు
+===============
+
+* అధికారిక డాక్యుమెంటేషన్: https://docs.searxng.org
+* GitHub Issues: https://github.com/searxng/searxng/issues
+* కమ్యూనిటీ చాట్: Matrix లో #searxng
+
+సహకారం
+========
+
+ఈ macOS సూచనలతో సమస్య కనుగొన్నారా? దయచేసి GitHub లో నివేదించండి లేదా pull request సమర్పించండి!
+
+----
+
+**పరీక్షించబడింది**: macOS Sequoia 15.7.1 (Build 24G231) Apple Silicon తో

--- a/docs/admin/installation-macos.rst
+++ b/docs/admin/installation-macos.rst
@@ -17,7 +17,7 @@ Prerequisites
 System Requirements
 -------------------
 
-* macOS 11 (Big Sur) or later
+* macOS 11 (Big Sur) or later (older versions may work but are untested)
 * macOS 15.7.1 (Sequoia) tested and confirmed working
 * At least 4GB of RAM
 * 2GB of free disk space
@@ -62,35 +62,34 @@ Method 1: Docker Installation (Recommended)
 
 This is the easiest method for macOS users.
 
-Step 1: Clone the Docker Repository
+For complete Docker installation instructions, please refer to the `searxng-docker documentation <https://github.com/searxng/searxng-docker>`_.
+
+macOS-Specific Docker Considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+When using Docker on macOS, keep these platform-specific notes in mind:
 
-    cd ~/Documents
-    git clone https://github.com/searxng/searxng-docker.git
-    cd searxng-docker
+**Apple Silicon (M1/M2/M3) Users**
 
-Step 2: Configure Your Instance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Ensure you download the Apple Silicon version of Docker Desktop
+* Docker Desktop automatically handles ARM64 architecture - no special configuration needed
 
-Edit the ``.env`` file::
+**Volume Mounting**
 
-    nano .env
+Docker Desktop on macOS has specific directory requirements. Keep your projects in:
 
-Set your instance name and other preferences.
+* ``~/Documents``
+* ``~/Desktop``  
+* ``~/Downloads``
+* Or add custom paths in Docker Desktop → Settings → Resources → File Sharing
 
-Step 3: Start SearXNG
-~~~~~~~~~~~~~~~~~~~~~
+**Port Conflicts**
 
-::
+Check for port conflicts before starting::
 
-    docker compose up -d
+    lsof -i :8080
 
-Step 4: Access Your Instance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Open your browser and go to: http://localhost:8080
+If the port is in use, either kill the conflicting process or change the port in ``docker-compose.yml``.
 
 Method 2: Native Installation
 ------------------------------
@@ -145,33 +144,6 @@ File Permissions
 If you encounter permission errors::
 
     sudo chown -R $(whoami) ~/Documents/searxng-docker/
-
-Volume Mounting
----------------
-
-Docker Desktop on macOS has specific directory requirements for volume mounting. Keep your projects in:
-
-* ``~/Documents``
-* ``~/Desktop``
-* ``~/Downloads``
-* Or add custom paths in Docker Desktop → Settings → Resources → File Sharing
-
-Port Conflicts
---------------
-
-Common macOS services that might conflict with default ports:
-
-Port 8080 conflict check::
-
-    lsof -i :8080
-
-If the port is in use, either:
-
-1. Kill the conflicting process::
-
-    kill -9 <PID>
-
-2. Or change the port in ``docker-compose.yml``
 
 Firewall Configuration
 ----------------------
@@ -228,9 +200,7 @@ If you experience slow performance:
 Python Version Issues
 ---------------------
 
-macOS Sequoia 15.7.1 comes with Python 3.13.5. If you encounter compatibility issues:
-
-::
+macOS Sequoia 15.7.1 comes with Python 3.13.5. If you encounter compatibility issues::
 
     brew install python@3.11
     pip3.11 install -r requirements.txt

--- a/docs/admin/installation-macos.rst
+++ b/docs/admin/installation-macos.rst
@@ -1,0 +1,281 @@
+.. _installation macos:
+
+=========================
+Installation on macOS
+=========================
+
+This guide covers SearXNG installation specifically for macOS systems, including both Apple Silicon (M1/M2/M3) and Intel-based Macs.
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+Prerequisites
+=============
+
+System Requirements
+-------------------
+
+* macOS 11 (Big Sur) or later
+* macOS 15.7.1 (Sequoia) tested and confirmed working
+* At least 4GB of RAM
+* 2GB of free disk space
+
+Required Software
+-----------------
+
+Homebrew Package Manager
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you don't have Homebrew installed::
+
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+After installation, follow the instructions to add Homebrew to your PATH.
+
+Docker Desktop for Mac
+~~~~~~~~~~~~~~~~~~~~~~
+
+Install Docker Desktop::
+
+    brew install --cask docker
+
+Or download directly from: https://www.docker.com/products/docker-desktop
+
+**Important for Apple Silicon users**: Ensure you download the Apple Silicon version of Docker Desktop.
+
+After installation:
+
+1. Launch Docker Desktop from Applications
+2. Wait for Docker to start (the whale icon in the menu bar should be steady)
+3. Verify Docker is running::
+
+    docker --version
+    docker compose version
+
+Installation Methods
+====================
+
+Method 1: Docker Installation (Recommended)
+--------------------------------------------
+
+This is the easiest method for macOS users.
+
+Step 1: Clone the Docker Repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    cd ~/Documents
+    git clone https://github.com/searxng/searxng-docker.git
+    cd searxng-docker
+
+Step 2: Configure Your Instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Edit the ``.env`` file::
+
+    nano .env
+
+Set your instance name and other preferences.
+
+Step 3: Start SearXNG
+~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    docker compose up -d
+
+Step 4: Access Your Instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Open your browser and go to: http://localhost:8080
+
+Method 2: Native Installation
+------------------------------
+
+For advanced users who prefer running SearXNG natively on macOS.
+
+Step 1: Install Python Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    brew install python3
+    pip3 install --upgrade pip
+    pip3 install searxng
+
+Step 2: Clone SearXNG Repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    cd ~/Documents
+    git clone https://github.com/searxng/searxng.git
+    cd searxng
+
+Step 3: Install Requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    pip3 install -r requirements.txt
+
+Step 4: Run SearXNG
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+    python3 searx/webapp.py
+
+Access at: http://localhost:8888
+
+macOS-Specific Considerations
+==============================
+
+Apple Silicon (M1/M2/M3) Notes
+------------------------------
+
+Docker Desktop for Mac handles architecture differences automatically. No special configuration needed for ARM64 architecture.
+
+File Permissions
+----------------
+
+If you encounter permission errors::
+
+    sudo chown -R $(whoami) ~/Documents/searxng-docker/
+
+Volume Mounting
+---------------
+
+Docker Desktop on macOS has specific directory requirements for volume mounting. Keep your projects in:
+
+* ``~/Documents``
+* ``~/Desktop``
+* ``~/Downloads``
+* Or add custom paths in Docker Desktop → Settings → Resources → File Sharing
+
+Port Conflicts
+--------------
+
+Common macOS services that might conflict with default ports:
+
+Port 8080 conflict check::
+
+    lsof -i :8080
+
+If the port is in use, either:
+
+1. Kill the conflicting process::
+
+    kill -9 <PID>
+
+2. Or change the port in ``docker-compose.yml``
+
+Firewall Configuration
+----------------------
+
+If you're having connection issues:
+
+1. System Settings → Network → Firewall
+2. Click "Options"
+3. Allow Docker Desktop
+4. Allow Python (if using native installation)
+
+Troubleshooting
+===============
+
+Docker Not Starting
+-------------------
+
+If Docker fails to start:
+
+1. Quit Docker Desktop completely
+2. Remove Docker data (optional - WARNING: removes all containers)::
+
+    rm -rf ~/Library/Containers/com.docker.docker
+    
+3. Restart Docker Desktop
+
+SearXNG Not Accessible
+----------------------
+
+If you can't access SearXNG at localhost:8080:
+
+1. Check Docker containers are running::
+
+    docker ps
+
+2. Check logs::
+
+    docker compose logs searxng
+
+3. Verify network settings::
+
+    docker network ls
+    docker network inspect searxng-docker_default
+
+Slow Performance on Apple Silicon
+----------------------------------
+
+If you experience slow performance:
+
+1. Ensure you're using the ARM64 version of Docker Desktop
+2. Increase Docker resources in Docker Desktop → Settings → Resources
+3. Allocate at least 4GB RAM and 2 CPUs
+
+Python Version Issues
+---------------------
+
+macOS Sequoia 15.7.1 comes with Python 3.13.5. If you encounter compatibility issues:
+
+::
+
+    brew install python@3.11
+    pip3.11 install -r requirements.txt
+
+Updating SearXNG
+================
+
+For Docker Installation
+-----------------------
+
+::
+
+    cd ~/Documents/searxng-docker
+    docker compose pull
+    docker compose up -d
+
+For Native Installation
+-----------------------
+
+::
+
+    cd ~/Documents/searxng
+    git pull origin master
+    pip3 install -r requirements.txt --upgrade
+
+Next Steps
+==========
+
+* :ref:`searxng settings`
+* :ref:`buildhosts`
+* Configure engines: See engine documentation
+* Set up HTTPS with nginx or Apache
+
+Additional Resources
+====================
+
+* Official Documentation: https://docs.searxng.org
+* GitHub Issues: https://github.com/searxng/searxng/issues
+* Community Chat: #searxng on Matrix
+
+Contributing
+============
+
+Found an issue with these macOS instructions? Please report it on GitHub or submit a pull request!
+
+----
+
+**Tested on**: macOS Sequoia 15.7.1 (Build 24G231) with Apple Silicon


### PR DESCRIPTION
## Summary
This PR adds a comprehensive macOS-specific installation guide to improve documentation for macOS users (both Apple Silicon and Intel Macs).

## What's Included
- macOS-specific prerequisites and system requirements
- Docker installation guide with reference to searxng-docker documentation
- Native installation method for advanced users
- macOS-specific troubleshooting (port conflicts, permissions, firewall)
- Apple Silicon (M1/M2/M3) considerations
- Volume mounting guidance specific to macOS Docker Desktop

## Motivation
Based on issue #5286 and community feedback, macOS users frequently encounter platform-specific challenges when installing SearXNG. This documentation aims to:
- Reduce support requests related to macOS installation
- Improve the onboarding experience for macOS users
- Provide clear troubleshooting steps for common macOS issues

## Changes in v2 (addressing review feedback)
- Referenced searxng-docker documentation instead of duplicating installation steps
- Clarified that macOS 11+ requirement is based on testing (older versions may work but are untested)
- Kept macOS-specific considerations and troubleshooting sections

## Testing
Tested on macOS Sequoia 15.7.1 (Build 24G231) with Apple Silicon