### PR TITLE
[fix] yandex engine: capture captcha from header instead of url path

### DIFF
--- a/searx/engines/yandex.py
+++ b/searx/engines/yandex.py
@@ -35,7 +35,7 @@ content_xpath = './/div[@class="b-serp-item__content"]//div[@class="b-serp-item_
 
 
 def catch_bad_response(resp):
-    if resp.url.path.startswith('/showcaptcha'):
+    if resp.headers.get('x-yandex-captcha') == 'captcha':
         raise SearxEngineCaptchaException()
 
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR fixes an issue where the CAPTCHA response from Yandex wouldn't be detected, resulting in `ParserError` when trying to parse the response to DOM.

<!-- explain the changes in your PR, algorithms, design, architecture -->

In this fix, I replaced the url condition and instead is checking if the `x-yandex-captcha` header is set, and is equal to `captcha`.

Alternatively, maybe something like `resp.headers.get('Location', '').startswith("https://yandex.com/showcaptcha")` could be done instead. Lastly, setting `params['allow_redirects'] = True` can also work, but this will waste an extra request. Just let me know.


## Why is this change important?

<!-- MANDATORY -->

Yandex engine will return parsing error instead of informing that a CAPTCHA was found. It is confusing for the admin and the users.

<!-- explain the motivation behind your PR -->

## Related issues

Closes #5415 
