### PR TITLE
[mod] yandex engine: add supported languages

### DIFF
--- a/searx/engines/yandex.py
+++ b/searx/engines/yandex.py
@@ -28,6 +28,20 @@ search_type = ""
 base_url_web = 'https://yandex.com/search/site/'
 base_url_images = 'https://yandex.com/images/search'
 
+# Supported languages
+yandex_supported_langs = [
+    "ru",  # Russian
+    "en",  # English
+    "be",  # Belarusian
+    "fr",  # French
+    "de",  # German
+    "id",  # Indonesian
+    "kk",  # Kazakh
+    "tt",  # Tatar
+    "tr",  # Turkish
+    "uk",  # Ukrainian
+]
+
 results_xpath = '//li[contains(@class, "serp-item")]'
 url_xpath = './/a[@class="b-serp-item__title-link"]/@href'
 title_xpath = './/h3[@class="b-serp-item__title"]/a[@class="b-serp-item__title-link"]/span'
@@ -47,6 +61,10 @@ def request(query, params):
         "frame": "1",
         "searchid": "3131712",
     }
+
+    lang = params["language"].split("-")[0]
+    if lang in yandex_supported_langs:
+        query_params_web["lang"] = lang
 
     query_params_images = {
         "text": query,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2134,22 +2134,21 @@ engines:
     search_type: web
     shortcut: yd
     disabled: true
-    inactive: true
 
   - name: yandex images
     engine: yandex
+    network: yandex
     categories: images
     search_type: images
     shortcut: ydi
     disabled: true
-    inactive: true
 
   - name: yandex music
     engine: yandex_music
+    network: yandex
     shortcut: ydm
     disabled: true
     # https://yandex.com/support/music/access.html
-    inactive: true
 
   - name: yahoo
     engine: yahoo


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR adds support for Yandex's supported languages; Russian, English, Belarusian, French, German, Indonesian, Kazakh, Tatar, Turkish and Ukrainian.

Yandex allows to select multiple languages at once. I'm not sure if we should choose nothing or everything if `all` is chosen  in SearXNG preferences. The results are a tiny bit different selecting all languages compared to selecting no language but mostly the same.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

It would be nice to have matching language when searching in German, French, Russian etc..

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->