### PR TITLE
[fix] drop goo engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2682,26 +2682,6 @@ engines:
     # sourcehut_sort_order: longest-active
     disabled: true
 
-  - name: goo
-    shortcut: goo
-    engine: xpath
-    paging: true
-    search_url: https://search.goo.ne.jp/web.jsp?MT={query}&FR={pageno}0
-    url_xpath: //div[@class="result"]/p[@class='title fsL1']/a/@href
-    title_xpath: //div[@class="result"]/p[@class='title fsL1']/a
-    content_xpath: //p[contains(@class,'url fsM')]/following-sibling::p
-    first_page_num: 0
-    categories: [general, web]
-    disabled: true
-    timeout: 4.0
-    about:
-      website: https://search.goo.ne.jp
-      wikidata_id: Q249044
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-      language: ja
-
   - name: bt4g
     engine: bt4g
     shortcut: bt4g


### PR DESCRIPTION
## What does this PR do?

This PR removes Goo (https://www.goo.ne.jp/) search engine.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

It is discontinued.

## Related issues

Closes #5409
