### PR TITLE
[fix] hackernews contains HTML escape codes

### DIFF
--- a/searx/engines/hackernews.py
+++ b/searx/engines/hackernews.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from dateutil.relativedelta import relativedelta
 
 from flask_babel import gettext
+from searx.utils import html_to_text
 
 # Engine metadata
 about = {
@@ -75,6 +76,7 @@ def response(resp):
         object_id = hit["objectID"]
         points = hit.get("points") or 0
         num_comments = hit.get("num_comments") or 0
+        content = hit.get("url") or html_to_text(hit.get("comment_text")) or html_to_text(hit.get("story_text"))
 
         metadata = ""
         if points != 0 or num_comments != 0:
@@ -83,7 +85,7 @@ def response(resp):
             {
                 "title": hit.get("title") or f"{gettext('author')}: {hit['author']}",
                 "url": f"https://news.ycombinator.com/item?id={object_id}",
-                "content": hit.get("url") or hit.get("comment_text") or hit.get("story_text") or "",
+                "content": content,
                 "metadata": metadata,
                 "author": hit["author"],
                 "publishedDate": datetime.fromtimestamp(hit["created_at_i"]),


### PR DESCRIPTION
Before:
<img width="709" height="486" alt="Hackernews_before" src="https://github.com/user-attachments/assets/5f52352d-edf9-4e9d-9812-3157817a1baa" />

After:
<img width="626" height="435" alt="Hackernews_after" src="https://github.com/user-attachments/assets/b37ec381-f595-4664-996a-aaa12ab889d6" />
