### PR TITLE
[feat] engines: add devicons engine

### DIFF
--- a/searx/engines/devicons.py
+++ b/searx/engines/devicons.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Devicons (icons)"""
+
+import typing as t
+
+from searx.result_types import EngineResults
+
+if t.TYPE_CHECKING:
+    from extended_types import SXNG_Response
+    from search.processors.online import OnlineParams
+
+
+about = {
+    "website": "https://devicon.dev/",
+    "wikidata_id": None,
+    "official_api_documentation": None,
+    "use_official_api": True,
+    "results": "JSON",
+}
+
+cdn_base_url = "https://cdn.jsdelivr.net/gh/devicons/devicon@latest"
+categories = ["images", "icons"]
+
+
+def request(query: str, params: "OnlineParams"):
+    params["url"] = f"{cdn_base_url}/devicon.json"
+    params['query'] = query
+    return params
+
+
+def response(resp: "SXNG_Response") -> EngineResults:
+    res = EngineResults()
+    query_parts = resp.search_params["query"].lower().split(" ")
+
+    def is_result_match(result: dict[str, t.Any]) -> bool:
+        for part in query_parts:
+            if part in result["name"]:
+                return True
+
+            for tag in result["altnames"] + result["tags"]:
+                if part in tag:
+                    return True
+
+        return False
+
+    filtered_results = filter(is_result_match, resp.json())
+    for result in filtered_results:
+        for image_type in result["versions"]["svg"]:
+            img_src = f"{cdn_base_url}/icons/{result['name']}/{result['name']}-{image_type}.svg"
+            res.add(
+                res.types.LegacyResult(
+                    {
+                        "template": "images.html",
+                        "url": img_src,
+                        "title": result["name"],
+                        "content": f"Base color: {result['color']}",
+                        "img_src": img_src,
+                        "img_format": "SVG",
+                    }
+                )
+            )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -736,6 +736,11 @@ engines:
     shortcut: da
     timeout: 3.0
 
+  - name: devicons
+    engine: devicons
+    shortcut: di
+    timeout: 3.0
+
   - name: ddg definitions
     engine: duckduckgo_definitions
     shortcut: ddd


### PR DESCRIPTION
- official website: https://devicon.dev/
- the engine contains a lot of icons of popular software frameworks (e.g. pytest),
so they could for example be useful for visualizing a diagram of the tech stack used in an app
