### PR TITLE
[fix] ahmia engine: requires rotating tokens to work

### DIFF
--- a/searx/engines/ahmia.py
+++ b/searx/engines/ahmia.py
@@ -3,9 +3,14 @@
 Ahmia (Onions)
 """
 
+import typing as t
+
 from urllib.parse import urlencode, urlparse, parse_qs
 from lxml.html import fromstring
+from searx.utils import gen_useragent, ElementType
 from searx.engines.xpath import extract_url, extract_text, eval_xpath_list, eval_xpath
+from searx.network import get
+from searx.enginelib import EngineCache
 
 # about
 about = {
@@ -23,6 +28,7 @@ paging = True
 page_size = 10
 
 # search url
+base_url = 'http://juhanurmihxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion'
 search_url = 'http://juhanurmihxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/search/?{query}'
 time_range_support = True
 time_range_dict = {'day': 1, 'week': 7, 'month': 30}
@@ -34,10 +40,44 @@ title_xpath = './h4/a[1]'
 content_xpath = './/p[1]'
 correction_xpath = '//*[@id="didYouMean"]//a'
 number_of_results_xpath = '//*[@id="totalResults"]'
+name_token_xpath = '//form[@id="searchForm"]/input[@type="hidden"]/@name'
+value_token_xpath = '//form[@id="searchForm"]/input[@type="hidden"]/@value'
+
+CACHE: EngineCache
+"""Persistent (SQLite) key/value cache that deletes its values after ``expire``
+seconds."""
+
+
+def setup(engine_settings: dict[str, t.Any]) -> bool:
+    global CACHE  # pylint: disable=global-statement
+    CACHE = EngineCache(engine_settings["name"])
+    return True
+
+
+def _get_tokens(dom: ElementType | None = None) -> str:
+    """
+    The tokens are hidden in a hidden input field.
+    They update every minute, but allow up to 1 hour old tokens to be used.
+    To spend the least amount of requests, it is best to always get the newest
+    tokens from each request. In worst case if it has expired, it would
+    need to do a total of 2 requests (over tor, might be ridiculously slow).
+    """
+    if dom is None:
+        resp = get(base_url, headers={'User-Agent': gen_useragent()})
+        dom = fromstring(resp.text)
+    name_token = extract_text(dom.xpath(name_token_xpath))
+    value_token = extract_text(dom.xpath(value_token_xpath))
+    return f"{name_token}:{value_token}"
 
 
 def request(query, params):
-    params['url'] = search_url.format(query=urlencode({'q': query}))
+    token_str: str | None = CACHE.get('ahmia-tokens')
+    if not token_str:
+        token_str = _get_tokens()
+        CACHE.set('ahmia-tokens', token_str, expire=60 * 60)
+    name_token, value_token = token_str.split(":")
+
+    params['url'] = search_url.format(query=urlencode({'q': query, name_token: value_token}))
 
     if params['time_range'] in time_range_dict:
         params['url'] += '&' + urlencode({'d': time_range_dict[params['time_range']]})
@@ -76,5 +116,9 @@ def response(resp):
             results.append({'number_of_results': int(extract_text(number_of_results))})
         except:  # pylint: disable=bare-except
             pass
+
+    # Update the tokens to the newest ones
+    token_str = _get_tokens(dom)
+    CACHE.set('ahmia-tokens', token_str, expire=60 * 60)
 
     return results

--- a/searx/engines/ahmia.py
+++ b/searx/engines/ahmia.py
@@ -44,8 +44,6 @@ name_token_xpath = '//form[@id="searchForm"]/input[@type="hidden"]/@name'
 value_token_xpath = '//form[@id="searchForm"]/input[@type="hidden"]/@value'
 
 CACHE: EngineCache
-"""Persistent (SQLite) key/value cache that deletes its values after ``expire``
-seconds."""
 
 
 def setup(engine_settings: dict[str, t.Any]) -> bool:

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -451,6 +451,9 @@ engines:
   # Requires Tor
   - name: ahmia
     engine: ahmia
+    # Might do up to two requests to perform a search.
+    # Since Tor is already slow by nature, the timeout is set very high.
+    timeout: 20.0
     categories: onions
     enable_http: true
     shortcut: ah


### PR DESCRIPTION
## What does this PR do?

Ahmia recently implemented a 60 minute rotating token system when searching. If these tokens are not provided, it will redirect to the homepage, and SearXNG returning a parsing error.
The tokens update every minute, but Ahmia allow up to 1 hour old tokens to be used.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

This implementation gets the keys from the hidden input using xpaths, and uses the `EngineCache` to prevent having to do 2 requests on every search. It will however search 2 times for the first initial request towards Ahmia, and also if tokens are older than 1 hour.

I took inspiration from [semantic scholar](/searxng/searxng/blob/7a1b959646c45a81d3495148b1fa6c2da585eb59/searx/engines/semantic_scholar.py) engine to set up the cache.

## Why is this change important?

As of now, SearXNG will return a parsing error when trying to search Ahmia because it is returning a redirect to the homepage.

There is also very few tor-specific search engines on SearXNG, and feel it is important that this works.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

1. Clone this PR
2. Set up tor socks proxy (usually it's on port 9050)
3. Use the following settings in settings.yml:
```yaml
categories_as_tabs:
  general:
  images:
  videos:
  news:
  map:
  music:
  it:
  science:
  files:
  social media:
  onions:
  
engines:
  - name: ahmia
    using_tor_proxy: true
    proxies:
      all://:
        - socks5h://127.0.0.1:9050
```
4. Start SearXNG
5. Search for `!ah test` for example

<!-- commands to run the tests or instructions to test the changes -->