### PR TITLE
[fix] drop alexandria.org

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -387,25 +387,6 @@ engines:
     timeout: 6
     disabled: true
 
-  - name: alexandria
-    engine: json_engine
-    shortcut: alx
-    categories: general
-    paging: true
-    search_url: https://api.alexandria.org/?a=1&q={query}&p={pageno}
-    results_query: results
-    title_query: title
-    url_query: url
-    content_query: snippet
-    timeout: 1.5
-    disabled: true
-    about:
-      website: https://alexandria.org/
-      official_api_documentation: https://github.com/alexandria-org/alexandria-api/raw/master/README.md
-      use_official_api: true
-      require_api_key: false
-      results: JSON
-
   - name: astrophysics data system
     engine: astrophysics_data_system
     shortcut: ads


### PR DESCRIPTION
alexandria.org keeps going down... I don't think that we should keep it.

as mentioned in https://github.com/searxng/searxng/issues/5442#issuecomment-3528932298 alexandria.org was previously removed, then re-added.

closes https://github.com/searxng/searxng/issues/5442