### PR TITLE
[fix] recoll engine: fix media preview

### DIFF
--- a/searx/engines/recoll.py
+++ b/searx/engines/recoll.py
@@ -38,7 +38,7 @@ Implementations
 import typing as t
 
 from datetime import date, timedelta
-from urllib.parse import urlencode, quote
+from urllib.parse import urlencode
 
 from searx.result_types import EngineResults
 
@@ -122,15 +122,14 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
         url = result.get("url", "").replace("file://" + mount_prefix, dl_prefix)
 
-        mtype = subtype = result.get("mime", "")
+        mtype = subtype = result.get("mtype", "")
         if mtype:
             mtype, subtype = (mtype.split("/", 1) + [""])[:2]
 
         # facilitate preview support for known mime types
         thumbnail = embedded = ""
         if mtype in ["audio", "video"]:
-            embedded_url = '<{ttype} controls height="166px" ' + 'src="{url}" type="{mtype}"></{ttype}>'
-            embedded = embedded_url.format(ttype=mtype, url=quote(url.encode("utf8"), "/:"), mtype=result["mtype"])
+            embedded = url
         if mtype in ["image"] and subtype in ["bmp", "gif", "jpeg", "png"]:
             thumbnail = url
 


### PR DESCRIPTION
## What does this PR do?

Corrects the name of the JSON field returned by recoll-webui.

Changes `embedded` in the results to point to URL of the media, as per documentation for the `File` class in 

https://github.com/searxng/searxng/blob/576c8ca99cde1a31e442ef61965e77c82349079b/searx/result_types/file.py#L56-L57

## Why is this change important?

The results from recoll engines are not displaying the usual toggle for showing media previews. I should perhaps remark that this was working as expected a couple of weeks ago, so the issue fixed by this PR is a regression. 

## How to test this PR locally?

You'll need access to an instance of [recoll-webui](https://framagit.org/medoc92/recollwebui) with some audio/video media indexed. After applying changes, the results for audio/video now show a button to toggle a preview of the media. Here are screenshots from my instance for before and after the changes:

<img width="2508" height="2110" alt="image" src="https://github.com/user-attachments/assets/78b35445-93cf-4988-bff4-7937153bb949" />

<img width="2510" height="3002" alt="image" src="https://github.com/user-attachments/assets/64d2db0e-523c-4e44-a8f0-85465ccbccaa" />


## Author's checklist

For reference, here is a sample from my instance of a JSON returned by [recoll-webui](https://framagit.org/medoc92/recollwebui):

```json
{
  "query": {
    "query": "filename:mp4",
    "before": "",
    "after": "",
    "dir": "<all>",
    "sort": "relevancyrating",
    "ascending": 0,
    "page": 1,
    "highlight": 1,
    "snippets": 1
  },
  "results": [
    {
      "abstract": " MPEG-4 audio (AAC LC), 3212.16 seconds, 157375 bps (audio/mp4) covr=[57671 bytes of data] desc=Discover how the concepts of zero and infinity revolutionized mathematics. ldes=Discover how the concepts of zero and infinity revolutionized",
      "author": "",
      "collapsecount": "",
      "dbytes": "359",
      "dmtime": "",
      "fbytes": "2705371968",
      "filename": "NOVA - Zero to Infinity.mp4",
      "fmtime": "01681324848",
      "ipath": "",
      "keywords": "",
      "mtime": "01681324848",
      "mtype": "video/mp4",
      "origcharset": "UTF-8",
      "relevancyrating": "100%",
      "sig": "27053719681715171381",
      "size": "359",
      "title": "NOVA - Zero to Infinity",
      "url": "file:///storage/library/videos/NOVA - Zero to Infinity.mp4",
      "label": "NOVA - Zero to Infinity",
      "snippet": " MPEG-4 audio (AAC LC), 3212.16 seconds, 157375 bps (audio/mp4) covr=[57671 bytes of data] desc=Discover how the concepts of zero and infinity revolutionized mathematics. ldes=Discover how the concepts of zero and infinity revolutionized",
      "time": "Wed Apr 12 15:40:48 2023",
      "sha": "1ed331ed60684cdcc2f67383c03fee8eadb70039"
    },
    {
      "abstract": " MPEG-4 audio (AAC LC), 2954.88 seconds, 94731 bps (audio/mp4) covr=[353495 bytes of data] desc=British mathematician Andrew Wiles's bid to find proof for Fermat's last theorem. ldes=British mathematician Andrew Wiles's bid to find proof for",
      "author": "",
      "collapsecount": "",
      "dbytes": "424",
      "dmtime": "",
      "fbytes": "626443687",
      "filename": "Horizon, 1995-1996, Fermat's Last Theorem.mp4",
      "fmtime": "01502981416",
      "ipath": "",
      "keywords": "",
      "mtime": "01502981416",
      "mtype": "video/mp4",
      "origcharset": "UTF-8",
      "relevancyrating": "100%",
      "sig": "6264436871727023896",
      "size": "424",
      "title": "Horizon, 1995-1996, Fermat's Last Theorem",
      "url": "file:///storage/library/videos/Horizon, 1995-1996, Fermat's Last Theorem.mp4",
      "label": "Horizon, 1995-1996, Fermat's Last Theorem",
      "snippet": " MPEG-4 audio (AAC LC), 2954.88 seconds, 94731 bps (audio/mp4) covr=[353495 bytes of data] desc=British mathematician Andrew Wiles's bid to find proof for Fermat's last theorem. ldes=British mathematician Andrew Wiles's bid to find proof for",
      "time": "Thu Aug 17 11:50:16 2017",
      "sha": "f1a69cb7554233f966badda06b72aa7c95319589"
    },
    {
      "abstract": " MPEG-4 audio (AAC LC), 1610.97 seconds, 125435 bps (audio/mp4) covr=[122102 bytes of data] desc=Lord Russell discusses his experiences, achievements, and unfulfilled ambitions. (1959) ldes=Lord Russell discusses his experiences, achievements, and",
      "author": "",
      "collapsecount": "",
      "dbytes": "418",
      "dmtime": "",
      "fbytes": "1048571609",
      "filename": "Face to Face, Bertrand Russell.mp4",
      "fmtime": "01489599778",
      "ipath": "",
      "keywords": "",
      "mtime": "01489599778",
      "mtype": "video/mp4",
      "origcharset": "UTF-8",
      "relevancyrating": "100%",
      "sig": "10485716091732479221",
      "size": "418",
      "title": "Face to Face, Bertrand Russell",
      "url": "file:///storage/library/videos/Face to Face, Bertrand Russell.mp4",
      "label": "Face to Face, Bertrand Russell",
      "snippet": " MPEG-4 audio (AAC LC), 1610.97 seconds, 125435 bps (audio/mp4) covr=[122102 bytes of data] desc=Lord Russell discusses his experiences, achievements, and unfulfilled ambitions. (1959) ldes=Lord Russell discusses his experiences, achievements, and",
      "time": "Wed Mar 15 14:42:58 2017",
      "sha": "7f39e21e9c2e5b58ac945025f6b267c50a5a04ec"
    }
  ]
}
```