### PR TITLE
[fix] presearch engine: blocked by captcha on every request

### DIFF
--- a/searx/engines/presearch.py
+++ b/searx/engines/presearch.py
@@ -89,6 +89,9 @@ time_range_support = True
 send_accept_language_header = True
 categories = ["general", "web"]  # general, images, videos, news
 
+# HTTP2 requests immediately get blocked by a CAPTCHA
+enable_http2 = False
+
 search_type = "search"
 """must be any of ``search``, ``images``, ``videos``, ``news``"""
 


### PR DESCRIPTION
Presearch responds with a Cloudflare captcha on each request when using HTTP2.
Using HTTP1.1, everything seems to work fine.

- other engines with the same issue: pixabay, uxwing
- closes https://github.com/searxng/searxng/issues/5438
