### PR TITLE
[fix] utils.js_variable_to_python - partial revert of 156d1eb8c

### DIFF
--- a/searx/utils.py
+++ b/searx/utils.py
@@ -807,11 +807,6 @@ def js_variable_to_python(js_variable: str) -> str:
     s = _JS_DECIMAL_RE.sub(":0.", s)
     # replace the surogate character by colon
     s = s.replace(chr(1), ':')
-    # replace single-quote followed by comma with double-quote and comma
-    # {"a": "\"12\"',"b": "13"}
-    # becomes
-    # {"a": "\"12\"","b": "13"}
-    s = s.replace("',", "\",")
     # load the JSON and return the result
     return json.loads(s)  # pyright: ignore[reportAny]
 


### PR DESCRIPTION
The JS string, whose encoding will be corrupted if all single quotes (followed by a comma) are replaced with double quotes. Bug was introduced in PR #4573.

Here is a simple example in which the list get corrupted

```python

    >>> s = r"""[ 'foo\'', 'bar']"""
    >>> print(s)
    [ 'foo\'', 'bar']
    >>> print(s.replace("',", "\","))
    [ 'foo\'", 'bar']
```