### PR TITLE
[fix] engines: typo

### DIFF
--- a/searx/engines/presearch.py
+++ b/searx/engines/presearch.py
@@ -140,7 +140,7 @@ def _get_request_id(query, params):
         if l.territory:
             headers['Accept-Language'] = f"{l.language}-{l.territory},{l.language};" "q=0.9,*;" "q=0.5"
 
-    resp = get(url, headers=headers, timout=5)
+    resp = get(url, headers=headers, timeout=5)
 
     for line in resp.text.split("\n"):
         if "window.searchId = " in line:

--- a/searx/engines/seznam.py
+++ b/searx/engines/seznam.py
@@ -27,7 +27,7 @@ base_url = 'https://search.seznam.cz/'
 
 
 def request(query, params):
-    response_index = get(base_url, headers=params['headers'], raise_for_httperror=True, timout=3)
+    response_index = get(base_url, headers=params['headers'], raise_for_httperror=True, timeout=3)
     dom = html.fromstring(response_index.text)
 
     url_params = {


### PR DESCRIPTION
Fix typo in engine timeout definition: 'timout' -> 'timeout'

```
AsyncClient.request() got an unexpected keyword argument 'timout'. Did you mean 'timeout'?
```

Related https://github.com/searxng/searxng/pull/5460