### PR TITLE
`can't register engine processor: wikidata` error

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -270,7 +270,14 @@ def load_engines(engine_list: list[dict[str, t.Any]]):
     categories.clear()
     categories['general'] = []
     for engine_data in engine_list:
+        if engine_data.get("inactive") is True:
+            continue
         engine = load_engine(engine_data)
         if engine:
             register_engine(engine)
+        else:
+            # if an engine can't be loaded (if for example the engine is missing
+            # tor or some other requirements) its set to inactive!
+            logger.error("loading engine %s failed: set engine to inactive!", engine_data.get("name", "???"))
+            engine_data["inactive"] = True
     return engines

--- a/searx/engines/invidious.py
+++ b/searx/engines/invidious.py
@@ -31,7 +31,7 @@ paging = True
 time_range_support = True
 
 # base_url can be overwritten by a list of URLs in the settings.yml
-base_url: list | str = []
+base_url: list[str] | str = []
 
 
 def init(_):

--- a/searx/engines/piped.py
+++ b/searx/engines/piped.py
@@ -72,7 +72,7 @@ categories = []
 paging = True
 
 # search-url
-backend_url: list[str] | str | None = None
+backend_url: list[str] | str = []
 """Piped-Backend_: The core component behind Piped.  The value is an URL or a
 list of URLs.  In the latter case instance will be selected randomly.  For a
 complete list of official instances see Piped-Instances (`JSON

--- a/searx/engines/pixiv.py
+++ b/searx/engines/pixiv.py
@@ -20,7 +20,7 @@ categories = ['images']
 
 # Search URL
 base_url = "https://www.pixiv.net/ajax/search/illustrations"
-pixiv_image_proxies: list = []
+pixiv_image_proxies: list[str] = []
 
 
 def request(query, params):

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -96,7 +96,7 @@ search_type = 'text'
 ``video`` are not yet implemented (Pull-Requests are welcome).
 """
 
-base_url: list[str] | str | None = None
+base_url: list[str] | str = []
 """The value is an URL or a list of URLs.  In the latter case instance will be
 selected randomly.
 """

--- a/searx/search/processors/__init__.py
+++ b/searx/search/processors/__init__.py
@@ -51,7 +51,6 @@ class ProcessorMap(dict[str, EngineProcessor]):
             eng_name: str = eng_settings["name"]
 
             if eng_settings.get("inactive", False) is True:
-                logger.info("Engine of name '%s' is inactive.", eng_name)
                 continue
 
             eng_obj = engines.engines.get(eng_name)

--- a/tests/unit/test_engines_init.py
+++ b/tests/unit/test_engines_init.py
@@ -61,7 +61,7 @@ class TestEnginesInit(SearxTestCase):
         with self.assertLogs('searx.engines', level='ERROR') as cm:  # pylint: disable=invalid-name
             engines.load_engines(engine_list)
             self.assertEqual(len(engines.engines), 0)
-            self.assertEqual(cm.output, ['ERROR:searx.engines:An engine does not have a "name" field'])
+            self.assertEqual(cm.output[0], 'ERROR:searx.engines:An engine does not have a "name" field')
 
     def test_missing_engine_field(self):
         settings['outgoing']['using_tor_proxy'] = False
@@ -72,5 +72,5 @@ class TestEnginesInit(SearxTestCase):
             engines.load_engines(engine_list)
             self.assertEqual(len(engines.engines), 0)
             self.assertEqual(
-                cm.output, ['ERROR:searx.engines:The "engine" field is missing for the engine named "engine2"']
+                cm.output[0], 'ERROR:searx.engines:The "engine" field is missing for the engine named "engine2"'
             )


### PR DESCRIPTION
### ```[fix] don't raise fatal exception when engine isn't available```

When wikidata or any other engine with a init method (is active!)  raises an
exception in it's init method, the engine is never registered.

[1] https://github.com/searxng/searxng/issues/5456#issuecomment-3567790287

Closes: 

- https://github.com/searxng/searxng/issues/5456


### ```[fix] engines initialization - if engine load fails, set to inactive```

- if engine load fails, set the engine to inactive
- dont' load a engine, when the config says its inactive


### ```[fix] engines: base URL can be a list or a string, but its not None!```

The code injection and monkey patching examine the names in the module of the
engine; if a variable there starts without an underscore and has the value None,
then this variable needs to be configured. This outdated concept does not fit
engines that may have multiple URLs. At least not as long as the value of the
base URL (list) is None.

The default is now an empty list instead of None
