### PR TITLE
[upd] ci: docker secret maintenance

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -194,8 +194,8 @@ jobs:
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           registry: "docker.io"
-          username: "${{ secrets.DOCKERHUB_USERNAME }}"
-          password: "${{ secrets.DOCKERHUB_TOKEN }}"
+          username: "${{ secrets.DOCKER_USER }}"
+          password: "${{ secrets.DOCKER_TOKEN }}"
 
       - name: Release
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,8 +32,8 @@ jobs:
         uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de  # v1.18.2
         with:
           organization: "searxng"
-          dockerhub-user: "${{ secrets.DOCKERHUB_USERNAME }}"
-          dockerhub-password: "${{ secrets.DOCKERHUB_TOKEN }}"
+          dockerhub-user: "${{ secrets.DOCKER_USER }}"
+          dockerhub-password: "${{ secrets.DOCKER_TOKEN }}"
           image: "registry://ghcr.io/searxng/searxng:latest"
           command: "cves"
           sarif-file: "./scout.sarif"


### PR DESCRIPTION
I've narrowed the permissions and rotated the token for the deploy account on DockerHub registry. I replaced the secret ref in GitHub so that it's available organization wide. No further actions are necessary.