### PR TITLE
[fix] recoll engine: remove HTML markup from result snippets

### DIFF
--- a/searx/engines/recoll.py
+++ b/searx/engines/recoll.py
@@ -41,6 +41,7 @@ from datetime import date, timedelta
 from urllib.parse import urlencode
 
 from searx.result_types import EngineResults
+from searx.utils import html_to_text
 
 if t.TYPE_CHECKING:
     from searx.extended_types import SXNG_Response
@@ -133,11 +134,14 @@ def response(resp: "SXNG_Response") -> EngineResults:
         if mtype in ["image"] and subtype in ["bmp", "gif", "jpeg", "png"]:
             thumbnail = url
 
+        # remove HTML from snippet
+        content = html_to_text(result.get("snippet", ""))
+
         res.add(
             res.types.File(
                 title=result.get("label", ""),
                 url=url,
-                content=result.get("snippet", ""),
+                content=content,
                 size=result.get("size", ""),
                 filename=result.get("filename", ""),
                 abstract=result.get("abstract", ""),


### PR DESCRIPTION
## What does this PR do?

Removes HTML markup in results received from [recoll-webui](https://framagit.org/medoc92/recollwebui). The markup is inserted by [recoll](https://www.recoll.org/) via [`makedocabstract`](https://framagit.org/medoc92/recoll/-/blob/master/src/doc/user/usermanual.html#L8750-L8765), which is [called by recoll-webui](https://framagit.org/medoc92/recollwebui/-/blob/master/webui.py#L405-L408).

## Why is this change important?

The markup is not consumed by SearX and is distracting to users.

## How to test this PR locally?

You need access to a working instance of [recoll-webui](https://framagit.org/medoc92/recollwebui) with documents indexed.

## Screenshots

Before and after:

<img width="2554" height="2962" alt="image" src="https://github.com/user-attachments/assets/17229be1-5962-4261-acc1-b34b3648ae06" />

<img width="2556" height="2934" alt="image" src="https://github.com/user-attachments/assets/3e8595ce-ce0e-46d2-b917-2430ad160b8f" />


