### PR TITLE
[fix] brave engines - web, images & videos

### DIFF
--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -155,8 +155,15 @@ class OnlineProcessor(EngineProcessor):
                     search_query.locale.language,
                 )
             headers["Accept-Language"] = ac_lang
-
         self.logger.debug("HTTP Accept-Language: %s", headers.get("Accept-Language", ""))
+
+        # https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header
+        headers["Sec-Fetch-Dest"] = "empty"
+        headers["Sec-Fetch-Mode"] = "cors"
+        headers["Sec-Fetch-Site"] = "same-origin"
+        headers["Sec-Fetch-User"] = "?1"
+        headers["Sec-GPC"] = "1"
+
         return params
 
     def _send_http_request(self, params: OnlineParams):


### PR DESCRIPTION
brave web:
  xpath selectors needed to be justified

brave images & videos:
  The JS code with the JS object was read incorrectly; not always, but quite
  often, it led to exceptions when the Python data structure was created from it.

BTW: A complete review was conducted and corrections or additions were made to the type definitions.

To test all brave engines in once::

    !br !brimg !brvid !brnews weather
