### PR TITLE
[feat] pixiv engine: add filter for AI generated images

### DIFF
--- a/searx/engines/pixiv.py
+++ b/searx/engines/pixiv.py
@@ -17,6 +17,7 @@ about = {
 # Engine configuration
 paging = True
 categories = ['images']
+remove_ai_images = False
 
 # Search URL
 base_url = "https://www.pixiv.net/ajax/search/illustrations"
@@ -33,6 +34,9 @@ def request(query, params):
         "type": "illust_and_ugoira",
         "lang": "en",
     }
+
+    if remove_ai_images is True:
+        query_params.update({"ai_type": 1})
 
     params["url"] = f"{base_url}/{query}?{urlencode(query_params)}"
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1622,6 +1622,7 @@ engines:
     engine: pixiv
     disabled: true
     inactive: true
+    remove_ai_images: false
     pixiv_image_proxies:
       - https://pximg.example.org
       # A proxy is required to load the images. Hosting an image proxy server


### PR DESCRIPTION
## What does this PR do?

Adds an option to filter AI generated pictures from pixiv search results.

## Why is this change important?

Some people may prefer to have AI generated pictures removed.
I might try to add similar filters to other image search engines when possible.

## How to test this PR locally?

Search with and without the filter. Some images will be removed.

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

related: https://github.com/searxng/searxng/issues/5029
