### PR TITLE
[fix] findthatmeme: hardening the response against KeyErrors

### DIFF
--- a/searx/engines/findthatmeme.py
+++ b/searx/engines/findthatmeme.py
@@ -42,8 +42,8 @@ def response(resp):
 
         results.append(
             {
-                'url': item['source_page_url'],
-                'title': item['source_site'],
+                'url': item.get('source_page_url'),
+                'title': item.get('source_site'),
                 'img_src': img if item['type'] == 'IMAGE' else thumb,
                 'filesize': humanize_bytes(item['meme_file_size']),
                 'publishedDate': formatted_date,


### PR DESCRIPTION
## What does this PR do?

fixes a keyerror when using findthatmeme engine

## Why is this change important?

solves the issue

## How to test this PR locally?

the keyerror occurred for me when searching 'bitcoin'
i have not have the issue with any other queries i tested

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
