### PR TITLE
[fix] plugin unit-converter - remove leftovers

### DIFF
--- a/searx/plugins/unit_converter.py
+++ b/searx/plugins/unit_converter.py
@@ -24,12 +24,6 @@ if typing.TYPE_CHECKING:
     from searx.plugins import PluginCfg
 
 
-name = ""
-description = gettext("")
-
-plugin_id = ""
-preference_section = ""
-
 CONVERT_KEYWORDS = ["in", "to", "as"]
 
 


### PR DESCRIPTION
Issu was reported by CI: https://github.com/searxng/searxng/actions/runs/19919624317/job/57105549395#step:8:603

```
2025-12-04 06:17:28,577 INFO:babel: extracting messages from searx/plugins/unit_converter.py
/home/runner/work/searxng/searxng/searx/plugins/unit_converter.py:28: warning: Empty msgid.  
It is reserved by GNU gettext: gettext("") returns the header entry with meta information,
not the empty string.
```