### PR TITLE
[debug] partial revert of 5e0e1c6b3

### DIFF
--- a/utils/lib_sxng_weblate.sh
+++ b/utils/lib_sxng_weblate.sh
@@ -59,8 +59,6 @@ weblate.to.translations() {
         wlc pull
         wlc commit
 
-        set -x # https://github.com/searxng/searxng/issues/5490
-
         # get the translations in a worktree
         weblate.translations.worktree
 
@@ -85,8 +83,6 @@ weblate.translations.commit() {
         pyenv.activate
         # lock change on weblate
         wlc lock
-
-        set -x # https://github.com/searxng/searxng/issues/5490
 
         # get translations branch in git worktree (TRANSLATIONS_WORKTREE)
         weblate.translations.worktree
@@ -150,9 +146,6 @@ weblate.push.translations() {
     (
         set -e
         pyenv.activate
-
-        set -x # https://github.com/searxng/searxng/issues/5490
-
         # get translations branch in git worktree (TRANSLATIONS_WORKTREE)
         weblate.translations.worktree
 


### PR DESCRIPTION
### `[debug] partial revert of` 5e0e1c6b3 

Issue #5490 was caused by a regression of GH action in v6.0.0, updating to v6.0.1 [2] fixed our workflow and debug messages [3] are no longer needed.

- [1] https://github.com/searxng/searxng/issues/5490#issuecomment-3616230451
- [2] https://github.com/searxng/searxng/pull/5530
- [3] https://github.com/searxng/searxng/actions/runs/19966501880/job/57259575596#step:8:780
