### PR TITLE
Update Marginalia Search integration to use the new API

### DIFF
--- a/searx/engines/marginalia.py
+++ b/searx/engines/marginalia.py
@@ -28,7 +28,7 @@ Implementations
 """
 
 import typing as t
-from urllib.parse import urlencode, quote_plus
+from urllib.parse import urlencode
 from searx.utils import searxng_useragent
 from searx.result_types import EngineResults
 from searx.extended_types import SXNG_Response
@@ -42,7 +42,7 @@ about = {
     "results": "JSON",
 }
 
-base_url = "https://api.marginalia.nu"
+base_url = "https://api2.marginalia-search.com"
 safesearch = True
 categories = ["general"]
 paging = False
@@ -85,13 +85,11 @@ class ApiSearchResults(t.TypedDict):
 
 def request(query: str, params: dict[str, t.Any]):
 
-    query_params = {
-        "count": results_per_page,
-        "nsfw": min(params["safesearch"], 1),
-    }
+    query_params = {"count": results_per_page, "nsfw": min(params["safesearch"], 1), "query": query}
 
-    params["url"] = f"{base_url}/{api_key}/search/{quote_plus(query)}?{urlencode(query_params)}"
+    params["url"] = f"{base_url}/search?{urlencode(query_params)}"
     params["headers"]["User-Agent"] = searxng_useragent()
+    params["headers"]["API-Key"] = api_key
 
 
 def response(resp: SXNG_Response):


### PR DESCRIPTION
## What does this PR do?

The code changes the marginalia search integration to use the newest version of the API,
which has better best practices such as not encoding the query as a path element.

## Why is this change important?

The old API is deprecated.  It will continue to be available, but not receive new features.

I am the maintainer and operator of Marginalia Search and would like to see API consumers use the v2 API instead of the deprecated V1 API.  

During testing I also noticed the old API integration incorrectly escapes the queries using quote_plus, which was not understood by the marginalia backend.  A %20-coding would have worked, but migrating to the new API accomplishes the same.

I'm attaching some screenshots showing this behavior, which is mitigated with the PR (though %20-encoding the query would have also fixed this issue as seen in the 2nd screenshot, which I included mostly to show what the expected search results are for the query).

<img width="772" height="658" alt="badquery" src="https://github.com/user-attachments/assets/d61e61cf-0639-4019-b7a4-441f192e82ef" />

<img width="868" height="760" alt="goodquery" src="https://github.com/user-attachments/assets/5774c011-d4a4-4a71-a779-4d31cf667ce1" />



## How to test this PR locally?

Edit settings.yml and add an API key to the marginalia block,
enable the search engine and verify results are returned.

## Author's checklist

I have ran the code locally and verified it works.

## Related issues

