### PR TITLE
360search bug 

### DIFF
--- a/searx/engines/360search.py
+++ b/searx/engines/360search.py
@@ -2,10 +2,18 @@
 # pylint: disable=invalid-name
 """360Search search engine for searxng"""
 
+import typing as t
+
 from urllib.parse import urlencode
 from lxml import html
 
+from searx import logger
+from searx.enginelib import EngineCache
 from searx.utils import extract_text
+from searx.network import get as http_get
+
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
 
 # Metadata
 about = {
@@ -26,6 +34,35 @@ time_range_dict = {'day': 'd', 'week': 'w', 'month': 'm', 'year': 'y'}
 
 # Base URL
 base_url = "https://www.so.com"
+COOKIE_CACHE_KEY = "cookie"
+COOKIE_CACHE_EXPIRATION_SECONDS = 3600
+
+CACHE: EngineCache
+"""Stores cookies from 360search to avoid re-fetching them on every request."""
+
+
+def setup(engine_settings: dict[str, t.Any]) -> bool:
+    """Initialization of the engine.
+
+    - Instantiate a cache for this engine (:py:obj:`CACHE`).
+
+    """
+    global CACHE  # pylint: disable=global-statement
+    # table name needs to be quoted to start with digits, so "cache" has been added to avoid sqlite complaining
+    CACHE = EngineCache("cache" + engine_settings["name"])
+    return True
+
+
+def get_cookie(url: str) -> str:
+    cookie: str | None = CACHE.get(COOKIE_CACHE_KEY)
+    if cookie:
+        return cookie
+    resp: SXNG_Response = http_get(url, timeout=10, allow_redirects=False)
+    headers = resp.headers
+    cookie = headers['set-cookie'].split(";")[0]
+    CACHE.set(key=COOKIE_CACHE_KEY, value=cookie, expire=COOKIE_CACHE_EXPIRATION_SECONDS)
+
+    return cookie
 
 
 def request(query, params):
@@ -36,8 +73,13 @@ def request(query, params):
 
     if time_range_dict.get(params['time_range']):
         query_params["adv_t"] = time_range_dict.get(params['time_range'])
-
     params["url"] = f"{base_url}/s?{urlencode(query_params)}"
+    # get token by calling the query page
+    logger.debug("querying url: %s", params["url"])
+    cookie = get_cookie(params["url"])
+    logger.debug("obtained cookie: %s", cookie)
+    params['headers'] = {'Cookie': cookie}
+
     return params
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -341,6 +341,7 @@ engines:
   - name: 360search
     engine: 360search
     shortcut: 360so
+    timeout: 10.0
     disabled: true
 
   - name: 360search videos


### PR DESCRIPTION
## What does this PR do?

I've added a mechanism to the 360search engine that retrieves the cookie used to check whether the request is legit. 
The cookie is then cached for 1 hour to avoid multiple requests.
I also increased the timeout for the engine to 10 seconds, since sometimes the default timeout is not enough to retrieve the results set.

## Why is this change important?

The engine was broken, a user reported the bug

## How to test this PR locally?

Just run searxng and try the engine

## Related issues

Fixes #5526 