### PR TITLE
[fix] searx.network: fix string concatenation of proxy error message

### DIFF
--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -106,9 +106,9 @@ class AsyncProxyTransportFixed(AsyncProxyTransport):
         except ProxyConnectionError as e:
             raise httpx.ProxyError("ProxyConnectionError: " + str(e.strerror), request=request) from e
         except ProxyTimeoutError as e:
-            raise httpx.ProxyError("ProxyTimeoutError: " + e.args[0], request=request) from e
+            raise httpx.ProxyError("ProxyTimeoutError: " + str(e.args[0]), request=request) from e
         except ProxyError as e:
-            raise httpx.ProxyError("ProxyError: " + e.args[0], request=request) from e
+            raise httpx.ProxyError("ProxyError: " + str(e.args[0]), request=request) from e
 
 
 def get_transport_for_socks_proxy(


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR fixes an issue where it will fail to concatenate a string when trying to raise a `ReplyError`, resulting in the engine(s) getting a "unexpected crash", instead of the correct "proxy error".

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

It is an important change, because it otherwise hides useful debug information we would like to see. If a person experiences an issue that is hard to reproduce, the current debug logs will only slow us down.

<!-- explain the motivation behind your PR -->

## Author's checklist

@Bnyro - If you would like to try this fix.

## Related issues

During testing of Ahmia onion engine fix (https://github.com/searxng/searxng/pull/5441), this issue was sometimes experienced. It is a bit hard to reproduce.

<!--
Closes #234
-->
