### PR TITLE
Fix brave brotli encoding issue

### DIFF
--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -214,6 +214,7 @@ def request(query: str, params: dict[str, t.Any]) -> None:
     if brave_category == "goggles":
         args["goggles_id"] = Goggles
 
+    params["headers"]["Accept-Encoding"] = "gzip, deflate"
     params["url"] = f"{base_url}{brave_category}?{urlencode(args)}"
     logger.debug("url %s", params["url"])
 


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

For some reason, I keep getting this error from the brave engine:

```
httpx.DecodingError: BrotliDecoderDecompressStream failed while processing the stream
```

Forcing the server to use either gzip or deflate fixes this issue.

## Why is this change important?

<!-- MANDATORY -->

This makes the brave engine work when the server seems to be encoding brotli incorrectly, or at least in a way incompatible with certain installs.

## How to test this PR locally?

Do a search with the brave engine and observe it doesn't crash with this patch.

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

- https://github.com/searxng/searxng/pull/1787
- https://github.com/searxng/searxng/pull/5536