### PR TITLE
Custom "content path" for MediaWiki engine 

### DIFF
--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -157,7 +157,7 @@ def response(resp):
         timestamp = result.get('timestamp')
 
         url = (
-            f"{base_url.rstrip('/')}".format(language=resp.search_params['language']) + content_path.rstrip('/') + '/' + quote(title.replace(' ', '_').encode())
+            base_url.format(language=resp.search_params['language']) + content_path.strip('/') + '/' + quote(title.replace(' ', '_').encode())
         )
         if sectiontitle:
             # in case of sectiontitle create a link to the section in the wiki page

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -27,7 +27,6 @@ Request:
 - :py:obj:`srenablerewrites`
 - :py:obj:`srsort`
 - :py:obj:`srprop`
-- :py:obj:`content_path`
 
 Implementations
 ===============

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -27,6 +27,7 @@ Request:
 - :py:obj:`srenablerewrites`
 - :py:obj:`srsort`
 - :py:obj:`srprop`
+- :py:obj:`content_path`
 
 Implementations
 ===============
@@ -99,6 +100,11 @@ The default path should work fine usually.
 timestamp_format = '%Y-%m-%dT%H:%M:%SZ'
 """The longhand version of MediaWiki time strings."""
 
+content_path: str = 'wiki/'
+"""The path to access wiki content.
+
+The default path should work fine usually.
+"""
 
 def request(query, params):
 
@@ -152,7 +158,7 @@ def response(resp):
         timestamp = result.get('timestamp')
 
         url = (
-            base_url.format(language=resp.search_params['language']) + 'wiki/' + quote(title.replace(' ', '_').encode())
+            base_url.format(language=resp.search_params['language']) + content_path.rstrip('/') + '/' + quote(title.replace(' ', '_').encode())
         )
         if sectiontitle:
             # in case of sectiontitle create a link to the section in the wiki page

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -157,7 +157,10 @@ def response(resp):
         timestamp = result.get('timestamp')
 
         url = (
-            base_url.format(language=resp.search_params['language']) + content_path.rstrip('/') + ('/' if content_path.rstrip('/') else '') + quote(title.replace(' ', '_').encode())
+            base_url.format(language=resp.search_params['language'])
+            + content_path.rstrip('/')
+            + ('/' if content_path.rstrip('/') else '')
+            + quote(title.replace(' ', '_').encode())
         )
         if sectiontitle:
             # in case of sectiontitle create a link to the section in the wiki page

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -157,7 +157,7 @@ def response(resp):
         timestamp = result.get('timestamp')
 
         url = (
-            base_url.format(language=resp.search_params['language']) + content_path.rstrip('/') + '/' if content_path.rstrip('/') else '' + quote(title.replace(' ', '_').encode())
+            base_url.format(language=resp.search_params['language']) + content_path.rstrip('/') + ('/' if content_path.rstrip('/') else '') + quote(title.replace(' ', '_').encode())
         )
         if sectiontitle:
             # in case of sectiontitle create a link to the section in the wiki page

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -105,6 +105,7 @@ content_path: str = 'wiki/'
 The default path should work fine usually.
 """
 
+
 def request(query, params):
 
     # write search-language back to params, required in response

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -157,7 +157,7 @@ def response(resp):
         timestamp = result.get('timestamp')
 
         url = (
-            base_url.format(language=resp.search_params['language']) + content_path.strip('/') + '/' + quote(title.replace(' ', '_').encode())
+            base_url.format(language=resp.search_params['language']) + content_path.rstrip('/') + '/' if content_path.rstrip('/') else '' + quote(title.replace(' ', '_').encode())
         )
         if sectiontitle:
             # in case of sectiontitle create a link to the section in the wiki page

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -157,7 +157,7 @@ def response(resp):
         timestamp = result.get('timestamp')
 
         url = (
-            base_url.format(language=resp.search_params['language']) + content_path.rstrip('/') + '/' + quote(title.replace(' ', '_').encode())
+            f"{base_url.rstrip('/')}".format(language=resp.search_params['language']) + content_path.rstrip('/') + '/' + quote(title.replace(' ', '_').encode())
         )
         if sectiontitle:
             # in case of sectiontitle create a link to the section in the wiki page


### PR DESCRIPTION
## What does this PR do?

This PR allows for custom content paths in URLs in the MediaWiki engine. Some wikis do not use the default and searxng generates incorrect links.

I'm running my fork locally and it seems to be working fine, though more tests should be done.
I am also far from proficient in Python and did the first thing that came to my mind.

Related to #5562