### PR TITLE
Search API Docs: usage and format support explanation

### DIFF
--- a/docs/dev/search_api.rst
+++ b/docs/dev/search_api.rst
@@ -4,14 +4,33 @@
 Search API
 ==========
 
-The search supports both ``GET`` and ``POST``.
+SearXNG supports querying via a simple HTTP API.
+Two endpoints, ``/`` and ``/search``, are supported for both GET and POST methods.
+The GET method expects parameters as URL query parameters, while the POST method expects parameters as form data.
 
-Furthermore, two endpoints ``/`` and ``/search`` are available for querying.
+If you want to consume the results as JSON, CSV, or RSS, you need to set the
+``format`` parameter accordingly. Supported formats are defined in settings.yml, under the ``search`` section.
+Requesting an unset format will return a 403 Forbidden error. Be aware that many public instances have these formats disabled. 
+You can still get HTML-formatted results and parse them yourself.
 
+
+Endpoints:
 
 ``GET /``
-
 ``GET /search``
+
+``POST /``
+``POST /search``
+
+example cURL calls:
+
+.. code-block:: bash
+
+   curl 'https://searx.example.org/search?q=searxng&format=json'
+
+   curl -X POST 'https://searx.example.org/search' -d 'q=searxng&format=csv'
+
+   curl -L -X POST -d 'q=searxng&format=json' 'https://searx.example.org/'
 
 Parameters
 ==========

--- a/docs/dev/search_api.rst
+++ b/docs/dev/search_api.rst
@@ -9,9 +9,8 @@ Two endpoints, ``/`` and ``/search``, are supported for both GET and POST method
 The GET method expects parameters as URL query parameters, while the POST method expects parameters as form data.
 
 If you want to consume the results as JSON, CSV, or RSS, you need to set the
-``format`` parameter accordingly. Supported formats are defined in settings.yml, under the ``search`` section.
-Requesting an unset format will return a 403 Forbidden error. Be aware that many public instances have these formats disabled. 
-You can still get HTML-formatted results and parse them yourself.
+``format`` parameter accordingly. Supported formats are defined in ``settings.yml``, under the ``search`` section.
+Requesting an unset format will return a 403 Forbidden error. Be aware that many public instances have these formats disabled.
 
 
 Endpoints:


### PR DESCRIPTION
## What does this PR do?

This PR aims to explain better how to configure and use the Search HTTP API.

## Why is this change important?

Some users complained about the docs being a little bit obscure, especially with respect to supported response formats.
I agree that the search api docs page could be better phrased, so I decided to rewrite it a little to make it more explicit.

## How to test this PR locally?

make docs.live and check the Search API docs page

## Related issues

Inspired by #5571 