### PR TITLE
[fix] yep: fix 403 forbidden errors

### DIFF
--- a/searx/engines/yep.py
+++ b/searx/engines/yep.py
@@ -19,6 +19,8 @@ search_type = "web"  # 'web', 'images', 'news'
 safesearch = True
 safesearch_map = {0: 'off', 1: 'moderate', 2: 'strict'}
 
+enable_http2 = False
+
 
 def request(query, params):
     args = {
@@ -30,6 +32,7 @@ def request(query, params):
     }
     params['url'] = f"{base_url}/fs/2/search?{urlencode(args)}"
     params['headers']['Referer'] = 'https://yep.com/'
+    params['headers']['Origin'] = 'https://yep.com'
     return params
 
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -686,7 +686,7 @@ engines:
     shortcut: yep
     categories: general
     search_type: web
-    timeout: 5
+    timeout: 15
     disabled: true
 
   - name: yep images


### PR DESCRIPTION
Apparently, yep has been broken for a while. Measures to fix it:
- only use HTTP/1.1, because our HTTP2 client gets fingerprinted and blocked
- send the `Origin` HTTP header
