### PR TITLE
[feat] add plugin which allows admins to hide thumbnails for search results

### DIFF
--- a/searx/plugins/hide_thumbnails.py
+++ b/searx/plugins/hide_thumbnails.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+This plugin removes the 'thumbnail' property from search results if the 'hide_thumbnails' setting is enabled.
+"""
+
+import typing
+from flask_babel import gettext
+
+from searx.plugins import Plugin, PluginInfo
+from searx.result_types import Result
+
+if typing.TYPE_CHECKING:
+    from searx.search import SearchWithPlugins
+    from searx.extended_types import SXNG_Request
+    from searx.result_types import Result
+    from searx.plugins import PluginCfg
+
+
+class SXNGPlugin(Plugin):
+    id: str = "hide_thumbnails"
+
+    def __init__(self, plg_cfg: "PluginCfg") -> None:
+        super().__init__(plg_cfg)
+        self.info = PluginInfo(
+            id=self.id,
+            name=gettext("Hide Thumbnails"),
+            description=gettext("Removes thumbnails from search results")
+        )
+
+    def on_result(
+        self,
+        request: "SXNG_Request",
+        search: "SearchWithPlugins",
+        result: "Result"
+    ) -> bool:  # pylint: disable=unused-argument
+        if hasattr(result, "thumbnail"):
+            result.thumbnail = None
+        return True

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -250,6 +250,9 @@ plugins:
   searx.plugins.tracker_url_remover.SXNGPlugin:
     active: true
 
+  searx.plugins.hide_thumbnails.SXNGPlugin:
+    active: false
+
 
 # Configuration of the "Hostnames plugin":
 #


### PR DESCRIPTION
## What does this PR do?

This PR adds a new official plugin that allows searxng instance administrators to easily disable thumbnails in search results.
It was done as a plugin instead of a theme option for simplicity.
The way it works is setting the `thumbnail` result attribute to None for all results.

## Why is this change important?

I have a scenario where there is a desire for a search engine with no images. This is possible with stock searxng except for the thumbnails in the search results.
I've also noticed others requesting this as a feature, so instead of being an external plugin, it seems appropriate as an official plugin

## How to test this PR locally?

1) Set the value of active to true in settings.yml (it is set to false by default of course)
2) Search for something likely to return a thumbnail, such as the word "chocolate".

```
  searx.plugins.hide_thumbnails.SXNGPlugin:
    active: true
```

## Related issues

Issue https://github.com/searxng/searxng/issues/2295 is closed as "not planned" but I'm hoping this contribution will be welcome.
