### PR TITLE
[fix] presearch - AttributeError: 'NoneType' object has no attribute 'territory'

### DIFF
--- a/searx/engines/presearch.py
+++ b/searx/engines/presearch.py
@@ -137,7 +137,7 @@ def _get_request_id(query, params):
         # performs an IP-based geolocation of the user, we don't want that in
         # SearXNG ;-)
 
-        if l.territory:
+        if l and l.territory:
             headers['Accept-Language'] = f"{l.language}-{l.territory},{l.language};" "q=0.9,*;" "q=0.5"
 
     resp = get(url, headers=headers, timeout=5)


### PR DESCRIPTION
For unknown locales, the return value of::

    locales.get_locale(params['searxng_locale'])

is ``None`` which cause the following issue::

    ERROR   searx.engines.presearch       : exception : 'NoneType' object has no attribute 'territory'
    Traceback (most recent call last):
      File "search/processors/online.py", line 256, in search
        search_results = self._search_basic(query, params)
      File "search/processors/online.py", line 231, in _search_basic
        self.engine.request(query, params)
        ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File "engines/presearch.py", line 153, in request
        request_id, cookies = _get_request_id(query, params)
                              ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
      File "engines/presearch.py", line 140, in _get_request_id
        if l.territory:
           ^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'territory'
