### PR TITLE
[fix] pixiv: update pixiv proxy docs URL in settings.yml

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1663,7 +1663,7 @@ engines:
       - https://pximg.example.org
       # A proxy is required to load the images. Hosting an image proxy server
       # for Pixiv:
-      #    --> https://pixivfe.pages.dev/hosting-image-proxy-server/
+      #    --> https://pixivfe-docs.pages.dev/hosting/image-proxy-server/
       # Proxies from public instances.  Ask the public instances owners if they
       # agree to receive traffic from SearXNG!
       #    --> https://codeberg.org/VnPower/PixivFE#instances


### PR DESCRIPTION
## What does this PR do?

Updates a link to the instructions.

## Why is this change important?

The old URL does not work.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
