### PR TITLE
docs: improve formats configuration documentation

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -72,10 +72,29 @@ search:
     # ReCAPTCHA
     recaptcha_SearxEngineCaptcha: 604800
 
-  # remove format to deny access, use lower case.
-  # formats: [html, csv, json, rss]
+  # Output formats available to users.
+  # To enable a format, add it to the list below (use lowercase).
+  # 
+  # Available formats:
+  #   - html: Web interface (always recommended)
+  #   - json: JSON API for programmatic access
+  #   - csv: CSV export for spreadsheets
+  #   - rss: RSS feeds for feed readers
+  #
+  # Security note: Enabling 'json' allows programmatic/API access.
+  # For public instances, consider enabling rate limiting (server.limiter: true)
+  # For private/local instances, json format is safe to enable.
+  #
+  # Example - Enable JSON API:
+  #   formats:
+  #     - html
+  #     - json
+  #
   formats:
     - html
+    # - json  # Uncomment to enable JSON API
+    # - csv   # Uncomment to enable CSV export
+    # - rss   # Uncomment to enable RSS feeds
 
 server:
   # Is overwritten by ${SEARXNG_PORT} and ${SEARXNG_BIND_ADDRESS}


### PR DESCRIPTION
## Problem

Many users struggle to enable JSON format for API access because the current documentation is minimal. Common issues include:

- Discussion #3542: "not returning json results, only html"  
- Multiple Stack Overflow questions about enabling JSON format
- User confusion about 403 Forbidden errors when trying JSON format
- No clear guidance on **how** to enable other formats or **why** they might want to

## Solution

This PR improves the `formats:` section documentation in `settings.yml` by:

✅ **Clearly listing all available formats** with descriptions:
- `html`: Web interface (always recommended)
- `json`: JSON API for programmatic access  
- `csv`: CSV export for spreadsheets
- `rss`: RSS feeds for feed readers

✅ **Providing commented examples** showing how to enable each format

✅ **Adding security guidance** about enabling JSON format:
- Notes that JSON enables programmatic/API access
- Recommends rate limiting for public instances
- Clarifies it's safe for private/local instances

✅ **Including a working example** of enabling JSON API

## Before
```yaml
  # remove format to deny access, use lower case.
  # formats: [html, csv, json, rss]
  formats:
    - html
```

## After  
```yaml
  # Output formats available to users.
  # To enable a format, add it to the list below (use lowercase).
  # 
  # Available formats:
  #   - html: Web interface (always recommended)
  #   - json: JSON API for programmatic access
  #   - csv: CSV export for spreadsheets
  #   - rss: RSS feeds for feed readers
  #
  # Security note: Enabling 'json' allows programmatic/API access.
  # For public instances, consider enabling rate limiting (server.limiter: true)
  # For private/local instances, json format is safe to enable.
  #
  # Example - Enable JSON API:
  #   formats:
  #     - html
  #     - json
  #
  formats:
    - html
    # - json  # Uncomment to enable JSON API
    # - csv   # Uncomment to enable CSV export
    # - rss   # Uncomment to enable RSS feeds
```

## Impact

This change makes it **immediately obvious** to new users:
1. What formats are available
2. How to enable them (just uncomment the line)
3. Security implications of enabling JSON
4. When to use each format

No code changes, just better documentation to reduce user friction.

## Testing

- ✅ YAML syntax validated
- ✅ Tested with Docker deployment (formats work as expected when uncommented)
- ✅ Backwards compatible (existing configs continue to work)
