### PR TITLE
[fix] migrate from typer-slim to typer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ markdown-it-py==3.0.0
 fasttext-predict==0.9.2.4
 tomli==2.4.0; python_version < '3.11'
 msgspec==0.20.0
-typer-slim==0.21.1
+typer==0.23.0
 isodate==0.7.2
 whitenoise==6.11.0
 typing-extensions==4.15.0


### PR DESCRIPTION
Package typer-slim does nothing other than depend on typer. The only reason this package exists is as a migration path for old projects that used to depend on typer-slim, so that they can get the latest version of typer. [1]

Install instead:

    pip install typer

Package typer-slimis deprecated and will stop receiving any updates and published versions.

[1] https://pypi.org/project/typer-slim/

Closes: https://github.com/searxng/searxng/issues/5742
