### PR TITLE
[fix] ci: cache keys

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -37,7 +37,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local"
 
       - name: Setup venv

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -87,7 +87,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local/"
 
       - name: Get date
@@ -99,8 +100,8 @@ jobs:
         with:
           key: "container-${{ matrix.arch }}-${{ steps.date.outputs.date }}-${{ hashFiles('./requirements*.txt') }}"
           restore-keys: |
-            "container-${{ matrix.arch }}-${{ steps.date.outputs.date }}-"
-            "container-${{ matrix.arch }}-"
+            container-${{ matrix.arch }}-${{ steps.date.outputs.date }}-
+            container-${{ matrix.arch }}-
           path: "/var/tmp/buildah-cache-*/*"
 
       - if: ${{ matrix.emulation }}

--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -54,7 +54,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local/"
 
       - name: Setup venv

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,7 +46,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local/"
 
       - name: Setup venv

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ matrix.python-version }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ matrix.python-version }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ matrix.python-version }}-${{ runner.arch }}-
           path: "./local/"
 
       - name: Setup venv
@@ -86,7 +87,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local/"
 
       - name: Setup venv

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -49,7 +49,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local/"
 
       - name: Setup venv
@@ -96,7 +97,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           key: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-${{ hashFiles('./requirements*.txt') }}"
-          restore-keys: "python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-"
+          restore-keys: |
+            python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local/"
 
       - name: Setup venv


### PR DESCRIPTION
YAML block (literal) scalar style also takes quotes into account:

Expected:
  `container-amd64-20260216-acbc0ea29f44f7fc7eeadcf91d421c66f26dbbdd48cc284691f8fd8982ab7323, container-amd64-20260216-, container-amd64-`

Got:
  `container-amd64-20260216-acbc0ea29f44f7fc7eeadcf91d421c66f26dbbdd48cc284691f8fd8982ab7323, "container-amd64-20260216-", "container-amd64-"`