### PR TITLE
[fix] searxng.sh fails: No module named 'typing_extensions'

### DIFF
--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -493,6 +493,7 @@ pip install -U setuptools
 pip install -U wheel
 pip install -U pyyaml
 pip install -U msgspec
+pip install -U typing-extensions
 cd ${SEARXNG_SRC}
 pip install --use-pep517 --no-build-isolation -e .
 EOF


### PR DESCRIPTION
Closes: #5761
