### PR TITLE
[fix] searxng.sh fails: No module named 'pybind11'

### DIFF
--- a/utils/searxng.sh
+++ b/utils/searxng.sh
@@ -494,6 +494,7 @@ pip install -U wheel
 pip install -U pyyaml
 pip install -U msgspec
 pip install -U typing-extensions
+pip install -U pybind11
 cd ${SEARXNG_SRC}
 pip install --use-pep517 --no-build-isolation -e .
 EOF


### PR DESCRIPTION
Related: https://github.com/searxng/searxng/discussions/5748#discussioncomment-15880660