### PR TITLE
[feat] autocomplete: add bing autocompleter

### DIFF
--- a/docs/admin/settings/settings_search.rst
+++ b/docs/admin/settings/settings_search.rst
@@ -36,6 +36,7 @@
 
   - ``360search``
   - ``baidu``
+  - ``bing``
   - ``brave``
   - ``dbpedia``
   - ``duckduckgo``

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """This module implements functions needed for the autocompleter."""
+
 # pylint: disable=use-dict-literal
+import string
+import random
 
 import json
 import typing as t
@@ -50,6 +53,26 @@ def baidu(query: str, _sxng_locale: str) -> list[str]:
         if 'g' in data:
             for item in data['g']:
                 results.append(item['q'])
+    return results
+
+
+def bing(query: str, _sxng_locale: str) -> list[str]:
+    # bing search autocompleter
+    base_url = "https://www.bing.com/AS/Suggestions?"
+    # cvid has to be a 32 character long string consisting of numbers and uppsercase characters
+    cvid = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(32))
+    response = get(base_url + urlencode({'qry': query, 'csr': 1, 'cvid': cvid}))
+    results: list[str] = []
+
+    if response.ok:
+        data: dict[str, t.Any] = response.json()
+        if 's' in data:
+            for item in data['s']:
+                completion: str = item['q']
+                # bing uses PUA unicode characters to highlight parts of the query
+                # we have to remove these manually (U+E000 and U+E001)
+                completion = completion.replace("\ue000", "").replace("\ue001", "")
+                results.append(completion)
     return results
 
 
@@ -331,6 +354,7 @@ def yandex(query: str, _sxng_locale: str) -> list[str]:
 backends: dict[str, t.Callable[[str, str], list[str]]] = {
     '360search': qihu360search,
     'baidu': baidu,
+    'bing': bing,
     'brave': brave,
     'dbpedia': dbpedia,
     'duckduckgo': duckduckgo,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -32,8 +32,8 @@ brand:
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
-  # Existing autocomplete backends: "360search", "baidu", "brave", "dbpedia", "duckduckgo", "google", "yandex",
-  # "mwmbl", "naver", "seznam", "sogou", "startpage", "swisscows", "quark", "qwant", "wikipedia" -
+  # Existing autocomplete backends: "360search", "baidu", "bing", "brave", "dbpedia", "duckduckgo", "google",
+  # "yandex", "mwmbl", "naver", "seznam", "sogou", "startpage", "swisscows", "quark", "qwant", "wikipedia" -
   # leave blank to turn it off by default.
   autocomplete: ""
   # minimun characters to type before autocompleter starts


### PR DESCRIPTION
## How to test this PR locally?
- go to the settings
- set the autocompleter to bing
- search something

## Author's checklist
- Bing returns some weird Unicode characters in its response, e.g. when you load ` https://www.bing.com/AS/Suggestions?pt=page.serp&qry=donald&csr=1&cvid=ABF762C5D15D4BAFBA24B0C3F9BC6712`  suggestions look like `donald glover`
- therefore we manually need to filter out these unicode characters

Apart from that the implementation is pretty straight forward.
