### PR TITLE
[feat] plugins: add blocklists plugin with support for easylist blocklists

### DIFF
--- a/docs/dev/easylist.rst
+++ b/docs/dev/easylist.rst
@@ -1,0 +1,13 @@
+.. _easylist parser:
+
+===============
+Easylist parser
+===============
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+.. automodule:: searx.easylist
+  :members:

--- a/docs/dev/plugins/blocklists.rst
+++ b/docs/dev/plugins/blocklists.rst
@@ -1,0 +1,9 @@
+.. _blocklists plugin:
+
+==========
+Blocklists
+==========
+
+.. automodule:: searx.plugins.blocklists
+   :members:
+

--- a/searx/easylist.py
+++ b/searx/easylist.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=too-few-public-methods
+"""Parser subset for the Easylist syntax.
+
+This implementation does NOT support using regular expressions or content filters.
+
+.. seealso:
+
+   `Adblock Plus guide about the EasyList syntax <https://help.eyeo.com/en/adblockplus/how-to-write-filters>`_
+
+   `uBlock origin about the syntax <https://github.com/gorhill/ublock/wiki/static-filter-syntax>`_
+
+   `Adguard guide about creating filters <https://adguard.com/kb/general/ad-filtering/create-own-filters/>`_
+"""
+
+import re
+
+import fnmatch
+import urllib.parse
+from enum import Enum
+
+_NON_SEPARATOR_CHARACTERS = r"a-z0-9_.%\-"
+"""
+Characters that may not be matched by the separator wildcard ``^``.
+
+For example, ``example.com^`` matches "example.com/foo", but not "example.commercial".
+"""
+
+
+class EasylistFilterParserException(Exception):
+    """Exception thrown when :ref:`parse` fails to execute."""
+
+
+class EasylistFilterWildcardType(Enum):
+    """
+    Described how the start/end of the glob should be matched.
+    """
+
+    WILDCARD = 1
+    """
+    Any characters may precede/come after the glob.
+    """
+    FULL_URL_EXACT = 3
+    """
+    Glob matches the full start of the URL.
+    """
+    DOMAIN_START_EXACT = 2
+    """
+    Start matching at the domain start of the URL.
+
+    This means that the subdomain has to match as well.
+    """
+
+
+class EasylistFilterRule:
+    """
+    This represents a parsed Easylist filter rule.
+    """
+
+    is_exception: bool = False
+    """
+    Exception rules are rules that allow a website to be visited.
+
+    For example, if one rule blocks ``||example.com``, the rule ``@@||foo.example.com`` unblocks the "foo" subdomain.
+    """
+
+    extra_options: list[str] = []
+    """
+    List of extra options that should be followed for matching this domain, e.g. ["document", "redirect=noopframe"].
+    """
+
+    filter_glob: str = ""
+    """
+    A `fnmatch <https://docs.python.org/3/library/fnmatch.html>`_-compatible glob used for filtering if a URL matches.
+
+    E.g. ``http*ample.com*`` would match *https://example.com*, *http://example.com/foo*, ...
+    """
+
+    start_wildcard_type: EasylistFilterWildcardType = EasylistFilterWildcardType.WILDCARD
+    """
+    How the start of the pattern should be matched.
+
+    Also see :py:obj:`EasylistFilterRule.end_wildcard_type`.
+    """
+
+    end_wildcard_type: EasylistFilterWildcardType = EasylistFilterWildcardType.WILDCARD
+    """
+    How the end of the pattern should be matched.
+
+    For example, ``svg|`` only matches URLs ending with "svg" like *https://example.com/logo.svg*,
+    but not URLs that contain "svg" in other places of the URL, such as *https://foo.svg/bar*.
+
+    Also see :py:obj:`EasylistFilterRule.start_wildcard_type`.
+    """
+
+    _compiled_regex: re.Pattern[str] | None = None
+    """
+    This is the compiled Regex version of :py:obj:``EasylistFilterRule.filter_glob``, with respect to
+    :py:obj:`EasylistFilterRule.start_wildcard_type` end :py:obj:`EasylistFilterRule.end_wildcard_type`.
+
+    This is used to cache the Regex to improve performance by >10x because compiling regular expressions
+    is very expensive.
+    """
+
+    # __eq__ and __hash__ are override for HashSet compatibility in blocklists.py
+    # both implementations ignore EasylistFilterRule.extra_options, as they're not
+    # relevant for our context (simply blocking URLs)
+    def __eq__(self, other):
+        if not isinstance(other, EasylistFilterRule):
+            return False
+
+        return (
+            self.filter_glob == other.filter_glob
+            and self.start_wildcard_type == other.start_wildcard_type
+            and self.end_wildcard_type == other.end_wildcard_type
+            and self.is_exception == other.is_exception
+        )
+
+    def __hash__(self):
+        return hash((self.filter_glob, self.start_wildcard_type, self.end_wildcard_type, self.is_exception))
+
+    def matches_url(self, url: urllib.parse.ParseResult) -> bool:
+        """
+        Check whether this :py:obj:`EasylistFilterRule` matches the given `url`.
+
+        The URL is matched case insensitively.
+        """
+
+        glob = self.filter_glob.lower()
+        to_match = url.geturl().lower()
+
+        if self.start_wildcard_type == EasylistFilterWildcardType.WILDCARD:
+            glob = f"*{glob}"
+        elif self.start_wildcard_type == EasylistFilterWildcardType.DOMAIN_START_EXACT:
+            # remove everything before the domain
+            scheme = f"{url.scheme.lower()}://"
+            to_match = to_match.removeprefix(scheme)
+
+        # exact domain is only support for the start of the pattern
+        # so there's no else case here
+        if self.end_wildcard_type == EasylistFilterWildcardType.WILDCARD:
+            glob = f"{glob}*"
+
+        # check if the regex was already compiled - if not, compile it now
+        if not self._compiled_regex:
+            # compile the glob string to a regular expression string
+            glob_re = fnmatch.translate(glob)
+            # cache the regex for future use
+            self._compiled_regex = re.compile(glob_re)
+
+        return self._compiled_regex.fullmatch(to_match) is not None
+
+
+def parse(line: str) -> EasylistFilterRule | None:
+    """
+    Parser a line into an Easylist filter rule.
+
+    Throws a :py:obj:`EasylistFilterParserException` if parsing fails.
+    """
+    line = line.strip()
+
+    if not line or line.startswith("!") or line.startswith("["):
+        # comment found, i.e. not a filter rule
+        return None
+
+    rule = EasylistFilterRule()
+
+    remaining = line
+    has_pattern_started = False
+    while len(remaining):
+        if remaining.startswith("@@"):
+            rule.is_exception = True
+            remaining = remaining[2:]
+        elif remaining.startswith("||"):
+            if has_pattern_started:
+                raise EasylistFilterParserException("`||` may only be used at the start of the rule")
+
+            rule.start_wildcard_type = EasylistFilterWildcardType.DOMAIN_START_EXACT
+            remaining = remaining[2:]
+        elif remaining.startswith("|"):
+            if has_pattern_started:
+                rule.end_wildcard_type = EasylistFilterWildcardType.FULL_URL_EXACT
+            else:
+                rule.start_wildcard_type = EasylistFilterWildcardType.FULL_URL_EXACT
+            remaining = remaining[1:]
+        elif remaining.startswith("$"):
+            rule.extra_options = remaining[1:].split(",")
+            remaining = ""  # extra options are always the last part of the URL
+        else:
+            # progress by one single character - this is not very clean, but it avoids
+            # doing complex regex operations which would slow down execution times
+            rule.filter_glob += remaining[0]
+            has_pattern_started = True
+            remaining = remaining[1:]
+
+    if not rule.filter_glob:
+        # this could be a rule like `$all,domain=example.com|example.org`, but we don't support that
+        return None
+
+    # this ensures compatibility with fnmatch, see https://docs.python.org/3/library/fnmatch.html
+    rule.filter_glob = rule.filter_glob.replace("^", f"[!{_NON_SEPARATOR_CHARACTERS}]")
+    return rule

--- a/searx/plugins/blocklists.py
+++ b/searx/plugins/blocklists.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=line-too-long
+"""At startup, this plugin downloads all files configured in ``blocklists:`` and
+parses them as Easylist filter files. Easylist is a common format for Adblock
+Rules, e.g. used by Adblock Plus, Adguard and uBlock Origin.
+
+The configuration syntax is as follows:
+
+.. code-block:: yaml
+
+   blocklists:
+     - "https://raw.githubusercontent.com/alvi-se/ai-ublock-blacklist/refs/heads/master/list.txt"
+
+All results that match any of the rules specified in ``list.txt`` will now be
+removed from the search results.
+
+.. hint::
+   Please make sure that the filter lists are not that large in size (less than
+   2000 entries if possible) - otherwise this has a very big impact on search
+   performance, i.e. will slow it down drastically.
+
+If you want to manually configure which URLs should be blocked instead of using premade blocklists, please see the :ref:`hostnames plugin`.
+"""
+
+import typing as t
+
+import time
+from gettext import gettext
+
+import searx.easylist
+from searx import settings, logger
+from searx.easylist import EasylistFilterRule
+from searx.plugins import Plugin, PluginInfo
+from searx.network import get
+
+if t.TYPE_CHECKING:
+    import flask
+    from searx.search import SearchWithPlugins
+    from searx.extended_types import SXNG_Request
+    from searx.result_types import Result
+    from searx.plugins import PluginCfg
+
+EXCEPTION_RULES: set[EasylistFilterRule] = set()
+FILTER_RULES: set[EasylistFilterRule] = set()
+
+
+class SXNGPlugin(Plugin):
+    """Block results by their URL based on Easylist filter lists"""
+
+    id = "blocklists"
+
+    def __init__(self, plg_cfg: "PluginCfg") -> None:
+        super().__init__(plg_cfg)
+        self.info = PluginInfo(
+            id=self.id,
+            name=gettext("Blocklists plugin"),
+            description=gettext("Removes results based on Easylist blocklists"),
+            preference_section="general",
+        )
+
+    def on_result(self, request: "SXNG_Request", search: "SearchWithPlugins", result: "Result") -> bool:
+        if not result.parsed_url:
+            return True
+
+        start = time.time()
+        for rule in EXCEPTION_RULES:
+            if rule.matches_url(result.parsed_url):
+                return True
+
+        for rule in FILTER_RULES:
+            if rule.matches_url(result.parsed_url):
+                return False
+
+        logger.debug(time.time() - start)
+        return True
+
+    def init(self, app: "flask.Flask") -> bool:  # pylint: disable=unused-argument
+        filter_list_urls = settings.get(self.id, {})
+        if not isinstance(filter_list_urls, list):
+            return False
+
+        for url in filter_list_urls:
+            plain_rule_list = load_list_from_web(url)
+
+            for line in plain_rule_list.splitlines():
+                rule = searx.easylist.parse(line)
+                if not rule:
+                    continue
+
+                if rule.is_exception:
+                    EXCEPTION_RULES.add(rule)
+                else:
+                    FILTER_RULES.add(rule)
+
+        return True
+
+
+def load_list_from_web(url: str) -> str:
+    """
+    Download a filterlist file from the provided ``url``.
+    """
+    # TODO: Currently, the filter lists are not cached  # pylint: disable=fixme
+    # that should be changed in the future to reduce startup times and network usage.
+    resp = get(url)
+
+    if not resp.ok:
+        raise IOError(f"failed to load filterlist from '{url}'")
+
+    return resp.text

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -238,6 +238,9 @@ plugins:
   searx.plugins.hostnames.SXNGPlugin:
     active: true
 
+  searx.plugins.blocklists.SXNGPlugin:
+    active: true
+
   searx.plugins.time_zone.SXNGPlugin:
     active: true
 
@@ -276,6 +279,13 @@ plugins:
 # '(.*\.)?youtube\.com$': 'yt.example.com'
 # '(.*\.)?youtu\.be$': 'yt.example.com'
 #
+
+
+# Configuration of the "Blocklists plugin":
+#
+# blocklists:
+#   - "https://raw.githubusercontent.com/alvi-se/ai-ublock-blacklist/refs/heads/master/list.txt"
+#   - "https://raw.githubusercontent.com/iam-py-test/my_filters_001/refs/heads/main/antimalware.txt"
 
 
 categories_as_tabs:

--- a/tests/unit/test_easylist.py
+++ b/tests/unit/test_easylist.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Tests for the Easylist adblock rules parser.
+"""
+
+import urllib.parse
+from parameterized import parameterized
+
+from searx.easylist import parse, EasylistFilterRule
+from tests import SearxTestCase
+
+
+class TestEasylistParser(SearxTestCase):
+    """
+    Test class for testing the Easylist adblock rules parser.
+    """
+
+    @parameterized.expand(
+        [
+            ("@@||example.com", "https://example.com", True),
+            ("@@||example.com", "https://foo.example.com", False),
+            ("svg|", "https://example.com/foo.svg", True),
+            ("svg|", "https://example.com/svg.foo", False),
+            ("@@example.co^", "https://example.co/path", True),
+            ("@@example.co^", "https://example.co.uk", False),
+            ("://*.example.com/", "https://foo.example.com/foo", True),
+            ("://*.example.com/", "https://example.com/foo", False),
+            ("|http://example.com", "http://example.com", True),
+            ("|http://example.com", "https://example.com", False),
+            ("||example.com/@username^$doc", "https://example.com/@username/about", True),
+            ("||example.com/@username^$doc", "https://foo.example.com/@username/about", False),
+        ]
+    )
+    def test_parse_rule(self, rule: str, url: str, should_match: bool):
+        parsed_rule = parse(rule)
+        self.assertIsInstance(parsed_rule, EasylistFilterRule)
+        parsed_url = urllib.parse.urlparse(url)
+        if parsed_rule:
+            self.assertEqual(parsed_rule.matches_url(parsed_url), should_match)


### PR DESCRIPTION
This plugin allows to load filter rules from Easylist filter rule files and blocks all results that match the filter.

These changes are motiviated by https://github.com/searxng/searxng/issues/5029: There also are filter lists that can block AI images, but I haven't done much research about what lists exist there. The lists suggested in the docs are only about filtering AI-generated articles frome the general search results.

Implementation notes:
- the filter rule files are loaded on each startup, so there's room for future improvement
- the performance is not that good if the filter lists are large - so lists should be <2000 entries in total

Relevant resources:
- https://help.eyeo.com/en/adblockplus/how-to-write-filters
- https://github.com/alvi-se/ai-ublock-blacklist
