### PR TITLE
Fix XSS via unsafe rendering of untrusted external data in templates

### DIFF
--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -41,7 +41,7 @@
   {%- if result.length and not result.thumbnail %}<div class="result_length">{{ _('Length') }}: {{ result.length }}</div>{% endif -%}
   {%- if result.views %}<div class="result_views">{{ _('Views') }}: {{ result.views }}</div>{% endif -%}
   {%- if result.author %}<div class="result_author">{{ _('Author') }}: {{ result.author }}</div>{% endif -%}
-  {%- if result.metadata %}<div class="highlight">{{ result.metadata|safe }}</div>{% endif -%}
+  {%- if result.metadata %}<div class="highlight">{{ result.metadata }}</div>{% endif -%}
 {%- endmacro -%}
 
 <!-- Draw result sub footer -->

--- a/searx/templates/simple/result_templates/code.html
+++ b/searx/templates/simple/result_templates/code.html
@@ -11,7 +11,7 @@
 {%- if result.repository -%}
   <p class="content">{{- '' -}}
     {{ _('Repository') }}: {{- ' ' -}}
-    <a href="{{ result.repository|safe }}"{{- ' ' -}}
+    <a href="{{ result.repository }}"{{- ' ' -}}
       {% if results_on_new_tab %}
       target="_blank" {{- ' ' -}}
       rel="noopener noreferrer"
@@ -26,7 +26,7 @@
 
 {%- if result.filename %}
   <p class="content">
-    {{ _('Filename') }}: {{ result.filename|safe }}
+    {{ _('Filename') }}: {{ result.filename }}
   </p>
 {% endif -%}
 

--- a/searx/templates/simple/result_templates/map.html
+++ b/searx/templates/simple/result_templates/map.html
@@ -32,10 +32,10 @@
     </tr>
     {%- endif %}
     {%- for info in result.data -%}
-    <tr><th scope="row">{{ info.label }}</th><td>{{ info.value|safe }}</td></tr>
+    <tr><th scope="row">{{ info.label }}</th><td>{{ info.value }}</td></tr>
     {%- endfor -%}
     {%- for link in result.links -%}
-    <tr><th scope="row">{{ link.label }}</th><td><a class="text-info cursor-pointer" href="{{ link.url }}">{{ link.url_label|safe }}</a></td></tr>
+    <tr><th scope="row">{{ link.label }}</th><td><a class="text-info cursor-pointer" href="{{ link.url }}">{{ link.url_label }}</a></td></tr>
     {%- endfor -%}
 </table>
 

--- a/searx/templates/simple/result_templates/paper.html
+++ b/searx/templates/simple/result_templates/paper.html
@@ -84,7 +84,7 @@
 {%- endif -%}
 
 {%- if result.metadata %}
-  <div class="highlight">{{ result.metadata|safe }}</div>
+  <div class="highlight">{{ result.metadata }}</div>
 {% endif -%}
 
 <p class="altlink">


### PR DESCRIPTION
Remove |safe filter from 6 template locations where data from external search engine APIs was rendered as raw HTML without sanitization. Jinja2 autoescape now properly escapes these fields.

The |safe filter was originally added in commit 213041adc (March 2021) by copying the pattern from result.title|safe and result.content|safe. However, title and content are pre-escaped via escape() in webapp.py lines 704-706 before highlight_content() adds trusted <span> tags for search term highlighting. The metadata, info.value, link.url_label, repository, and filename fields never go through any escaping and flow directly from external API responses to the template.

Affected templates and their untrusted data sources:
- macros.html: result.metadata from DuckDuckGo, Reuters, Presearch, Podcast Index, Fyyd, bpb, moviepilot, mediawiki, and others
- paper.html: result.metadata from academic search engines
- map.html: info.value and link.url_label from OpenStreetMap user-contributed extratags
- code.html: result.repository and result.filename from GitHub API

Example exploit: a search engine API returning
metadata='<img src=x onerror=alert(document.cookie)>' would execute arbitrary JavaScript in every user's browser viewing that result.

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->
