### PR TITLE
[fix] XSS via unsafe rendering of untrusted external data in templates

### DIFF
--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -41,7 +41,7 @@
   {%- if result.length and not result.thumbnail %}<div class="result_length">{{ _('Length') }}: {{ result.length }}</div>{% endif -%}
   {%- if result.views %}<div class="result_views">{{ _('Views') }}: {{ result.views }}</div>{% endif -%}
   {%- if result.author %}<div class="result_author">{{ _('Author') }}: {{ result.author }}</div>{% endif -%}
-  {%- if result.metadata %}<div class="highlight">{{ result.metadata|safe }}</div>{% endif -%}
+  {%- if result.metadata %}<div class="highlight">{{ result.metadata }}</div>{% endif -%}
 {%- endmacro -%}
 
 <!-- Draw result sub footer -->

--- a/searx/templates/simple/result_templates/code.html
+++ b/searx/templates/simple/result_templates/code.html
@@ -11,7 +11,7 @@
 {%- if result.repository -%}
   <p class="content">{{- '' -}}
     {{ _('Repository') }}: {{- ' ' -}}
-    <a href="{{ result.repository|safe }}"{{- ' ' -}}
+    <a href="{{ result.repository }}"{{- ' ' -}}
       {% if results_on_new_tab %}
       target="_blank" {{- ' ' -}}
       rel="noopener noreferrer"
@@ -26,7 +26,7 @@
 
 {%- if result.filename %}
   <p class="content">
-    {{ _('Filename') }}: {{ result.filename|safe }}
+    {{ _('Filename') }}: {{ result.filename }}
   </p>
 {% endif -%}
 

--- a/searx/templates/simple/result_templates/map.html
+++ b/searx/templates/simple/result_templates/map.html
@@ -32,10 +32,10 @@
     </tr>
     {%- endif %}
     {%- for info in result.data -%}
-    <tr><th scope="row">{{ info.label }}</th><td>{{ info.value|safe }}</td></tr>
+    <tr><th scope="row">{{ info.label }}</th><td>{{ info.value }}</td></tr>
     {%- endfor -%}
     {%- for link in result.links -%}
-    <tr><th scope="row">{{ link.label }}</th><td><a class="text-info cursor-pointer" href="{{ link.url }}">{{ link.url_label|safe }}</a></td></tr>
+    <tr><th scope="row">{{ link.label }}</th><td><a class="text-info cursor-pointer" href="{{ link.url }}">{{ link.url_label }}</a></td></tr>
     {%- endfor -%}
 </table>
 

--- a/searx/templates/simple/result_templates/paper.html
+++ b/searx/templates/simple/result_templates/paper.html
@@ -84,7 +84,7 @@
 {%- endif -%}
 
 {%- if result.metadata %}
-  <div class="highlight">{{ result.metadata|safe }}</div>
+  <div class="highlight">{{ result.metadata }}</div>
 {% endif -%}
 
 <p class="altlink">


### PR DESCRIPTION
## What does this PR do?

Remove `|safe` Jinja2 filter from 6 template locations where data from external search engine APIs is rendered as raw HTML without any prior sanitization. Jinja2 autoescape (enabled by default in Flask) now properly HTML-escapes these fields.

The `|safe` filter was originally added in commit 213041adc (March 2021) by copying the pattern from `result.title|safe` and `result.content|safe`. However, `title` and `content` are pre-escaped via `escape()` in `webapp.py` (lines 704-706) before `highlight_content()` adds trusted `<span>` tags for search term highlighting. The `metadata`, `info.value`, `link.url_label`, `repository`, and `filename` fields never go through any escaping and flow directly from external API responses to the template.

Affected templates and their untrusted data sources:
- `macros.html`: `result.metadata` from DuckDuckGo, Reuters, Presearch, Podcast Index, Fyyd, bpb, moviepilot, mediawiki, and others
- `paper.html`: `result.metadata` from academic search engines
- `map.html`: `info.value` and `link.url_label` from OpenStreetMap user-contributed extratags
- `code.html`: `result.repository` and `result.filename` from GitHub API

## Why is this change important?

This is a stored/reflected XSS vulnerability present since March 2021. A malicious or compromised search engine API returning crafted data (e.g. `metadata='<img src=x onerror=alert(document.cookie)>'`) would execute arbitrary JavaScript in every user's browser viewing that result.

The most exploitable path is `result.metadata` which is set by multiple engines (duckduckgo_extra.py, reuters.py, presearch.py, etc.) directly from raw JSON API responses with zero sanitization.

## How to test this PR locally?

The fix relies on Jinja2 autoescape which is enabled by default in Flask. Verify with:

```python
from jinja2 import Environment
env = Environment(autoescape=True)

malicious = '<img src=x onerror="alert(1)">'
normal = 'Author Name | Category | 2024'

# Before fix: |safe bypasses escaping
print(env.from_string("{{ m|safe }}").render(m=malicious))
# <img src=x onerror="alert(1)">  (XSS fires)

# After fix: autoescape handles it
print(env.from_string("{{ m }}").render(m=malicious))
# &lt;img src=x onerror=&#34;alert(1)&#34;&gt;  (safe)

print(env.from_string("{{ m }}").render(m=normal))
# Author Name | Category | 2024  (unchanged)
```

Normal text metadata renders identically. No Python code changes needed.

## Author's checklist

- [x] Verified the vulnerability is real by tracing the full data flow from engine APIs to template rendering
- [x] Confirmed `metadata` is never escaped in `webapp.py` (only `title` and `content` are)
- [x] Confirmed `_normalize_text_fields()` only processes `title` and `content`
- [x] Verified normal metadata (plain text) renders identically after the fix
- [x] All modified templates parse without errors
- [x] No changes to Python code required

## Related issues

Security fix: XSS via `|safe` filter on unsanitized external data (present since commit 213041adc, March 2021).