### PR TITLE
[fix] engines: remove google arc/async params

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -287,9 +287,7 @@ def request(query: str, params: "OnlineParams") -> None:
     """Google search request"""
     # pylint: disable=line-too-long
     start = (params["pageno"] - 1) * 10
-    str_async = ui_async(start)
     google_info = get_google_info(params, traits)
-    logger.debug("ARC_ID: %s", str_async)
 
     # https://www.google.de/search?q=corona&hl=de&lr=lang_de&start=0&tbs=qdr%3Ad&safe=medium
     query_url = (
@@ -313,8 +311,8 @@ def request(query: str, params: "OnlineParams") -> None:
                 # 'sa': 'N',
                 # 'sstk': 'AcOHfVkD7sWCSAheZi-0tx_09XDO55gTWY0JNq3_V26cNN-c8lfD45aZYPI8s_Bqp8s57AHz5pxchDtAGCA_cikAWSjy9kw3kgg'
                 # formally known as use_mobile_ui
-                "asearch": "arc",
-                "async": str_async,
+                # "asearch": "arc",
+                # "async": str_async,
             }
         )
     )


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

Removes the `asearch` and `async` command from searches using the google engine. 

Deployed on my instance to see if it can work in production - https://github.com/privau/searxng/commit/acada95f9fc33a9a8f23cf7e3a349950a3690924

PR is a draft currently as the thumbnails aren't working. (They weren't working before as well to be fair.) I do believe they are being returned in the HTML though, so they just need to be parsed correctly.

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

I found that this fixes the current problem with the google engine not returning any results.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

`make run`

Confirm google engine is working.

## Author's checklist

<!-- additional notes for reviewers -->

 - [ ] Thumbnails to return with results


