### PR TITLE
[fix] duckduckgo engines: add rate limiter and CAPTCHA cooldown

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -269,9 +269,7 @@ def _get_cache_int(key: str) -> int:
     try:
         return int(value)
     except (TypeError, ValueError):
-        logger.debug(
-            "DDG state: ignore invalid cached value for key '%s': %r", key, value
-        )
+        logger.debug("DDG state: ignore invalid cached value for key '%s': %r", key, value)
         return 0
 
 
@@ -285,14 +283,42 @@ def get_ddg_global_blocked_until_ms() -> int:
 
 def set_ddg_global_blocked_until_ms(until_ms: int) -> None:
     current = get_ddg_global_blocked_until_ms()
-    if until_ms <= current:
-        until_ms = current
+    until_ms = max(until_ms, current)
     _set_cache_int(key=_DDG_GLOBAL_BLOCKED_UNTIL_KEY, value=until_ms, expire=3605)
 
 
 def is_ddg_globally_blocked(now_ms: int | None = None) -> bool:
     now_ms = get_now_ms() if now_ms is None else now_ms
     return now_ms < get_ddg_global_blocked_until_ms()
+
+
+def _check_and_reserve_web_slot(now_ms: int, params: "OnlineParams") -> bool:
+    """Returns False and sets params["url"]=None if the web request must be skipped."""
+    with _DDG_STATE_LOCK:
+        blocked_until_ms = get_ddg_global_blocked_until_ms()
+        if now_ms < blocked_until_ms:
+            logger.debug(
+                "DDG cooldown active: skip web request for %d ms",
+                blocked_until_ms - now_ms,
+            )
+            params["url"] = None
+            return False
+
+        next_allowed_ms = _get_cache_int(_DDG_WEB_NEXT_ALLOWED_AT_KEY)
+        if now_ms < next_allowed_ms:
+            logger.debug(
+                "DDG web rate limit active: skip request for %d ms",
+                next_allowed_ms - now_ms,
+            )
+            params["url"] = None
+            return False
+
+        _set_cache_int(
+            key=_DDG_WEB_NEXT_ALLOWED_AT_KEY,
+            value=now_ms + _DDG_WEB_MIN_INTERVAL_MS,
+            expire=60,
+        )
+    return True
 
 
 def get_ddg_lang(
@@ -411,30 +437,8 @@ def request(query: str, params: "OnlineParams") -> None:
         return
 
     now_ms = get_now_ms()
-    with _DDG_STATE_LOCK:
-        blocked_until_ms = get_ddg_global_blocked_until_ms()
-        if now_ms < blocked_until_ms:
-            logger.debug(
-                "DDG cooldown active: skip web request for %d ms",
-                blocked_until_ms - now_ms,
-            )
-            params["url"] = None
-            return
-
-        next_allowed_ms = _get_cache_int(_DDG_WEB_NEXT_ALLOWED_AT_KEY)
-        if now_ms < next_allowed_ms:
-            logger.debug(
-                "DDG web rate limit active: skip request for %d ms",
-                next_allowed_ms - now_ms,
-            )
-            params["url"] = None
-            return
-
-        _set_cache_int(
-            key=_DDG_WEB_NEXT_ALLOWED_AT_KEY,
-            value=now_ms + _DDG_WEB_MIN_INTERVAL_MS,
-            expire=60,
-        )
+    if not _check_and_reserve_web_slot(now_ms, params):
+        return
 
     query = quote_ddg_bangs(query)
     eng_region: str = traits.get_region(
@@ -540,12 +544,8 @@ def response(resp: "SXNG_Response") -> EngineResults:
         blocked_until_ms = get_now_ms() + _DDG_CAPTCHA_COOLDOWN_MS
         with _DDG_STATE_LOCK:
             set_ddg_global_blocked_until_ms(blocked_until_ms)
-        logger.info(
-            "DDG CAPTCHA detected: activate shared cooldown until %d", blocked_until_ms
-        )
-        raise SearxEngineCaptchaException(
-            message=f"CAPTCHA ({params['data'].get('kl')})"
-        )
+        logger.info("DDG CAPTCHA detected: activate shared cooldown until %d", blocked_until_ms)
+        raise SearxEngineCaptchaException(message=f"CAPTCHA ({params['data'].get('kl')})")
 
     form = eval_xpath(doc, '//input[@name="vqd"]/..')
 
@@ -562,13 +562,9 @@ def response(resp: "SXNG_Response") -> EngineResults:
         )
 
     # just select "web-result" and ignore results of class "result--ad result--ad--small"
-    for div_result in eval_xpath(
-        doc, '//div[@id="links"]/div[contains(@class, "web-result")]'
-    ):
+    for div_result in eval_xpath(doc, '//div[@id="links"]/div[contains(@class, "web-result")]'):
         _title = eval_xpath(div_result, ".//h2/a")
-        _content = eval_xpath_getindex(
-            div_result, './/a[contains(@class, "result__snippet")]', 0, []
-        )
+        _content = eval_xpath_getindex(div_result, './/a[contains(@class, "result__snippet")]', 0, [])
         res.add(
             res.types.MainResult(
                 title=extract_text(_title) or "",
@@ -588,9 +584,7 @@ def response(resp: "SXNG_Response") -> EngineResults:
         res.add(
             res.types.Answer(
                 answer=zero_click,
-                url=eval_xpath_getindex(
-                    doc, '//div[@id="zero_click_abstract"]/a/@href', 0
-                ),
+                url=eval_xpath_getindex(doc, '//div[@id="zero_click_abstract"]/a/@href', 0),
             )
         )
     return res

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -164,6 +164,7 @@ Terms / phrases that you keep coming across:
    https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Language
 
 """
+
 # pylint: disable=global-statement
 
 import json

--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -168,6 +168,8 @@ Terms / phrases that you keep coming across:
 
 import json
 import re
+import threading
+import time
 import typing as t
 
 import babel
@@ -217,6 +219,11 @@ _CACHE: EngineCache = None  # pyright: ignore[reportAssignmentType]
 seconds."""
 
 _HTTP_User_Agent: str = gen_useragent()
+_DDG_WEB_MIN_INTERVAL_MS: int = 3000
+_DDG_CAPTCHA_COOLDOWN_MS: int = 3600_000
+_DDG_WEB_NEXT_ALLOWED_AT_KEY: str = "ddg_web_next_allowed_at_ms"
+_DDG_GLOBAL_BLOCKED_UNTIL_KEY: str = "ddg_global_blocked_until_ms"
+_DDG_STATE_LOCK = threading.Lock()
 
 
 def get_cache() -> EngineCache:
@@ -248,6 +255,43 @@ def get_vqd(
     if value:
         logger.debug("get_vqd: re-use cached value: %s", value)
     return value
+
+
+def get_now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _get_cache_int(key: str) -> int:
+    value = get_cache().get(key=key)
+    if value in (None, ""):
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.debug(
+            "DDG state: ignore invalid cached value for key '%s': %r", key, value
+        )
+        return 0
+
+
+def _set_cache_int(key: str, value: int, expire: int) -> None:
+    get_cache().set(key=key, value=str(value), expire=expire)
+
+
+def get_ddg_global_blocked_until_ms() -> int:
+    return _get_cache_int(_DDG_GLOBAL_BLOCKED_UNTIL_KEY)
+
+
+def set_ddg_global_blocked_until_ms(until_ms: int) -> None:
+    current = get_ddg_global_blocked_until_ms()
+    if until_ms <= current:
+        until_ms = current
+    _set_cache_int(key=_DDG_GLOBAL_BLOCKED_UNTIL_KEY, value=until_ms, expire=3605)
+
+
+def is_ddg_globally_blocked(now_ms: int | None = None) -> bool:
+    now_ms = get_now_ms() if now_ms is None else now_ms
+    return now_ms < get_ddg_global_blocked_until_ms()
 
 
 def get_ddg_lang(
@@ -365,6 +409,32 @@ def request(query: str, params: "OnlineParams") -> None:
         params["url"] = None
         return
 
+    now_ms = get_now_ms()
+    with _DDG_STATE_LOCK:
+        blocked_until_ms = get_ddg_global_blocked_until_ms()
+        if now_ms < blocked_until_ms:
+            logger.debug(
+                "DDG cooldown active: skip web request for %d ms",
+                blocked_until_ms - now_ms,
+            )
+            params["url"] = None
+            return
+
+        next_allowed_ms = _get_cache_int(_DDG_WEB_NEXT_ALLOWED_AT_KEY)
+        if now_ms < next_allowed_ms:
+            logger.debug(
+                "DDG web rate limit active: skip request for %d ms",
+                next_allowed_ms - now_ms,
+            )
+            params["url"] = None
+            return
+
+        _set_cache_int(
+            key=_DDG_WEB_NEXT_ALLOWED_AT_KEY,
+            value=now_ms + _DDG_WEB_MIN_INTERVAL_MS,
+            expire=60,
+        )
+
     query = quote_ddg_bangs(query)
     eng_region: str = traits.get_region(
         params["searxng_locale"],
@@ -466,8 +536,15 @@ def response(resp: "SXNG_Response") -> EngineResults:
     params = resp.search_params
 
     if is_ddg_captcha(doc):
-        # set suspend time to zero is OK --> ddg does not block the IP
-        raise SearxEngineCaptchaException(suspended_time=0, message=f"CAPTCHA ({params['data'].get('kl')})")
+        blocked_until_ms = get_now_ms() + _DDG_CAPTCHA_COOLDOWN_MS
+        with _DDG_STATE_LOCK:
+            set_ddg_global_blocked_until_ms(blocked_until_ms)
+        logger.info(
+            "DDG CAPTCHA detected: activate shared cooldown until %d", blocked_until_ms
+        )
+        raise SearxEngineCaptchaException(
+            message=f"CAPTCHA ({params['data'].get('kl')})"
+        )
 
     form = eval_xpath(doc, '//input[@name="vqd"]/..')
 
@@ -484,9 +561,13 @@ def response(resp: "SXNG_Response") -> EngineResults:
         )
 
     # just select "web-result" and ignore results of class "result--ad result--ad--small"
-    for div_result in eval_xpath(doc, '//div[@id="links"]/div[contains(@class, "web-result")]'):
+    for div_result in eval_xpath(
+        doc, '//div[@id="links"]/div[contains(@class, "web-result")]'
+    ):
         _title = eval_xpath(div_result, ".//h2/a")
-        _content = eval_xpath_getindex(div_result, './/a[contains(@class, "result__snippet")]', 0, [])
+        _content = eval_xpath_getindex(
+            div_result, './/a[contains(@class, "result__snippet")]', 0, []
+        )
         res.add(
             res.types.MainResult(
                 title=extract_text(_title) or "",
@@ -506,7 +587,9 @@ def response(resp: "SXNG_Response") -> EngineResults:
         res.add(
             res.types.Answer(
                 answer=zero_click,
-                url=eval_xpath_getindex(doc, '//div[@id="zero_click_abstract"]/a/@href', 0),
+                url=eval_xpath_getindex(
+                    doc, '//div[@id="zero_click_abstract"]/a/@href', 0
+                ),
             )
         )
     return res

--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -26,6 +26,8 @@ if t.TYPE_CHECKING:
     from searx.extended_types import SXNG_Response
     from searx.search.processors import OnlineParams
 
+__all__ = ["fetch_traits"]
+
 # about
 about = {
     "website": "https://duckduckgo.com/",
@@ -53,9 +55,7 @@ _HTTP_User_Agent: str = gen_useragent()
 def init(engine_settings: dict[str, t.Any]):
 
     if engine_settings["ddg_category"] not in ["images", "videos", "news"]:
-        raise ValueError(
-            f"Unsupported DuckDuckGo category: {engine_settings['ddg_category']}"
-        )
+        raise ValueError(f"Unsupported DuckDuckGo category: {engine_settings['ddg_category']}")
 
 
 def fetch_vqd(
@@ -80,9 +80,7 @@ def fetch_vqd(
         if value:
             logger.debug("vqd value from duckduckgo.com request: '%s'", value)
         else:
-            logger.error(
-                "vqd: can't parse value from ddg response (return empty string)"
-            )
+            logger.error("vqd: can't parse value from ddg response (return empty string)")
             return ""
     else:
         logger.error("vqd: got HTTP %s from duckduckgo.com", resp.status_code)
@@ -163,16 +161,14 @@ def request(query: str, params: "OnlineParams") -> None:
         params["cookies"]["p"] = safe_search  # "-2", "1"
         args["p"] = safe_search
 
-    params["url"] = (
-        f"https://duckduckgo.com/{search_path_map[ddg_category]}.js?{urlencode(args)}"
-    )
+    params["url"] = f"https://duckduckgo.com/{search_path_map[ddg_category]}.js?{urlencode(args)}"
 
     logger.debug("param headers: %s", params["headers"])
     logger.debug("param data: %s", params["data"])
     logger.debug("param cookies: %s", params["cookies"])
 
 
-def _image_result(result):
+def _image_result(result: dict[str, t.Any]) -> dict[str, t.Any]:
     return {
         "template": "images.html",
         "url": result["url"],
@@ -185,7 +181,7 @@ def _image_result(result):
     }
 
 
-def _video_result(result):
+def _video_result(result: dict[str, t.Any]) -> dict[str, t.Any]:
     return {
         "template": "videos.html",
         "url": result["content"],
@@ -199,7 +195,7 @@ def _video_result(result):
     }
 
 
-def _news_result(result):
+def _news_result(result: dict[str, t.Any]) -> dict[str, t.Any]:
     return {
         "url": result["url"],
         "title": result["title"],
@@ -209,11 +205,11 @@ def _news_result(result):
     }
 
 
-def response(resp):
-    results = []
-    res_json = resp.json()
+def response(resp: "SXNG_Response") -> list[dict[str, t.Any]]:
+    results: list[dict[str, t.Any]] = []
+    res_json = t.cast(dict[str, t.Any], resp.json())
 
-    for result in res_json["results"]:
+    for result in t.cast(list[dict[str, t.Any]], res_json["results"]):
         if ddg_category == "images":
             results.append(_image_result(result))
         elif ddg_category == "videos":

--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -14,7 +14,13 @@ from searx.utils import get_embeded_stream_url, html_to_text, gen_useragent, ext
 from searx.network import get  # see https://github.com/searxng/searxng/issues/762
 
 from searx.engines.duckduckgo import fetch_traits  # pylint: disable=unused-import
-from searx.engines.duckduckgo import get_ddg_lang, get_vqd, set_vqd
+from searx.engines.duckduckgo import (
+    get_ddg_lang,
+    get_now_ms,
+    get_vqd,
+    is_ddg_globally_blocked,
+    set_vqd,
+)
 
 if t.TYPE_CHECKING:
     from searx.extended_types import SXNG_Response
@@ -47,13 +53,19 @@ _HTTP_User_Agent: str = gen_useragent()
 def init(engine_settings: dict[str, t.Any]):
 
     if engine_settings["ddg_category"] not in ["images", "videos", "news"]:
-        raise ValueError(f"Unsupported DuckDuckGo category: {engine_settings['ddg_category']}")
+        raise ValueError(
+            f"Unsupported DuckDuckGo category: {engine_settings['ddg_category']}"
+        )
 
 
 def fetch_vqd(
     query: str,
     params: "OnlineParams",
 ):
+    now_ms = get_now_ms()
+    if is_ddg_globally_blocked(now_ms):
+        logger.debug("DDG cooldown active: skip vqd fetch for %s request", ddg_category)
+        return ""
 
     logger.debug("fetch_vqd: request value from from duckduckgo.com")
     resp = get(
@@ -68,7 +80,9 @@ def fetch_vqd(
         if value:
             logger.debug("vqd value from duckduckgo.com request: '%s'", value)
         else:
-            logger.error("vqd: can't parse value from ddg response (return empty string)")
+            logger.error(
+                "vqd: can't parse value from ddg response (return empty string)"
+            )
             return ""
     else:
         logger.error("vqd: got HTTP %s from duckduckgo.com", resp.status_code)
@@ -87,6 +101,12 @@ def request(query: str, params: "OnlineParams") -> None:
         params["url"] = None
         return
 
+    now_ms = get_now_ms()
+    if is_ddg_globally_blocked(now_ms):
+        logger.debug("DDG cooldown active: skip %s request", ddg_category)
+        params["url"] = None
+        return
+
     # HTTP headers
     # ============
 
@@ -94,7 +114,13 @@ def request(query: str, params: "OnlineParams") -> None:
     # The vqd value is generated from the query and the UA header. To be able to
     # reuse the vqd value, the UA header must be static.
     headers["User-Agent"] = _HTTP_User_Agent
-    vqd = get_vqd(query=query, params=params) or fetch_vqd(query=query, params=params)
+    vqd = get_vqd(query=query, params=params)
+    if not vqd:
+        vqd = fetch_vqd(query=query, params=params)
+    if not vqd:
+        logger.debug("DDG vqd unavailable: skip %s request", ddg_category)
+        params["url"] = None
+        return
 
     headers["Accept"] = "*/*"
     headers["Referer"] = "https://duckduckgo.com/"
@@ -137,7 +163,9 @@ def request(query: str, params: "OnlineParams") -> None:
         params["cookies"]["p"] = safe_search  # "-2", "1"
         args["p"] = safe_search
 
-    params["url"] = f"https://duckduckgo.com/{search_path_map[ddg_category]}.js?{urlencode(args)}"
+    params["url"] = (
+        f"https://duckduckgo.com/{search_path_map[ddg_category]}.js?{urlencode(args)}"
+    )
 
     logger.debug("param headers: %s", params["headers"])
     logger.debug("param data: %s", params["data"])
@@ -146,38 +174,38 @@ def request(query: str, params: "OnlineParams") -> None:
 
 def _image_result(result):
     return {
-        'template': 'images.html',
-        'url': result['url'],
-        'title': result['title'],
-        'content': '',
-        'thumbnail_src': result['thumbnail'],
-        'img_src': result['image'],
-        'resolution': '%s x %s' % (result['width'], result['height']),
-        'source': result['source'],
+        "template": "images.html",
+        "url": result["url"],
+        "title": result["title"],
+        "content": "",
+        "thumbnail_src": result["thumbnail"],
+        "img_src": result["image"],
+        "resolution": "%s x %s" % (result["width"], result["height"]),
+        "source": result["source"],
     }
 
 
 def _video_result(result):
     return {
-        'template': 'videos.html',
-        'url': result['content'],
-        'title': result['title'],
-        'content': result['description'],
-        'thumbnail': result['images'].get('small') or result['images'].get('medium'),
-        'iframe_src': get_embeded_stream_url(result['content']),
-        'source': result['provider'],
-        'length': result['duration'],
-        'metadata': result.get('uploader'),
+        "template": "videos.html",
+        "url": result["content"],
+        "title": result["title"],
+        "content": result["description"],
+        "thumbnail": result["images"].get("small") or result["images"].get("medium"),
+        "iframe_src": get_embeded_stream_url(result["content"]),
+        "source": result["provider"],
+        "length": result["duration"],
+        "metadata": result.get("uploader"),
     }
 
 
 def _news_result(result):
     return {
-        'url': result['url'],
-        'title': result['title'],
-        'content': html_to_text(result['excerpt']),
-        'source': result['source'],
-        'publishedDate': datetime.fromtimestamp(result['date']),
+        "url": result["url"],
+        "title": result["title"],
+        "content": html_to_text(result["excerpt"]),
+        "source": result["source"],
+        "publishedDate": datetime.fromtimestamp(result["date"]),
     }
 
 
@@ -185,12 +213,12 @@ def response(resp):
     results = []
     res_json = resp.json()
 
-    for result in res_json['results']:
-        if ddg_category == 'images':
+    for result in res_json["results"]:
+        if ddg_category == "images":
             results.append(_image_result(result))
-        elif ddg_category == 'videos':
+        elif ddg_category == "videos":
             results.append(_video_result(result))
-        elif ddg_category == 'news':
+        elif ddg_category == "news":
             results.append(_news_result(result))
         else:
             raise ValueError(f"Invalid duckduckgo category: {ddg_category}")

--- a/searx/engines/duckduckgo_weather.py
+++ b/searx/engines/duckduckgo_weather.py
@@ -17,7 +17,6 @@ from searx.result_types import EngineResults
 from searx.extended_types import SXNG_Response
 from searx import weather
 
-
 about = {
     "website": "https://duckduckgo.com/",
     "wikidata_id": "Q12805",

--- a/searx/engines/duckduckgo_weather.py
+++ b/searx/engines/duckduckgo_weather.py
@@ -11,7 +11,7 @@ from urllib.parse import quote
 from dateutil import parser as date_parser
 
 from searx.engines.duckduckgo import fetch_traits  # pylint: disable=unused-import
-from searx.engines.duckduckgo import get_ddg_lang
+from searx.engines.duckduckgo import get_ddg_lang, get_now_ms, is_ddg_globally_blocked
 
 from searx.result_types import EngineResults
 from searx.extended_types import SXNG_Response
@@ -19,8 +19,8 @@ from searx import weather
 
 
 about = {
-    "website": 'https://duckduckgo.com/',
-    "wikidata_id": 'Q12805',
+    "website": "https://duckduckgo.com/",
+    "wikidata_id": "Q12805",
     "official_api_documentation": None,
     "use_official_api": True,
     "require_api_key": False,
@@ -74,9 +74,9 @@ def _weather_data(location: weather.GeoLocation, data: dict[str, t.Any]):
 
     return EngineResults.types.WeatherAnswer.Item(
         location=location,
-        temperature=weather.Temperature(val=data['temperature'], unit="°C"),
+        temperature=weather.Temperature(val=data["temperature"], unit="°C"),
         condition=WEATHERKIT_TO_CONDITION[data["conditionCode"]],
-        feels_like=weather.Temperature(val=data['temperatureApparent'], unit="°C"),
+        feels_like=weather.Temperature(val=data["temperatureApparent"], unit="°C"),
         wind_from=weather.Compass(data["windDirection"]),
         wind_speed=weather.WindSpeed(val=data["windSpeed"], unit="mi/h"),
         pressure=weather.Pressure(val=data["pressure"], unit="hPa"),
@@ -87,16 +87,22 @@ def _weather_data(location: weather.GeoLocation, data: dict[str, t.Any]):
 
 def request(query: str, params: dict[str, t.Any]):
 
-    eng_region = traits.get_region(params['searxng_locale'], traits.all_locale)
-    eng_lang = get_ddg_lang(traits, params['searxng_locale'])
+    now_ms = get_now_ms()
+    if is_ddg_globally_blocked(now_ms):
+        logger.debug("DDG cooldown active: skip weather request")
+        params["url"] = None
+        return
+
+    eng_region = traits.get_region(params["searxng_locale"], traits.all_locale)
+    eng_lang = get_ddg_lang(traits, params["searxng_locale"])
 
     # !ddw paris :es-AR --> {'ad': 'es_AR', 'ah': 'ar-es', 'l': 'ar-es'}
-    params['cookies']['ad'] = eng_lang
-    params['cookies']['ah'] = eng_region
-    params['cookies']['l'] = eng_region
-    logger.debug("cookies: %s", params['cookies'])
+    params["cookies"]["ad"] = eng_lang
+    params["cookies"]["ah"] = eng_region
+    params["cookies"]["l"] = eng_region
+    logger.debug("cookies: %s", params["cookies"])
 
-    params["url"] = base_url.format(query=quote(query), lang=eng_lang.split('_')[0])
+    params["url"] = base_url.format(query=quote(query), lang=eng_lang.split("_")[0])
     return params
 
 
@@ -106,7 +112,7 @@ def response(resp: SXNG_Response):
     if resp.text.strip() == "ddg_spice_forecast();":
         return res
 
-    json_data = loads(resp.text[resp.text.find('\n') + 1 : resp.text.rfind('\n') - 2])
+    json_data = loads(resp.text[resp.text.find("\n") + 1 : resp.text.rfind("\n") - 2])
 
     geoloc = weather.GeoLocation.by_query(resp.search_params["query"])
 
@@ -115,8 +121,8 @@ def response(resp: SXNG_Response):
         service="duckduckgo weather",
     )
 
-    for forecast in json_data['forecastHourly']['hours']:
-        forecast_time = date_parser.parse(forecast['forecastStart'])
+    for forecast in json_data["forecastHourly"]["hours"]:
+        forecast_time = date_parser.parse(forecast["forecastStart"])
         forecast_data = _weather_data(geoloc, forecast)
         forecast_data.datetime = weather.DateTime(forecast_time)
         weather_answer.forecasts.append(forecast_data)

--- a/searx/engines/duckduckgo_weather.py
+++ b/searx/engines/duckduckgo_weather.py
@@ -17,6 +17,11 @@ from searx.result_types import EngineResults
 from searx.extended_types import SXNG_Response
 from searx import weather
 
+if t.TYPE_CHECKING:
+    from searx.search.processors import OnlineParams
+
+__all__ = ["fetch_traits"]
+
 about = {
     "website": "https://duckduckgo.com/",
     "wikidata_id": "Q12805",
@@ -84,7 +89,7 @@ def _weather_data(location: weather.GeoLocation, data: dict[str, t.Any]):
     )
 
 
-def request(query: str, params: dict[str, t.Any]):
+def request(query: str, params: "OnlineParams") -> None:
 
     now_ms = get_now_ms()
     if is_ddg_globally_blocked(now_ms):
@@ -92,8 +97,8 @@ def request(query: str, params: dict[str, t.Any]):
         params["url"] = None
         return
 
-    eng_region = traits.get_region(params["searxng_locale"], traits.all_locale)
-    eng_lang = get_ddg_lang(traits, params["searxng_locale"])
+    eng_region: str = t.cast(str, traits.get_region(params["searxng_locale"], traits.all_locale) or traits.all_locale)
+    eng_lang: str = get_ddg_lang(traits, params["searxng_locale"]) or "en_US"
 
     # !ddw paris :es-AR --> {'ad': 'es_AR', 'ah': 'ar-es', 'l': 'ar-es'}
     params["cookies"]["ad"] = eng_lang
@@ -102,7 +107,6 @@ def request(query: str, params: dict[str, t.Any]):
     logger.debug("cookies: %s", params["cookies"])
 
     params["url"] = base_url.format(query=quote(query), lang=eng_lang.split("_")[0])
-    return params
 
 
 def response(resp: SXNG_Response):

--- a/tests/unit/test_engine_duckduckgo.py
+++ b/tests/unit/test_engine_duckduckgo.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-# pylint: disable=missing-module-docstring,missing-class-docstring
+# pylint: disable=missing-module-docstring,missing-class-docstring,invalid-name,protected-access
 
 import logging
 import threading
-from collections import defaultdict
+import typing as t
 from unittest.mock import Mock
 
 from tests import SearxTestCase
+
+if t.TYPE_CHECKING:
+    from searx.search.processors import OnlineParams
 
 
 class FakeCache:
@@ -15,11 +18,11 @@ class FakeCache:
         self.store: dict[str, str] = {}
         self._lock = threading.Lock()
 
-    def get(self, key, default=None, **kwargs):
+    def get(self, key, default=None, **_kwargs):
         with self._lock:
             return self.store.get(key, default)
 
-    def set(self, key, value, expire=None, **kwargs):
+    def set(self, key, value, _expire=None, **_kwargs):
         with self._lock:
             self.store[key] = value
 
@@ -39,7 +42,7 @@ class FakeTraits:
             return default
         return "us-en"
 
-    def get_language(self, sxng_locale, default):
+    def get_language(self, _sxng_locale, _default):
         return "en_US"
 
 
@@ -48,9 +51,9 @@ class DuckDuckGoTests(SearxTestCase):
     def setUp(self):
         super().setUp()
 
-        import searx.engines.duckduckgo as duckduckgo
-        import searx.engines.duckduckgo_extra as duckduckgo_extra
-        import searx.engines.duckduckgo_weather as duckduckgo_weather
+        from searx.engines import duckduckgo  # pylint: disable=import-outside-toplevel
+        from searx.engines import duckduckgo_extra  # pylint: disable=import-outside-toplevel
+        from searx.engines import duckduckgo_weather  # pylint: disable=import-outside-toplevel
 
         self.ddg = duckduckgo
         self.ddg_extra = duckduckgo_extra
@@ -88,16 +91,29 @@ class DuckDuckGoTests(SearxTestCase):
     def _set_time_ms(self, now_ms):
         self.setattr4test(self.ddg.time, "time", lambda: now_ms / 1000)
 
-    def _make_params(self, **overrides):
-        params = defaultdict(dict)
-        params["headers"] = {}
-        params["data"] = {}
-        params["cookies"] = {}
-        params["searxng_locale"] = "en-US"
-        params["pageno"] = 1
-        params["time_range"] = None
-        params["safesearch"] = 0
-        params.update(overrides)
+    def _make_params(self, *, pageno: int = 1) -> "OnlineParams":
+        params: "OnlineParams" = {
+            "method": "GET",
+            "headers": {},
+            "data": {},
+            "json": {},
+            "content": b"",
+            "url": "",
+            "cookies": {},
+            "allow_redirects": False,
+            "max_redirects": 0,
+            "soft_max_redirects": 0,
+            "auth": None,
+            "verify": None,
+            "raise_for_httperror": True,
+            "query": "",
+            "category": "general",
+            "pageno": pageno,
+            "safesearch": 0,
+            "time_range": None,
+            "engine_data": {},
+            "searxng_locale": "en-US",
+        }
         return params
 
     def test_web_request_rate_limits_with_exact_threshold(self):
@@ -168,9 +184,7 @@ class DuckDuckGoTests(SearxTestCase):
         self.ddg.request("blocked", params)
 
         self.assertIsNone(params["url"])
-        self.assertEqual(
-            0, self.ddg._get_cache_int(self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY)
-        )
+        self.assertEqual(0, self.ddg._get_cache_int(self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY))
 
     def test_extra_request_honors_global_cooldown_before_vqd_lookup(self):
         self._set_time_ms(5_000)
@@ -223,6 +237,8 @@ class DuckDuckGoTests(SearxTestCase):
         params = self._make_params()
         self.ddg_extra.request("cats", params)
 
+        self.assertIsNotNone(params["url"])
+        assert params["url"] is not None
         self.assertIn("/i.js?", params["url"])
         self.assertIn("vqd=cached-vqd", params["url"])
 
@@ -243,6 +259,8 @@ class DuckDuckGoTests(SearxTestCase):
         params = self._make_params()
         self.ddg_weather.request("Paris", params)
 
+        self.assertIsNotNone(params["url"])
+        assert params["url"] is not None
         self.assertIn("/js/spice/forecast/Paris/en", params["url"])
         self.assertEqual("en_US", params["cookies"]["ad"])
         self.assertEqual("us-en", params["cookies"]["ah"])
@@ -264,9 +282,7 @@ class DuckDuckGoTests(SearxTestCase):
         self.ddg.request("x" * 500, skipped_params)
 
         self.assertIsNone(skipped_params["url"])
-        self.assertEqual(
-            0, self.ddg._get_cache_int(self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY)
-        )
+        self.assertEqual(0, self.ddg._get_cache_int(self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY))
 
         allowed_params = self._make_params()
         self.ddg.request("short query", allowed_params)
@@ -346,20 +362,15 @@ class DuckDuckGoTests(SearxTestCase):
         def run_request(params):
             try:
                 self.ddg.request("parallel", params)
-            except Exception as exc:  # pragma: no cover
+            except BaseException as exc:  # pragma: no cover
                 errors.append(exc)
 
-        threads = [
-            threading.Thread(target=run_request, args=(params,))
-            for params in params_list
-        ]
+        threads = [threading.Thread(target=run_request, args=(params,)) for params in params_list]
         for thread in threads:
             thread.start()
         for thread in threads:
             thread.join()
 
         self.assertEqual([], errors)
-        self.assertEqual(
-            1, sum(1 for params in params_list if params["url"] == self.ddg.ddg_url)
-        )
+        self.assertEqual(1, sum(1 for params in params_list if params["url"] == self.ddg.ddg_url))
         self.assertEqual(2, sum(1 for params in params_list if params["url"] is None))

--- a/tests/unit/test_engine_duckduckgo.py
+++ b/tests/unit/test_engine_duckduckgo.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,missing-class-docstring
+
+import logging
+import threading
+from collections import defaultdict
+from unittest.mock import Mock
+
+from tests import SearxTestCase
+
+
+class FakeCache:
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key, default=None, **kwargs):
+        with self._lock:
+            return self.store.get(key, default)
+
+    def set(self, key, value, expire=None, **kwargs):
+        with self._lock:
+            self.store[key] = value
+
+    def secret_hash(self, value):
+        return str(value)
+
+
+class FakeTraits:
+
+    all_locale = "wt-wt"
+
+    def __init__(self):
+        self.custom = {"lang_region": {}}
+
+    def get_region(self, sxng_locale, default):
+        if sxng_locale == "all":
+            return default
+        return "us-en"
+
+    def get_language(self, sxng_locale, default):
+        return "en_US"
+
+
+class DuckDuckGoTests(SearxTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        import searx.engines.duckduckgo as duckduckgo
+        import searx.engines.duckduckgo_extra as duckduckgo_extra
+        import searx.engines.duckduckgo_weather as duckduckgo_weather
+
+        self.ddg = duckduckgo
+        self.ddg_extra = duckduckgo_extra
+        self.ddg_weather = duckduckgo_weather
+
+        self.cache = FakeCache()
+        self.traits = FakeTraits()
+        self.logger = logging.getLogger("tests.ddg")
+
+        self._set_module_attr(self.ddg, "logger", self.logger)
+        self._set_module_attr(self.ddg_extra, "logger", self.logger)
+        self._set_module_attr(self.ddg_weather, "logger", self.logger)
+
+        self._set_module_attr(self.ddg, "traits", self.traits)
+        self._set_module_attr(self.ddg_extra, "traits", self.traits)
+        self._set_module_attr(self.ddg_weather, "traits", self.traits)
+
+        self.setattr4test(self.ddg, "get_cache", lambda: self.cache)
+        self.setattr4test(self.ddg, "_CACHE", None)
+        self.setattr4test(self.ddg_extra, "ddg_category", "images")
+        self._set_time_ms(0)
+
+    def _set_module_attr(self, module, attr, value):
+        if hasattr(module, attr):
+            self.setattr4test(module, attr, value)
+            return
+
+        setattr(module, attr, value)
+
+        def cleanup():
+            delattr(module, attr)
+
+        self.addCleanup(cleanup)
+
+    def _set_time_ms(self, now_ms):
+        self.setattr4test(self.ddg.time, "time", lambda: now_ms / 1000)
+
+    def _make_params(self, **overrides):
+        params = defaultdict(dict)
+        params["headers"] = {}
+        params["data"] = {}
+        params["cookies"] = {}
+        params["searxng_locale"] = "en-US"
+        params["pageno"] = 1
+        params["time_range"] = None
+        params["safesearch"] = 0
+        params.update(overrides)
+        return params
+
+    def test_web_request_rate_limits_with_exact_threshold(self):
+        params = self._make_params()
+
+        self.ddg.request("open source", params)
+
+        self.assertEqual(self.ddg.ddg_url, params["url"])
+        self.assertEqual("POST", params["method"])
+        self.assertFalse(any(key.startswith("Sec-Fetch-") for key in params["headers"]))
+
+        self._set_time_ms(2999)
+        skipped_params = self._make_params()
+        self.ddg.request("open source", skipped_params)
+        self.assertIsNone(skipped_params["url"])
+
+        self._set_time_ms(3000)
+        resumed_params = self._make_params()
+        self.ddg.request("open source", resumed_params)
+        self.assertEqual(self.ddg.ddg_url, resumed_params["url"])
+        self.assertEqual("POST", resumed_params["method"])
+
+    def test_captcha_sets_global_cooldown_and_raises(self):
+        self._set_time_ms(12_345)
+        response = Mock()
+        response.status_code = 200
+        response.text = '<html><body><form id="challenge-form"></form></body></html>'
+        response.search_params = {"data": {"kl": "us-en"}}
+
+        with self.assertRaises(self.ddg.SearxEngineCaptchaException) as exc:
+            self.ddg.response(response)
+
+        self.assertGreater(exc.exception.suspended_time, 0)
+        self.assertEqual(
+            12_345 + self.ddg._DDG_CAPTCHA_COOLDOWN_MS,
+            self.ddg.get_ddg_global_blocked_until_ms(),
+        )
+
+    def test_captcha_does_not_shorten_existing_cooldown(self):
+        self._set_time_ms(12_345)
+        self.ddg.set_ddg_global_blocked_until_ms(9_999_999)
+
+        response = Mock()
+        response.status_code = 200
+        response.text = '<html><body><form id="challenge-form"></form></body></html>'
+        response.search_params = {"data": {"kl": "us-en"}}
+
+        with self.assertRaises(self.ddg.SearxEngineCaptchaException):
+            self.ddg.response(response)
+
+        self.assertEqual(9_999_999, self.ddg.get_ddg_global_blocked_until_ms())
+
+    def test_web_request_skips_when_global_cooldown_is_active(self):
+        self._set_time_ms(5_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+
+        params = self._make_params()
+        self.ddg.request("blocked", params)
+
+        self.assertIsNone(params["url"])
+
+    def test_global_cooldown_has_priority_over_web_rate_limit_slot(self):
+        self._set_time_ms(5_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+        self.cache.store[self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY] = "0"
+
+        params = self._make_params()
+        self.ddg.request("blocked", params)
+
+        self.assertIsNone(params["url"])
+        self.assertEqual(
+            0, self.ddg._get_cache_int(self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY)
+        )
+
+    def test_extra_request_honors_global_cooldown_before_vqd_lookup(self):
+        self._set_time_ms(5_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+        self.setattr4test(
+            self.ddg_extra,
+            "get_vqd",
+            lambda **kwargs: self.fail("get_vqd should not run"),
+        )
+        self.setattr4test(
+            self.ddg_extra,
+            "fetch_vqd",
+            lambda **kwargs: self.fail("fetch_vqd should not run"),
+        )
+
+        params = self._make_params()
+        self.ddg_extra.request("cats", params)
+
+        self.assertIsNone(params["url"])
+
+    def test_fetch_vqd_honors_global_cooldown_before_network_get(self):
+        self._set_time_ms(5_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+        self.setattr4test(
+            self.ddg_extra,
+            "get",
+            lambda **kwargs: self.fail("network get should not run"),
+        )
+
+        params = self._make_params()
+
+        self.assertEqual("", self.ddg_extra.fetch_vqd("cats", params))
+
+    def test_extra_request_skips_when_vqd_is_unavailable(self):
+        self._set_time_ms(9_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+        self.setattr4test(self.ddg_extra, "get_vqd", lambda **kwargs: "")
+        self.setattr4test(self.ddg_extra, "fetch_vqd", lambda **kwargs: "")
+
+        params = self._make_params()
+        self.ddg_extra.request("cats", params)
+
+        self.assertIsNone(params["url"])
+
+    def test_extra_request_resumes_after_global_cooldown_expires(self):
+        self._set_time_ms(9_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+        self.setattr4test(self.ddg_extra, "get_vqd", lambda **kwargs: "cached-vqd")
+
+        params = self._make_params()
+        self.ddg_extra.request("cats", params)
+
+        self.assertIn("/i.js?", params["url"])
+        self.assertIn("vqd=cached-vqd", params["url"])
+
+    def test_weather_request_honors_global_cooldown(self):
+        self._set_time_ms(5_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+
+        params = self._make_params()
+        self.ddg_weather.request("Paris", params)
+
+        self.assertIsNone(params["url"])
+        self.assertEqual({}, params["cookies"])
+
+    def test_weather_request_resumes_after_global_cooldown_expires(self):
+        self._set_time_ms(9_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+
+        params = self._make_params()
+        self.ddg_weather.request("Paris", params)
+
+        self.assertIn("/js/spice/forecast/Paris/en", params["url"])
+        self.assertEqual("en_US", params["cookies"]["ad"])
+        self.assertEqual("us-en", params["cookies"]["ah"])
+        self.assertEqual("us-en", params["cookies"]["l"])
+
+    def test_vqd_missed_keeps_zero_suspension(self):
+        params = self._make_params(pageno=2)
+
+        with self.assertRaises(self.ddg.SearxEngineCaptchaException) as exc:
+            self.ddg.request("next page", params)
+
+        self.assertEqual(0, exc.exception.suspended_time)
+        self.assertIn("VQD missed", exc.exception.message)
+        self.assertEqual(0, self.ddg.get_ddg_global_blocked_until_ms())
+
+    def test_long_query_skip_does_not_consume_rate_limit_slot(self):
+        skipped_params = self._make_params()
+
+        self.ddg.request("x" * 500, skipped_params)
+
+        self.assertIsNone(skipped_params["url"])
+        self.assertEqual(
+            0, self.ddg._get_cache_int(self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY)
+        )
+
+        allowed_params = self._make_params()
+        self.ddg.request("short query", allowed_params)
+        self.assertEqual(self.ddg.ddg_url, allowed_params["url"])
+
+    def test_invalid_cached_state_is_ignored(self):
+        self.cache.store[self.ddg._DDG_GLOBAL_BLOCKED_UNTIL_KEY] = "bad-value"
+        self.cache.store[self.ddg._DDG_WEB_NEXT_ALLOWED_AT_KEY] = "also-bad"
+
+        params = self._make_params()
+        self.ddg.request("open source", params)
+
+        self.assertEqual(self.ddg.ddg_url, params["url"])
+        self.assertEqual(0, self.ddg.get_ddg_global_blocked_until_ms())
+
+    def test_set_global_cooldown_is_monotonic(self):
+        self.ddg.set_ddg_global_blocked_until_ms(9_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+
+        self.assertEqual(9_000, self.ddg.get_ddg_global_blocked_until_ms())
+
+    def test_web_rate_limit_remains_active_after_global_cooldown_expires(self):
+        self._set_time_ms(5_000)
+        self.ddg.set_ddg_global_blocked_until_ms(8_000)
+
+        skipped_params = self._make_params()
+        self.ddg.request("blocked", skipped_params)
+        self.assertIsNone(skipped_params["url"])
+
+        self._set_time_ms(9_000)
+        first_params = self._make_params()
+        self.ddg.request("resumed", first_params)
+        self.assertEqual(self.ddg.ddg_url, first_params["url"])
+
+        self._set_time_ms(10_000)
+        throttled_params = self._make_params()
+        self.ddg.request("resumed", throttled_params)
+        self.assertIsNone(throttled_params["url"])
+
+    def test_extra_long_query_skips_without_vqd_lookup(self):
+        self.setattr4test(
+            self.ddg_extra,
+            "get_vqd",
+            lambda **kwargs: self.fail("get_vqd should not run"),
+        )
+        self.setattr4test(
+            self.ddg_extra,
+            "fetch_vqd",
+            lambda **kwargs: self.fail("fetch_vqd should not run"),
+        )
+
+        params = self._make_params()
+        self.ddg_extra.request("x" * 500, params)
+
+        self.assertIsNone(params["url"])
+
+    def test_page2_without_vqd_raises_captcha_zero_suspension(self):
+        params_p1 = self._make_params(pageno=1)
+        self.ddg.request("search query", params_p1)
+        self.assertEqual(self.ddg.ddg_url, params_p1["url"])
+
+        self._set_time_ms(5_000)
+        params_p2 = self._make_params(pageno=2)
+        with self.assertRaises(self.ddg.SearxEngineCaptchaException) as exc:
+            self.ddg.request("search query", params_p2)
+
+        self.assertEqual(0, exc.exception.suspended_time)
+        self.assertIn("VQD missed", exc.exception.message)
+        # Global cooldown must NOT be set for a VQD miss
+        self.assertEqual(0, self.ddg.get_ddg_global_blocked_until_ms())
+
+    def test_concurrent_web_requests_allow_only_one_slot(self):
+        self._set_time_ms(10_000)
+        params_list = [self._make_params() for _ in range(3)]
+        errors = []
+
+        def run_request(params):
+            try:
+                self.ddg.request("parallel", params)
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=run_request, args=(params,))
+            for params in params_list
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual([], errors)
+        self.assertEqual(
+            1, sum(1 for params in params_list if params["url"] == self.ddg.ddg_url)
+        )
+        self.assertEqual(2, sum(1 for params in params_list if params["url"] is None))


### PR DESCRIPTION
## What does this PR do?

This PR hardens the DuckDuckGo engines against short request bursts and CAPTCHA cooldowns.

It adds:
- a 3-second throttle for the web DuckDuckGo engine in `searx/engines/duckduckgo.py`
- a shared DuckDuckGo cooldown stored in `EngineCache`
- shared cooldown checks in `duckduckgo_extra.py` and `duckduckgo_weather.py`
- unit tests covering throttling, cooldown propagation, CAPTCHA handling, and concurrency

It keeps `duckduckgo_definitions.py` unchanged, because it uses `api.duckduckgo.com` and is intentionally out of scope for the shared cooldown.

When a DuckDuckGo CAPTCHA is detected, the engine sets a shared 1-hour cooldown in cache, while the processor suspension uses SearXNG's central CAPTCHA suspension setting.

Preventive skips remain silent (`params["url"] = None`) by design, so they do not inflate engine error backoff.

## Why is this change important?

DuckDuckGo may return a CAPTCHA after short bursts of requests.

Because SearXNG executes engines in parallel, concurrent users can easily trigger these bursts on a shared outgoing IP. The current DuckDuckGo engine does not prevent avoidable burst traffic before the request is sent, and its previous CAPTCHA handling could lead to overly aggressive retries.

This PR reduces avoidable DDG requests, makes CAPTCHA handling consistent with SearXNG's standard CAPTCHA suspension behavior, and ensures that related DuckDuckGo engines (`web`, `extra`, `weather`) honor the same cooldown.

## How to test this PR locally?

```bash
SEARXNG_DEBUG=1 ./manage pyenv.cmd python -m nose2 -s tests/unit test_engine_duckduckgo
```

This test suite covers:

- web throttle behavior, including the exact threshold
- shared cooldown propagation to duckduckgo_extra and duckduckgo_weather
- CAPTCHA cooldown handling
- VQD missed remaining at suspended_time=0
- long-query skips
- invalid cached state handling
- single-process concurrency behavior

## Author's checklist

- `duckduckgo_definitions.py` is intentionally not modified
- no `Sec-Fetch-*` headers are reintroduced
- preventive skips are silent by design
- scope is intentionally limited to best-effort single-process coordination
- no cross-process or cross-instance lock is introduced in this PR

## Related issues

Closes #4824