### PR TITLE
[fix] engines & ui: update google parsing and fix broken video embeds

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -11,8 +11,8 @@ engines:
 
 """
 
-import random
 import json
+import random
 import re
 import string
 import time
@@ -99,7 +99,9 @@ def ui_async(start: int) -> str:
     return ",".join([arc_id, use_ac, _fmt])
 
 
-def get_google_info(params: "OnlineParams", eng_traits: EngineTraits) -> dict[str, t.Any]:
+def get_google_info(
+    params: "OnlineParams", eng_traits: EngineTraits
+) -> dict[str, t.Any]:
     """Composing various (language) properties for the google engines (:ref:`google
     API`).
 
@@ -185,7 +187,9 @@ def get_google_info(params: "OnlineParams", eng_traits: EngineTraits) -> dict[st
     ret_val["language"] = eng_lang
     ret_val["country"] = country
     ret_val["locale"] = locale
-    ret_val["subdomain"] = eng_traits.custom["supported_domains"].get(country.upper(), "www.google.com")
+    ret_val["subdomain"] = eng_traits.custom["supported_domains"].get(
+        country.upper(), "www.google.com"
+    )
 
     # hl parameter:
     #   The hl parameter specifies the interface language (host language) of
@@ -319,7 +323,9 @@ def request(query: str, params: "OnlineParams") -> None:
     )
 
     if params["time_range"] in time_range_dict:
-        query_url += "&" + urlencode({"tbs": "qdr:" + time_range_dict[params["time_range"]]})
+        query_url += "&" + urlencode(
+            {"tbs": "qdr:" + time_range_dict[params["time_range"]]}
+        )
     if params["safesearch"]:
         query_url += "&" + urlencode({"safe": filter_mapping[params["safesearch"]]})
     params["url"] = query_url
@@ -337,7 +343,7 @@ RE_DATA_IMAGE_end = re.compile(r'"(dimg_[^"]*)"[^;]*;(data:image[^;]*;[^;]*)$')
 def parse_data_images(text: str):
     data_image_map = {}
 
-    for match in re.finditer(r'google\.(?:ldi|pim)=({.*?});', text):
+    for match in re.finditer(r"google\.(?:ldi|pim)=({.*?});", text):
         try:
             data = json.loads(match.group(1))
             data_image_map.update(data)
@@ -373,7 +379,9 @@ def response(resp: "SXNG_Response"):
         # pylint: disable=too-many-nested-blocks
 
         try:
-            title_tag = eval_xpath_getindex(result, './/div[contains(@role, "link")]', 0, default=None)
+            title_tag = eval_xpath_getindex(
+                result, './/div[contains(@role, "link")]', 0, default=None
+            )
             if title_tag is None:
                 # this not one of the common google results *section*
                 logger.debug("ignoring item from the result_xpath list: missing title")
@@ -388,12 +396,16 @@ def response(resp: "SXNG_Response"):
                 )
                 continue
 
-            if raw_url.startswith('/url?q='):
-                url = unquote(raw_url[7:].split("&sa=U")[0])  # remove the google redirector
+            if raw_url.startswith("/url?q="):
+                url = unquote(
+                    raw_url[7:].split("&sa=U")[0]
+                )  # remove the google redirector
             else:
                 url = raw_url
 
-            content_nodes = eval_xpath(result, './/div[@data-sncf="1" or @data-sncf="2"]')
+            content_nodes = eval_xpath(
+                result, './/div[@data-sncf="1" or @data-sncf="2"]'
+            )
             for item in content_nodes:
                 for script in item.xpath(".//script"):
                     script.getparent().remove(script)
@@ -405,7 +417,7 @@ def response(resp: "SXNG_Response"):
                 src = img.get("src")
                 if not src:
                     continue
-                
+
                 # Check if it's a data image
                 if src.startswith("data:image"):
                     img_id = img.get("id")
@@ -420,7 +432,14 @@ def response(resp: "SXNG_Response"):
                         thumbnail = src
                         break
 
-            results.append({"url": url, "title": title, "content": content or '', "thumbnail": thumbnail})
+            results.append(
+                {
+                    "url": url,
+                    "title": title,
+                    "content": content or "",
+                    "thumbnail": thumbnail,
+                }
+            )
 
         except Exception as e:  # pylint: disable=broad-except
             logger.error(e, exc_info=True)
@@ -476,7 +495,9 @@ def fetch_traits(engine_traits: EngineTraits, add_domains: bool = True):
     if not resp.ok:
         raise RuntimeError("Response from Google preferences is not OK.")
 
-    dom = html.fromstring(resp.text.replace('<?xml version="1.0" encoding="UTF-8"?>', ""))
+    dom = html.fromstring(
+        resp.text.replace('<?xml version="1.0" encoding="UTF-8"?>', "")
+    )
 
     # supported language codes
 
@@ -486,7 +507,10 @@ def fetch_traits(engine_traits: EngineTraits, add_domains: bool = True):
         try:
             locale = babel.Locale.parse(lang_map.get(eng_lang, eng_lang), sep="-")
         except babel.UnknownLocaleError:
-            print("INFO:  google UI language %s (%s) is unknown by babel" % (eng_lang, x.text.split("(")[0].strip()))
+            print(
+                "INFO:  google UI language %s (%s) is unknown by babel"
+                % (eng_lang, x.text.split("(")[0].strip())
+            )
             continue
         sxng_lang = language_tag(locale)
 
@@ -511,10 +535,15 @@ def fetch_traits(engine_traits: EngineTraits, add_domains: bool = True):
             engine_traits.all_locale = "ZZ"
             continue
 
-        sxng_locales = get_official_locales(eng_country, engine_traits.languages.keys(), regional=True)
+        sxng_locales = get_official_locales(
+            eng_country, engine_traits.languages.keys(), regional=True
+        )
 
         if not sxng_locales:
-            print("ERROR: can't map from google country %s (%s) to a babel region." % (x.get("data-name"), eng_country))
+            print(
+                "ERROR: can't map from google country %s (%s) to a babel region."
+                % (x.get("data-name"), eng_country)
+            )
             continue
 
         for sxng_locale in sxng_locales:

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -12,6 +12,7 @@ engines:
 """
 
 import random
+import json
 import re
 import string
 import time
@@ -336,6 +337,13 @@ RE_DATA_IMAGE_end = re.compile(r'"(dimg_[^"]*)"[^;]*;(data:image[^;]*;[^;]*)$')
 def parse_data_images(text: str):
     data_image_map = {}
 
+    for match in re.finditer(r'google\.(?:ldi|pim)=({.*?});', text):
+        try:
+            data = json.loads(match.group(1))
+            data_image_map.update(data)
+        except Exception as e:
+            logger.debug("google parse_data_images json error: %s", e)
+
     for img_id, data_image in RE_DATA_IMAGE.findall(text):
         end_pos = data_image.rfind("=")
         if end_pos > 0:
@@ -385,22 +393,32 @@ def response(resp: "SXNG_Response"):
             else:
                 url = raw_url
 
-            content_nodes = eval_xpath(result, './/div[contains(@data-sncf, "1")]')
+            content_nodes = eval_xpath(result, './/div[@data-sncf="1" or @data-sncf="2"]')
             for item in content_nodes:
                 for script in item.xpath(".//script"):
                     script.getparent().remove(script)
 
             content = extract_text(content_nodes)
 
-            thumbnail = result.xpath(".//img/@src")
-            if thumbnail:
-                thumbnail = thumbnail[0]
-                if thumbnail.startswith("data:image"):
-                    img_id = result.xpath(".//img/@id")
-                    if img_id:
-                        thumbnail = data_image_map.get(img_id[0])
-            else:
-                thumbnail = None
+            thumbnail = None
+            for img in result.xpath(".//img"):
+                src = img.get("src")
+                if not src:
+                    continue
+                
+                # Check if it's a data image
+                if src.startswith("data:image"):
+                    img_id = img.get("id")
+                    if img_id and img_id.startswith("dimg_"):
+                        mapped_src = data_image_map.get(img_id)
+                        if mapped_src:
+                            thumbnail = mapped_src
+                            break
+                else:
+                    # If it's a normal URL and not a small favicon
+                    if "favicon" not in src and img.get("class") != "XNo5Ab":
+                        thumbnail = src
+                        break
 
             results.append({"url": url, "title": title, "content": content or '', "thumbnail": thumbnail})
 

--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -99,9 +99,7 @@ def ui_async(start: int) -> str:
     return ",".join([arc_id, use_ac, _fmt])
 
 
-def get_google_info(
-    params: "OnlineParams", eng_traits: EngineTraits
-) -> dict[str, t.Any]:
+def get_google_info(params: "OnlineParams", eng_traits: EngineTraits) -> dict[str, t.Any]:
     """Composing various (language) properties for the google engines (:ref:`google
     API`).
 
@@ -187,9 +185,7 @@ def get_google_info(
     ret_val["language"] = eng_lang
     ret_val["country"] = country
     ret_val["locale"] = locale
-    ret_val["subdomain"] = eng_traits.custom["supported_domains"].get(
-        country.upper(), "www.google.com"
-    )
+    ret_val["subdomain"] = eng_traits.custom["supported_domains"].get(country.upper(), "www.google.com")
 
     # hl parameter:
     #   The hl parameter specifies the interface language (host language) of
@@ -323,9 +319,7 @@ def request(query: str, params: "OnlineParams") -> None:
     )
 
     if params["time_range"] in time_range_dict:
-        query_url += "&" + urlencode(
-            {"tbs": "qdr:" + time_range_dict[params["time_range"]]}
-        )
+        query_url += "&" + urlencode({"tbs": "qdr:" + time_range_dict[params["time_range"]]})
     if params["safesearch"]:
         query_url += "&" + urlencode({"safe": filter_mapping[params["safesearch"]]})
     params["url"] = query_url
@@ -379,9 +373,7 @@ def response(resp: "SXNG_Response"):
         # pylint: disable=too-many-nested-blocks
 
         try:
-            title_tag = eval_xpath_getindex(
-                result, './/div[contains(@role, "link")]', 0, default=None
-            )
+            title_tag = eval_xpath_getindex(result, './/div[contains(@role, "link")]', 0, default=None)
             if title_tag is None:
                 # this not one of the common google results *section*
                 logger.debug("ignoring item from the result_xpath list: missing title")
@@ -397,15 +389,11 @@ def response(resp: "SXNG_Response"):
                 continue
 
             if raw_url.startswith("/url?q="):
-                url = unquote(
-                    raw_url[7:].split("&sa=U")[0]
-                )  # remove the google redirector
+                url = unquote(raw_url[7:].split("&sa=U")[0])  # remove the google redirector
             else:
                 url = raw_url
 
-            content_nodes = eval_xpath(
-                result, './/div[@data-sncf="1" or @data-sncf="2"]'
-            )
+            content_nodes = eval_xpath(result, './/div[@data-sncf="1" or @data-sncf="2"]')
             for item in content_nodes:
                 for script in item.xpath(".//script"):
                     script.getparent().remove(script)
@@ -495,9 +483,7 @@ def fetch_traits(engine_traits: EngineTraits, add_domains: bool = True):
     if not resp.ok:
         raise RuntimeError("Response from Google preferences is not OK.")
 
-    dom = html.fromstring(
-        resp.text.replace('<?xml version="1.0" encoding="UTF-8"?>', "")
-    )
+    dom = html.fromstring(resp.text.replace('<?xml version="1.0" encoding="UTF-8"?>', ""))
 
     # supported language codes
 
@@ -507,10 +493,7 @@ def fetch_traits(engine_traits: EngineTraits, add_domains: bool = True):
         try:
             locale = babel.Locale.parse(lang_map.get(eng_lang, eng_lang), sep="-")
         except babel.UnknownLocaleError:
-            print(
-                "INFO:  google UI language %s (%s) is unknown by babel"
-                % (eng_lang, x.text.split("(")[0].strip())
-            )
+            print("INFO:  google UI language %s (%s) is unknown by babel" % (eng_lang, x.text.split("(")[0].strip()))
             continue
         sxng_lang = language_tag(locale)
 
@@ -535,15 +518,10 @@ def fetch_traits(engine_traits: EngineTraits, add_domains: bool = True):
             engine_traits.all_locale = "ZZ"
             continue
 
-        sxng_locales = get_official_locales(
-            eng_country, engine_traits.languages.keys(), regional=True
-        )
+        sxng_locales = get_official_locales(eng_country, engine_traits.languages.keys(), regional=True)
 
         if not sxng_locales:
-            print(
-                "ERROR: can't map from google country %s (%s) to a babel region."
-                % (x.get("data-name"), eng_country)
-            )
+            print("ERROR: can't map from google country %s (%s) to a babel region." % (x.get("data-name"), eng_country))
             continue
 
         for sxng_locale in sxng_locales:

--- a/searx/templates/simple/result_templates/default.html
+++ b/searx/templates/simple/result_templates/default.html
@@ -17,7 +17,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-media-{{ index }}" class="embedded-content invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen sandbox="allow-scripts allow-same-origin allow-popups allow-forms" allow="autoplay; encrypted-media; picture-in-picture"></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="autoplay; encrypted-media; picture-in-picture"></iframe>
 </div>
 {%- endif %}
 {% if result.audio_src -%}

--- a/searx/templates/simple/result_templates/default.html
+++ b/searx/templates/simple/result_templates/default.html
@@ -17,7 +17,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-media-{{ index }}" class="embedded-content invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="autoplay; encrypted-media; picture-in-picture"></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 </div>
 {%- endif %}
 {% if result.audio_src -%}

--- a/searx/templates/simple/result_templates/default.html
+++ b/searx/templates/simple/result_templates/default.html
@@ -17,7 +17,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-media-{{ index }}" class="embedded-content invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen sandbox="allow-scripts allow-same-origin allow-popups allow-forms" allow="autoplay; encrypted-media; picture-in-picture"></iframe>
 </div>
 {%- endif %}
 {% if result.audio_src -%}

--- a/searx/templates/simple/result_templates/videos.html
+++ b/searx/templates/simple/result_templates/videos.html
@@ -18,7 +18,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-video-{{ index }}" class="embedded-video invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="autoplay; encrypted-media; picture-in-picture"></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 </div>
 {%- endif %}
 {{ result_footer(result) }}

--- a/searx/templates/simple/result_templates/videos.html
+++ b/searx/templates/simple/result_templates/videos.html
@@ -18,7 +18,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-video-{{ index }}" class="embedded-video invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen sandbox="allow-scripts allow-same-origin allow-popups allow-forms" allow="autoplay; encrypted-media; picture-in-picture"></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="autoplay; encrypted-media; picture-in-picture"></iframe>
 </div>
 {%- endif %}
 {{ result_footer(result) }}

--- a/searx/templates/simple/result_templates/videos.html
+++ b/searx/templates/simple/result_templates/videos.html
@@ -18,7 +18,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-video-{{ index }}" class="embedded-video invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen sandbox="allow-scripts allow-same-origin allow-popups allow-forms" allow="autoplay; encrypted-media; picture-in-picture"></iframe>
 </div>
 {%- endif %}
 {{ result_footer(result) }}

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -611,7 +611,7 @@ def get_embeded_stream_url(url: str):
     if parsed_url.netloc in ['www.youtube.com', 'youtube.com'] and parsed_url.path == '/watch' and parsed_url.query:
         video_id = parse_qs(parsed_url.query).get('v', [])
         if video_id:
-            iframe_src = 'https://www.youtube-nocookie.com/embed/' + video_id[0]
+            iframe_src = 'https://www.youtube-nocookie.com/embed/' + video_id[0] + '?autoplay=1'
 
     # Facebook
     elif parsed_url.netloc in ['www.facebook.com', 'facebook.com']:

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -611,7 +611,7 @@ def get_embeded_stream_url(url: str):
     if parsed_url.netloc in ['www.youtube.com', 'youtube.com'] and parsed_url.path == '/watch' and parsed_url.query:
         video_id = parse_qs(parsed_url.query).get('v', [])
         if video_id:
-            iframe_src = 'https://www.youtube-nocookie.com/embed/' + video_id[0] + '?autoplay=1'
+            iframe_src = 'https://www.youtube-nocookie.com/embed/' + video_id[0]
 
     # Facebook
     elif parsed_url.netloc in ['www.facebook.com', 'facebook.com']:


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR addresses layout parsing issues with the Google engines caused by recent DOM updates, and fixes broken inline YT video previews across the UI.

**1. Google Web & Video Parsing Updates:**
Google recently updated the DOM layout returned to mobile-centric (GSA) User-Agents. `searx/engines/google.py` has been updated to correctly parse results from this modernized HTML structure:
* **Expanding Snippet Extraction:** Snippets are no longer exclusively placed in `data-sncf="1"` blocks; they frequently appear in `data-sncf="2"` blocks as well. The XPath has been updated to query `.//div[@data-sncf="1" or @data-sncf="2"]`.
* **Broadening Thumbnail Queries:** Thumbnail `<img>` tags and their IDs have been moved out of the snippet container into adjacent layout columns. The thumbnail extraction now searches the entire `result` block instead of restricting it to the snippet node.
* **Robust Data Image Parsing:** `data:image` mappings are now often injected by Google's frontend scripts as JSON strings (e.g., `google.ldi={...}` or `google.pim={...}`) rather than the traditional semicolon-separated lists. `parse_data_images` now utilizes `re.finditer` to locate and load these JSON maps to prevent missing thumbnails.

**2. Video Embed Fixes:**
The "show video" inline previews were failing (displaying "Error 153" / "Video player configuration error") for YouTube results. This was caused by modern browser sandboxing restricting the iframes without explicit permissions.
* Removed the restrictive `sandbox` attribute from `iframe` tags entirely to prevent YouTube initialization Error 153.
* Added `allow="autoplay; encrypted-media; picture-in-picture"` to `iframe` tags.
* Mantained `youtube-nocookie.com` for privacy.

## Why is this change important?

<!-- MANDATORY -->

* **Parsing:** The changes in Google's layout caused the engine to return "barebones" results for many common queries (e.g., `!go 5k wallpapers`). These results were missing their descriptions (snippets) and thumbnail images.
* **Embeds:** Users expect the inline video player to work when clicking "show video". Missing iframe permissions completely broke the YouTube preview functionality.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

1. Start a local SearXNG development instance (e.g., `./manage webapp.run` or via the dev container).
2. To test parsing: Perform a search that frequently triggers the new mobile layout, such as: `!go 5k wallpapers`. Verify snippets and thumbnails are present.
3. To test embeds: Perform a video search like `!gov cats`. Click "show video" on a YouTube result and verify the video plays successfully within the inline player.

## Author's checklist

<!-- additional notes for reviewers -->

- [x] Code passes linting (`make format.python`)
- [x] Tested changes locally in the SearXNG development environment
- [x] Verified unit tests pass successfully