### PR TITLE
docs: add AI policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -13,7 +13,7 @@ assignees: ''
 in order to fetch the latest commit ID:
 ```
 git log -1
-``` 
+```
 If you are using searxng-docker then look at the bottom of the SearXNG page
 and check for the version after "Powered by SearXNG"
 
@@ -37,3 +37,5 @@ or manually by executing the searx/webapp.py file? -->
 
 **Additional context**
 <!-- Add any other context about the problem here. -->
+
+- [ ] I read the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst) and hereby confirm that this issue conforms with the policy.

--- a/.github/ISSUE_TEMPLATE/engine-request.md
+++ b/.github/ISSUE_TEMPLATE/engine-request.md
@@ -29,3 +29,5 @@ You can add multiple categories at the same time. -->
 
 **Additional context**
 <!-- Add any other context about this engine here. -->
+
+- [ ] I read the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst) and hereby confirm that this issue conforms with the policy.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -19,3 +19,5 @@ assignees: ''
 
 **Additional context**
 <!-- Add any other context or screenshots about the feature request here. -->
+
+- [ ] I read the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst) and hereby confirm that this issue conforms with the policy.

--- a/AI_POLICY.rst
+++ b/AI_POLICY.rst
@@ -1,0 +1,20 @@
+.. SPDX-License-Identifier: AGPL-3.0-or-later
+
+AI Policy
+=========
+
+Restrictions on Generative AI Usage
+-----------------------------------
+- **All AI usage in any form must be disclosed.** You must state the tool you used (e.g. Claude Code, Cursor, Amp) along with the extent that the work was AI-assisted.
+- **The human-in-the-loop must fully understand all code.** If you use generative AI tools as an aid in developing code or documentation changes, ensure that you fully understand the proposed changes and can explain why they are the correct approach.
+- **AI should never be the main author of the PR.** AI may be used as a tool to help with developing, but the human contribution to the code changes should always be reasonably larger than the part written by AI. For example, you should be the one that decides about the structure of the PR, not the LLM.
+- **Issues and PR descriptions must be fully human-written.** Do not post output from Large Language Models or similar generative AI as comments on any of our discussion forums (e.g. GitHub Issues, Matrix, ...), as such comments tend to be formulaic and low content. If you're a not a native English speaker, using AI for translating self-written issue texts to English is okay, but please keep the wording as close as possible to the original wording.
+- **Bad AI drivers will be denounced.** People who produce bad contributions that are clearly AI (slop) will be blocked for all future contributions.
+
+There are Humans Here
+---------------------
+Every discussion, issue, and pull request is read and reviewed by humans. It is a boundary point at which people interact with each other and the work done. It is rude and disrespectful to approach this boundary with low-effort, unqualified work, since it puts the burden of validation on the maintainer.
+
+It takes a lot of maintainer time and energy to review AI-generated contributions! Sending the output of an LLM to open source project maintainers extracts work from them in the form of design and code review, so we call this kind of contribution an "extractive contribution".
+
+The *golden rule* is that a contribution should be worth more to the project than the time it takes to review it, which is usually not the case if large parts of your PR were written by LLMs.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,6 +2,7 @@
 
 .. _Quickstart guide: https://docs.searxng.org/dev/quickstart.html
 .. _Commits guide: https://docs.searxng.org/dev/commits.html
+.. _AI Policy: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst
 .. _Weblate: https://translate.codeberg.org/projects/searxng/searxng/
 .. _GitHub Codespaces: https://docs.github.com/en/codespaces/overview
 .. _120 hours per month: https://github.com/settings/billing
@@ -90,3 +91,8 @@ rules in this project are:
 - Prefer fewer arguments.
 - Do not add obvious comments to code.
 - Do not comment out code, delete lines instead.
+
+AI Policy
+~~~~~~~~~
+
+For our policy on the use of AI tools, please read `AI Policy`_.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,8 @@
 <!--
 Closes #234
 -->
+
+## AI Disclosure
+<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
+- [ ] I hereby confirm that I have not used any AI tools for creating this PR.
+- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.


### PR DESCRIPTION
## What does this PR do?
- This adds an AI policy, based on the ones from other projects (linked below).
- Basically, we allow AI usage to a certain extent, but the human definitely is fully responsible for the code and must understand everything.
- I'm personally in favor of banning LLMs completely from the project, but as discussed internally, we couldn't find a general agreement there.

## Why is this change important?
- We're seeing an increasing amount of low effort AI-generated PRs, that don't match our code structure at all, touch unrelated code parts or do other bad things

Related policies at other projects:
- https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md
- https://github.com/rnk/llvm-project/blob/tool-policy/llvm/docs/AIToolPolicy.md
- https://github.com/matplotlib/matplotlib/blob/main/doc/devel/contribute.rst#L189

Overview of general attitude towards AI in FOSS projects:
- https://oss-ai-policies.netlify.app/

Examples of low-effort PRs:
- https://github.com/searxng/searxng/pull/5841
- https://github.com/searxng/searxng/pull/5824
- https://github.com/searxng/searxng/pull/5840
- https://github.com/searxng/searxng/pull/5602