### PR TITLE
[mod] right dao: remove engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1792,24 +1792,6 @@ engines:
     # https://docs.searxng.org/dev/engines/online/reuters.html
     # sort_order = "relevance"
 
-  - name: right dao
-    engine: xpath
-    paging: true
-    page_size: 12
-    search_url: https://rightdao.com/search?q={query}&start={pageno}
-    results_xpath: //div[contains(@class, "description")]
-    url_xpath: ../div[contains(@class, "title")]/a/@href
-    title_xpath: ../div[contains(@class, "title")]
-    content_xpath: .
-    categories: general
-    shortcut: rd
-    disabled: true
-    about:
-      website: https://rightdao.com/
-      use_official_api: false
-      require_api_key: false
-      results: HTML
-
   - name: rottentomatoes
     engine: rottentomatoes
     shortcut: rt


### PR DESCRIPTION
Since about a month, the website just says "temporarily unavailable", so it's safe to assume that it's just no longer working

Related:

- https://github.com/searxng/searxng/pull/3798
