### PR TITLE
[fix] google: fix snippets, thumbnails and video embeds

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -12,6 +12,7 @@ engines:
 """
 
 import random
+import json
 import re
 import string
 import time
@@ -336,6 +337,13 @@ RE_DATA_IMAGE_end = re.compile(r'"(dimg_[^"]*)"[^;]*;(data:image[^;]*;[^;]*)$')
 def parse_data_images(text: str):
     data_image_map = {}
 
+    for match in re.finditer(r'google\.(?:ldi|pim)=({.*?});', text):
+        try:
+            data = json.loads(match.group(1))
+            data_image_map.update(data)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.debug("google parse_data_images json error: %s", e)
+
     for img_id, data_image in RE_DATA_IMAGE.findall(text):
         end_pos = data_image.rfind("=")
         if end_pos > 0:
@@ -385,23 +393,27 @@ def response(resp: "SXNG_Response"):
             else:
                 url = raw_url
 
-            content_nodes = eval_xpath(result, './/div[contains(@data-sncf, "1")]')
+            content_nodes = eval_xpath(result, './/div[@data-sncf="1" or @data-sncf="2"]')
             for item in content_nodes:
                 for script in item.xpath(".//script"):
                     script.getparent().remove(script)
 
             content = extract_text(content_nodes)
 
-            thumbnail = result.xpath(".//img/@src")
-            if thumbnail:
-                thumbnail = thumbnail[0]
-                if thumbnail.startswith("data:image"):
-                    img_id = result.xpath(".//img/@id")
-                    if img_id:
-                        thumbnail = data_image_map.get(img_id[0])
-            else:
-                thumbnail = None
+            thumbnail = None
+            for img in result.xpath('.//img'):
+                src = img.get('src')
+                if not src:
+                    continue
 
+                if src.startswith('data:image'):
+                    img_id = img.get('id')
+                    thumbnail = data_image_map.get(img_id)
+                    if thumbnail:
+                        break
+                elif 'favicon' not in src and img.get('class') != 'XNo5Ab':
+                    thumbnail = src
+                    break
             results.append({"url": url, "title": title, "content": content or '', "thumbnail": thumbnail})
 
         except Exception as e:  # pylint: disable=broad-except

--- a/searx/templates/simple/result_templates/default.html
+++ b/searx/templates/simple/result_templates/default.html
@@ -17,7 +17,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-media-{{ index }}" class="embedded-content invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="autoplay; encrypted-media; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 </div>
 {%- endif %}
 {% if result.audio_src -%}

--- a/searx/templates/simple/result_templates/videos.html
+++ b/searx/templates/simple/result_templates/videos.html
@@ -18,7 +18,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-video-{{ index }}" class="embedded-video invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen allow="autoplay; encrypted-media; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin"></iframe>
 </div>
 {%- endif %}
 {{ result_footer(result) }}


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR modernizes Google engine parsing and restores broken inline video previews:

* **Google Engine:** Updated XPaths to support `data-sncf="2"` snippet blocks and added JSON-based `data:image` extraction to handle modern mobile (GSA) layouts.
* **Video UI:** Resolved "Error 153" in YouTube previews by adding `referrerpolicy="strict-origin-when-cross-origin"`, allowing the player to verify playback permissions.
* **Minimal Embeds:** Purposefully reduced the default YouTube embed code to the bare-bones minimal set (`allow="autoplay; encrypted-media; picture-in-picture"`) to ensure DRM/playback functionality while stripping out unnecessary hardware-access permissions.

## Why is this change important?

<!-- MANDATORY -->

Google's recent DOM updates caused results to appear "barebones" (missing snippets and thumbnails), and restrictive browser policies had completely broken the inline "show video" preview feature for YouTube results.

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

1. Perform a search for `!go 5k wallpapers` and verify that both descriptions and thumbnails are present.
2. Perform a video search for `!gov cats`, click "show video" on a YouTube result, and verify it plays without initialization errors.

## Author's checklist

<!-- additional notes for reviewers -->

- [x] Code passes linting (`make format.python`)
- [x] Tested changes locally in the SearXNG development environment
- [x] Verified unit tests pass successfully

## Related issues
Closes #5844
Closes #5843

