### PR TITLE
[fix] google_videos: restore broken video descriptions in results

### DIFF
--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -110,7 +110,7 @@ def response(resp):
         title = extract_text(
             eval_xpath_getindex(
                 result,
-                './/h3[contains(@class, "DKV0Md")]' ' | .//h3[contains(@class, "LC20lb")]' ' | .//div[@role="heading"]',
+                './/h3[contains(@class, "DKV0Md")] | .//h3[contains(@class, "LC20lb")] | .//div[@role="heading"]',
                 0,
                 default=None,
             ),
@@ -144,7 +144,7 @@ def response(resp):
         )
 
         if not content:
-            # 2. Fallback for "Grid" layouts where the HTML body omits the snippet:
+            # 2. Fallback for "dense" layouts where the HTML body omits the snippet:
             # The descriptive text is often still present in the link's aria-label.
             content = eval_xpath_getindex(result, './/a[@aria-label]/@aria-label', 0, default='')
 

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -68,7 +68,6 @@ def request(query, params):
                 'tbm': "vid",
                 'start': start,
                 **google_info['params'],
-                # Use async parameters to ensure results are returned correctly across regions
                 'asearch': 'arc',
                 'async': ui_async(start),
             }
@@ -111,9 +110,7 @@ def response(resp):
         title = extract_text(
             eval_xpath_getindex(
                 result,
-                './/h3[contains(@class, "DKV0Md")]'
-                ' | .//h3[contains(@class, "LC20lb")]'
-                ' | .//div[@role="heading"]',
+                './/h3[contains(@class, "DKV0Md")]' ' | .//h3[contains(@class, "LC20lb")]' ' | .//div[@role="heading"]',
                 0,
                 default=None,
             ),
@@ -122,7 +119,10 @@ def response(resp):
 
         # URL extraction via stable jsname="UWckNb" or fallback redirector decoding
         url = eval_xpath_getindex(
-            result, './/a[@jsname="UWckNb"]/@href | .//a[contains(@href, "/url?q=")]/@href | .//a/@href', 0, default=None
+            result,
+            './/a[@jsname="UWckNb"]/@href | .//a[contains(@href, "/url?q=")]/@href | .//a/@href',
+            0,
+            default=None,
         )
         if url and url.startswith('/url?q='):
             url = unquote(url[7:].split('&sa=U')[0])

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -68,6 +68,7 @@ def request(query, params):
                 'tbm': "vid",
                 'start': start,
                 **google_info['params'],
+                # Use async parameters to ensure results are returned correctly across regions
                 'asearch': 'arc',
                 'async': ui_async(start),
             }
@@ -95,23 +96,58 @@ def response(resp):
     # convert the text to dom
     dom = html.fromstring(resp.text)
 
-    result_divs = eval_xpath_list(dom, '//div[contains(@class, "MjjYud")]')
+    # Target individual result containers (jsname="pKB8Bc" and WVV5ke are modern stable attributes)
+    # Exclude top-level MjjYud if it contains pKB8Bc to avoid duplicate results.
+    result_divs = eval_xpath_list(
+        dom,
+        '//div[@jsname="pKB8Bc"]'
+        ' | //div[contains(@class, "WVV5ke")]'
+        ' | //div[contains(@class, "g ") and not(descendant::div[@jsname="pKB8Bc"])]',
+    )
 
     # parse results
     for result in result_divs:
+        # Title extraction supporting modern heading roles and LC20lb/DKV0Md classes
         title = extract_text(
-            eval_xpath_getindex(result, './/h3[contains(@class, "LC20lb")] | .//div[@role="heading"]', 0, default=None),
+            eval_xpath_getindex(
+                result,
+                './/h3[contains(@class, "DKV0Md")]'
+                ' | .//h3[contains(@class, "LC20lb")]'
+                ' | .//div[@role="heading"]',
+                0,
+                default=None,
+            ),
             allow_none=True,
         )
+
+        # URL extraction via stable jsname="UWckNb" or fallback redirector decoding
         url = eval_xpath_getindex(
-            result, './/a[@jsname="UWckNb"]/@href | .//a[contains(@href, "/url?q=")]/@href', 0, default=None
+            result, './/a[@jsname="UWckNb"]/@href | .//a[contains(@href, "/url?q=")]/@href | .//a/@href', 0, default=None
         )
         if url and url.startswith('/url?q='):
             url = unquote(url[7:].split('&sa=U')[0])
 
+        # Multi-layered description extraction
+        # 1. Search for known modern snippet containers (ITZIwc, p4wth, data-sncf, fzUZNc)
         content = extract_text(
-            eval_xpath_getindex(result, './/div[contains(@class, "ITZIwc")]', 0, default=None), allow_none=True
+            eval_xpath_list(
+                result,
+                './/div[contains(@class, "ITZIwc")]'
+                ' | .//div[contains(@class, "p4wth")]'
+                ' | .//div[@data-sncf="1" or @data-sncf="2"]'
+                ' | .//div[contains(@class, "VwiC3b")]'
+                ' | .//div[contains(@class, "MUwY9d")]'
+                ' | .//span[contains(@class, "MUwY9d")]'
+                ' | .//div[contains(@class, "fzUZNc")]',
+            ),
+            allow_none=True,
         )
+
+        if not content:
+            # 2. Fallback for "Grid" layouts where the HTML body omits the snippet:
+            # The descriptive text is often still present in the link's aria-label.
+            content = eval_xpath_getindex(result, './/a[@aria-label]/@aria-label', 0, default='')
+
         pub_info = extract_text(
             eval_xpath_getindex(
                 result, './/div[contains(@class, "gqF9jc")] | .//div[contains(@class, "WRu9Cd")]', 0, default=None


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->
After painstaking testing, this PR now fixes an issue where results returned by the google videos engine did not include descriptions.
<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->
For quality of results and consistency. As other engines correctly return video descriptions. This ensures google videos now works correctly and returns descriptions as well.
<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->
Simply use `!gov <query>` to perform a video search using the google videos engine and confirm that it is now correctly returning video descriptions.

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [ x] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.

 Tool: Gemini CLI
 Usage:
- Analyzed Google's modern DOM (identifying jsname, role="heading", and aria-label attributes) to resolve missing descriptions.
- Developed XPath expressions for google_videos.py to ensure compatibility with different search layouts returned by google.
- Every change was manually reviewed, tested, and verified by me.