### PR TITLE
[fix] Youtube video - "Error 153" send HTTP Referrer (referrerpolicy)

### DIFF
--- a/searx/templates/simple/result_templates/videos.html
+++ b/searx/templates/simple/result_templates/videos.html
@@ -18,7 +18,11 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-video-{{ index }}" class="embedded-video invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen></iframe>
+  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen
+    {% if result.parsed_url.hostname in ("www.youtube.com", ) -%}
+    allow="picture-in-picture" referrerpolicy="origin">
+    {%- endif -%}
+  </iframe>
 </div>
 {%- endif %}
 {{ result_footer(result) }}


### PR DESCRIPTION
For videos from ``www.youtube.com`` this patch adds ``referrerpolicy`` and other by YT required permission policies for the iframe.

API Clients that use the YouTube embedded player (including the YouTube IFrame Player API) must provide identification through the HTTP ``Referer`` request header[1].

If the error still occurs, check if server headers (e.g., in .htaccess or Nginx) are overriding the referrer policy[2].

[1] https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity
[2] hint comes from AI: https://chat.mistral.ai
[3] https://developers.google.com/youtube/player_parameters


Close: https://github.com/searxng/searxng/issues/5844