### PR TITLE
[feat] Implement manifest.json

### DIFF
--- a/client/simple/tools/img.ts
+++ b/client/simple/tools/img.ts
@@ -18,8 +18,10 @@ export type Src2Dest = {
  * Convert a list of SVG files to PNG.
  *
  * @param items - Array of SVG files (src: SVG, dest:PNG) to convert.
+ * @param width - (optional) width of the PNG pictures
+ * @param height - (optional) height of the PNG pictures.
  */
-export const svg2png = (items: Src2Dest[]): void => {
+export const svg2png = (items: Src2Dest[], width?: number, height?: number): void => {
   for (const item of items) {
     fs.mkdirSync(path.dirname(item.dest), { recursive: true });
 
@@ -28,6 +30,9 @@ export const svg2png = (items: Src2Dest[]): void => {
         force: true,
         compressionLevel: 9,
         palette: true
+      })
+      .resize(width, height, {
+        fit: "contain"
       })
       .toFile(item.dest)
       .then((info) => {

--- a/client/simple/tools/plg.ts
+++ b/client/simple/tools/plg.ts
@@ -17,13 +17,15 @@ import { type Src2Dest, svg2png, svg2svg } from "./img.ts";
  * Vite plugin to convert a list of SVG files to PNG.
  *
  * @param items - Array of SVG files (src: SVG, dest:PNG) to convert.
+ * @param width - (optional) width of the PNG picture
+ * @param height - (optional) height of the PNG picture
  */
-export const plg_svg2png = (items: Src2Dest[]): Plugin => {
+export const plg_svg2png = (items: Src2Dest[], width?: number, height?: number): Plugin => {
   return {
     name: "searxng-simple-svg2png",
     apply: "build",
     writeBundle: () => {
-      svg2png(items);
+      svg2png(items, width, height);
     }
   };
 };

--- a/client/simple/vite.config.ts
+++ b/client/simple/vite.config.ts
@@ -132,6 +132,28 @@ export default {
       }
     ]),
 
+    // SearXNG PWA Icons (static)
+    plg_svg2png(
+      [
+        {
+          src: `${PATH.brand}/searxng-wordmark.svg`,
+          dest: `${PATH.dist}/img/512.png`
+        }
+      ],
+      512,
+      512
+    ),
+    plg_svg2png(
+      [
+        {
+          src: `${PATH.brand}/searxng-wordmark.svg`,
+          dest: `${PATH.dist}/img/192.png`
+        }
+      ],
+      192,
+      192
+    ),
+
     // -- svg
     plg_svg2svg(
       [

--- a/searx/brand.py
+++ b/searx/brand.py
@@ -18,6 +18,17 @@ class BrandCustom(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):
     """Custom entries in the footer of the WEB page: ``[title]: [link]``"""
 
 
+class ThemeColors(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):
+    """Custom settings for theme colors in the brand section."""
+
+    theme_color_light: str = "#3050ff"
+    background_color_light: str = "#fff"
+    theme_color_dark: str = "#58f"
+    background_color_dark: str = "#222428"
+    theme_color_black: str = "#3050ff"
+    background_color_black: str = "#000"
+
+
 class SettingsBrand(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):
     """Options for configuring brand properties.
 
@@ -53,6 +64,9 @@ class SettingsBrand(msgspec.Struct, kw_only=True, forbid_unknown_fields=True):
     .. autoclass:: searx.brand.BrandCustom
        :members:
     """
+
+    pwa_colors: ThemeColors = msgspec.field(default_factory=ThemeColors)
+    """Custom settings for PWA colors."""
 
     # new_issue_url is a hackish solution tailored for only one hoster (GH).  As
     # long as we don't have a more general solution, we should support it in the

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -28,6 +28,15 @@ brand:
   #   links:
   #     Uptime: https://uptime.searxng.org/history/darmarit-org
   #     About: "https://searxng.org"
+  # pwa_colors:
+  #   # Custom settings for PWA icon an colors used in manifest.json
+  #   # Default colors are:
+  #    theme_color_light: "#3050ff"
+  #    background_color_light: "fff"
+  #    theme_color_dark: "#58f"
+  #    background_color_dark: "#222428"
+  #    theme_color_black: "#3050ff"
+  #    background_color_black: "#000"
 
 search:
   # Filter results. 0: None, 1: Moderate, 2: Strict

--- a/searx/templates/simple/base.html
+++ b/searx/templates/simple/base.html
@@ -26,6 +26,7 @@
   <link rel="icon" href="{{ url_for('static', filename='img/favicon.png') }}" sizes="any">
   <link rel="icon" href="{{ url_for('static', filename='img/favicon.svg') }}" type="image/svg+xml">
   <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/favicon.png') }}">
+  <link rel="manifest" href="{{ url_for('manifest') }}" />
 </head>
 <body class="{{ endpoint }}_endpoint" >
   <main id="main_{{  self._TemplateReference__context.name|replace("simple/", "")|replace(".html", "") }}" class="{{body_class}}">

--- a/searx/templates/simple/manifest.json
+++ b/searx/templates/simple/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "{{ instance_name }}",
+  "short_name": "{{ instance_name }}",
+  "icons": [
+    {
+      "src": "{{ url_for('static', filename='img/favicon.svg', _external=True) }}",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "{{ url_for('static', filename='img/192.png', _external=True) }}",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "{{ url_for('static', filename='img/512.png', _external=True) }}",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "{{ url_for('index') }}",
+  "theme_color": "{{ theme_color }}" ,
+  "background_color": "{{ background_color }}",
+  "display": "standalone"
+}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1216,6 +1216,29 @@ def opensearch():
     return resp
 
 
+@app.route('/manifest.json', methods=['GET'])
+def manifest():
+    theme = sxng_request.preferences.get_value('simple_style')
+    if theme not in ("light", "dark", "black"):
+        theme = "light"
+
+    theme_color = get_setting(f'brand.pwa_colors.theme_color_{theme}')
+    background_color = get_setting(f'brand.pwa_colors.background_color_{theme}')
+    ret = render('manifest.json', theme_color=theme_color, background_color=background_color)
+    resp = Response(response=ret, status=200, mimetype="application/json")
+    return resp
+
+
+@app.route('/logo/<resolution>')
+def manifest_logo(resolution=0):
+    theme = sxng_request.preferences.get_value("theme")
+    return send_from_directory(
+        os.path.join(app.root_path, settings['ui']['static_path'], 'themes', theme, 'img', 'logos'),  # type: ignore
+        resolution,
+        mimetype='image/vnd.microsoft.icon',
+    )
+
+
 @app.route('/favicon.ico')
 def favicon():
     theme = sxng_request.preferences.get_value("theme")


### PR DESCRIPTION
## What does this PR do?

Implementing mainfest.json as template. Add the different logo sizes to simple_theme. And add manifest link in base.html.

## Why is this change important?

Better support for PWAs

## How to test this PR locally?

- Go to /manifest.json and check the manifest
- Go in Firefox development tools in Application -> Manifest the parsed output

## Author's checklist

-

## Related issues

Closes #563 

## AI Disclosure

 - [x] I hereby confirm that I have not used any AI tools for creating this PR.
 - [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
