### PR TITLE
[fix] google engine: Result image thumbnails

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -327,23 +327,16 @@ def request(query: str, params: "OnlineParams") -> None:
     params["headers"].update(google_info["headers"])
 
 
-# =26;[3,"dimg_ZNMiZPCqE4apxc8P3a2tuAQ_137"]a87;data:image/jpeg;base64,/9j/4AAQSkZJRgABA
-# ...6T+9Nl4cnD+gr9OK8I56/tX3l86nWYw//2Q==26;
-RE_DATA_IMAGE = re.compile(r'"(dimg_[^"]*)"[^;]*;(data:image[^;]*;[^;]*);')
-RE_DATA_IMAGE_end = re.compile(r'"(dimg_[^"]*)"[^;]*;(data:image[^;]*;[^;]*)$')
+# regex match to get image map that is found inside the returned javascript:
+# (function(){google.ldi={ ... };google.pim={ ... };google.sib=false;google ...
+RE_DATA_IMAGE = re.compile(r'"((?:dimg|pimg|tsuid)_[^"]*)":"((?:https?:)?//[^"]*)')
 
 
-def parse_data_images(text: str):
+def parse_url_images(text: str):
     data_image_map = {}
 
-    for img_id, data_image in RE_DATA_IMAGE.findall(text):
-        end_pos = data_image.rfind("=")
-        if end_pos > 0:
-            data_image = data_image[: end_pos + 1]
-        data_image_map[img_id] = data_image
-    last = RE_DATA_IMAGE_end.search(text)
-    if last:
-        data_image_map[last.group(1)] = last.group(2)
+    for img_id, image_url in RE_DATA_IMAGE.findall(text):
+        data_image_map[img_id] = image_url.encode('utf-8').decode("unicode-escape")
     logger.debug("data:image objects --> %s", list(data_image_map.keys()))
     return data_image_map
 
@@ -352,7 +345,7 @@ def response(resp: "SXNG_Response"):
     """Get response from google's search request"""
     # pylint: disable=too-many-branches, too-many-statements
     detect_google_sorry(resp)
-    data_image_map = parse_data_images(resp.text)
+    data_image_map = parse_url_images(resp.text)
 
     results = EngineResults()
 
@@ -392,15 +385,16 @@ def response(resp: "SXNG_Response"):
 
             content = extract_text(content_nodes)
 
-            thumbnail = result.xpath(".//img/@src")
-            if thumbnail:
-                thumbnail = thumbnail[0]
+            # Images that are NOT the favicon
+            xpath_image = eval_xpath_getindex(result, './/img[not(@class="XNo5Ab")]', index=0, default=None)
+
+            thumbnail = None
+            if xpath_image is not None:
+                thumbnail = xpath_image.get("src")
                 if thumbnail.startswith("data:image"):
-                    img_id = result.xpath(".//img/@id")
+                    img_id = xpath_image.get("id")
                     if img_id:
-                        thumbnail = data_image_map.get(img_id[0])
-            else:
-                thumbnail = None
+                        thumbnail = data_image_map.get(img_id)
 
             results.append({"url": url, "title": title, "content": content or '', "thumbnail": thumbnail})
 

--- a/searx/engines/google_videos.py
+++ b/searx/engines/google_videos.py
@@ -11,7 +11,7 @@
 .. _data URLs:
    https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 """
-
+import re
 from urllib.parse import urlencode, urlparse, parse_qs, unquote
 from lxml import html
 
@@ -29,7 +29,6 @@ from searx.engines.google import (
     suggestion_xpath,
     detect_google_sorry,
     ui_async,
-    parse_data_images,
 )
 from searx.utils import get_embeded_stream_url
 
@@ -50,6 +49,23 @@ max_page = 50
 language_support = True
 time_range_support = True
 safesearch = True
+
+
+# =26;[3,"dimg_ZNMiZPCqE4apxc8P3a2tuAQ_137"]a87;data:image/jpeg;base64,/9j/4AAQSkZJRgABA
+# ...6T+9Nl4cnD+gr9OK8I56/tX3l86nWYw//2Q==26;
+RE_DATA_IMAGE = re.compile(r'"(dimg_[^"]*)"[^;]*;(data:image[^;]*;[^;]*);?')
+
+
+def parse_data_images(text: str):
+    data_image_map = {}
+
+    for img_id, data_image in RE_DATA_IMAGE.findall(text):
+        end_pos = data_image.rfind("=")
+        if end_pos > 0:
+            data_image = data_image[: end_pos + 1]
+        data_image_map[img_id] = data_image
+    logger.debug("data:image objects --> %s", list(data_image_map.keys()))
+    return data_image_map
 
 
 def request(query, params):


### PR DESCRIPTION
## What does this PR do?

<!-- MANDATORY -->

This PR fixes an issue where the favicon of the results returned by google becomes the thumbnail of the result.

<!-- explain the changes in your PR, algorithms, design, architecture -->

When testing it seems like the old way of matching the image mappings only works for google videos, not normal google searches (tested with some 15 different searches or so). Because of that, I moved the `parse_data_images` function out from the google engine over to the google videos engine. Then I created a new function for the google engine to extract the image map.

I tried my best to stick to already used conventions in the code.

This regex matching also matches in the same way it does for google videos, to group them together by key and value in the for loop.

The links are baked inside a map in the returned javascript from google that looks something like this:

```javascript
google.ldi={"dimg_xdG2afTRA42D9u8PlOnfiAk_7":"https://ssl.gstatic.com/kpui/social/fb_32x32.png","dimg_xdG2afTRA42D9u8PlOnfiAk_9":"https://ssl.gstatic.com/kpui/social/whatsapp_solid_bg_36x36.png","dimg_xdG2afTRA42D9u8PlOnfiAk_11":"https://ssl.gstatic.com/kpui/social/x_32x32.png","dimg_xdG2afTRA42D9u8PlOnfiAk_13":"https://ssl.gstatic.com/images/icons/material/system/1x/email_grey600_24dp.png","tsuid_xdG2afTRA42D9u8PlOnfiAk_89":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcRcWK5oFZZvEyiz_tD49EbW_6TxCK9G8gieIKpZt1z5_ikgTYnTJB5ukfU\u0026s","tsuid_xdG2afTRA42D9u8PlOnfiAk_119":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQLgrMXq5pgXNeINSdKk51g6gRG7etd1BhR5h0Bvdb4DHkGKMopiTbRZwM\u0026s","tsuid_xdG2afTRA42D9u8PlOnfiAk_121":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcRyQcn_b-3MmL3WstFaQNQsvK2YTBLEbhQaId47ggTJrxc5axpSjfMBufs\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_5":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQN2mAikh08TPWZ2g-MiiGRJ3bB8t6y9KSqSRbiijRn-j-9CoP6unVzfmQ\u0026usqp\u003dCAE\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_29":"//encrypted-tbn0.gstatic.com/licensed-image?q\u003dtbn:ANd9GcRLRMibern3MpiGRXhg3f38KrI69TbktpI5NxO097txyAE7lECV0Vm2U_ucvNWIQxjwu5T6J3Dj\u0026s\u003d19","dimg_xdG2afTRA42D9u8PlOnfiAk_35":"//encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcSi3UIxWddgfAQtUm_lXydG4A5hdQFpEs3fsC5NvioBQUucnbHYTUzd\u0026s\u003d0","dimg_xdG2afTRA42D9u8PlOnfiAk_39":"//encrypted-tbn0.gstatic.com/licensed-image?q\u003dtbn:ANd9GcRgR3tws8ht1jwJw4t8jwzYzDmMS2GXNv3K8LucSsS70LcJ_N1Q5xeQYTLr3YLzpkoCRf-yVZI\u0026s\u003d19","dimg_xdG2afTRA42D9u8PlOnfiAk_41":"//encrypted-tbn0.gstatic.com/licensed-image?q\u003dtbn:ANd9GcQO2XlaJGqTtNFD5GZCdn54Xeyq6xywtA2pSPZG0KkZmpZ99B-zZZugKC_p_qKQTYW63XFh25Io\u0026s\u003d19","dimg_xdG2afTRA42D9u8PlOnfiAk_43":"//encrypted-tbn0.gstatic.com/licensed-image?q\u003dtbn:ANd9GcSCOjRzQAwovwAEn0k-HF-eMKK9k8mvvXKLyEKwD3cbl7_HKvIQsvCAmZdMJAwU2LwAprvYbew\u0026s\u003d19","dimg_xdG2afTRA42D9u8PlOnfiAk_45":"//encrypted-tbn0.gstatic.com/licensed-image?q\u003dtbn:ANd9GcQGosCZQGcxBFio77P7DhfyHahNnkYHcY5zIewoaNIDHp0VRRQeCW5jd_XbhxaJlLrZBd4XN75W\u0026s\u003d19","dimg_xdG2afTRA42D9u8PlOnfiAk_47":"//encrypted-tbn0.gstatic.com/licensed-image?q\u003dtbn:ANd9GcS5Vksr0nmVfhc2h_q52VRZXTTktfieaZjZ5K9NJKGnrxMRroS1-hbGt_j4Adeia6M_kZTqqr1D\u0026s\u003d19","dimg_xdG2afTRA42D9u8PlOnfiAk_49":"//encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcRIm3sp3sGPcQyLRU_4Fc3v02N2-wfSwT0YB3TvkBJE8zR08DZ69dPM\u0026s\u003d0","pimg_xdG2afTRA42D9u8PlOnfiAk_1":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcT8wvIPqxau4O7152kzmFl0KePcuG0qlFXBJEVWAS7zietdOy4OJNKJTBY\u0026s","pimg_xdG2afTRA42D9u8PlOnfiAk_3":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQjQB1xsx4kDwcPondeyd4VQsQcWYNSvTOx7H0c7E2_xZcFrmZYe4Cl-y0mrw\u0026s","pimg_xdG2afTRA42D9u8PlOnfiAk_5":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTO9AkX8ohLdFpTqrZM6PHtw0WRSuKsSw6YT5TamtH7FCXwyHr5WPAL6c6viA\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_37":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTl8bXwKGeW7YdFGomugWNeF7ccFdgPJFFBrbVd1XJgyQqWE8RAw5XWs2E\u0026usqp\u003dCAE\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_1":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTJIQekJ7Y2JZIXGhayw_TtizIv0EduhFcJJxgBViWl99OdDGVpunRx2w\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_19":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTZ16z2D1zjNk9ceOjWlK-GqYx1yEISanEB46hPkZLoQT93lCoANragFA\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_21":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcS9uLHbHPLX8QGjwXAr4q1BXNOBFRVt0BkSQ0nSojyu4UrcCgxkvd89BA\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_17":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTbgOEA7t1KHBFw7UyAUwDbMPSBAJuODmtn6eWpBps2JrCVti8n1-Jv08o\u0026s\u003d10","dimg_xdG2afTRA42D9u8PlOnfiAk_25":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTsYVlszXl-q4E8aXUp_HJeQg7KqbVqWkXORcf6PX70aj5TJ6TmDV-_fA0\u0026s\u003d10","dimg_xdG2afTRA42D9u8PlOnfiAk_33":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQhOuV52_WUtpIbwlfUshBZfS4AplNNDZPblL-LCPslfRGjfYUhykwD4iY\u0026s\u003d10","dimg_xdG2afTRA42D9u8PlOnfiAk_3":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcS4Ez4HQAgXVyk7lOILzjBwA5HWGyiS3GkffumSjTVy0WtF80mGoiwDHcc\u0026usqp\u003dCAE\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_15":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcRhbjbhCZ2li0_LyFSH31gzi9LdeH8bYwpSJ3g62C8si2BzhVwnx7hewc0\u0026usqp\u003dCAE\u0026s","dimg_xdG2afTRA42D9u8PlOnfiAk_27":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQUWTGAKLlCPdxr1BDJ8wCkKztIgRhPTplQVcQ9_r0AF4f5XjBZ1L2mr8U\u0026usqp\u003dCAE\u0026s"};google.pim={"pimg_xdG2afTRA42D9u8PlOnfiAk_7":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcS1z0MNdTTI2xe3KYWoZ91bswo5KelsnhVm_9MMHEEv1BDA41on17RlyT-DPhVkaMB_IcXxvJzHjWwLKT1C90ASPranoYMhHXeNQqqH5LOT\u0026s\u003d10","pimg_xdG2afTRA42D9u8PlOnfiAk_13":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTSbYH2uL1Ql3QEblrPooP73v7RqQZ56PHOuG6vTg60l-kEIhpuo-VZyyP___cv3oXS1BhHYVXC17HQej2_FRKojUvSeqJfVCuEmhCdZOR9dA\u0026s\u003d10","pimg_xdG2afTRA42D9u8PlOnfiAk_11":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQYCgr0KGzDR7yD9PStHDaOgqHk00g6mckaypNVPYVWori1Iz7wXca4uYDnQ2cJivbxs1N2igFgs2nZ5KKYwXMohmzUfTxIs-yUNc1_J0gJ\u0026s\u003d10","pimg_xdG2afTRA42D9u8PlOnfiAk_9":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcTm3ujdZndEFQOE75j7HeMz-ARDx8st0KKDIIzNws2CDxSWAbr7K5QjM-fwpEa2ovf-w7WOy-2PWfykYXO8SzcIQ7LD6rMzxGXRq8u6wnahDQ\u0026s\u003d10","pimg_xdG2afTRA42D9u8PlOnfiAk_17":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQtB5rBKNLA3F-6i1ElVN6_5AXjOYEm-UCtWjoi2RU35vcDU2dqS-wFZMVdKgEaTu6SPw6cauWqE3gyi_skaKe9nbsZ-_xbNpDJ6dECpsn2vQ\u0026s\u003d10","pimg_xdG2afTRA42D9u8PlOnfiAk_15":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcQxRCx38MA90Xqk11bWj1A0yCHj3KSl1oQ7DKShD8Rr3ONcUQ_FtTr74s7LYT62u8eR64TWwvthqgUzZfMeQh4gT8Eyxt4sePHhxBU4B2a5\u0026s\u003d10","pimg_xdG2afTRA42D9u8PlOnfiAk_19":"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcR3GYjeZ4AL5bXjn8nugcWMNfDvaSsZ-dj_2JGaI3B0mObnxGLpOqg5jXIiLZ9s8QJqxp_fhmY47JaKyUfrOT3blr7L_hBV-4FbLlYR4iC7\u0026s\u003d10"}
```

The urls in the map are not exactly working links out of the bat, like containing backslash and stuff. This is why `image_url.encode('utf-8').decode("unicode-escape")` was done. To convert:

"https://encrypted-tbn0.gstatic.com/images?q\u003dtbn:ANd9GcR3GYjeZ4AL5bXjn8nugcWMNfDvaSsZ-dj_2JGaI3B0mObnxGLpOqg5jXIiLZ9s8QJqxp_fhmY47JaKyUfrOT3blr7L_hBV-4FbLlYR4iC7\u0026s\u003d10"

into

"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3GYjeZ4AL5bXjn8nugcWMNfDvaSsZ-dj_2JGaI3B0mObnxGLpOqg5jXIiLZ9s8QJqxp_fhmY47JaKyUfrOT3blr7L_hBV-4FbLlYR4iC7&s=10"

I kind of dislike that part of the code, and I could also change it to grab the entire `google.ldi={ ... };google.pim={ ... }` blocks as JSON instead perhaps.. What is faster or not, what is more robust or not I am not sure.

Before (left) and after (right):

<img width="2481" height="1290" alt="image" src="https://github.com/user-attachments/assets/39d8ac81-7493-437c-b238-95ced5a3d492" />

<img width="2472" height="1283" alt="image" src="https://github.com/user-attachments/assets/31b6b43a-00f7-4cca-8d46-6abe3bf115be" />


## Why is this change important?

<!-- MANDATORY -->

Google is one of the most important engines of SearXNG, and it is important that it is robust.

<!-- explain the motivation behind your PR -->

I wanted to take a grip at what was previously done by @SeriousConcept1134 in his previously closed PRs (https://github.com/searxng/searxng/pull/5846 https://github.com/searxng/searxng/pull/5850 ).

My solution has obviously taken inspiration from his solution.

## How to test this PR locally?

To test that thumbnails are showing up, search for something using the google engine that is very likely to show images. In my examples, I used this search query: `!go norwegian forest cat`.

To test that the favicon thumbnails are gone, just search for `!go test`

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

@vojkovic - If you can check if the google shopping sidebar issue appears as discussed in #5843. I think this PR likely does not fix that part. I am struggling a bit to reproduce it.

<!-- additional notes for reviewers -->

## Related issues

Closes #5843

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [ ] I hereby confirm that I have not used any AI tools for creating this PR.
- [X] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.

I used deepseek to give me a clue on how to decode the `image_url` to a working URL. I also looked at many other alternatives before deciding to pick its suggestion.

I also sometimes use Jetbrains built-in autocomplete, pressing TAB to autocomplete their AI suggestion. This is mostly for boilerplate code, and I don't think it was ever used in this PR.