### PR TITLE
[enh] preferences: extend preferences.lock to cover hotkeys, url_formatting, engines and plugins

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -262,6 +262,8 @@ class BooleanChoices:
         return values
 
     def parse_cookie(self, data_disabled: str, data_enabled: str):
+        if self.locked:
+            return
         for disabled in data_disabled.split(','):
             if disabled in self.choices:
                 self.choices[disabled] = False
@@ -303,14 +305,14 @@ class BooleanChoices:
 class EnginesSetting(BooleanChoices):
     """Engine settings"""
 
-    def __init__(self, default_value, engines: Iterable[Engine]):
+    def __init__(self, default_value, engines: Iterable[Engine], locked: bool = False):
         choices = {}
         for engine in engines:
             for category in engine.categories:
                 if not category in list(settings['categories_as_tabs'].keys()) + [DEFAULT_CATEGORY]:
                     continue
                 choices['{}__{}'.format(engine.name, category)] = not engine.disabled
-        super().__init__(default_value, choices)
+        super().__init__(default_value, choices, locked)
 
     def transform_form_items(self, items):
         return [item[len('engine_') :].replace('_', ' ').replace('  ', '__') for item in items]
@@ -328,8 +330,8 @@ class EnginesSetting(BooleanChoices):
 class PluginsSetting(BooleanChoices):
     """Plugin settings"""
 
-    def __init__(self, default_value, plugins: Iterable[searx.plugins.Plugin]):
-        super().__init__(default_value, {plugin.id: plugin.active for plugin in plugins})
+    def __init__(self, default_value, plugins: Iterable[searx.plugins.Plugin], locked: bool = False):
+        super().__init__(default_value, {plugin.id: plugin.active for plugin in plugins}, locked)
 
     def transform_form_items(self, items):
         return [item[len('plugin_') :] for item in items]
@@ -482,17 +484,19 @@ class Preferences:
             ),
             'hotkeys': EnumStringSetting(
                 settings['ui']['hotkeys'],
-                choices=['default', 'vim']
+                choices=['default', 'vim'],
+                locked=is_locked('hotkeys')
             ),
             'url_formatting': EnumStringSetting(
                 settings['ui']['url_formatting'],
-                choices=['pretty', 'full', 'host']
+                choices=['pretty', 'full', 'host'],
+                locked=is_locked('url_formatting')
             ),
             # fmt: on
         }
 
-        self.engines = EnginesSetting('engines', engines=engines.values())
-        self.plugins = PluginsSetting('plugins', plugins=plugins)
+        self.engines = EnginesSetting('engines', engines=engines.values(), locked=is_locked('engines'))
+        self.plugins = PluginsSetting('plugins', plugins=plugins, locked=is_locked('plugins'))
         self.tokens = SetSetting('tokens')
         self.client = client or ClientPref()
 
@@ -582,8 +586,10 @@ class Preferences:
             if self.key_value_settings[user_setting_name].locked:
                 continue
             user_setting.save(user_setting_name, resp)
-        self.engines.save(resp)
-        self.plugins.save(resp)
+        if not self.engines.locked:
+            self.engines.save(resp)
+        if not self.plugins.locked:
+            self.plugins.save(resp)
         self.tokens.save('tokens', resp)
         return resp
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -164,6 +164,10 @@ ui:
 #     - method
 #     - image_proxy
 #     - query_in_title
+#     - hotkeys         # Locks hotkey style; hides the UI control
+#     - url_formatting  # Locks URL display format; hides the UI control
+#     - engines         # Ignores user engine enable/disable changes; hides the Engines tab
+#     - plugins         # Ignores user plugin enable/disable changes; hides plugin toggles
 
 # communication with search engines
 #

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -187,7 +187,9 @@
       {%- include 'simple/preferences/safesearch.html' -%}
     {%- endif -%}
     {%- include 'simple/preferences/tokens.html' -%}
-    {{- plugin_preferences('general') -}}
+    {%- if 'plugins' not in locked_preferences -%}
+      {{- plugin_preferences('general') -}}
+    {%- endif -%}
 
 
     {%- if 'doi_resolver' not in locked_preferences %}
@@ -210,9 +212,15 @@
     {%- if 'search_on_category_select' not in locked_preferences -%}
       {%- include 'simple/preferences/search_on_category_select.html' -%}
     {%- endif -%}
-    {%- include 'simple/preferences/hotkeys.html' -%}
-    {%- include 'simple/preferences/urlformatting.html' -%}
-    {{- plugin_preferences('ui') -}}
+    {%- if 'hotkeys' not in locked_preferences -%}
+      {%- include 'simple/preferences/hotkeys.html' -%}
+    {%- endif -%}
+    {%- if 'url_formatting' not in locked_preferences -%}
+      {%- include 'simple/preferences/urlformatting.html' -%}
+    {%- endif -%}
+    {%- if 'plugins' not in locked_preferences -%}
+      {{- plugin_preferences('ui') -}}
+    {%- endif -%}
     {{- tab_footer() -}}
 
     {# tab: privacy #}
@@ -227,11 +235,14 @@
     {%- if 'query_in_title' not in locked_preferences -%}
       {%- include 'simple/preferences/query_in_title.html' -%}
     {%- endif -%}
-    {{- plugin_preferences('privacy') -}}
+    {%- if 'plugins' not in locked_preferences -%}
+      {{- plugin_preferences('privacy') -}}
+    {%- endif -%}
     {{- tab_footer() -}}
 
     {# tab: enignes #}
 
+    {%- if 'engines' not in locked_preferences -%}
     {{- tab_header('maintab', 'engines', _('Engines')) -}}
     <p>
       {{- _('Currently used search engines') -}}
@@ -240,6 +251,7 @@
     {%- include 'simple/preferences/engines.html' -%}
     {{- tabs_close() -}}
     {{- tab_footer() -}}
+    {%- endif -%}
 
     {# tab: query #}
 

--- a/searx/templates/simple/preferences/answerers.html
+++ b/searx/templates/simple/preferences/answerers.html
@@ -33,7 +33,11 @@
     {%- for plugin in plugins_storage -%}
       {%- if plugin.preference_section == 'query' -%}
         <tr>{{- '' -}}
-          <td class="checkbox-col">{{- checkbox_onoff_reversed('plugin_' + plugin.id, plugin.id not in allowed_plugins, 'plugin_labelledby' + plugin.id) -}}</td>{{- '' -}}
+          <td class="checkbox-col">
+            {%- if 'plugins' not in locked_preferences -%}
+              {{- checkbox_onoff_reversed('plugin_' + plugin.id, plugin.id not in allowed_plugins, 'plugin_labelledby' + plugin.id) -}}
+            {%- endif -%}
+          </td>{{- '' -}}
           <td>{{ plugin.keywords|join(', ') }}</td>{{- '' -}}
           <td>{{ _(plugin.name) }}</td>{{- '' -}}
           <td id="{{ 'plugin_labelledby' + plugin.id }}">{{ _(plugin.description) }}</td>{{- '' -}}


### PR DESCRIPTION
The `preferences.lock` mechanism in `settings.yml` allows administrators to lock user preferences for managed/shared instances.  However, four controls were previously not lockable: `hotkeys`, `url_formatting`, engine toggles, and plugin toggles.

This means an admin deploying SearXNG for an organisation could not prevent users from changing their hotkey style, URL display format, or the active set of engines and plugins — defeating the purpose of a controlled deployment.

**Changes**

- `searx/preferences.py`:
  - `BooleanChoices.parse_cookie`: honour the `locked` flag (skip cookie parsing when the setting is locked, consistent with the existing behaviour of `parse_form`).
  - `EnginesSetting` / `PluginsSetting`: accept a `locked` parameter and forward it to `BooleanChoices.__init__`.
  - `Preferences.__init__`: wire `locked=is_locked('engines')` and `locked=is_locked('plugins')` into the two `BooleanChoices` subclasses; add `locked=is_locked('hotkeys')` and `locked=is_locked('url_formatting')` to their `EnumStringSetting` constructors.
  - `Preferences.save`: skip `engines.save` / `plugins.save` when the respective setting is locked so no stale cookies are written.

- `searx/templates/simple/preferences.html`:
  - Wrap the `hotkeys` and `urlformatting` includes with `{% if 'hotkeys'/'url_formatting' not in locked_preferences %}`.
  - Wrap every `plugin_preferences(section)` call (general / ui / privacy) with `{% if 'plugins' not in locked_preferences %}`.
  - Wrap the entire Engines tab (`tab_header` … `tab_footer`) with `{% if 'engines' not in locked_preferences %}`.

- `searx/templates/simple/preferences/answerers.html`:
  - Suppress the plugin toggle checkbox in the *Special Queries* tab when `'plugins' in locked_preferences`.

- `searx/settings.yml`:
  - Document the four new keys in the `preferences.lock` comment block.

**Backward compatibility**

All four keys are opt-in via `preferences.lock` and the list defaults to empty, so existing deployments are unaffected.

**How to test**

Add any combination of the new keys to `settings.yml`:

```yaml
preferences:
  lock:
    - hotkeys
    - url_formatting
    - engines
    - plugins
```

https://github.com/searxng/searxng/issues/5878

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [ ] I hereby confirm that I have not used any AI tools for creating this PR.
- [x] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
