### PR TITLE
Fill in template in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,9 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    SearXNG is a metasearch engine. Users are neither tracked nor profiled.
+    Copyright (C) 2026  Markus Heiser, Ivan Gabaldon, Paul Braeuning, 
+    Léon Tiekötter, Bnyro and Brock Vojkovic
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
Changed some forgotten template fields of the AGPLv3 LICENSE according to the 
project site's informations. This is done to prevent potential upcoming problems 
with lawsuits in the future. 