### PR TITLE
[mod] drop support for Python releases older than 4 years

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # minimal version we support
-python = "3.10"
+python = "3.11"
 node = "25"
 go = "1.24.5"
 shellcheck = "0.11.0"


### PR DESCRIPTION
The end-of-life (EOL) of a Python release is reached after 5 years, with the last three years dedicated to security fixes. [1]

Unfortunately, this doesn't apply to common libraries (dependencies): bug fixes are often only included in major releases, and minor releases with corresponding security fixes are rarely offered.

To make matters worse, these dependencies often prematurely discontinue their support for older Python releases (because, for example, they want/need to use new Python features).

If we want to offer secure software, we are faced with the dilemma of either supporting old Python releases and accepting that there are security bugs in the dependencies, or ending support for older Python versions before the actual EOL of the Python release.

[1] https://devguide.python.org/versions/

- Closes: https://github.com/searxng/searxng/issues/5869