### PR TITLE
[enh] py: add default HTTP headers

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -113,10 +113,7 @@ server:
   # Is overwritten by ${SEARXNG_METHOD}
   method: "POST"
   default_http_headers:
-    X-Content-Type-Options: nosniff
-    X-Download-Options: noopen
-    X-Robots-Tag: noindex, nofollow
-    Referrer-Policy: no-referrer
+    Server: SearXNG
 
 valkey:
   # URL to connect valkey database. Is overwritten by ${SEARXNG_VALKEY_URL}.

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -521,7 +521,21 @@ def pre_request():
 @app.after_request
 def add_default_headers(response: flask.Response):
     # set default http headers
-    for header, value in settings['server']['default_http_headers'].items():
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https:; "
+        "font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self'; img-src * data:; "
+        "frame-src https:; manifest-src 'self';"
+    )
+    response.headers["Permissions-Policy"] = (
+        "accelerometer=(),camera=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()"
+    )
+    response.headers["Referrer-Policy"] = "same-origin"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Download-Options"] = "noopen"
+    response.headers["X-Robots-Tag"] = "noindex, noimageindex, nofollow"
+
+    for header, value in settings["server"]["default_http_headers"].items():
         if header in response.headers:
             continue
         response.headers[header] = value
@@ -1384,9 +1398,21 @@ def init():
 
 
 def static_headers(headers: Headers, _path: str, _url: str) -> None:
-    headers['Cache-Control'] = 'public, max-age=30, stale-while-revalidate=60'
+    headers["Cache-Control"] = "public, max-age=30, stale-while-revalidate=60"
+    headers["Content-Security-Policy"] = (
+        "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https:; "
+        "font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self'; img-src * data:; "
+        "frame-src https:; manifest-src 'self';"
+    )
+    headers["Permissions-Policy"] = (
+        "accelerometer=(),camera=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()"
+    )
+    headers["Referrer-Policy"] = "same-origin"
+    headers["X-Content-Type-Options"] = "nosniff"
+    headers["X-Download-Options"] = "noopen"
+    headers["X-Robots-Tag"] = "noindex, noimageindex, nofollow"
 
-    for header, value in settings['server']['default_http_headers'].items():
+    for header, value in settings["server"]["default_http_headers"].items():
         # cast value to string, as WhiteNoise requires header values to be strings
         headers[header] = str(value)
 


### PR DESCRIPTION
Set default HTTP headers from the [searxng-docker repo](https://github.com/searxng/searxng-docker/blob/master/Caddyfile) on both dynamic and static assets.

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [x] I hereby confirm that I have not used any AI tools for creating this PR.
- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.