### PR TITLE
[fix] engine - karmasearch crash when searching with long queries

### DIFF
--- a/searx/engines/karmasearch.py
+++ b/searx/engines/karmasearch.py
@@ -125,7 +125,11 @@ def _parse_images(result: dict[str, t.Any]) -> LegacyResult:
 def response(resp: "SXNG_Response") -> EngineResults:
     res = EngineResults()
 
-    for result in resp.json()["results"]:
+    json_resp: dict[str, t.Any] = resp.json()
+    if not isinstance(json_resp, dict):
+        return res  # pyright: ignore[reportUnreachable]
+
+    for result in json_resp["results"]:
         # hide sponsored results
         if result.get("sponsored", False):
             continue


### PR DESCRIPTION
Karmasearch seem to crash when searching with long queries >= 100 characters. The returned JSON is exactly this `["",[]]`, which will crash when trying to access `resp.json()["results"]`

Close: 

- https://github.com/searxng/searxng/issues/5911

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [x] I hereby confirm that I have not used any AI tools for creating this PR.
