### PR TITLE
[fix] google: improve CAPTCHA detection and use suspended_time=0

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -278,8 +278,26 @@ def get_google_info(params: "OnlineParams", eng_traits: EngineTraits) -> dict[st
     return ret_val
 
 
-def detect_google_sorry(resp):
+def detect_google_sorry(resp: "SXNG_Response"):
+    """Detect Google's bot-protection responses (CAPTCHA / sorry pages).
+
+    Google may block requests in several ways:
+
+    1. Redirect to sorry.google.com (standard CAPTCHA).
+    2. HTTP 302 redirect to ``/sorry/index?...`` on the same host -- when the
+       HTTP client doesn't follow the redirect, the response body is a short
+       HTML stub with a link to the sorry page.
+    3. Short HTML response (<2000 bytes) containing "/sorry/" -- a meta-refresh
+       or JS redirect variant.
+    """
+
     if resp.url.host == "sorry.google.com" or resp.url.path.startswith("/sorry"):
+        raise SearxEngineCaptchaException()
+
+    if resp.status_code == 302:
+        raise SearxEngineCaptchaException()
+
+    if len(resp.text) < 2000 and "/sorry/" in resp.text:
         raise SearxEngineCaptchaException()
 
 


### PR DESCRIPTION
## What does this PR do?

Improves `detect_google_sorry()` in `searx/engines/google.py` to catch two additional block scenarios that currently cause the engine to silently return 0 results:

1. **HTTP 302 responses**: Google redirects blocked IPs to `/sorry/index?...` via HTTP 302. When `httpx` doesn't follow the redirect, the engine receives a 302 response with a short HTML body containing a link to the sorry page. The current check only inspects `resp.url.host` and `resp.url.path`, which still point to the original search URL — so the block goes undetected and the parser returns 0 results without any error.

2. **Short HTML with `/sorry/` link**: Some Google block variants return a small HTML stub (<2000 bytes) with a meta-refresh or anchor to `/sorry/index?...`. This is now detected by checking the response body length and content.

~Additionally, all `SearxEngineCaptchaException` calls now use `suspended_time=0` instead of the default (which reads `search.suspended_times.SearxEngineCaptcha`, defaulting to 86400 seconds = 24 hours). With `suspended_time=0`, the engine is immediately available for the next request. This is particularly important when using rotating outgoing proxies, since the next request will go through a different IP anyway — suspending the engine for 24 hours after a single CAPTCHA hit on one IP penalizes all subsequent users/requests unnecessarily.~

Instances with rotating IPs can set the `suspended_times.SearxEngineCaptcha` to 0 in the [search settings](https://docs.searxng.org/admin/settings/settings_search.html), the next request will typically use a different outgoing IP when rotating proxies are configured

Since `detect_google_sorry` is imported and used by `google_images.py`, `google_news.py`, and `google_videos.py`, all four Google engines benefit from this fix.

## Why is this change important?

When running SearXNG behind residential rotating proxies (e.g. via `outgoing.proxies`), a significant percentage of requests (~30-50% depending on the proxy provider) hit IPs that Google blocks. The current detection only catches the `sorry.google.com` host redirect, missing the 302 and short-body variants. This causes the engine to silently return empty results — no error is logged, no exception is raised, and the user gets 0 Google results without knowing why.

With this fix, all three block variants are properly detected and raise `SearxEngineCaptchaException`, which:
- Logs the error so admins can see the block rate
- Allows SearXNG's retry/fallback logic to handle it
- With `suspended_time=0`, doesn't unnecessarily disable the engine

## How to test this PR locally?

1. Configure SearXNG with a proxy that occasionally triggers Google CAPTCHAs
2. Make repeated Google searches and observe that 302 responses are now properly caught (check logs for CAPTCHA exceptions instead of silent 0-result responses)
3. Verify that `suspended_time=0` keeps the engine available for immediate retry
4. Normal operation (no proxy, no CAPTCHAs) is unaffected — the new checks only trigger on 302 status codes and very short response bodies

## AI Disclosure

AI tools (Claude) were used for researching the SearXNG codebase, understanding the `detect_google_sorry()` flow, and identifying the root cause (HTTP 302 responses not being caught). The fix itself was designed and validated by running real tests against Google through residential proxies, confirming that ~50% of failures are 302 redirects to `/sorry/index?...` that bypass the current detection. The PR description was written by the author.