### PR TITLE
[fix] tubearchivist engine: add trailing slash to API URL

### DIFF
--- a/searx/engines/tubearchivist.py
+++ b/searx/engines/tubearchivist.py
@@ -127,7 +127,7 @@ def request(query, params):
         return False
 
     args = {'query': query}
-    params['url'] = f"{base_url.rstrip('/')}/api/search?{urlencode(args)}"
+    params['url'] = f"{base_url.rstrip('/')}/api/search/?{urlencode(args)}"
     params['headers']['Authorization'] = f'Token {ta_token}'
 
     return params


### PR DESCRIPTION
## What does this PR do?

The base URL for tubearchivist's search now requires a trailing backslash (`/`). This is required because TubeArchivist rewrote the backend to Django. Django will return a 404 without the trailing slash.

## Why is this change important?

The TubeArchivist engine is broken actively without this trailing backslash since the TubeArchivist update.

## How to test this PR locally?

Have an existing TubeArchivist instance.
Use the existing instance, note that it breaks, in the UI it reports a 404 error.
Adding the slash then resolves this issue.

## Author's checklist


## Related issues

<!--
Closes #234
-->

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [x] I hereby confirm that I have not used any AI tools for creating this PR.
- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
