### PR TITLE
DDG: Restoring Sec-Fetch-* headers

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -379,6 +379,12 @@ def request(query: str, params: "OnlineParams") -> None:
     # The vqd value is generated from the query and the UA header. To be able to
     # reuse the vqd value, the UA header must be static.
     headers["User-Agent"] = _HTTP_User_Agent
+
+    headers["Sec-Fetch-Dest"] = "document"
+    headers["Sec-Fetch-Mode"] = "navigate"
+    headers["Sec-Fetch-Site"] = "same-origin"
+    headers["Sec-Fetch-User"] = "?1"
+
     headers["Referer"] = "https://html.duckduckgo.com/"
 
     ui_lang = params["searxng_locale"]


### PR DESCRIPTION
## What does this PR do?

Looks like those headers are needed to bypass the bot detection.

Those were removed in 2e6eeb1 saying that "Sec-Fetch-* headers are already set by the OnlineProcessor". But in 029b74e those headers were removed from OnlineProcessor.

## Why is this change important?

DDG is blocking requests pretty fast, just two consecutive searches without a few seconds is enought to get blocked

## How to test this PR locally?

Open several tabs (like 4) to search simultaneously.

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

Should fix or improve #4824 

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [X] I hereby confirm that I have not used any AI tools for creating this PR.
- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
