### PR TITLE
[fix] karmasearch engine: setting Referer header to bypass bot detection

### DIFF
--- a/searx/engines/karmasearch.py
+++ b/searx/engines/karmasearch.py
@@ -64,6 +64,9 @@ def request(query: str, params: "OnlineParams") -> None:
     if params["time_range"]:
         args["freshness"] = time_range_map[params["time_range"]]
 
+    # Needed to circumvent Cloudflare bot protection
+    params['headers']['Referer'] = "https://karmasearch.org"
+
     params["url"] = f"{base_url}/search/{search_type}?{urlencode(args)}"
 
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a "Referer" header when searching towards Karmasearch so that the Cloudflare bot protection doesn't show up. As I remember it, Karmasearch was added a few weeks ago, and was rate-limiting SearXNG pretty fast after that was made. I don't know how long this solution will hold.

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

Right now Karmasearch returns a 403 for all SearXNG searches.

I think Karmasearch gives good results, and that it is important that the engine works.

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

make run
<!-- commands to run the tests or instructions to test the changes -->

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [x] I hereby confirm that I have not used any AI tools for creating this PR.
- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
