### PR TITLE
[fix] pexels: circumvent botdetection by passing referer header

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ typer==0.24.1
 isodate==0.7.2
 whitenoise==6.12.0
 typing-extensions==4.15.0
-cloudscraper==1.2.71

--- a/searx/engines/pexels.py
+++ b/searx/engines/pexels.py
@@ -25,6 +25,11 @@ about = {
 
 base_url = 'https://www.pexels.com'
 categories = ['images']
+
+api_key = "H2jk9uKnhRmL6WPwh89zBezWvr"
+"""
+Fallback API key to use when SearXNG fails to automatically extract one from the website.
+"""
 results_per_page = 20
 
 paging = True
@@ -87,10 +92,14 @@ def request(query, params):
     # cache api key for future requests
     secret_key = CACHE.get(SECRET_KEY_DB_KEY)
     if not secret_key:
-        secret_key = _get_secret_key()
-        CACHE.set(SECRET_KEY_DB_KEY, secret_key)
+        try:
+            secret_key = _get_secret_key()
+            CACHE.set(SECRET_KEY_DB_KEY, secret_key)
+        except SearxEngineAPIException as e:
+            logger.debug("failed to extract API key %s" % e)
+            secret_key = api_key
 
-    params["headers"]["secret-key"] = CACHE.get(SECRET_KEY_DB_KEY)
+    params["headers"]["secret-key"] = secret_key
 
     return params
 

--- a/searx/engines/pexels.py
+++ b/searx/engines/pexels.py
@@ -6,10 +6,8 @@ import re
 from urllib.parse import urlencode
 from lxml import html
 
-import cloudscraper
-
 from searx.result_types import EngineResults
-from searx.utils import eval_xpath_list
+from searx.utils import eval_xpath_list, gen_useragent
 from searx.enginelib import EngineCache
 from searx.exceptions import SearxEngineAPIException
 from searx.network import get
@@ -40,6 +38,8 @@ SECRET_KEY_DB_KEY = "secret-key"
 CACHE: EngineCache
 """Cache to store the secret API key for the engine."""
 
+enable_http2 = False
+
 
 def init(engine_settings):
     global CACHE  # pylint: disable=global-statement
@@ -47,8 +47,15 @@ def init(engine_settings):
 
 
 def _get_secret_key():
-    scraper = cloudscraper.create_scraper()
-    resp = scraper.get(base_url)
+    resp = get(
+        base_url,
+        headers={
+            # circumvents Cloudflare bot protections
+            "User-Agent": gen_useragent(),
+            "Referer": base_url,
+        },
+    )
+
     if resp.status_code != 200:
         raise SearxEngineAPIException("failed to obtain secret key")
 


### PR DESCRIPTION
As a side effect, Cloudscraper is no longer needed.
It probably only ever worked by setting the correct request headers,
so we don't really need it since we can just set the right request
headers and ciphersuites ourselves.
