### PR TITLE
[fix] tagesschau: parse error when there's no first sentence

### DIFF
--- a/searx/engines/tagesschau.py
+++ b/searx/engines/tagesschau.py
@@ -81,7 +81,7 @@ def _story(item):
         'title': item['title'],
         'thumbnail': item.get('teaserImage', {}).get('imageVariants', {}).get('16x9-256'),
         'publishedDate': datetime.strptime(item['date'][:19], '%Y-%m-%dT%H:%M:%S'),
-        'content': item['firstSentence'],
+        'content': item.get('firstSentence'),
         'url': item['shareURL'] if use_source_url else item['detailsweb'],
     }
 


### PR DESCRIPTION
Example:
```json
{
    "sophoraId" : "rbb-von-24-trockentoiletten-in-berliner-parks-bleiben-acht-im-betrieb-102",
    "externalId" : "tagesschau_fm-story-rbb_park-toilette-klimafreundlich",
    "title" : "Von 24 Trockentoiletten in Berliner Parks bleiben acht im Betrieb",
    "date" : "2026-04-09T19:16:51.000+02:00",
    "teaserImage" : {
      "title" : "402109255",
      "copyright" : "dpa/Paul Zinken",
      "alttext" : "\"Toilette\" steht auf dem Schild an einer neuen Parktoilette in einem Park in Berlin. (Quelle: dpa/Paul Zinken)",
      "imageVariants" : {
        "1x1-144" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStQvU/1x1-144.jpg",
        "1x1-256" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStSJ8/1x1-256.jpg",
        "1x1-432" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStTkw/1x1-432.jpg",
        "1x1-640" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStU_E/1x1-640.jpg",
        "1x1-840" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStWZo/1x1-840.jpg",
        "16x9-256" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvh0M/16x9-256.jpg",
        "16x9-384" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvjXw/16x9-384.jpg",
        "16x9-512" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvlIQ/16x9-512.jpg",
        "16x9-640" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvmjA/16x9-640.jpg",
        "16x9-960" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvpk8/16x9-960.jpg",
        "16x9-1280" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSveow/16x9-1280.jpg",
        "16x9-1920" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvgNE/16x9-1920.jpg"
      },
      "type" : "image"
    },
    "tags" : [ {
      "tag" : "rbb"
    }, {
      "tag" : "Berlin"
    } ],
    "updateCheckUrl" : "https://www.tagesschau.de/api2u/rbb-von-24-trockentoiletten-in-berliner-parks-bleiben-acht-im-betrieb-102.json?view=hasChanged&lastKnown=C168EFEC89F7D1C16BC08D8E641A0503",
    "content" : [ {
      "value" : "Von 24 kostenlosen Trockentoiletten in Berliner Parks sind 16 Anlagen im März wieder abgebaut worden. Acht Toiletten werden nach Auskunft der Senatsverwaltung für Klimaschutz und Umwelt weiterbetrieben.",
      "type" : "text"
    }, {
      "value" : "Die Toiletten waren laut den Angaben der Senatsverwaltung Teil eines Pilotprojekts. Es startete im März 2023 und war zunächst als einjähriger Test angelegt. Für den Fall einer positiven Nutzung und eines reibungslosen Betriebs wurden vertraglich zwei Verlängerungsoptionen von jeweils einem weiteren Jahr vorgesehen. Diese Optionen seien in Anspruch genommen worden und nun ausgeschöpft.",
      "type" : "text"
    }, {
      "value" : "<h2>Nutzer waren zufrieden</h2>",
      "type" : "headline"
    }, {
      "value" : "Dabei waren die Nutzerinnen und Nutzer offensichtlich recht zufrieden mit den Klos, wie aus Befragungsdaten der Senatsverwaltung hervorgeht. Die Befragten bewerteten die Toiletten weitgehend als attraktiv. Auch die Sauberkeit und der Geruch wurden überwiegend positiv bewertet. [<a href=\"https://www.berlin.de/sen/uvk/mobilitaet-und-verkehr/infrastruktur/oeffentliche-toiletten/klimafreundliche-parktoiletten/\" type=\"extern\">berlin.de</a>]",
      "type" : "text"
    }, {
      "box" : {
        "text" : "<ul><br/><li>Lichtenberg: Naturerfahrungsraum Herzberge (neuer Standort)</li><br/><li>Mitte: Kulturforum (neuer Standort)</li><br/><li>Steglitz-Zehlendorf: Stadtpark Steglitz und Spielplatz am Lauenburger Platz</li><br/><li>Tempelhof-Schöneberg: Cheruskerpark und Heinrich-Lassen-Park</li><br/><li>Friedrichshain-Kreuzberg: Engelwiese Alt-Stralau</li><br/><li>Treptow-Köpenick: Wuhlheide an der Treskowallee</li><br/></ul>",
        "title" : "Diese Trockentoiletten werden weiterbetrieben",
        "infobox" : false
      },
      "type" : "box"
    }, {
      "value" : "<h2>Neues Vergabeverfahren für Parktoiletten</h2>",
      "type" : "headline"
    }, {
      "value" : "Im Anschluss an das Pilotprojekt sei geplant, im Rahmen eines Vergabeverfahrens neue Parktoiletten zu beschaffen, teilte ein Sprecher der Senatsverwaltung rbb|24 mit. Wie genau diese Anlagen aussehen sollen, wurde nicht gesagt. Die Versorgung solle aber durch \"modernere Anlagen mit höheren Kapazitäten und einer besseren Barrierefreiheit\" verbessert werden.<br /> <br />Das Vergabeverfahren wird den Angaben zufolge derzeit vorbereitet, sodass die ersten neuen Anlagen möglichst ab 2027 errichtet werden können.",
      "type" : "text"
    }, {
      "value" : "Sendung: rbb|24, 09.04.2026, 19:16 Uhr<br /> <br />Video: rbb|24, 09.04.2026, Johanna Steinlen",
      "type" : "text"
    } ],
    "tracking" : [ {
      "sid" : "app.inland.regional.berlin.rbb-von-24-trockentoiletten-in-berliner-parks-bleiben-acht-im-betrieb-102",
      "src" : "rbb",
      "ctp" : "nicht-definiert",
      "pdt" : "20260409T1920",
      "otp" : "meldung",
      "cid" : "rbb-von-24-trockentoiletten-in-berliner-parks-bleiben-acht-im-betrieb-102",
      "pti" : "Von_24_Trockentoiletten_in_Berliner_Parks_bleiben_acht_im_Betrieb",
      "bcr" : "nein",
      "type" : "generic",
      "av_full_show" : false
    } ],
    "topline" : "Berlin",
    "images" : [ {
      "title" : "402109255",
      "copyright" : "dpa/Paul Zinken",
      "alttext" : "\"Toilette\" steht auf dem Schild an einer neuen Parktoilette in einem Park in Berlin. (Quelle: dpa/Paul Zinken)",
      "imageVariants" : {
        "1x1-144" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStQvU/1x1-144.jpg",
        "1x1-256" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStSJ8/1x1-256.jpg",
        "1x1-432" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStTkw/1x1-432.jpg",
        "1x1-640" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStU_E/1x1-640.jpg",
        "1x1-840" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSStWZo/1x1-840.jpg",
        "16x9-256" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvh0M/16x9-256.jpg",
        "16x9-384" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvjXw/16x9-384.jpg",
        "16x9-512" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvlIQ/16x9-512.jpg",
        "16x9-640" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvmjA/16x9-640.jpg",
        "16x9-960" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvpk8/16x9-960.jpg",
        "16x9-1280" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSveow/16x9-1280.jpg",
        "16x9-1920" : "https://images.tagesschau.de/image/5dad7c26-72b0-4c5c-9758-cf3e351d86ac/AAABnXNCEmI/AAABnSSvgNE/16x9-1920.jpg"
      },
      "type" : "image"
    } ],
    "brandingImage" : {
      "title" : "Logo Rundfunk Berlin-Brandenburg",
      "copyright" : "rbb24",
      "alttext" : "Logo Rundfunk Berlin-Brandenburg",
      "imageVariants" : {
        "original" : "https://images.tagesschau.de/image/e03b1ea1-c03d-4d50-bfb2-41c40808e93a/AAABlaqAiSQ/AAABnR8VW9w/original.png"
      },
      "type" : "image"
    },
    "details" : "https://www.tagesschau.de/api2u/inland/regional/berlin/rbb-von-24-trockentoiletten-in-berliner-parks-bleiben-acht-im-betrieb-102.json",
    "detailsweb" : "https://www.tagesschau.de/inland/regional/berlin/rbb-von-24-trockentoiletten-in-berliner-parks-bleiben-acht-im-betrieb-102.html",
    "shareURL" : "https://www.rbb24.de/panorama/beitrag/2026/04/park-toilette-klimafreundlich.html",
    "geotags" : [ ],
    "regionId" : 3,
    "regionIds" : [ 3 ],
    "breakingNews" : false,
    "type" : "story"
  }
```
