### PR TITLE
[mod] result templates: move iframe to macro and fix page rendering for non-YouTube links

### DIFF
--- a/searx/templates/simple/macros.html
+++ b/searx/templates/simple/macros.html
@@ -67,3 +67,13 @@
          class="checkbox-onoff"{{- ' ' -}}
          {%- if checked -%} checked{%- endif -%}/>
 {%- endmacro -%}
+
+<!-- iframe that additionally sets some extra feature attrs for videos -->
+{%- macro iframe(iframe_src) -%}
+  <iframe data-src="{{iframe_src}}" frameborder="0" allowfullscreen
+    {% if result.parsed_url.hostname in ("www.youtube.com", ) -%}
+    allow="picture-in-picture" referrerpolicy="origin"
+    {%- endif -%}
+    >
+  </iframe>
+{%- endmacro -%}

--- a/searx/templates/simple/result_templates/default.html
+++ b/searx/templates/simple/result_templates/default.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer with context %}
+{% from 'simple/macros.html' import iframe, result_header, result_sub_header, result_sub_footer, result_footer with context %}
 
 {{ result_header(result, favicons, image_proxify) -}}
 {{- result_sub_header(result) -}}
@@ -17,7 +17,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-media-{{ index }}" class="embedded-content invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen></iframe>
+  {{ iframe(result.iframe_src) }}
 </div>
 {%- endif %}
 {% if result.audio_src -%}

--- a/searx/templates/simple/result_templates/videos.html
+++ b/searx/templates/simple/result_templates/videos.html
@@ -1,4 +1,4 @@
-{% from 'simple/macros.html' import result_header, result_sub_header, result_sub_footer, result_footer with context %}
+{% from 'simple/macros.html' import iframe, result_header, result_sub_header, result_sub_footer, result_footer with context %}
 
 {{ result_header(result, favicons, image_proxify) }}
 {{ result_sub_header(result) }}
@@ -18,11 +18,7 @@
 {{- result_sub_footer(result) -}}
 {% if result.iframe_src -%}
 <div id="result-video-{{ index }}" class="embedded-video invisible">
-  <iframe data-src="{{result.iframe_src}}" frameborder="0" allowfullscreen
-    {% if result.parsed_url.hostname in ("www.youtube.com", ) -%}
-    allow="picture-in-picture" referrerpolicy="origin">
-    {%- endif -%}
-  </iframe>
+  {{ iframe(result.iframe_src) }}
 </div>
 {%- endif %}
 {{ result_footer(result) }}


### PR DESCRIPTION

## What does this PR do?
- This PR moves the `iframe` logic into a macro, so that `videos.html` and `general.html` both can benefit from the workaround to fix YouTube results by @return42 in https://github.com/searxng/searxng/pull/5858
- It also fixes that only YouTube videos contained the closing `>` after `<iframe border="0" ...`, the regression has been caused by https://github.com/searxng/searxng/pull/5858

## Why is this change important?
Currently, the page breaks if there's any non-YouTube Iframe:
<img width="814" height="592" alt="Screenshot from 2026-04-09 22-09-48" src="https://github.com/user-attachments/assets/c8a426f0-1ef5-403a-bf2f-906116b154e4" />

Here, the page ends in the middle of the results and the footer and page number selector are not visible.

## How to test this PR locally?
- search for videos with iframes that are not from YouTube
- see that the page doesn't break


## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [X] I hereby confirm that I have not used any AI tools for creating this PR.
- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
