### PR TITLE
[feat] engines: add GMX search engine

### DIFF
--- a/searx/engines/gmx.py
+++ b/searx/engines/gmx.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""GMX (general)
+
+It's unclear which index it uses, the results were the most similar to Google's.
+
+In theory it supports multiple languages, but even if changing the region on their website,
+most of the results are still in English."""
+
+import time
+import typing as t
+
+from urllib.parse import urlencode
+
+from searx.result_types import EngineResults
+from searx.extended_types import SXNG_Response
+from searx.utils import extr, gen_useragent, html_to_text
+from searx.network import get
+
+if t.TYPE_CHECKING:
+    from searx.search.processors import OnlineParams
+
+about = {
+    "website": "https://search.gmx.com",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+base_url = "https://search.gmx.com"  # alternatively: search.gmx.net
+categories = ["general"]
+
+paging = True
+safesearch = True
+time_range_support = True
+
+time_range_map = {"day": "d", "week": "w", "month": "m", "year": "y"}
+
+
+def _get_page_hash(query: str, page: int, headers: dict[str, str]) -> str:
+    resp = get(f"{base_url}/web/result?q={query}&page={page}", headers=headers)
+
+    # the text we search for looks like:
+    # load("/desk?lang="+eV.p.param['hl']+"&q="+eV['p']['q_encode']+"&page=5&h=aa45603&t=177582576&origin=web&comp=web_serp_pag&p=gmx-com&sp=&lr="+eV.p.param['lr0']+"&mkt="+eV.p.param['mkt0']+"&family="+eV.p.param['familyFilter']+"&fcons="+eV.p.perm.fCons,"google", "eMMO", "eMH","eMP");  # pylint: disable=line-too-long
+    return extr(resp.text, "&h=", "&t=")
+
+
+def request(query: str, params: 'OnlineParams'):
+    # the headers have to be as close to normal browsers as possible, otherwise you get rate-limited quickly
+    # the user agent for loading the hash and requesting the results has to be the same
+    headers = {
+        "User-Agent": gen_useragent(),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Connection": "keep-alive",
+        "Referer": base_url,
+    }
+
+    # the "h" parameter has to be set to the current time in seconds with the last digit removed
+    # e.g., if the current time is 1775829848, h has to be 177582984
+    now = int(time.time() / 10)
+
+    # the page hash depends on the query and page number
+    page_hash = _get_page_hash(query, params["pageno"], headers)
+    # the headers have to match the ones from the previous request
+
+    args = {"lang": "en", "q": query, "page": params["pageno"], "h": page_hash, "t": now}
+    if params["safesearch"]:
+        args["family"] = True
+    if params.get("time_range"):
+        args["time"] = time_range_map[params["time_range"]]
+
+    params["url"] = f"{base_url}/desk?{urlencode(args)}"
+
+    params["headers"].update(headers)
+
+
+def response(resp: 'SXNG_Response') -> EngineResults:
+    res = EngineResults()
+
+    results = resp.json()["results"]
+
+    for suggestion in results["rs"]:
+        res.add(res.types.LegacyResult({"suggestion": suggestion["t"]}))
+
+    for result in results["hits"]:
+        res.add(
+            res.types.MainResult(
+                url=result["u"],
+                title=html_to_text(result["t"]),
+                content=html_to_text(result["s"]),
+            )
+        )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1033,6 +1033,11 @@ engines:
     shortcut: gitea
     disabled: true
 
+  - name: gmx
+    engine: gmx
+    shortcut: gmx
+    disabled: true
+
   - name: goodreads
     engine: goodreads
     shortcut: good


### PR DESCRIPTION
## What does this PR do?
- add support for <https://search.gmx.net>

## How to test this PR locally?
- `!gmx test`

## Author's checklist
- Safesearch doesn't seem to work properly?
- In theory multiple languages are supported, but even in the web UI, they don't work properly
- Possibly, we could cache the request hashes (h query parameter), I'm not sure if it ever changes

You get ratelimited (captcha) quite quickly if you don't pass the right headers, but I think that the current configuration should be quite reliable for not getting ratelimited. Script I used to test this:
```py
import time
import random
import httpx

headers = {
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0",
    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
    "Accept-Language": "en-US,en;q=0.9",
    "Connection": "keep-alive",
    "Priority": "u=0, i",
    "Referer": "https://search.gmx.com",
    "Sec-Fetch-Dest": "document",
    "Sec-Fetch-Mode": "navigate",
    "Sec-Fetch-Site": "same-origin",
    "Sec-Fetch-User": "?1",
    "Sec-GPC": "1",
    "TE": "trailers",
    "Upgrade-Insecure-Requests": "1",
}


def request(query, page, range):
    resp = httpx.get(
        f"https://search.gmx.com/web/result?q={query}&origin=web&comp=web_serp_pag&p=gmx-com&page={page}&time={range}",
        headers=headers,
    )
    load_params_start = resp.text.find("&h=")
    left = resp.text[load_params_start + 3 :]
    load_params_end = left.find("&t=")
    req_hash = left[:load_params_end]

    print(req_hash)

    now = int(time.time() / 10)
    resp = httpx.get(
        f"https://search.gmx.com/desk?lang=en&q={query}&page={page}&h={req_hash}&t={now}&mkt=us",
        headers=headers,
    )
    try:
        resp.json()
    except Exception:
        print("got ratelimited")


queries = ["foo", "bar", "baz", "weltfrieden", "schnee", "test", "bäume"]
time_range = [None, "d", "y", "m"]
while True:
    query = random.choice(queries)
    page = random.randint(0, 10)
    range = random.choice(time_range)
    request(query, page, range)
```

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [X] I hereby confirm that I have not used any AI tools for creating this PR.
- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
