### PR TITLE
[mod] GH workflow "update translations from Weblate" (area:i18n)

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -132,7 +132,7 @@ jobs:
           body: |
             [l10n] update translations from Weblate
           labels: |
-            translation
+            area:i18n
 
       - name: Display information
         run: |


### PR DESCRIPTION
Rename label of the Weblate updates (PR) from `translation` to `area:i18n`.

## AI Disclosure

- [x] I hereby confirm that I have not used any AI tools for creating this PR.

----

@inetol Does this patch fit your concept for labeling issues and PRs?