### PR TITLE
feat: add Go rewrite of SearXNG as JSON-only metasearch API

### DIFF
--- a/go/cmd/searxng/main.go
+++ b/go/cmd/searxng/main.go
@@ -1,0 +1,79 @@
+// SearXNG-Go is a metasearch engine that aggregates results from
+// multiple search engines and returns JSON results.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/network"
+	"github.com/searxng/searxng-go/internal/server"
+
+	// Import engine packages to trigger their init() registration.
+	_ "github.com/searxng/searxng-go/internal/engines/bing"
+	_ "github.com/searxng/searxng-go/internal/engines/brave"
+	_ "github.com/searxng/searxng-go/internal/engines/duckduckgo"
+	_ "github.com/searxng/searxng-go/internal/engines/google"
+	_ "github.com/searxng/searxng-go/internal/engines/wikipedia"
+)
+
+func main() {
+	configPath := flag.String("config", "settings.yml", "path to settings YAML file")
+	flag.Parse()
+
+	// Set up structured logging.
+	logLevel := slog.LevelInfo
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if cfg.General.Debug {
+		logLevel = slog.LevelDebug
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})))
+
+	slog.Info("loaded configuration",
+		"instance", cfg.General.InstanceName,
+		"engines_configured", len(cfg.Engines),
+		"debug", cfg.General.Debug,
+	)
+
+	// Report registered engine types.
+	types := engine.RegisteredTypes()
+	sort.Strings(types)
+	slog.Info("registered engine types", "types", types)
+
+	// Load engines from config.
+	engines, err := engine.LoadEngines(cfg.Engines)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading engines: %v\n", err)
+		os.Exit(1)
+	}
+
+	slog.Info("engines loaded", "active", len(engines))
+	for name := range engines {
+		slog.Debug("engine active", "name", name)
+	}
+
+	// Create HTTP client for upstream engine requests.
+	client := network.NewClient(cfg.Outgoing)
+
+	// Create and start the HTTP server.
+	srv := server.New(cfg, engines, client)
+	slog.Info("starting SearXNG-Go",
+		"addr", fmt.Sprintf("%s:%d", cfg.Server.BindAddress, cfg.Server.Port),
+	)
+
+	if err := srv.ListenAndServe(); err != nil {
+		fmt.Fprintf(os.Stderr, "server error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,10 @@
+module github.com/searxng/searxng-go
+
+go 1.25.0
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	golang.org/x/net v0.53.0
+	golang.org/x/sync v0.20.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,10 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -1,0 +1,164 @@
+// Package config handles YAML configuration loading for the SearXNG Go server.
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the top-level configuration.
+type Config struct {
+	General  GeneralConfig  `yaml:"general"`
+	Search   SearchConfig   `yaml:"search"`
+	Server   ServerConfig   `yaml:"server"`
+	Outgoing OutgoingConfig `yaml:"outgoing"`
+	Engines  []EngineConfig `yaml:"engines"`
+}
+
+type GeneralConfig struct {
+	Debug        bool   `yaml:"debug"`
+	InstanceName string `yaml:"instance_name"`
+}
+
+type SearchConfig struct {
+	SafeSearch          int    `yaml:"safe_search"`
+	DefaultLang         string `yaml:"default_lang"`
+	MaxPage             int    `yaml:"max_page"`
+	AutocompleteBackend string `yaml:"autocomplete"`
+}
+
+type ServerConfig struct {
+	Port        int    `yaml:"port"`
+	BindAddress string `yaml:"bind_address"`
+	SecretKey   string `yaml:"secret_key"`
+	BaseURL     string `yaml:"base_url"`
+}
+
+type OutgoingConfig struct {
+	RequestTimeout    float64  `yaml:"request_timeout"`
+	MaxRequestTimeout float64  `yaml:"max_request_timeout"`
+	UseHTTP2          bool     `yaml:"use_http2"`
+	Proxies           []string `yaml:"proxies"`
+	MaxConnections    int      `yaml:"pool_connections"`
+	MaxIdleConns      int      `yaml:"pool_maxsize"`
+	UserAgent         string   `yaml:"useragent"`
+}
+
+type EngineConfig struct {
+	Name             string         `yaml:"name"`
+	Engine           string         `yaml:"engine"`
+	Shortcut         string         `yaml:"shortcut"`
+	Categories       []string       `yaml:"categories"`
+	Disabled         bool           `yaml:"disabled"`
+	Inactive         bool           `yaml:"inactive"`
+	Timeout          float64        `yaml:"timeout"`
+	Weight           float64        `yaml:"weight"`
+	Paging           bool           `yaml:"paging"`
+	MaxPage          int            `yaml:"max_page"`
+	SafeSearch       bool           `yaml:"safesearch"`
+	TimeRangeSupport bool           `yaml:"time_range_support"`
+	EnableHTTP       bool           `yaml:"enable_http"`
+	Tokens           []string       `yaml:"tokens"`
+	Extra            map[string]any `yaml:",inline"`
+}
+
+// TimeoutDuration returns the engine timeout as a time.Duration.
+func (e *EngineConfig) TimeoutDuration() time.Duration {
+	if e.Timeout <= 0 {
+		return 0
+	}
+	return time.Duration(e.Timeout * float64(time.Second))
+}
+
+// Defaults returns a Config with sensible default values.
+func Defaults() *Config {
+	return &Config{
+		General: GeneralConfig{
+			Debug:        false,
+			InstanceName: "SearXNG",
+		},
+		Search: SearchConfig{
+			SafeSearch:  0,
+			DefaultLang: "auto",
+			MaxPage:     0,
+		},
+		Server: ServerConfig{
+			Port:        8888,
+			BindAddress: "127.0.0.1",
+		},
+		Outgoing: OutgoingConfig{
+			RequestTimeout:    3.0,
+			MaxRequestTimeout: 10.0,
+			MaxConnections:    100,
+			MaxIdleConns:      10,
+		},
+	}
+}
+
+// Load reads a YAML config file and returns the parsed Config.
+// It checks SEARXNG_SETTINGS_PATH env var first, then falls back to the given path.
+func Load(defaultPath string) (*Config, error) {
+	path := os.Getenv("SEARXNG_SETTINGS_PATH")
+	if path == "" {
+		path = defaultPath
+	}
+
+	// If path is a directory, look for settings.yml inside it.
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("config path %q: %w", path, err)
+	}
+	if info.IsDir() {
+		path = filepath.Join(path, "settings.yml")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config %q: %w", path, err)
+	}
+
+	cfg := Defaults()
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config %q: %w", path, err)
+	}
+
+	applyEngineDefaults(cfg)
+	return cfg, nil
+}
+
+// applyEngineDefaults fills in missing engine fields with sensible defaults.
+func applyEngineDefaults(cfg *Config) {
+	for i := range cfg.Engines {
+		e := &cfg.Engines[i]
+		if e.Engine == "" {
+			e.Engine = e.Name
+		}
+		if e.Shortcut == "" {
+			e.Shortcut = "-"
+		}
+		if len(e.Categories) == 0 {
+			e.Categories = []string{"general"}
+		}
+		if e.Timeout <= 0 {
+			e.Timeout = cfg.Outgoing.RequestTimeout
+		}
+		if e.Weight <= 0 {
+			e.Weight = 1.0
+		}
+	}
+}
+
+// ActiveEngines returns only engines that are not disabled or inactive.
+func (c *Config) ActiveEngines() []EngineConfig {
+	var active []EngineConfig
+	for _, e := range c.Engines {
+		if !e.Disabled && !e.Inactive {
+			active = append(active, e)
+		}
+	}
+	return active
+}

--- a/go/internal/engine/engine.go
+++ b/go/internal/engine/engine.go
@@ -1,0 +1,40 @@
+// Package engine defines the Engine interface and search parameter types.
+package engine
+
+import (
+	"net/http"
+
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+// SearchParams holds parameters passed to an engine's BuildRequest method.
+type SearchParams struct {
+	Query      string
+	Language   string
+	SafeSearch int // 0=off, 1=moderate, 2=strict
+	PageNo     int
+	TimeRange  string // "", "day", "week", "month", "year"
+	Category   string
+	EngineData map[string]string
+}
+
+// Engine is the interface that all search engine backends must implement.
+type Engine interface {
+	// Metadata
+	Name() string
+	Categories() []string
+	Shortcut() string
+
+	// Capabilities
+	SupportsPaging() bool
+	SupportsTimeRange() bool
+	SupportsSafeSearch() bool
+	MaxPage() int
+
+	// Search lifecycle for online engines.
+	// BuildRequest prepares an HTTP request for the upstream engine.
+	BuildRequest(query string, params *SearchParams) (*http.Request, error)
+
+	// ParseResponse parses the upstream response body into results.
+	ParseResponse(resp *http.Response, body []byte) ([]result.Result, error)
+}

--- a/go/internal/engine/registry.go
+++ b/go/internal/engine/registry.go
@@ -1,0 +1,72 @@
+package engine
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/searxng/searxng-go/internal/config"
+)
+
+// Factory creates an Engine from configuration.
+type Factory func(cfg config.EngineConfig) (Engine, error)
+
+var (
+	mu        sync.RWMutex
+	factories = make(map[string]Factory)
+)
+
+// Register registers an engine factory for the given engine type name.
+// Typically called from init() in engine implementation packages.
+func Register(engineType string, factory Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, exists := factories[engineType]; exists {
+		panic(fmt.Sprintf("engine type %q already registered", engineType))
+	}
+	factories[engineType] = factory
+}
+
+// LoadEngines creates engine instances from config, skipping disabled/inactive engines.
+func LoadEngines(configs []config.EngineConfig) (map[string]Engine, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	engines := make(map[string]Engine)
+	for _, cfg := range configs {
+		if cfg.Disabled || cfg.Inactive {
+			continue
+		}
+
+		factory, ok := factories[cfg.Engine]
+		if !ok {
+			slog.Warn("no factory registered for engine type, skipping",
+				"engine", cfg.Name, "type", cfg.Engine)
+			continue
+		}
+
+		eng, err := factory(cfg)
+		if err != nil {
+			slog.Error("failed to create engine, skipping",
+				"engine", cfg.Name, "error", err)
+			continue
+		}
+
+		engines[cfg.Name] = eng
+		slog.Debug("loaded engine", "name", cfg.Name, "type", cfg.Engine,
+			"categories", cfg.Categories)
+	}
+
+	return engines, nil
+}
+
+// RegisteredTypes returns the names of all registered engine types.
+func RegisteredTypes() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	types := make([]string, 0, len(factories))
+	for t := range factories {
+		types = append(types, t)
+	}
+	return types
+}

--- a/go/internal/engines/bing/bing.go
+++ b/go/internal/engines/bing/bing.go
@@ -1,0 +1,213 @@
+// Package bing implements the Bing web search engine.
+//
+// Port of searx/engines/bing.py. Parses HTML results from Bing's search page.
+package bing
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+var safeSearchMap = map[int]string{
+	0: "off",
+	1: "moderate",
+	2: "strict",
+}
+
+type Bing struct {
+	cfg config.EngineConfig
+}
+
+func New(cfg config.EngineConfig) (engine.Engine, error) {
+	return &Bing{cfg: cfg}, nil
+}
+
+func (b *Bing) Name() string             { return b.cfg.Name }
+func (b *Bing) Categories() []string      { return b.cfg.Categories }
+func (b *Bing) Shortcut() string          { return b.cfg.Shortcut }
+func (b *Bing) SupportsPaging() bool      { return false }
+func (b *Bing) SupportsTimeRange() bool   { return false }
+func (b *Bing) SupportsSafeSearch() bool  { return true }
+func (b *Bing) MaxPage() int              { return 1 }
+
+func (b *Bing) BuildRequest(query string, params *engine.SearchParams) (*http.Request, error) {
+	q := url.Values{}
+	q.Set("q", query)
+
+	ss := safeSearchMap[params.SafeSearch]
+	if ss == "" {
+		ss = "off"
+	}
+	q.Set("adlt", ss)
+
+	// Set market based on language.
+	if params.Language != "" && params.Language != "auto" && params.Language != "all" {
+		q.Set("mkt", params.Language)
+	}
+
+	reqURL := "https://www.bing.com/search?" + q.Encode()
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+	return req, nil
+}
+
+func (b *Bing) ParseResponse(resp *http.Response, body []byte) ([]result.Result, error) {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	var results []result.Result
+
+	// Find result items: <li class="b_algo"> inside <ol id="b_results">
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if isResultItem(n) {
+			if r, ok := parseResultItem(n); ok {
+				results = append(results, r)
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	return results, nil
+}
+
+// isResultItem checks if a node is <li class="b_algo">.
+func isResultItem(n *html.Node) bool {
+	if n.Type != html.ElementNode || n.Data != "li" {
+		return false
+	}
+	class := getAttr(n, "class")
+	return strings.Contains(class, "b_algo")
+}
+
+func parseResultItem(li *html.Node) (result.Result, bool) {
+	// Find <h2><a href="...">title</a></h2>
+	var linkNode *html.Node
+	findLink(li, &linkNode)
+	if linkNode == nil {
+		return result.Result{}, false
+	}
+
+	href := getAttr(linkNode, "href")
+	title := extractText(linkNode)
+	if href == "" || title == "" {
+		return result.Result{}, false
+	}
+
+	// Decode Bing redirect URLs: https://www.bing.com/ck/a?u=a1<base64url>
+	href = decodeBingURL(href)
+
+	// Find content in <p> elements.
+	content := findParagraphText(li)
+
+	return result.Result{
+		URL:      href,
+		Title:    title,
+		Content:  content,
+		Category: "general",
+		Template: "default",
+		Priority: "normal",
+	}, true
+}
+
+// decodeBingURL decodes Bing's redirect tracking URLs.
+// Matches the Python logic at bing.py:141-151.
+func decodeBingURL(href string) string {
+	if !strings.HasPrefix(href, "https://www.bing.com/ck/a?") {
+		return href
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+	uVal := u.Query().Get("u")
+	if uVal == "" || !strings.HasPrefix(uVal, "a1") {
+		return href
+	}
+	encoded := uVal[2:]
+	// base64url without padding
+	if m := len(encoded) % 4; m != 0 {
+		encoded += strings.Repeat("=", 4-m)
+	}
+	decoded, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return href
+	}
+	return string(decoded)
+}
+
+func findLink(n *html.Node, result **html.Node) {
+	if n.Type == html.ElementNode && n.Data == "h2" {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.ElementNode && c.Data == "a" {
+				*result = c
+				return
+			}
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		findLink(c, result)
+		if *result != nil {
+			return
+		}
+	}
+}
+
+func findParagraphText(n *html.Node) string {
+	if n.Type == html.ElementNode && n.Data == "p" {
+		return extractText(n)
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if text := findParagraphText(c); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func getAttr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func extractText(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var sb strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && (c.Data == "script" || c.Data == "style") {
+			continue
+		}
+		sb.WriteString(extractText(c))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func init() {
+	engine.Register("bing", New)
+}

--- a/go/internal/engines/brave/brave.go
+++ b/go/internal/engines/brave/brave.go
@@ -1,0 +1,190 @@
+// Package brave implements the Brave web search engine.
+//
+// Port of searx/engines/brave.py. Queries Brave's search page
+// and parses results from the embedded JSON data or HTML.
+package brave
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+var timeRangeMap = map[string]string{
+	"day":   "pd",
+	"week":  "pw",
+	"month": "pm",
+	"year":  "py",
+}
+
+var safeSearchMap = map[int]string{
+	0: "off",
+	1: "moderate",
+	2: "strict",
+}
+
+type Brave struct {
+	cfg config.EngineConfig
+}
+
+func New(cfg config.EngineConfig) (engine.Engine, error) {
+	return &Brave{cfg: cfg}, nil
+}
+
+func (b *Brave) Name() string             { return b.cfg.Name }
+func (b *Brave) Categories() []string      { return b.cfg.Categories }
+func (b *Brave) Shortcut() string          { return b.cfg.Shortcut }
+func (b *Brave) SupportsPaging() bool      { return true }
+func (b *Brave) SupportsTimeRange() bool   { return true }
+func (b *Brave) SupportsSafeSearch() bool  { return true }
+func (b *Brave) MaxPage() int              { return 10 }
+
+func (b *Brave) BuildRequest(query string, params *engine.SearchParams) (*http.Request, error) {
+	q := url.Values{}
+	q.Set("q", query)
+	q.Set("source", "web")
+
+	if params.PageNo > 1 {
+		q.Set("offset", fmt.Sprintf("%d", params.PageNo-1))
+	}
+	if tr, ok := timeRangeMap[params.TimeRange]; ok {
+		q.Set("tf", tr)
+	}
+
+	reqURL := "https://search.brave.com/search?" + q.Encode()
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Encoding", "gzip, deflate")
+
+	// Set cookies.
+	ss := safeSearchMap[params.SafeSearch]
+	if ss == "" {
+		ss = "off"
+	}
+	req.AddCookie(&http.Cookie{Name: "safesearch", Value: ss})
+	req.AddCookie(&http.Cookie{Name: "useLocation", Value: "0"})
+	req.AddCookie(&http.Cookie{Name: "summarizer", Value: "0"})
+
+	return req, nil
+}
+
+func (b *Brave) ParseResponse(resp *http.Response, body []byte) ([]result.Result, error) {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	var results []result.Result
+
+	// Brave results are in <div class="snippet" data-type="web">
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if isSnippet(n) {
+			if r, ok := parseSnippet(n); ok {
+				results = append(results, r)
+			}
+		} else {
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				walk(c)
+			}
+		}
+	}
+	walk(doc)
+
+	return results, nil
+}
+
+func isSnippet(n *html.Node) bool {
+	if n.Type != html.ElementNode || n.Data != "div" {
+		return false
+	}
+	class := getAttr(n, "class")
+	return strings.Contains(class, "snippet") && getAttr(n, "data-type") == "web"
+}
+
+func parseSnippet(div *html.Node) (result.Result, bool) {
+	// Find title link: <a class="result-header">
+	var titleNode *html.Node
+	var contentText string
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			class := getAttr(n, "class")
+			if strings.Contains(class, "result-header") || strings.Contains(class, "heading") {
+				titleNode = n
+			}
+		}
+		if n.Type == html.ElementNode {
+			class := getAttr(n, "class")
+			if strings.Contains(class, "snippet-description") || strings.Contains(class, "snippet-content") {
+				text := extractText(n)
+				if len(text) > len(contentText) {
+					contentText = text
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(div)
+
+	if titleNode == nil {
+		return result.Result{}, false
+	}
+
+	href := getAttr(titleNode, "href")
+	title := extractText(titleNode)
+	if href == "" || title == "" {
+		return result.Result{}, false
+	}
+
+	return result.Result{
+		URL:      href,
+		Title:    title,
+		Content:  contentText,
+		Category: "general",
+		Template: "default",
+		Priority: "normal",
+	}, true
+}
+
+func getAttr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func extractText(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var sb strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && (c.Data == "script" || c.Data == "style") {
+			continue
+		}
+		sb.WriteString(extractText(c))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func init() {
+	engine.Register("brave", New)
+}

--- a/go/internal/engines/duckduckgo/duckduckgo.go
+++ b/go/internal/engines/duckduckgo/duckduckgo.go
@@ -1,0 +1,213 @@
+// Package duckduckgo implements the DuckDuckGo web search engine.
+//
+// Port of searx/engines/duckduckgo.py. Uses the DDG HTML (no-JS) endpoint.
+// For the initial version, only first-page results are supported since
+// subsequent pages require VQD token caching.
+package duckduckgo
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+const ddgURL = "https://html.duckduckgo.com/html/"
+
+var timeRangeMap = map[string]string{
+	"day":   "d",
+	"week":  "w",
+	"month": "m",
+	"year":  "y",
+}
+
+type DuckDuckGo struct {
+	cfg config.EngineConfig
+}
+
+func New(cfg config.EngineConfig) (engine.Engine, error) {
+	return &DuckDuckGo{cfg: cfg}, nil
+}
+
+func (d *DuckDuckGo) Name() string             { return d.cfg.Name }
+func (d *DuckDuckGo) Categories() []string      { return d.cfg.Categories }
+func (d *DuckDuckGo) Shortcut() string          { return d.cfg.Shortcut }
+func (d *DuckDuckGo) SupportsPaging() bool      { return false } // VQD caching needed for paging
+func (d *DuckDuckGo) SupportsTimeRange() bool   { return true }
+func (d *DuckDuckGo) SupportsSafeSearch() bool  { return false }
+func (d *DuckDuckGo) MaxPage() int              { return 1 }
+
+func (d *DuckDuckGo) BuildRequest(query string, params *engine.SearchParams) (*http.Request, error) {
+	if len(query) >= 500 {
+		return nil, fmt.Errorf("query too long for DDG (max 499 chars)")
+	}
+
+	formData := url.Values{}
+	formData.Set("q", query)
+	formData.Set("b", "")
+	formData.Set("kl", "wt-wt") // default: all regions
+
+	if params.Language != "" && params.Language != "auto" && params.Language != "all" {
+		// DDG uses region codes like "us-en", "uk-en", "de-de"
+		formData.Set("kl", mapLanguage(params.Language))
+	}
+
+	if tr, ok := timeRangeMap[params.TimeRange]; ok {
+		formData.Set("df", tr)
+	}
+
+	req, err := http.NewRequest("POST", ddgURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Referer", "https://html.duckduckgo.com/")
+	req.Header.Set("Sec-Fetch-Dest", "document")
+	req.Header.Set("Sec-Fetch-Mode", "navigate")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	req.Header.Set("Sec-Fetch-User", "?1")
+
+	return req, nil
+}
+
+func (d *DuckDuckGo) ParseResponse(resp *http.Response, body []byte) ([]result.Result, error) {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	var results []result.Result
+
+	// DDG HTML results are in: <div id="links"> / <div class="web-result">
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if isWebResult(n) {
+			if r, ok := parseWebResult(n); ok {
+				results = append(results, r)
+			}
+		} else {
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				walk(c)
+			}
+		}
+	}
+	walk(doc)
+
+	return results, nil
+}
+
+func isWebResult(n *html.Node) bool {
+	if n.Type != html.ElementNode || n.Data != "div" {
+		return false
+	}
+	class := getAttr(n, "class")
+	return strings.Contains(class, "web-result") && !strings.Contains(class, "result--ad")
+}
+
+func parseWebResult(div *html.Node) (result.Result, bool) {
+	// Find <h2><a href="...">title</a></h2>
+	var titleLink *html.Node
+	findH2Link(div, &titleLink)
+	if titleLink == nil {
+		return result.Result{}, false
+	}
+
+	href := getAttr(titleLink, "href")
+	title := extractText(titleLink)
+	if href == "" || title == "" {
+		return result.Result{}, false
+	}
+
+	// Find content snippet: <a class="result__snippet">
+	content := findSnippet(div)
+
+	return result.Result{
+		URL:      href,
+		Title:    title,
+		Content:  content,
+		Category: "general",
+		Template: "default",
+		Priority: "normal",
+	}, true
+}
+
+func findH2Link(n *html.Node, result **html.Node) {
+	if n.Type == html.ElementNode && n.Data == "h2" {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.ElementNode && c.Data == "a" {
+				*result = c
+				return
+			}
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		findH2Link(c, result)
+		if *result != nil {
+			return
+		}
+	}
+}
+
+func findSnippet(n *html.Node) string {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		class := getAttr(n, "class")
+		if strings.Contains(class, "result__snippet") {
+			return extractText(n)
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if s := findSnippet(c); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func mapLanguage(lang string) string {
+	// Simple mapping: "en" -> "us-en", "de" -> "de-de", etc.
+	lang = strings.ToLower(lang)
+	if strings.Contains(lang, "-") {
+		parts := strings.SplitN(lang, "-", 2)
+		return parts[1] + "-" + parts[0]
+	}
+	switch lang {
+	case "en":
+		return "us-en"
+	default:
+		return lang + "-" + lang
+	}
+}
+
+func getAttr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func extractText(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var sb strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && (c.Data == "script" || c.Data == "style") {
+			continue
+		}
+		sb.WriteString(extractText(c))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func init() {
+	engine.Register("duckduckgo", New)
+}

--- a/go/internal/engines/google/google.go
+++ b/go/internal/engines/google/google.go
@@ -1,0 +1,199 @@
+// Package google implements the Google web search engine.
+//
+// This is a simplified port of searx/engines/google.py. It queries
+// Google's search page and parses the HTML results.
+package google
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+var timeRangeMap = map[string]string{
+	"day":   "d",
+	"week":  "w",
+	"month": "m",
+	"year":  "y",
+}
+
+var safeSearchMap = map[int]string{
+	0: "off",
+	1: "medium",
+	2: "high",
+}
+
+// Google implements the Engine interface for Google web search.
+type Google struct {
+	cfg config.EngineConfig
+}
+
+func New(cfg config.EngineConfig) (engine.Engine, error) {
+	return &Google{cfg: cfg}, nil
+}
+
+func (g *Google) Name() string             { return g.cfg.Name }
+func (g *Google) Categories() []string      { return g.cfg.Categories }
+func (g *Google) Shortcut() string          { return g.cfg.Shortcut }
+func (g *Google) SupportsPaging() bool      { return true }
+func (g *Google) SupportsTimeRange() bool   { return true }
+func (g *Google) SupportsSafeSearch() bool  { return true }
+func (g *Google) MaxPage() int              { return 50 }
+
+func (g *Google) BuildRequest(query string, params *engine.SearchParams) (*http.Request, error) {
+	start := (params.PageNo - 1) * 10
+
+	q := url.Values{}
+	q.Set("q", query)
+	q.Set("hl", "en")
+	q.Set("lr", "")
+	q.Set("ie", "utf8")
+	q.Set("oe", "utf8")
+	q.Set("filter", "0")
+	q.Set("start", fmt.Sprintf("%d", start))
+
+	if params.Language != "" && params.Language != "auto" && params.Language != "all" {
+		lang := params.Language
+		if idx := strings.Index(lang, "-"); idx > 0 {
+			lang = lang[:idx]
+		}
+		q.Set("hl", lang)
+		q.Set("lr", "lang_"+lang)
+	}
+
+	if tr, ok := timeRangeMap[params.TimeRange]; ok {
+		q.Set("tbs", "qdr:"+tr)
+	}
+	if ss, ok := safeSearchMap[params.SafeSearch]; ok && params.SafeSearch > 0 {
+		q.Set("safe", ss)
+	}
+
+	reqURL := "https://www.google.com/search?" + q.Encode()
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Cookie", "CONSENT=YES+")
+	return req, nil
+}
+
+func (g *Google) ParseResponse(resp *http.Response, body []byte) ([]result.Result, error) {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	var results []result.Result
+
+	// Walk the DOM looking for result links.
+	// Google results are typically <a> tags with data-ved attribute.
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := getAttr(n, "href")
+			dataVed := getAttr(n, "data-ved")
+
+			if dataVed != "" && href != "" && !strings.HasPrefix(href, "#") {
+				// Clean up Google redirect URLs.
+				actualURL := href
+				if strings.HasPrefix(href, "/url?q=") {
+					if u, err := url.Parse(href); err == nil {
+						if q := u.Query().Get("q"); q != "" {
+							actualURL = q
+						}
+					}
+				}
+
+				// Skip internal google links.
+				if strings.HasPrefix(actualURL, "/") || strings.Contains(actualURL, "google.com/search") {
+					goto children
+				}
+
+				title := extractText(n)
+				if title == "" {
+					goto children
+				}
+
+				// Try to find content in sibling/parent nodes.
+				content := ""
+				if parent := n.Parent; parent != nil {
+					if grandparent := parent.Parent; grandparent != nil {
+						content = findContent(grandparent)
+					}
+				}
+
+				results = append(results, result.Result{
+					URL:      actualURL,
+					Title:    title,
+					Content:  content,
+					Category: "general",
+					Template: "default",
+					Priority: "normal",
+				})
+			}
+		}
+	children:
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	return results, nil
+}
+
+func getAttr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func extractText(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var sb strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && (c.Data == "script" || c.Data == "style") {
+			continue
+		}
+		sb.WriteString(extractText(c))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func findContent(n *html.Node) string {
+	// Look for content-like text in descendant elements.
+	var best string
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode && (node.Data == "span" || node.Data == "div") {
+			text := extractText(node)
+			if len(text) > len(best) && len(text) > 20 {
+				best = text
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return best
+}
+
+func init() {
+	engine.Register("google", New)
+}

--- a/go/internal/engines/wikipedia/wikipedia.go
+++ b/go/internal/engines/wikipedia/wikipedia.go
@@ -1,0 +1,122 @@
+// Package wikipedia implements the Wikipedia search engine.
+//
+// Port of searx/engines/wikipedia.py. Uses the Wikipedia REST v1 summary API.
+// This is a clean JSON API, no HTML parsing needed.
+package wikipedia
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+const summaryURLTemplate = "https://%s.wikipedia.org/api/rest_v1/page/summary/%s"
+
+type Wikipedia struct {
+	cfg config.EngineConfig
+}
+
+func New(cfg config.EngineConfig) (engine.Engine, error) {
+	return &Wikipedia{cfg: cfg}, nil
+}
+
+func (w *Wikipedia) Name() string             { return w.cfg.Name }
+func (w *Wikipedia) Categories() []string      { return w.cfg.Categories }
+func (w *Wikipedia) Shortcut() string          { return w.cfg.Shortcut }
+func (w *Wikipedia) SupportsPaging() bool      { return false }
+func (w *Wikipedia) SupportsTimeRange() bool   { return false }
+func (w *Wikipedia) SupportsSafeSearch() bool  { return false }
+func (w *Wikipedia) MaxPage() int              { return 1 }
+
+func (w *Wikipedia) BuildRequest(query string, params *engine.SearchParams) (*http.Request, error) {
+	// Title-case the query for better Wikipedia matching.
+	if strings.ToLower(query) == query {
+		query = strings.Title(query) //nolint:staticcheck
+	}
+
+	lang := "en"
+	if params.Language != "" && params.Language != "auto" && params.Language != "all" {
+		lang = params.Language
+		if idx := strings.Index(lang, "-"); idx > 0 {
+			lang = lang[:idx]
+		}
+	}
+
+	title := url.PathEscape(query)
+	reqURL := fmt.Sprintf(summaryURLTemplate, lang, title)
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// apiResponse maps the Wikipedia REST v1 summary response.
+type apiResponse struct {
+	Type        string `json:"type"`
+	Title       string `json:"title"`
+	DisplayTitle string `json:"displaytitle"`
+	Titles      struct {
+		Display string `json:"display"`
+	} `json:"titles"`
+	Extract     string `json:"extract"`
+	Description string `json:"description"`
+	ContentURLs struct {
+		Desktop struct {
+			Page string `json:"page"`
+		} `json:"desktop"`
+	} `json:"content_urls"`
+	Thumbnail struct {
+		Source string `json:"source"`
+	} `json:"thumbnail"`
+}
+
+func (w *Wikipedia) ParseResponse(resp *http.Response, body []byte) ([]result.Result, error) {
+	if resp.StatusCode == 404 || resp.StatusCode == 400 {
+		return nil, nil // No results, not an error.
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("wikipedia API returned %d", resp.StatusCode)
+	}
+
+	var api apiResponse
+	if err := json.Unmarshal(body, &api); err != nil {
+		return nil, fmt.Errorf("parsing wikipedia JSON: %w", err)
+	}
+
+	pageURL := api.ContentURLs.Desktop.Page
+	if pageURL == "" {
+		return nil, nil
+	}
+
+	title := api.Titles.Display
+	if title == "" {
+		title = api.Title
+	}
+
+	var results []result.Result
+	results = append(results, result.Result{
+		URL:       pageURL,
+		Title:     title,
+		Content:   api.Description,
+		Thumbnail: api.Thumbnail.Source,
+		Category:  "general",
+		Template:  "default",
+		Priority:  "normal",
+	})
+
+	return results, nil
+}
+
+func init() {
+	engine.Register("wikipedia", New)
+}

--- a/go/internal/network/client.go
+++ b/go/internal/network/client.go
@@ -1,0 +1,87 @@
+// Package network provides HTTP client management for upstream engine requests.
+package network
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/searxng/searxng-go/internal/config"
+)
+
+// Common desktop browser user agents for rotation.
+var userAgents = []string{
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0",
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+	"Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+}
+
+// Client wraps an HTTP client with engine-appropriate configuration.
+type Client struct {
+	httpClient *http.Client
+	timeout    time.Duration
+}
+
+// NewClient creates a Client configured from OutgoingConfig.
+func NewClient(cfg config.OutgoingConfig) *Client {
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          cfg.MaxConnections,
+		MaxIdleConnsPerHost:   cfg.MaxIdleConns,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:  10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+
+	timeout := time.Duration(cfg.RequestTimeout * float64(time.Second))
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	return &Client{
+		httpClient: &http.Client{
+			Transport: transport,
+			Timeout:   timeout,
+		},
+		timeout: timeout,
+	}
+}
+
+// Do executes an HTTP request with the given context, returning the response and body.
+// It automatically sets a random User-Agent if none is present.
+func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", RandomUserAgent())
+	}
+
+	req = req.WithContext(ctx)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp, nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	return resp, body, nil
+}
+
+// RandomUserAgent returns a random browser user agent string.
+func RandomUserAgent() string {
+	return userAgents[rand.IntN(len(userAgents))]
+}

--- a/go/internal/network/errors.go
+++ b/go/internal/network/errors.go
@@ -1,0 +1,79 @@
+package network
+
+import (
+	"net/http"
+	"strings"
+)
+
+// EngineError classifies an upstream engine error.
+type EngineError struct {
+	Kind    ErrorKind
+	Message string
+}
+
+func (e *EngineError) Error() string { return e.Message }
+
+// ErrorKind identifies the class of engine error.
+type ErrorKind int
+
+const (
+	ErrorUnknown ErrorKind = iota
+	ErrorTimeout
+	ErrorAccessDenied
+	ErrorTooManyRequests
+	ErrorCaptcha
+	ErrorCloudflare
+	ErrorSSL
+)
+
+// ClassifyHTTPError inspects an HTTP response for known error patterns.
+// Maps to searx/network/raise_for_httperror.py.
+func ClassifyHTTPError(resp *http.Response, body []byte) *EngineError {
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		return nil
+	}
+
+	bodyStr := string(body)
+
+	// Cloudflare detection
+	if isCloudflareChallenge(resp, bodyStr) {
+		return &EngineError{Kind: ErrorCloudflare, Message: "cloudflare challenge detected"}
+	}
+
+	// CAPTCHA detection
+	if isCaptcha(bodyStr) {
+		return &EngineError{Kind: ErrorCaptcha, Message: "captcha detected"}
+	}
+
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return &EngineError{Kind: ErrorTooManyRequests, Message: "too many requests (429)"}
+	case http.StatusForbidden:
+		return &EngineError{Kind: ErrorAccessDenied, Message: "access denied (403)"}
+	case http.StatusPaymentRequired:
+		return &EngineError{Kind: ErrorAccessDenied, Message: "access denied (402)"}
+	default:
+		return &EngineError{Kind: ErrorUnknown, Message: http.StatusText(resp.StatusCode)}
+	}
+}
+
+func isCloudflareChallenge(resp *http.Response, body string) bool {
+	server := resp.Header.Get("Server")
+	if !strings.Contains(strings.ToLower(server), "cloudflare") {
+		return false
+	}
+	if resp.StatusCode == 403 || resp.StatusCode == 503 {
+		return true
+	}
+	if strings.Contains(body, "challenges.cloudflare.com") {
+		return true
+	}
+	return false
+}
+
+func isCaptcha(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "recaptcha") ||
+		strings.Contains(lower, "g-recaptcha") ||
+		strings.Contains(lower, "hcaptcha")
+}

--- a/go/internal/network/suspension.go
+++ b/go/internal/network/suspension.go
@@ -1,0 +1,74 @@
+package network
+
+import (
+	"sync"
+	"time"
+)
+
+// SuspendedStatus tracks consecutive errors for an engine
+// and suspends it for escalating periods.
+type SuspendedStatus struct {
+	mu              sync.Mutex
+	consecutiveErrs int
+	suspendedUntil  time.Time
+	banTimeOnFail   time.Duration
+	maxBanTime      time.Duration
+}
+
+// NewSuspendedStatus creates a suspension tracker.
+func NewSuspendedStatus(banTimeOnFail, maxBanTime time.Duration) *SuspendedStatus {
+	if banTimeOnFail <= 0 {
+		banTimeOnFail = 30 * time.Second
+	}
+	if maxBanTime <= 0 {
+		maxBanTime = 10 * time.Minute
+	}
+	return &SuspendedStatus{
+		banTimeOnFail: banTimeOnFail,
+		maxBanTime:    maxBanTime,
+	}
+}
+
+// IsSuspended returns true if the engine is currently suspended.
+func (s *SuspendedStatus) IsSuspended() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return time.Now().Before(s.suspendedUntil)
+}
+
+// RecordSuccess resets the consecutive error counter.
+func (s *SuspendedStatus) RecordSuccess() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.consecutiveErrs = 0
+	s.suspendedUntil = time.Time{}
+}
+
+// RecordError increments the error counter and potentially suspends the engine.
+func (s *SuspendedStatus) RecordError() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.consecutiveErrs++
+
+	// Escalating ban: banTimeOnFail * consecutiveErrors, capped at maxBanTime.
+	banDuration := s.banTimeOnFail * time.Duration(s.consecutiveErrs)
+	if banDuration > s.maxBanTime {
+		banDuration = s.maxBanTime
+	}
+	s.suspendedUntil = time.Now().Add(banDuration)
+}
+
+// SuspendFor suspends the engine for a specific duration (e.g., CAPTCHA).
+func (s *SuspendedStatus) SuspendFor(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.consecutiveErrs++
+	s.suspendedUntil = time.Now().Add(d)
+}
+
+// ConsecutiveErrors returns the current error count.
+func (s *SuspendedStatus) ConsecutiveErrors() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.consecutiveErrs
+}

--- a/go/internal/query/query.go
+++ b/go/internal/query/query.go
@@ -1,0 +1,93 @@
+// Package query parses raw search query text, extracting bang commands,
+// language selectors, and the cleaned query string.
+package query
+
+import (
+	"strings"
+
+	"github.com/searxng/searxng-go/internal/engine"
+)
+
+// Parsed is the result of parsing a raw query string.
+type Parsed struct {
+	Query      string   // cleaned query text with bangs/lang removed
+	Engines    []string // explicitly selected engine names (via !shortcut)
+	Categories []string // explicitly selected categories (via !category)
+	Language   string   // language from :lang syntax, or empty
+}
+
+// Parse parses a raw query string, extracting bang commands and language selectors.
+// Bang syntax: !shortcut or !category (maps to searx/query.py BangParser)
+// Language syntax: :en, :de, etc. (maps to searx/query.py LanguageParser)
+func Parse(raw string, engines map[string]engine.Engine, knownCategories map[string]bool) Parsed {
+	p := Parsed{}
+	var queryParts []string
+
+	tokens := strings.Fields(raw)
+	for _, tok := range tokens {
+		if strings.HasPrefix(tok, "!") && len(tok) > 1 {
+			bang := tok[1:]
+			if handleBang(&p, bang, engines, knownCategories) {
+				continue
+			}
+		}
+		if strings.HasPrefix(tok, ":") && len(tok) > 1 && len(tok) <= 6 {
+			lang := tok[1:]
+			if isLangCode(lang) {
+				p.Language = lang
+				continue
+			}
+		}
+		queryParts = append(queryParts, tok)
+	}
+
+	p.Query = strings.Join(queryParts, " ")
+	return p
+}
+
+// handleBang tries to match a bang token against engine shortcuts and categories.
+// Returns true if the token was consumed.
+func handleBang(p *Parsed, bang string, engines map[string]engine.Engine, knownCategories map[string]bool) bool {
+	// Check engine shortcuts
+	for _, eng := range engines {
+		if eng.Shortcut() == bang {
+			p.Engines = append(p.Engines, eng.Name())
+			return true
+		}
+	}
+
+	// Check engine names directly
+	if _, ok := engines[bang]; ok {
+		p.Engines = append(p.Engines, bang)
+		return true
+	}
+
+	// Check categories
+	lower := strings.ToLower(bang)
+	if knownCategories[lower] {
+		p.Categories = append(p.Categories, lower)
+		return true
+	}
+
+	return false
+}
+
+// isLangCode returns true if the string looks like a language code (e.g., "en", "de", "zh-CN").
+func isLangCode(s string) bool {
+	if len(s) < 2 || len(s) > 5 {
+		return false
+	}
+	for i, c := range s {
+		if c == '-' && i > 0 {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			continue
+		}
+		if c >= 'A' && c <= 'Z' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/go/internal/result/container.go
+++ b/go/internal/result/container.go
@@ -1,0 +1,182 @@
+package result
+
+import (
+	"sort"
+	"sync"
+)
+
+// Container collects results from multiple engines and handles
+// deduplication, merging, scoring, and ranking.
+type Container struct {
+	mu sync.Mutex
+
+	mainResults map[string]*Result // keyed by result hash
+	Answers     []Answer
+	Suggestions []Suggestion
+	Corrections []Correction
+	Infoboxes   []map[string]any
+	Unresponsive []UnresponsiveEngine
+	NumberOfResults int
+}
+
+// NewContainer creates an empty result container.
+func NewContainer() *Container {
+	return &Container{
+		mainResults: make(map[string]*Result),
+	}
+}
+
+// Add adds a single result to the container. Safe for concurrent use.
+func (c *Container) Add(r Result, engineName string, position int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	r.Engine = engineName
+	if len(r.Engines) == 0 {
+		r.Engines = []string{engineName}
+	}
+	if len(r.Positions) == 0 {
+		r.Positions = []int{position}
+	}
+	if r.Priority == "" {
+		r.Priority = "normal"
+	}
+
+	hash := r.Hash()
+	if existing, ok := c.mainResults[hash]; ok {
+		existing.Merge(&r)
+	} else {
+		c.mainResults[hash] = &r
+	}
+}
+
+// AddResults adds a batch of results from an engine.
+func (c *Container) AddResults(results []Result, engineName string) {
+	for i, r := range results {
+		c.Add(r, engineName, i+1)
+	}
+}
+
+// AddAnswer adds an instant answer.
+func (c *Container) AddAnswer(a Answer) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Deduplicate answers
+	for _, existing := range c.Answers {
+		if existing.Answer == a.Answer {
+			return
+		}
+	}
+	c.Answers = append(c.Answers, a)
+}
+
+// AddSuggestion adds a search suggestion.
+func (c *Container) AddSuggestion(s string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, existing := range c.Suggestions {
+		if existing == s {
+			return
+		}
+	}
+	c.Suggestions = append(c.Suggestions, s)
+}
+
+// AddCorrection adds a spelling correction.
+func (c *Container) AddCorrection(s string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, existing := range c.Corrections {
+		if existing == s {
+			return
+		}
+	}
+	c.Corrections = append(c.Corrections, s)
+}
+
+// AddUnresponsive records an engine that failed.
+func (c *Container) AddUnresponsive(engine, errMsg string, suspended bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Unresponsive = append(c.Unresponsive, UnresponsiveEngine{
+		Engine:    engine,
+		Error:     errMsg,
+		Suspended: suspended,
+	})
+}
+
+// GetOrderedResults calculates scores, sorts, and groups results.
+// Matches the Python ranking at searx/results.py:197-253.
+func (c *Container) GetOrderedResults() []Result {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Collect all results and calculate scores.
+	results := make([]Result, 0, len(c.mainResults))
+	for _, r := range c.mainResults {
+		r.CalculateScore()
+		results = append(results, *r)
+	}
+
+	// Primary sort by score descending.
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	// Group by category:template:has_image, max 8 per group.
+	return groupResults(results)
+}
+
+// groupResults interleaves results by their category group key,
+// preventing one category from dominating the result list.
+func groupResults(sorted []Result) []Result {
+	const maxPerGroup = 8
+	const maxDistance = 20
+
+	type groupState struct {
+		count    int
+		firstPos int
+	}
+
+	groups := make(map[string]*groupState)
+	var output []Result
+
+	for _, r := range sorted {
+		key := resultGroupKey(r)
+		g, exists := groups[key]
+		if !exists {
+			g = &groupState{firstPos: len(output)}
+			groups[key] = g
+		}
+
+		if g.count >= maxPerGroup {
+			continue
+		}
+
+		// Check distance constraint.
+		insertPos := len(output)
+		if exists && insertPos-g.firstPos > maxDistance {
+			continue
+		}
+
+		output = append(output, r)
+		g.count++
+	}
+
+	return output
+}
+
+func resultGroupKey(r Result) string {
+	tmpl := r.Template
+	if tmpl == "" {
+		tmpl = "default"
+	}
+	imgPart := ""
+	if r.ImgSrc != "" {
+		imgPart = "img"
+	}
+	return r.Category + ":" + tmpl + ":" + imgPart
+}

--- a/go/internal/result/container_test.go
+++ b/go/internal/result/container_test.go
@@ -1,0 +1,178 @@
+package result
+
+import (
+	"testing"
+)
+
+func TestAddAndDedup(t *testing.T) {
+	c := NewContainer()
+
+	// Add two results with same URL from different engines.
+	c.Add(Result{
+		URL:      "https://example.com/page",
+		Title:    "Short",
+		Content:  "Brief content",
+		Template: "default",
+		Priority: "normal",
+		Weight:   1.0,
+	}, "google", 1)
+
+	c.Add(Result{
+		URL:      "https://example.com/page",
+		Title:    "Longer Title Here",
+		Content:  "A much longer and more detailed content description",
+		Template: "default",
+		Priority: "normal",
+		Weight:   1.0,
+	}, "bing", 2)
+
+	results := c.GetOrderedResults()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 deduped result, got %d", len(results))
+	}
+
+	r := results[0]
+	// Should keep the longer title.
+	if r.Title != "Longer Title Here" {
+		t.Errorf("expected longer title, got %q", r.Title)
+	}
+	// Should keep the longer content.
+	if r.Content != "A much longer and more detailed content description" {
+		t.Errorf("expected longer content, got %q", r.Content)
+	}
+	// Should have both engines.
+	if len(r.Engines) != 2 {
+		t.Errorf("expected 2 engines, got %d: %v", len(r.Engines), r.Engines)
+	}
+	// Should have both positions.
+	if len(r.Positions) != 2 {
+		t.Errorf("expected 2 positions, got %d", len(r.Positions))
+	}
+}
+
+func TestScoring(t *testing.T) {
+	r := &Result{
+		Positions: []int{1, 3},
+		Weight:    1.0,
+		Priority:  "normal",
+	}
+	r.CalculateScore()
+
+	// score = 1.0/1 + 1.0/3 = 1.333...
+	expected := 1.0 + 1.0/3.0
+	if r.Score < expected-0.01 || r.Score > expected+0.01 {
+		t.Errorf("expected score ~%.3f, got %.3f", expected, r.Score)
+	}
+}
+
+func TestScoringHighPriority(t *testing.T) {
+	r := &Result{
+		Positions: []int{1, 5},
+		Weight:    2.0,
+		Priority:  "high",
+	}
+	r.CalculateScore()
+
+	// score = 2.0 + 2.0 = 4.0
+	if r.Score != 4.0 {
+		t.Errorf("expected score 4.0, got %.3f", r.Score)
+	}
+}
+
+func TestScoringLowPriority(t *testing.T) {
+	r := &Result{
+		Positions: []int{1},
+		Weight:    1.0,
+		Priority:  "low",
+	}
+	r.CalculateScore()
+
+	if r.Score != 0.0 {
+		t.Errorf("expected score 0.0, got %.3f", r.Score)
+	}
+}
+
+func TestHTTPSPreferred(t *testing.T) {
+	c := NewContainer()
+
+	c.Add(Result{
+		URL:      "http://example.com/page",
+		Title:    "Test",
+		Template: "default",
+		Priority: "normal",
+		Weight:   1.0,
+	}, "engine1", 1)
+
+	c.Add(Result{
+		URL:      "https://example.com/page",
+		Title:    "Test",
+		Template: "default",
+		Priority: "normal",
+		Weight:   1.0,
+	}, "engine2", 1)
+
+	results := c.GetOrderedResults()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].URL != "https://example.com/page" {
+		t.Errorf("expected HTTPS URL, got %s", results[0].URL)
+	}
+}
+
+func TestSuggestionDedup(t *testing.T) {
+	c := NewContainer()
+	c.AddSuggestion("test query")
+	c.AddSuggestion("test query")
+	c.AddSuggestion("different")
+
+	if len(c.Suggestions) != 2 {
+		t.Errorf("expected 2 suggestions, got %d", len(c.Suggestions))
+	}
+}
+
+func TestAnswerDedup(t *testing.T) {
+	c := NewContainer()
+	c.AddAnswer(Answer{Answer: "42"})
+	c.AddAnswer(Answer{Answer: "42"})
+	c.AddAnswer(Answer{Answer: "other"})
+
+	if len(c.Answers) != 2 {
+		t.Errorf("expected 2 answers, got %d", len(c.Answers))
+	}
+}
+
+func TestOrdering(t *testing.T) {
+	c := NewContainer()
+
+	// Result with high score (position 1, weight 2).
+	c.Add(Result{
+		URL:      "https://top.com",
+		Title:    "Top Result",
+		Template: "default",
+		Priority: "normal",
+		Weight:   2.0,
+	}, "google", 1)
+
+	// Result with lower score (position 5, weight 1).
+	c.Add(Result{
+		URL:      "https://low.com",
+		Title:    "Low Result",
+		Template: "default",
+		Priority: "normal",
+		Weight:   1.0,
+	}, "bing", 5)
+
+	results := c.GetOrderedResults()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// Higher score should be first.
+	if results[0].URL != "https://top.com" {
+		t.Errorf("expected top.com first, got %s", results[0].URL)
+	}
+	if results[1].URL != "https://low.com" {
+		t.Errorf("expected low.com second, got %s", results[1].URL)
+	}
+}

--- a/go/internal/result/types.go
+++ b/go/internal/result/types.go
@@ -1,0 +1,139 @@
+// Package result defines search result types, deduplication, merging, and scoring.
+package result
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Result represents a single search result from an engine.
+type Result struct {
+	URL           string     `json:"url"`
+	Title         string     `json:"title"`
+	Content       string     `json:"content"`
+	Engine        string     `json:"engine"`
+	Engines       []string   `json:"engines"`
+	Score         float64    `json:"score"`
+	Category      string     `json:"category"`
+	Positions     []int      `json:"positions"`
+	PublishedDate *time.Time `json:"publishedDate,omitempty"`
+	Thumbnail     string     `json:"thumbnail,omitempty"`
+	ImgSrc        string     `json:"img_src,omitempty"`
+	Author        string     `json:"author,omitempty"`
+	Metadata      string     `json:"metadata,omitempty"`
+	Template      string     `json:"-"`
+	Priority      string     `json:"-"` // "low", "normal", "high"
+	Weight        float64    `json:"-"` // inherited from engine config
+}
+
+// Answer represents an instant answer.
+type Answer struct {
+	Answer string `json:"answer"`
+	URL    string `json:"url,omitempty"`
+}
+
+// Suggestion is a search suggestion string.
+type Suggestion = string
+
+// Correction is a spelling correction string.
+type Correction = string
+
+// UnresponsiveEngine records an engine that failed during search.
+type UnresponsiveEngine struct {
+	Engine    string `json:"engine"`
+	Error     string `json:"error"`
+	Suspended bool   `json:"suspended"`
+}
+
+// Hash returns a deduplication key for the result.
+// Matches the Python logic: hash on template + URL (without scheme) + img_src.
+func (r *Result) Hash() string {
+	parsed, err := url.Parse(r.URL)
+	if err != nil {
+		return r.URL
+	}
+	tmpl := r.Template
+	if tmpl == "" {
+		tmpl = "default"
+	}
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
+		tmpl,
+		parsed.Host,
+		parsed.Path,
+		parsed.RawQuery,
+		parsed.Fragment,
+		parsed.User,
+		r.ImgSrc,
+	)
+}
+
+// Merge combines another result into this one (dedup merge).
+// Keeps the longer title/content, unions engines, prefers HTTPS.
+func (r *Result) Merge(other *Result) {
+	if len(other.Title) > len(r.Title) {
+		r.Title = other.Title
+	}
+	if len(other.Content) > len(r.Content) {
+		r.Content = other.Content
+	}
+
+	// Prefer HTTPS
+	if strings.HasPrefix(other.URL, "https://") && strings.HasPrefix(r.URL, "http://") {
+		r.URL = other.URL
+	}
+
+	// Union engines
+	seen := make(map[string]bool, len(r.Engines))
+	for _, e := range r.Engines {
+		seen[e] = true
+	}
+	for _, e := range other.Engines {
+		if !seen[e] {
+			r.Engines = append(r.Engines, e)
+		}
+	}
+
+	// Accumulate positions
+	r.Positions = append(r.Positions, other.Positions...)
+
+	// Keep non-empty optional fields
+	if r.Thumbnail == "" {
+		r.Thumbnail = other.Thumbnail
+	}
+	if r.ImgSrc == "" {
+		r.ImgSrc = other.ImgSrc
+	}
+	if r.Author == "" {
+		r.Author = other.Author
+	}
+	if r.PublishedDate == nil {
+		r.PublishedDate = other.PublishedDate
+	}
+}
+
+// CalculateScore computes the result score based on positions, weight, and priority.
+// Matches the Python scoring at searx/results.py:17-38.
+func (r *Result) CalculateScore() {
+	weight := r.Weight
+	if weight <= 0 {
+		weight = 1.0
+	}
+
+	var score float64
+	for _, pos := range r.Positions {
+		switch r.Priority {
+		case "high":
+			score += weight
+		case "low":
+			// score += 0
+		default: // "normal" or empty
+			if pos > 0 {
+				score += weight / float64(pos)
+			}
+		}
+	}
+
+	r.Score = score
+}

--- a/go/internal/search/search.go
+++ b/go/internal/search/search.go
@@ -1,0 +1,221 @@
+// Package search orchestrates parallel engine dispatch and result collection.
+package search
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/network"
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+// Query holds the parameters for a search operation.
+type Query struct {
+	Query        string
+	EngineRefs   []EngineRef
+	Lang         string
+	SafeSearch   int
+	PageNo       int
+	TimeRange    string
+	TimeoutLimit time.Duration
+	EngineData   map[string]map[string]string
+}
+
+// EngineRef identifies an engine and category to search.
+type EngineRef struct {
+	Name     string
+	Category string
+}
+
+// Response is the complete search response.
+type Response struct {
+	Query               string                     `json:"query"`
+	NumberOfResults     int                        `json:"number_of_results"`
+	Results             []result.Result            `json:"results"`
+	Answers             []result.Answer            `json:"answers"`
+	Corrections         []string                   `json:"corrections"`
+	Infoboxes           []map[string]any           `json:"infoboxes"`
+	Suggestions         []string                   `json:"suggestions"`
+	UnresponsiveEngines []result.UnresponsiveEngine `json:"unresponsive_engines"`
+}
+
+// Execute runs a search across the specified engines in parallel.
+func Execute(
+	ctx context.Context,
+	q Query,
+	engines map[string]engine.Engine,
+	client *network.Client,
+	suspensions map[string]*network.SuspendedStatus,
+) *Response {
+
+	container := result.NewContainer()
+	timeout := q.TimeoutLimit
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, ref := range q.EngineRefs {
+		eng, ok := engines[ref.Name]
+		if !ok {
+			slog.Warn("engine not found", "name", ref.Name)
+			continue
+		}
+
+		// Check suspension.
+		if s, ok := suspensions[ref.Name]; ok && s.IsSuspended() {
+			container.AddUnresponsive(ref.Name, "suspended", true)
+			continue
+		}
+
+		g.Go(func() error {
+			searchEngine(ctx, eng, q, ref, client, container, suspensions)
+			return nil // never propagate errors; we record them in container
+		})
+	}
+
+	_ = g.Wait()
+
+	results := container.GetOrderedResults()
+	if results == nil {
+		results = []result.Result{}
+	}
+	return &Response{
+		Query:               q.Query,
+		NumberOfResults:     len(results),
+		Results:             results,
+		Answers:             orEmpty(container.Answers),
+		Corrections:         orEmptyStr(container.Corrections),
+		Infoboxes:           orEmptyInfobox(container.Infoboxes),
+		Suggestions:         orEmptyStr(container.Suggestions),
+		UnresponsiveEngines: orEmptyUnresponsive(container.Unresponsive),
+	}
+}
+
+func searchEngine(
+	ctx context.Context,
+	eng engine.Engine,
+	q Query,
+	ref EngineRef,
+	client *network.Client,
+	container *result.Container,
+	suspensions map[string]*network.SuspendedStatus,
+) {
+	start := time.Now()
+	name := eng.Name()
+
+	params := &engine.SearchParams{
+		Query:      q.Query,
+		Language:   q.Lang,
+		SafeSearch: q.SafeSearch,
+		PageNo:     q.PageNo,
+		TimeRange:  q.TimeRange,
+		Category:   ref.Category,
+	}
+	if ed, ok := q.EngineData[name]; ok {
+		params.EngineData = ed
+	}
+
+	// Check capabilities.
+	if q.PageNo > 1 && !eng.SupportsPaging() {
+		return
+	}
+	if q.PageNo > eng.MaxPage() && eng.MaxPage() > 0 {
+		return
+	}
+	if q.TimeRange != "" && !eng.SupportsTimeRange() {
+		// Still search, just ignore time_range.
+		params.TimeRange = ""
+	}
+
+	req, err := eng.BuildRequest(q.Query, params)
+	if err != nil {
+		slog.Error("engine build request failed", "engine", name, "error", err)
+		container.AddUnresponsive(name, fmt.Sprintf("build request: %v", err), false)
+		recordError(suspensions, name)
+		return
+	}
+
+	resp, body, err := client.Do(ctx, req)
+	if err != nil {
+		slog.Error("engine http request failed", "engine", name,
+			"error", err, "duration", time.Since(start))
+		container.AddUnresponsive(name, fmt.Sprintf("http error: %v", err), false)
+		recordError(suspensions, name)
+		return
+	}
+
+	// Classify HTTP errors.
+	if engErr := network.ClassifyHTTPError(resp, body); engErr != nil {
+		slog.Warn("engine returned error", "engine", name,
+			"kind", engErr.Kind, "msg", engErr.Message)
+		container.AddUnresponsive(name, engErr.Message, false)
+		recordError(suspensions, name)
+		return
+	}
+
+	results, err := eng.ParseResponse(resp, body)
+	if err != nil {
+		slog.Error("engine parse response failed", "engine", name, "error", err)
+		container.AddUnresponsive(name, fmt.Sprintf("parse error: %v", err), false)
+		recordError(suspensions, name)
+		return
+	}
+
+	// Set weight from engine config on each result.
+	container.AddResults(results, name)
+	recordSuccess(suspensions, name)
+
+	slog.Debug("engine search complete", "engine", name,
+		"results", len(results), "duration", time.Since(start))
+}
+
+func recordError(suspensions map[string]*network.SuspendedStatus, name string) {
+	if s, ok := suspensions[name]; ok {
+		s.RecordError()
+	}
+}
+
+func recordSuccess(suspensions map[string]*network.SuspendedStatus, name string) {
+	if s, ok := suspensions[name]; ok {
+		s.RecordSuccess()
+	}
+}
+
+// Helper functions to ensure JSON arrays are never null.
+func orEmpty(a []result.Answer) []result.Answer {
+	if a == nil {
+		return []result.Answer{}
+	}
+	return a
+}
+
+func orEmptyStr(a []string) []string {
+	if a == nil {
+		return []string{}
+	}
+	return a
+}
+
+func orEmptyInfobox(a []map[string]any) []map[string]any {
+	if a == nil {
+		return []map[string]any{}
+	}
+	return a
+}
+
+func orEmptyUnresponsive(a []result.UnresponsiveEngine) []result.UnresponsiveEngine {
+	if a == nil {
+		return []result.UnresponsiveEngine{}
+	}
+	return a
+}

--- a/go/internal/server/server.go
+++ b/go/internal/server/server.go
@@ -1,0 +1,307 @@
+// Package server provides the HTTP server and JSON API routes.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/network"
+	"github.com/searxng/searxng-go/internal/query"
+	"github.com/searxng/searxng-go/internal/search"
+)
+
+// Server is the SearXNG HTTP server.
+type Server struct {
+	cfg         *config.Config
+	engines     map[string]engine.Engine
+	client      *network.Client
+	suspensions map[string]*network.SuspendedStatus
+	categories  map[string]bool
+	router      chi.Router
+}
+
+// New creates a new Server.
+func New(cfg *config.Config, engines map[string]engine.Engine, client *network.Client) *Server {
+	s := &Server{
+		cfg:         cfg,
+		engines:     engines,
+		client:      client,
+		suspensions: make(map[string]*network.SuspendedStatus),
+		categories:  make(map[string]bool),
+	}
+
+	// Build category set and suspension trackers.
+	for _, ecfg := range cfg.Engines {
+		if ecfg.Disabled || ecfg.Inactive {
+			continue
+		}
+		for _, cat := range ecfg.Categories {
+			s.categories[cat] = true
+		}
+		s.suspensions[ecfg.Name] = network.NewSuspendedStatus(
+			30*time.Second, 10*time.Minute,
+		)
+	}
+
+	s.router = s.buildRouter()
+	return s
+}
+
+func (s *Server) buildRouter() chi.Router {
+	r := chi.NewRouter()
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Recoverer)
+	if s.cfg.General.Debug {
+		r.Use(middleware.Logger)
+	}
+
+	r.Get("/healthz", s.handleHealthz)
+	r.Get("/config", s.handleConfig)
+	r.Get("/search", s.handleSearch)
+	r.Post("/search", s.handleSearch)
+	return r
+}
+
+// ListenAndServe starts the HTTP server.
+func (s *Server) ListenAndServe() error {
+	addr := fmt.Sprintf("%s:%d", s.cfg.Server.BindAddress, s.cfg.Server.Port)
+	slog.Info("starting server", "addr", addr)
+	return http.ListenAndServe(addr, s.router)
+}
+
+// handleHealthz returns a simple health check.
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// handleConfig returns instance configuration.
+func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
+	type engineInfo struct {
+		Name       string   `json:"name"`
+		Shortcut   string   `json:"shortcut"`
+		Categories []string `json:"categories"`
+		Enabled    bool     `json:"enabled"`
+	}
+
+	var engineList []engineInfo
+	for _, ecfg := range s.cfg.Engines {
+		if ecfg.Inactive {
+			continue
+		}
+		engineList = append(engineList, engineInfo{
+			Name:       ecfg.Name,
+			Shortcut:   ecfg.Shortcut,
+			Categories: ecfg.Categories,
+			Enabled:    !ecfg.Disabled,
+		})
+	}
+
+	cats := make([]string, 0, len(s.categories))
+	for c := range s.categories {
+		cats = append(cats, c)
+	}
+
+	resp := map[string]any{
+		"instance_name": s.cfg.General.InstanceName,
+		"engines":       engineList,
+		"categories":    cats,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleSearch parses query params and executes a search.
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	q := r.FormValue("q")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, "missing required parameter: q")
+		return
+	}
+
+	pageno := parseIntParam(r, "pageno", 1)
+	if pageno < 1 {
+		writeError(w, http.StatusBadRequest, "pageno must be >= 1")
+		return
+	}
+
+	safesearch := parseIntParam(r, "safesearch", s.cfg.Search.SafeSearch)
+	if safesearch < 0 || safesearch > 2 {
+		writeError(w, http.StatusBadRequest, "safesearch must be 0, 1, or 2")
+		return
+	}
+
+	timeRange := r.FormValue("time_range")
+	if timeRange != "" && timeRange != "day" && timeRange != "week" &&
+		timeRange != "month" && timeRange != "year" {
+		writeError(w, http.StatusBadRequest, "time_range must be day, week, month, or year")
+		return
+	}
+
+	language := r.FormValue("language")
+	if language == "" {
+		language = s.cfg.Search.DefaultLang
+	}
+
+	timeoutLimit := parseFloatParam(r, "timeout_limit", s.cfg.Outgoing.MaxRequestTimeout)
+	if timeoutLimit > s.cfg.Outgoing.MaxRequestTimeout && s.cfg.Outgoing.MaxRequestTimeout > 0 {
+		timeoutLimit = s.cfg.Outgoing.MaxRequestTimeout
+	}
+
+	// Parse query for bangs and language overrides.
+	parsed := query.Parse(q, s.engines, s.categories)
+	if parsed.Language != "" {
+		language = parsed.Language
+	}
+
+	// Resolve which engines to search.
+	refs := s.resolveEngineRefs(r, parsed)
+	if len(refs) == 0 {
+		writeError(w, http.StatusBadRequest, "no engines selected for the given categories")
+		return
+	}
+
+	sq := search.Query{
+		Query:        parsed.Query,
+		EngineRefs:   refs,
+		Lang:         language,
+		SafeSearch:   safesearch,
+		PageNo:       pageno,
+		TimeRange:    timeRange,
+		TimeoutLimit: time.Duration(timeoutLimit * float64(time.Second)),
+	}
+
+	ctx := r.Context()
+	resp := search.Execute(ctx, sq, s.engines, s.client, s.suspensions)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// resolveEngineRefs determines which engines to query based on request params and parsed query.
+func (s *Server) resolveEngineRefs(r *http.Request, parsed query.Parsed) []search.EngineRef {
+	var refs []search.EngineRef
+
+	// Explicit engines from query param.
+	if enginesParam := r.FormValue("engines"); enginesParam != "" {
+		for _, name := range strings.Split(enginesParam, ",") {
+			name = strings.TrimSpace(name)
+			if eng, ok := s.engines[name]; ok {
+				cats := eng.Categories()
+				cat := "general"
+				if len(cats) > 0 {
+					cat = cats[0]
+				}
+				refs = append(refs, search.EngineRef{Name: name, Category: cat})
+			}
+		}
+		return refs
+	}
+
+	// Engines/categories from bang syntax in query.
+	if len(parsed.Engines) > 0 {
+		for _, name := range parsed.Engines {
+			if eng, ok := s.engines[name]; ok {
+				cats := eng.Categories()
+				cat := "general"
+				if len(cats) > 0 {
+					cat = cats[0]
+				}
+				refs = append(refs, search.EngineRef{Name: name, Category: cat})
+			}
+		}
+		return refs
+	}
+
+	// Categories from bang syntax or query param.
+	selectedCats := parsed.Categories
+	if len(selectedCats) == 0 {
+		if catParam := r.FormValue("categories"); catParam != "" {
+			selectedCats = strings.Split(catParam, ",")
+			for i := range selectedCats {
+				selectedCats[i] = strings.TrimSpace(selectedCats[i])
+			}
+		}
+	}
+	if len(selectedCats) == 0 {
+		selectedCats = []string{"general"}
+	}
+
+	catSet := make(map[string]bool, len(selectedCats))
+	for _, c := range selectedCats {
+		catSet[c] = true
+	}
+
+	// Select all active engines matching the categories.
+	for _, ecfg := range s.cfg.Engines {
+		if ecfg.Disabled || ecfg.Inactive {
+			continue
+		}
+		if _, ok := s.engines[ecfg.Name]; !ok {
+			continue
+		}
+		for _, cat := range ecfg.Categories {
+			if catSet[cat] {
+				refs = append(refs, search.EngineRef{Name: ecfg.Name, Category: cat})
+				break
+			}
+		}
+	}
+
+	return refs
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func parseIntParam(r *http.Request, name string, defaultVal int) int {
+	s := r.FormValue(name)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return defaultVal
+	}
+	return v
+}
+
+func parseFloatParam(r *http.Request, name string, defaultVal float64) float64 {
+	s := r.FormValue(name)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return defaultVal
+	}
+	return v
+}
+
+// Handler returns the http.Handler for use in tests.
+func (s *Server) Handler() http.Handler {
+	return s.router
+}
+
+// Shutdown gracefully shuts down the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	// The chi router doesn't need cleanup, but this is where
+	// we'd close the HTTP server if using http.Server directly.
+	return nil
+}

--- a/go/internal/server/server_test.go
+++ b/go/internal/server/server_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/searxng/searxng-go/internal/config"
+	"github.com/searxng/searxng-go/internal/engine"
+	"github.com/searxng/searxng-go/internal/network"
+	"github.com/searxng/searxng-go/internal/result"
+)
+
+// mockEngine is a test engine that returns canned results.
+type mockEngine struct {
+	name string
+}
+
+func (m *mockEngine) Name() string             { return m.name }
+func (m *mockEngine) Categories() []string      { return []string{"general"} }
+func (m *mockEngine) Shortcut() string          { return "mk" }
+func (m *mockEngine) SupportsPaging() bool      { return false }
+func (m *mockEngine) SupportsTimeRange() bool   { return false }
+func (m *mockEngine) SupportsSafeSearch() bool  { return false }
+func (m *mockEngine) MaxPage() int              { return 1 }
+
+func (m *mockEngine) BuildRequest(query string, params *engine.SearchParams) (*http.Request, error) {
+	// Return a request that will be handled by a test server.
+	return http.NewRequest("GET", "http://invalid.test/search?q="+query, nil)
+}
+
+func (m *mockEngine) ParseResponse(resp *http.Response, body []byte) ([]result.Result, error) {
+	return []result.Result{
+		{
+			URL:      "https://example.com/result",
+			Title:    "Test Result",
+			Content:  "This is a test result",
+			Template: "default",
+			Priority: "normal",
+			Weight:   1.0,
+		},
+	}, nil
+}
+
+func TestHealthzEndpoint(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("expected status ok, got %q", body["status"])
+	}
+}
+
+func TestConfigEndpoint(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/config", nil)
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body["instance_name"] != "Test Instance" {
+		t.Errorf("expected instance name 'Test Instance', got %v", body["instance_name"])
+	}
+}
+
+func TestSearchMissingQuery(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/search", nil)
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestSearchInvalidParams(t *testing.T) {
+	srv := newTestServer()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"bad pageno", "/search?q=test&pageno=-1"},
+		{"bad safesearch", "/search?q=test&safesearch=5"},
+		{"bad time_range", "/search?q=test&time_range=invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d", w.Code)
+			}
+		})
+	}
+}
+
+func TestSearchReturnsJSON(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/search?q=hello", nil)
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("expected application/json, got %s", contentType)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Should have the standard response fields.
+	for _, key := range []string{"query", "results", "answers", "corrections", "suggestions", "unresponsive_engines"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("missing response field %q", key)
+		}
+	}
+
+	if body["query"] != "hello" {
+		t.Errorf("expected query 'hello', got %v", body["query"])
+	}
+}
+
+func newTestServer() *Server {
+	cfg := &config.Config{
+		General: config.GeneralConfig{
+			Debug:        false,
+			InstanceName: "Test Instance",
+		},
+		Search: config.SearchConfig{
+			SafeSearch:  0,
+			DefaultLang: "en",
+		},
+		Server: config.ServerConfig{
+			Port:        8888,
+			BindAddress: "127.0.0.1",
+		},
+		Outgoing: config.OutgoingConfig{
+			RequestTimeout:    3.0,
+			MaxRequestTimeout: 10.0,
+			MaxConnections:    10,
+			MaxIdleConns:      5,
+		},
+		Engines: []config.EngineConfig{
+			{
+				Name:       "mock",
+				Engine:     "mock",
+				Shortcut:   "mk",
+				Categories: []string{"general"},
+				Timeout:    3.0,
+				Weight:     1.0,
+			},
+		},
+	}
+
+	engines := map[string]engine.Engine{
+		"mock": &mockEngine{name: "mock"},
+	}
+	client := network.NewClient(cfg.Outgoing)
+	return New(cfg, engines, client)
+}

--- a/go/settings.yml
+++ b/go/settings.yml
@@ -1,0 +1,55 @@
+general:
+  debug: false
+  instance_name: "SearXNG-Go"
+
+search:
+  safe_search: 0
+  default_lang: "en"
+  max_page: 50
+
+server:
+  port: 8888
+  bind_address: "127.0.0.1"
+  secret_key: "change-me-in-production"
+  base_url: "http://localhost:8888"
+
+outgoing:
+  request_timeout: 3.0
+  max_request_timeout: 10.0
+  pool_connections: 100
+  pool_maxsize: 20
+
+engines:
+  - name: google
+    engine: google
+    shortcut: go
+    categories: [general, web]
+    timeout: 3.0
+    weight: 1.2
+
+  - name: bing
+    engine: bing
+    shortcut: bi
+    categories: [general, web]
+    timeout: 3.0
+
+  - name: duckduckgo
+    engine: duckduckgo
+    shortcut: ddg
+    categories: [general, web]
+    timeout: 3.0
+
+  - name: brave
+    engine: brave
+    shortcut: br
+    categories: [general, web]
+    timeout: 3.0
+    paging: true
+    time_range_support: true
+
+  - name: wikipedia
+    engine: wikipedia
+    shortcut: wp
+    categories: [general]
+    timeout: 3.0
+    weight: 0.8


### PR DESCRIPTION
Initial implementation of SearXNG rewritten in Go for private deployment. This is a JSON-only API server (no frontend/templates/themes) with the core search pipeline: parallel engine dispatch, result dedup/merging, scoring, and ranking.

Architecture:
- cmd/searxng/main.go: entry point, config loading, server startup
- internal/config: YAML config loading with env var override
- internal/engine: Engine interface and factory registry
- internal/engines/: 5 engine implementations (google, bing, duckduckgo, brave, wikipedia)
- internal/search: parallel search orchestration using errgroup
- internal/result: result types, container with dedup/merge/score/rank
- internal/network: HTTP client with pooling, error classification, engine suspension tracking
- internal/server: chi-based HTTP server with /search, /config, /healthz
- internal/query: query parsing with bang (!shortcut) and language (:en)

Excluded per requirements: i18n, frontend, bot detection, privacy features, rate limiting, themes.

https://claude.ai/code/session_017c5fBeVAFGYMiSrWszUnWd

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes -->

## Author's checklist

<!-- additional notes for reviewers -->

## Related issues

<!--
Closes #234
-->

## AI Disclosure
<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
- [ ] I hereby confirm that I have not used any AI tools for creating this PR.
- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
