### PR TITLE
[mod] improves the readability of PR and issue templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,41 +1,50 @@
 ---
-name: Bug report
-about: Report a bug in SearXNG
-title: ''
-labels: bug
-assignees: ''
-
+name: "Bug report"
+about: Report a bug in SearXNG"
+labels: ["bug"]
+type: "bug"
 ---
-<!-- PLEASE FILL THESE FIELDS, IT REALLY HELPS THE MAINTAINERS OF SearXNG -->
 
-**Version of SearXNG, commit number if you are using on master branch and stipulate if you forked SearXNG**
-<!-- If you are running on master branch using git execute this command
-in order to fetch the latest commit ID:
-```
-git log -1
-```
-If you are using searxng-docker then look at the bottom of the SearXNG page
-and check for the version after "Powered by SearXNG"
+_Replace this placeholder with a meaningful and precise description of the bug._
 
-Please also stipulate if you are using a forked version of SearXNG and
-include a link to the fork source code.
+<!-- FILL IN THESE FIELDS .. and delete the comments after reading.
+
+     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
 -->
-**How did you install SearXNG?**
-<!-- Did you install SearXNG using the official wiki or using searxng-docker
-or manually by executing the searx/webapp.py file? -->
-**What happened?**
-<!-- A clear and concise description of what the bug is. -->
 
-**How To Reproduce**
-<!-- How can we reproduce this issue? (as minimally and as precisely as possible) -->
+### How To Reproduce?
 
-**Expected behavior**
+<!-- How can we reproduce this issue? (as minimally and as precisely as
+     possible) -->
+
+### Expected behavior
+
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Screenshots & Logs**
+### Screenshots & Logs
+
 <!-- If applicable, add screenshots, logs to help explain your problem. -->
 
-**Additional context**
+### Version of SearXNG
+
+<!-- Commit number if you are using on master branch and stipulate if you forked
+     SearXNG -->
+
+<!-- Look at the bottom of the SearXNG page and check for the version after
+     "Powered by SearXNG" If you are using a forked version of SearXNG include a
+     link to the fork source code. -->
+
+### How did you install SearXNG?
+
+<!-- Did you install SearXNG using the official documentation or using
+     searxng-docker? -->
+
+### Additional context
+
 <!-- Add any other context about the problem here. -->
 
-- [ ] I read the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst) and hereby confirm that this issue conforms with the policy.
+### Code of Conduct
+
+[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst
+
+- [ ] I read the [AI Policy] and hereby confirm that this issue conforms with the policy.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions & Answers (Q&A)
     url: https://github.com/searxng/searxng/discussions/categories/q-a

--- a/.github/ISSUE_TEMPLATE/engine-request.md
+++ b/.github/ISSUE_TEMPLATE/engine-request.md
@@ -1,33 +1,46 @@
 ---
-name: Engine request
-about: Request a new engine in SearXNG
-title: ''
-labels: enhancement, engine request
-assignees: ''
-
+name: Engine request"
+about: Request a new engine in SearXNG"
+labels: ["engine request"]
+type: "feature"
 ---
-<!-- PLEASE FILL THESE FIELDS, IT REALLY HELPS THE MAINTAINERS OF SearXNG -->
 
-**Working URL to the engine**
-<!-- Please check if the engine is responding correctly before submitting it. -->
+<!-- FILL IN THESE FIELDS .. and delete the comments after reading.
 
-**Why do you want to add this engine?**
-<!-- What's special about this engine? Is it open source or libre? -->
+     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
+-->
 
-**Features of this engine**
-<!-- Features of this engine: Doesn't track its users, fast, easy to integrate, ... -->
+### Working URL to the engine
 
-**How can SearXNG fetch the information from this engine?**
-<!-- List API URL, example code (using the correct markdown) and more
-that could be useful for the developers in order to implement this engine.
-If you don't know what to write, let this part blank. -->
+<!-- Please check if the engine is responding correctly before submitting -->
 
-**Applicable category of this engine**
-<!-- Where should this new engine fit in SearXNG? Current categories in SearXNG:
-general, files, images, it, map, music, news, science, social media and videos.
-You can add multiple categories at the same time. -->
+### Why do you want to add this engine?
 
-**Additional context**
-<!-- Add any other context about this engine here. -->
+<!-- What's special about this engine?  -->
 
-- [ ] I read the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst) and hereby confirm that this issue conforms with the policy.
+### Features of this engine
+
+<!-- Features of this engine: Serves special content, is fast, is easy to
+     integrate, ... ? -->
+
+### How can SearXNG fetch results from this engine?
+
+<!-- List API URL, example code and more that could be useful for the developers
+     in order to implement this engine.  If you don't know what to write, let
+     this part blank. -->
+
+### Applicable category of this engine
+
+<!-- Where should this new engine fit in SearXNG?  Current categories in
+     SearXNG: general, files, images, it, map, music, news, science, social
+     media and videos. -->
+
+### Additional context
+
+<!-- Add any other context about the problem here. -->
+
+### Code of Conduct
+
+[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst
+
+- [ ] I read the [AI Policy] and hereby confirm that this issue conforms with the policy.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,23 +1,32 @@
 ---
-name: Feature request
-about: Request a new feature in SearXNG
-title: ''
-labels: enhancement
-assignees: ''
-
+name: "Feature request"
+about: "Request a new feature in SearXNG"
+labels: ["new feature"]
+type: "feature"
 ---
-<!-- PLEASE FILL THESE FIELDS, IT REALLY HELPS THE MAINTAINERS OF SearXNG -->
 
-**Is your feature request related to a problem? Please describe.**
-<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+_Replace this placeholder with a concise description of the feature._
 
-**Describe the solution you'd like**
+<!-- FILL IN THESE FIELDS .. and delete the comments after reading.
+
+     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
+-->
+
+### Is your feature request related to a problem?
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always
+     frustrated when [...] -->
+
+### Describe the solution you'd like
+
 <!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 <!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-<!-- Add any other context or screenshots about the feature request here. -->
+### Code of Conduct
 
-- [ ] I read the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst) and hereby confirm that this issue conforms with the policy.
+[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst
+
+- [ ] I read the [AI Policy] and hereby confirm that this issue conforms with the policy.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,34 @@
-## What does this PR do?
+<!-- FILL IN THESE FIELDS .. and delete the comments after reading.
 
-<!-- MANDATORY -->
-
-<!-- explain the changes in your PR, algorithms, design, architecture -->
-
-## Why is this change important?
-
-<!-- MANDATORY -->
-
-<!-- explain the motivation behind your PR -->
-
-## How to test this PR locally?
-
-<!-- commands to run the tests or instructions to test the changes -->
-
-## Author's checklist
-
-<!-- additional notes for reviewers -->
-
-## Related issues
-
-<!--
-Closes #234
+     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
 -->
 
-## AI Disclosure
-<!-- please read https://github.com/searxng/searxng/blob/master/AI_POLICY.rst -->
-- [ ] I hereby confirm that I have not used any AI tools for creating this PR.
-- [ ] I have used AI tools for working on the changes in this pull request and will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.
+### What does this PR do?
+
+<!-- Explain the motivation and changes in your pull request.  -->
+
+### How to test this PR locally?
+
+<!-- Commands to run the tests or instructions to test the changes.  Are there
+     any edge cases (environment, language, or other contexts) to take into
+     account?  -->
+
+### Related issues
+
+<!--
+Closes: #234
+-->
+
+### Code of Conduct
+
+<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
+     that are clearly AI (slop) will be blocked for all future contributions.
+     -->
+
+[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst
+
+- [ ] **I hereby confirm that this PR conforms with the [AI Policy].**
+
+  If I have used AI tools for working on the changes in this PR, I will
+  attach a list of all AI tools I used and how I used them. I hereby confirm
+  that I haven't used any other tools than the ones I mention below.


### PR DESCRIPTION
### What does this PR do?

Adjustments to the PR & issue templates / Blank issues are no longer allowed (`blank_issues_enabled: false`)

Improves the readability of PR and issue templates to make filling them out a little easier (at least visually in Markdown).

### How to test this PR locally?

C&P the markdown into a GH issue / PR and click on the "Preview" tab.

### Related issues

- https://github.com/searxng/searxng/pull/5848

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.