### PR TITLE
[mod] aol engines: disable by default

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -426,18 +426,21 @@ engines:
     search_type: search
     categories: [general]
     shortcut: aol
+    disabled: true
 
   - name: aol images
     engine: aol
     search_type: image
     categories: [images]
     shortcut: aoli
+    disabled: true
 
   - name: aol videos
     engine: aol
     search_type: video
     categories: [videos]
     shortcut: aolv
+    disabled: true
 
   - name: arch linux wiki
     engine: archlinux


### PR DESCRIPTION
### What does this PR do?

Disable all AOL engines by default.

The AOL engines deliver no results or too many incorrect results; in #5972 it is reported that the AOL-images do not work, and on AOL-web the language selection seems to depend more on the IP than on the selected language / Locally, the language selection works for me, on the public server only English results are displayed, which significantly worsens the result list.

### How to test this PR locally?

Do some queries .. there should be none AOL results in :-)

### Related issues

- #5972 

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.