### PR TITLE
fix(startpage): handle string date field in news results

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -345,7 +345,10 @@ def _get_news_result(result):
 
     publishedDate = None
     if result.get("date"):
-        publishedDate = datetime.fromtimestamp(result["date"] / 1000)
+        try:
+            publishedDate = datetime.fromtimestamp(float(result["date"]) / 1000)
+        except (ValueError, TypeError):
+            pass
 
     thumbnailUrl = None
     if result.get("thumbnailUrl"):


### PR DESCRIPTION
## Problem

The Startpage news engine crashes with a `TypeError` when the `date` field in the API response is returned as a string instead of an integer.

**Error:**
```
TypeError: unsupported operand type(s) for /: 'str' and 'int'
File "searx/engines/startpage.py", line 348, in _get_news_result
    publishedDate = datetime.fromtimestamp(result["date"] / 1000)
```

## Root Cause

Line 348 in `searx/engines/startpage.py` performs arithmetic division `result["date"] / 1000` directly on the API response value. Startpage's API inconsistently returns the timestamp as either an integer or a string — when it's a string (e.g., `"1713244800000"`), Python raises `TypeError` because you can't divide a string by an int.

## Fix

Wrapped the conversion in `float()` with a `try/except` guard, following the same defensive pattern already used in other engines (e.g., `piratebay.py` uses `float(result["added"])` inside a bare except). The fix:

1. Uses `float()` instead of raw division — handles both `int` and `str` inputs
2. Catches `ValueError` (unconvertible strings) and `TypeError` (None/non-numeric)
3. Falls back to `publishedDate = None` on failure, so the result still returns

**Changed lines: 347-350 in `searx/engines/startpage.py`**

## Testing

- Verified the fix handles: integer timestamps, string timestamps (e.g., `"1713244800000"`), `None`, empty string, and non-numeric strings
- Syntax check passes (auto-verified by patch tool)
- No test file exists for startpage engine; the fix is minimal and follows established project patterns

## Impact

- **Scope:** Startpage news category only
- **Risk:** Very low — `float()` is a superset of the original behavior for numeric inputs; try/except is purely additive
- **Backward compatibility:** Fully maintained — existing integer timestamps work identically

Fixes #5979
