### PR TITLE
[feat] engines: add optional google api engines

### DIFF
--- a/docs/admin/settings/settings_engines.rst
+++ b/docs/admin/settings/settings_engines.rst
@@ -136,6 +136,10 @@ engine is shown.  Most of the options have a default value or even are optional.
   Remove the engine from the settings (*disabled & removed*).  This defaults to ``true`` for engines
   that require an API key, please see the ``api_key`` section if you want to enable such an engine.
 
+  Example use cases include optional API-backed engines such as
+  ``google_api`` and its related ``google_images_api``, ``google_news_api``
+  and ``google_videos_api`` variants.
+
 ``language`` : optional
   If you want to use another language for a specific engine, you can define it
   by using the ISO code of language (and region), like ``fr``, ``en-US``,

--- a/docs/dev/engines/online/google_api.rst
+++ b/docs/dev/engines/online/google_api.rst
@@ -1,0 +1,82 @@
+==================
+Google API Engines
+==================
+
+.. contents:: Contents
+   :depth: 2
+   :local:
+   :backlinks: entry
+
+These engines provide Google result types through third-party JSON SERP APIs.
+They share the same engine semantics and differ only by the configured
+provider (currently ``serpbase`` or ``serper``).
+
+- ``serpbase``: https://serpbase.dev / https://serpbase.dev/docs
+- ``serper``: https://serper.dev
+
+Both providers are intended to be low-cost Google SERP API options.
+
+They are optional additions to the existing Google engines.  Enabling
+``google_api``, ``google_images_api``, ``google_news_api`` or
+``google_videos_api`` does not replace ``google``, ``google_images``,
+``google_news`` or ``google_videos``.
+
+
+Configuration
+-------------
+
+These engines are configured in :origin:`searx/settings.yml` with
+``inactive: true`` by default, because they require an API key.
+
+Example configuration::
+
+  - name: google api
+    engine: google_api
+    provider: serpbase
+    api_key: "your-api-key"
+    shortcut: goapi
+    inactive: false
+
+  - name: google images api
+    engine: google_images_api
+    provider: serpbase
+    api_key: "your-api-key"
+    shortcut: goiapi
+    inactive: false
+
+Set ``provider`` to ``serper`` to use that backend instead.
+
+.. _google_api engine:
+
+Google API
+----------
+
+.. automodule:: searx.engines.google_api
+   :members:
+
+.. _google_images_api engine:
+
+Google Images API
+-----------------
+
+.. automodule:: searx.engines.google_images_api
+   :members:
+
+.. _google_news_api engine:
+
+Google News API
+---------------
+
+.. automodule:: searx.engines.google_news_api
+   :members:
+
+.. _google_videos_api engine:
+
+Google Videos API
+-----------------
+
+.. automodule:: searx.engines.google_videos_api
+   :members:
+
+.. automodule:: searx.engines.google_api_providers
+   :members:

--- a/searx/botdetection/config.py
+++ b/searx/botdetection/config.py
@@ -13,7 +13,10 @@ import copy
 import logging
 import pathlib
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
 
 __all__ = ['Config', 'UNSET', 'SchemaIssue', 'set_global_cfg', 'get_global_cfg']
 

--- a/searx/engines/google_api.py
+++ b/searx/engines/google_api.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Google Web API engine using pluggable SERP API providers.
+
+Configuration
+=============
+
+- :py:obj:`provider`
+- :py:obj:`api_key`
+
+.. code:: yaml
+
+  - name: google api
+    engine: google_api
+    provider: serpbase  # or serper
+    api_key: 'YOUR-API-KEY'
+"""
+
+from searx.engines.google_api_providers import (
+    request_google_api,
+    response_google_api,
+    validate_google_api_config,
+)
+
+about = {
+    "website": "https://www.google.com",
+    "wikidata_id": "Q9366",
+    "official_api_documentation": None,
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": "JSON",
+}
+
+categories = ["general", "web"]
+paging = True
+time_range_support = True
+safesearch = True
+timeout = 10.0
+
+provider = "serpbase"
+api_key = ""
+
+
+def init(_):
+    validate_google_api_config(provider, api_key)
+
+
+def request(query, params):
+    request_google_api(
+        query, params, provider=provider, api_key=api_key, search_type="search"
+    )
+    return params
+
+
+def response(resp):
+    return response_google_api(resp, provider=provider, search_type="search")

--- a/searx/engines/google_api_providers.py
+++ b/searx/engines/google_api_providers.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Shared provider integration for Google API engines."""
+
+from __future__ import annotations
+
+import typing as t
+from datetime import datetime
+import re
+from urllib.parse import parse_qs, urlparse
+
+from dateutil import parser as date_parser
+
+from searx.exceptions import (
+    SearxEngineAPIException,
+    SearxEngineTooManyRequestsException,
+)
+from searx.locales import get_locale
+from searx.utils import get_embeded_stream_url
+
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
+    from searx.search.processors import OnlineParams
+
+GOOGLE_API_PROVIDERS = {"serpbase", "serper"}
+GOOGLE_API_SEARCH_TYPES = {"search", "images", "news", "videos"}
+
+TIME_RANGE_DICT = {"day": "d", "week": "w", "month": "m", "year": "y"}
+SAFESEARCH_DICT = {0: "off", 1: "active", 2: "active"}
+SERPBASE_POSTED_RE = re.compile(r"Posted:\s*(.+)$")
+SERPBASE_META_SEPARATOR_RE = re.compile(r"\s+[^\w\s]{1,3}\s+")
+
+SERPBASE_ENDPOINTS = {
+    "search": "https://api.serpbase.dev/google/search",
+    "images": "https://api.serpbase.dev/google/images",
+    "news": "https://api.serpbase.dev/google/news",
+    "videos": "https://api.serpbase.dev/google/videos",
+}
+
+SERPER_ENDPOINTS = {
+    "search": "https://google.serper.dev/search",
+    "images": "https://google.serper.dev/images",
+    "news": "https://google.serper.dev/news",
+    "videos": "https://google.serper.dev/videos",
+}
+
+
+def validate_google_api_config(provider: str, api_key: str) -> None:
+    if provider not in GOOGLE_API_PROVIDERS:
+        raise SearxEngineAPIException(f"Unsupported Google API provider: {provider}")
+    if not api_key:
+        raise SearxEngineAPIException("No API key provided")
+
+
+def get_google_api_locale(searxng_locale: str) -> tuple[str, str]:
+    locale = get_locale(searxng_locale)
+    if locale is None:
+        return "en", "us"
+
+    language = locale.language or "en"
+    if locale.script and language == "zh":
+        language = f"{language}-{locale.script}"
+
+    country = locale.territory or "US"
+    return language, country.lower()
+
+
+def request_google_api(
+    query: str,
+    params: "OnlineParams",
+    *,
+    provider: str,
+    api_key: str,
+    search_type: str,
+) -> None:
+    validate_google_api_config(provider, api_key)
+    if search_type not in GOOGLE_API_SEARCH_TYPES:
+        raise SearxEngineAPIException(
+            f"Unsupported Google API search type: {search_type}"
+        )
+
+    hl, gl = get_google_api_locale(params["searxng_locale"])
+    payload: dict[str, t.Any] = {
+        "q": query,
+        "hl": hl,
+        "gl": gl,
+        "page": params["pageno"],
+    }
+
+    params["method"] = "POST"
+    params["headers"]["Content-Type"] = "application/json"
+
+    if provider == "serpbase":
+        params["headers"]["X-API-Key"] = api_key
+        params["url"] = SERPBASE_ENDPOINTS[search_type]
+    else:
+        time_range = params.get("time_range")
+        if time_range in TIME_RANGE_DICT:
+            payload["tbs"] = f"qdr:{TIME_RANGE_DICT[time_range]}"
+
+        if "safesearch" in params:
+            payload["safe"] = SAFESEARCH_DICT.get(params["safesearch"], "off")
+
+        params["headers"]["X-API-KEY"] = api_key
+        params["url"] = SERPER_ENDPOINTS[search_type]
+
+    params["json"] = payload
+
+
+def response_google_api(
+    resp: "SXNG_Response", *, provider: str, search_type: str
+) -> list[dict[str, t.Any]]:
+    if search_type not in GOOGLE_API_SEARCH_TYPES:
+        raise SearxEngineAPIException(
+            f"Unsupported Google API search type: {search_type}"
+        )
+
+    data: dict[str, t.Any] = resp.json()
+    if provider == "serpbase":
+        _raise_serpbase_error(data)
+        normalized = _normalize_serpbase(data, search_type)
+    elif provider == "serper":
+        _raise_serper_error(data, search_type)
+        normalized = _normalize_serper(data, search_type)
+    else:
+        raise SearxEngineAPIException(f"Unsupported Google API provider: {provider}")
+
+    return _to_searx_results(normalized, search_type)
+
+
+def _raise_serpbase_error(data: dict[str, t.Any]) -> None:
+    status = data.get("status")
+    if status == 0:
+        return
+
+    message = data.get("error") or f"SerpBase API error: status={status}"
+    if status == 1029:
+        raise SearxEngineTooManyRequestsException(message=message)
+    raise SearxEngineAPIException(message)
+
+
+def _raise_serper_error(data: dict[str, t.Any], search_type: str) -> None:
+    result_key = "organic" if search_type == "search" else search_type
+    if data.get("message") and not data.get(result_key):
+        raise SearxEngineAPIException(data["message"])
+
+
+def _normalize_serpbase(data: dict[str, t.Any], search_type: str) -> dict[str, t.Any]:
+    items_key = "organic" if search_type == "search" else search_type
+    return {
+        "items": [
+            _normalize_item(item, search_type, "serpbase")
+            for item in data.get(items_key, [])
+        ],
+        "suggestions": list(data.get("related_searches", [])),
+    }
+
+
+def _normalize_serper(data: dict[str, t.Any], search_type: str) -> dict[str, t.Any]:
+    items_key = "organic" if search_type == "search" else search_type
+    suggestions: list[str] = []
+    for suggestion in data.get("relatedSearches", []):
+        if isinstance(suggestion, dict):
+            query = suggestion.get("query")
+        else:
+            query = suggestion
+        if query:
+            suggestions.append(query)
+
+    return {
+        "items": [
+            _normalize_item(item, search_type, "serper")
+            for item in data.get(items_key, [])
+        ],
+        "suggestions": suggestions,
+    }
+
+
+def _normalize_item(
+    item: dict[str, t.Any], search_type: str, provider: str
+) -> dict[str, t.Any]:
+    if search_type == "search":
+        return {
+            "url": item.get("link"),
+            "title": item.get("title"),
+            "content": item.get("snippet", ""),
+            "thumbnail": item.get("icon"),
+        }
+
+    if search_type == "images":
+        image_url = item.get("imageUrl") or item.get("image_url") or item.get("img_src")
+        thumbnail_url = (
+            item.get("thumbnailUrl") or item.get("thumbnail_url") or image_url
+        )
+        resolution = None
+        width = item.get("imageWidth") or item.get("width")
+        height = item.get("imageHeight") or item.get("height")
+        if width and height:
+            resolution = f"{width} x {height}"
+
+        return {
+            "url": item.get("link"),
+            "title": item.get("title"),
+            "content": item.get("snippet", item.get("domain", "")),
+            "source": item.get("source", item.get("domain", "")),
+            "img_src": image_url,
+            "thumbnail_src": thumbnail_url,
+            "resolution": resolution,
+            "template": "images.html" if image_url or thumbnail_url else None,
+        }
+
+    if search_type == "news":
+        meta = (
+            _parse_serpbase_source_meta(item.get("source"))
+            if provider == "serpbase"
+            else {}
+        )
+        snippet = item.get("snippet", item.get("source", ""))
+        published_raw = (
+            item.get("date") or item.get("time") or meta.get("published_raw")
+        )
+        published_date = _parse_published_date(published_raw)
+        return {
+            "url": item.get("link"),
+            "title": item.get("title"),
+            "content": snippet,
+            "thumbnail": item.get("imageUrl") or item.get("thumbnail_url"),
+            "author": (
+                (
+                    _parse_serpbase_news_author(snippet, item.get("time"))
+                    or meta.get("author")
+                )
+                if provider == "serpbase"
+                else item.get("source")
+            ),
+            "publishedDate": published_date,
+        }
+
+    iframe_src = (
+        get_embeded_stream_url(item.get("link", "")) if item.get("link") else None
+    ) or _get_video_embed_url(item.get("link"))
+    meta = _parse_serpbase_video_meta(item) if provider == "serpbase" else {}
+    author = item.get("channel") or meta.get("author")
+    if provider != "serpbase" and not author:
+        author = item.get("source")
+    published_date = _parse_published_date(
+        item.get("date") or item.get("time") or meta.get("published_raw")
+    )
+    thumbnail = (
+        item.get("imageUrl")
+        or item.get("thumbnail_url")
+        or _get_video_thumbnail(item.get("link"))
+    )
+
+    return {
+        "url": item.get("link"),
+        "title": item.get("title"),
+        "content": item.get("snippet") or meta.get("description") or "",
+        "thumbnail": thumbnail,
+        "author": author,
+        "length": item.get("duration") or meta.get("duration"),
+        "publishedDate": published_date,
+        "iframe_src": iframe_src,
+        "template": "videos.html",
+    }
+
+
+def _to_searx_results(
+    normalized: dict[str, t.Any], search_type: str
+) -> list[dict[str, t.Any]]:
+    results: list[dict[str, t.Any]] = []
+    for item in normalized["items"]:
+        if not item.get("url") or not item.get("title"):
+            continue
+        if search_type == "images" and not item.get("template"):
+            item.pop("template", None)
+            item.pop("img_src", None)
+            item.pop("thumbnail_src", None)
+        results.append(item)
+
+    if search_type == "search":
+        for suggestion in normalized["suggestions"]:
+            results.append({"suggestion": suggestion})
+
+    return results
+
+
+def _parse_published_date(value: t.Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return date_parser.parse(value)
+    except (ValueError, TypeError, OverflowError):
+        return None
+
+
+def _join_nonempty(*parts: t.Any) -> str | None:
+    values = [part for part in parts if isinstance(part, str) and part]
+    return " | ".join(values) if values else None
+
+
+def _parse_serpbase_source_meta(value: t.Any) -> dict[str, str]:
+    if not isinstance(value, str) or not value.strip():
+        return {}
+
+    raw = value.strip()
+    posted_match = SERPBASE_POSTED_RE.search(raw)
+    published_raw = posted_match.group(1).strip() if posted_match else ""
+    duration = ""
+    author = raw
+
+    if raw.startswith("Duration:"):
+        duration_part = raw[len("Duration:") :]
+        if posted_match:
+            duration_part = duration_part[: posted_match.start() - len("Duration:")]
+        duration = duration_part.strip(" -|")
+        if duration == "Posted:" or duration.startswith("Posted:"):
+            duration = ""
+        author = ""
+    elif posted_match:
+        author = raw[: posted_match.start()].strip(" -|")
+
+    if not author or author == raw:
+        author = ""
+
+    description_parts = [part for part in [author, duration, published_raw] if part]
+    description = " | ".join(description_parts)
+    if not description and raw.startswith("Duration:"):
+        description = ""
+    return {
+        "author": author,
+        "duration": duration,
+        "published_raw": published_raw,
+        "description": description,
+    }
+
+
+def _parse_serpbase_video_meta(item: dict[str, t.Any]) -> dict[str, str]:
+    raw = item.get("source")
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+
+    raw = raw.strip()
+    posted_match = SERPBASE_POSTED_RE.search(raw)
+    published_raw = (
+        (item.get("time") or "").strip() if isinstance(item.get("time"), str) else ""
+    )
+    if not published_raw and posted_match:
+        published_raw = posted_match.group(1).strip()
+
+    duration = item.get("duration") if isinstance(item.get("duration"), str) else ""
+    if not duration and raw.startswith("Duration:"):
+        duration_part = raw[len("Duration:") :]
+        if posted_match:
+            duration_part = duration_part[: posted_match.start() - len("Duration:")]
+        duration = duration_part.strip(" -|")
+        if duration == "Posted:" or duration.startswith("Posted:"):
+            duration = ""
+
+    if raw.startswith("Duration:"):
+        return {
+            "author": "",
+            "duration": duration,
+            "published_raw": published_raw,
+            "description": "",
+        }
+
+    if posted_match:
+        author = raw[: posted_match.start()].strip(" -|")
+        return {
+            "author": author,
+            "duration": duration,
+            "published_raw": published_raw,
+            "description": "",
+        }
+
+    if len(raw.split()) <= 4:
+        return {
+            "author": raw,
+            "duration": duration,
+            "published_raw": published_raw,
+            "description": "",
+        }
+
+    return {
+        "author": "",
+        "duration": duration,
+        "published_raw": published_raw,
+        "description": raw,
+    }
+
+
+def _parse_serpbase_news_author(snippet: t.Any, relative_time: t.Any) -> str | None:
+    if not isinstance(snippet, str) or not snippet.strip():
+        return None
+    if not isinstance(relative_time, str) or not relative_time.strip():
+        return None
+
+    parts = [
+        part.strip()
+        for part in SERPBASE_META_SEPARATOR_RE.split(snippet.strip())
+        if part.strip()
+    ]
+    if len(parts) == 2 and parts[1] == relative_time.strip():
+        return parts[0]
+    return None
+
+
+def _get_video_thumbnail(url: t.Any) -> str | None:
+    video_id = _get_youtube_video_id(url)
+    if not video_id:
+        return None
+    return f"https://img.youtube.com/vi/{video_id}/hqdefault.jpg"
+
+
+def _get_video_embed_url(url: t.Any) -> str | None:
+    video_id = _get_youtube_video_id(url)
+    if not video_id:
+        return None
+    return f"https://www.youtube-nocookie.com/embed/{video_id}"
+
+
+def _get_youtube_video_id(url: t.Any) -> str | None:
+    if not isinstance(url, str) or not url:
+        return None
+
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    if host.endswith("youtube.com"):
+        return parse_qs(parsed.query).get("v", [None])[0]
+    if host == "youtu.be":
+        return parsed.path.strip("/") or None
+    return None

--- a/searx/engines/google_images_api.py
+++ b/searx/engines/google_images_api.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Google Images API engine using pluggable SERP API providers."""
+
+from searx.engines.google_api_providers import (
+    request_google_api,
+    response_google_api,
+    validate_google_api_config,
+)
+
+about = {
+    "website": "https://images.google.com",
+    "wikidata_id": "Q521550",
+    "official_api_documentation": None,
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": "JSON",
+}
+
+categories = ["images", "web"]
+paging = True
+time_range_support = True
+safesearch = True
+timeout = 10.0
+
+provider = "serpbase"
+api_key = ""
+
+
+def init(_):
+    validate_google_api_config(provider, api_key)
+
+
+def request(query, params):
+    request_google_api(
+        query, params, provider=provider, api_key=api_key, search_type="images"
+    )
+    return params
+
+
+def response(resp):
+    return response_google_api(resp, provider=provider, search_type="images")

--- a/searx/engines/google_news_api.py
+++ b/searx/engines/google_news_api.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Google News API engine using pluggable SERP API providers."""
+
+from searx.engines.google_api_providers import (
+    request_google_api,
+    response_google_api,
+    validate_google_api_config,
+)
+
+about = {
+    "website": "https://news.google.com",
+    "wikidata_id": "Q12020",
+    "official_api_documentation": None,
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": "JSON",
+}
+
+categories = ["news"]
+paging = True
+time_range_support = False
+safesearch = True
+timeout = 10.0
+
+provider = "serpbase"
+api_key = ""
+
+
+def init(_):
+    validate_google_api_config(provider, api_key)
+
+
+def request(query, params):
+    request_google_api(
+        query, params, provider=provider, api_key=api_key, search_type="news"
+    )
+    return params
+
+
+def response(resp):
+    return response_google_api(resp, provider=provider, search_type="news")

--- a/searx/engines/google_videos_api.py
+++ b/searx/engines/google_videos_api.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Google Videos API engine using pluggable SERP API providers."""
+
+from searx.engines.google_api_providers import (
+    request_google_api,
+    response_google_api,
+    validate_google_api_config,
+)
+
+about = {
+    "website": "https://www.google.com",
+    "wikidata_id": "Q219885",
+    "official_api_documentation": None,
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": "JSON",
+}
+
+categories = ["videos", "web"]
+paging = True
+time_range_support = True
+safesearch = True
+timeout = 10.0
+
+provider = "serpbase"
+api_key = ""
+
+
+def init(_):
+    validate_google_api_config(provider, api_key)
+
+
+def request(query, params):
+    request_google_api(
+        query, params, provider=provider, api_key=api_key, search_type="videos"
+    )
+    return params
+
+
+def response(resp):
+    return response_google_api(resp, provider=provider, search_type="videos")

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1063,6 +1063,34 @@ engines:
     engine: google_videos
     shortcut: gov
 
+  - name: google api
+    engine: google_api
+    provider: serpbase
+    api_key: ""
+    shortcut: goapi
+    inactive: true
+
+  - name: google images api
+    engine: google_images_api
+    provider: serpbase
+    api_key: ""
+    shortcut: goiapi
+    inactive: true
+
+  - name: google news api
+    engine: google_news_api
+    provider: serpbase
+    api_key: ""
+    shortcut: gonapi
+    inactive: true
+
+  - name: google videos api
+    engine: google_videos_api
+    provider: serpbase
+    api_key: ""
+    shortcut: govapi
+    inactive: true
+
   - name: google scholar
     engine: google_scholar
     shortcut: gos

--- a/tests/unit/engines/test_google_api_engines.py
+++ b/tests/unit/engines/test_google_api_engines.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring
+
+from collections import defaultdict
+from unittest.mock import Mock
+
+from searx.engines import (
+    google_api,
+    google_images_api,
+    google_news_api,
+    google_videos_api,
+)
+from searx.engines.google_api_providers import get_google_api_locale
+from searx.exceptions import (
+    SearxEngineAPIException,
+    SearxEngineTooManyRequestsException,
+)
+
+
+def test_google_api_locale_uses_script_and_region():
+    assert get_google_api_locale("zh-HK") == ("zh-Hant", "hk")
+    assert get_google_api_locale("en-GB") == ("en", "gb")
+
+
+def test_google_api_request_builds_serper_search_request():
+    google_api.provider = "serper"
+    google_api.api_key = "test-key"
+    params = defaultdict(dict)
+    params["headers"] = {}
+    params["pageno"] = 2
+    params["searxng_locale"] = "en-GB"
+    params["time_range"] = "week"
+    params["safesearch"] = 2
+
+    google_api.request("python asyncio", params)
+
+    assert params["method"] == "POST"
+    assert params["url"] == "https://google.serper.dev/search"
+    assert params["headers"]["X-API-KEY"] == "test-key"
+    assert params["json"] == {
+        "q": "python asyncio",
+        "hl": "en",
+        "gl": "gb",
+        "page": 2,
+        "tbs": "qdr:w",
+        "safe": "active",
+    }
+
+
+def test_google_api_response_maps_serpbase_results_and_suggestions():
+    google_api.provider = "serpbase"
+    response = Mock()
+    response.json.return_value = {
+        "status": 0,
+        "organic": [
+            {
+                "title": "Asyncio in Python",
+                "link": "https://example.com/asyncio",
+                "snippet": "Structured search result.",
+                "icon": "https://example.com/favicon.ico",
+            }
+        ],
+        "related_searches": ["python async await"],
+    }
+
+    results = google_api.response(response)
+
+    assert len(results) == 2
+    assert results[0]["title"] == "Asyncio in Python"
+    assert results[0]["url"] == "https://example.com/asyncio"
+    assert results[0]["thumbnail"] == "https://example.com/favicon.ico"
+    assert results[1]["suggestion"] == "python async await"
+
+
+def test_google_api_response_raises_on_serpbase_rate_limit():
+    google_api.provider = "serpbase"
+    response = Mock()
+    response.json.return_value = {"status": 1029, "error": "rate limited"}
+
+    try:
+        google_api.response(response)
+        assert False
+    except SearxEngineTooManyRequestsException as exc:
+        assert "rate limited" in str(exc)
+
+
+def test_google_images_api_maps_serper_image_results():
+    google_images_api.provider = "serper"
+    response = Mock()
+    response.json.return_value = {
+        "images": [
+            {
+                "title": "Asyncio in Python",
+                "imageUrl": "https://example.com/full.png",
+                "thumbnailUrl": "https://example.com/thumb.png",
+                "imageWidth": 800,
+                "imageHeight": 600,
+                "source": "Example",
+                "link": "https://example.com/page",
+            }
+        ]
+    }
+
+    results = google_images_api.response(response)
+
+    assert len(results) == 1
+    assert results[0]["template"] == "images.html"
+    assert results[0]["img_src"] == "https://example.com/full.png"
+    assert results[0]["thumbnail_src"] == "https://example.com/thumb.png"
+    assert results[0]["resolution"] == "800 x 600"
+
+
+def test_google_images_api_falls_back_for_sparse_serpbase_results():
+    google_images_api.provider = "serpbase"
+    response = Mock()
+    response.json.return_value = {
+        "status": 0,
+        "images": [
+            {
+                "title": "Asyncio in Python",
+                "link": "https://example.com/page",
+                "domain": "example.com",
+            }
+        ],
+    }
+
+    results = google_images_api.response(response)
+
+    assert len(results) == 1
+    assert results[0]["title"] == "Asyncio in Python"
+    assert results[0]["url"] == "https://example.com/page"
+    assert "template" not in results[0]
+
+
+def test_google_news_api_maps_news_metadata():
+    google_news_api.provider = "serper"
+    response = Mock()
+    response.json.return_value = {
+        "news": [
+            {
+                "title": "Asyncio News",
+                "link": "https://example.com/news",
+                "snippet": "Latest async news.",
+                "source": "Example News",
+                "date": "Sep 27, 2025",
+                "imageUrl": "https://example.com/news.png",
+            }
+        ]
+    }
+
+    results = google_news_api.response(response)
+
+    assert len(results) == 1
+    assert results[0]["author"] == "Example News"
+    assert results[0]["publishedDate"].year == 2025
+    assert results[0]["thumbnail"] == "https://example.com/news.png"
+
+
+def test_google_videos_api_maps_embed_and_metadata():
+    google_videos_api.provider = "serper"
+    response = Mock()
+    response.json.return_value = {
+        "videos": [
+            {
+                "title": "Asyncio Video",
+                "link": "https://www.youtube.com/watch?v=oAkLSJNr5zY",
+                "snippet": "Video description.",
+                "imageUrl": "https://example.com/video.png",
+                "duration": "1:42:41",
+                "channel": "Corey Schafer",
+                "date": "Aug 20, 2025",
+            }
+        ]
+    }
+
+    results = google_videos_api.response(response)
+
+    assert len(results) == 1
+    assert results[0]["template"] == "videos.html"
+    assert results[0]["length"] == "1:42:41"
+    assert results[0]["author"] == "Corey Schafer"
+    assert results[0]["publishedDate"].year == 2025
+    assert (
+        results[0]["iframe_src"] == "https://www.youtube-nocookie.com/embed/oAkLSJNr5zY"
+    )
+
+
+def test_google_videos_api_parses_sparse_serpbase_metadata():
+    google_videos_api.provider = "serpbase"
+    response = Mock()
+    response.json.return_value = {
+        "status": 0,
+        "videos": [
+            {
+                "title": "OpenAI's New Era - YouTube",
+                "link": "https://www.youtube.com/watch?v=jUiZg4LQgiY",
+                "source": "Duration: 12:34 Posted: Feb 9 2026",
+            },
+            {
+                "title": "OpenAI - YouTube",
+                "link": "https://www.youtube.com/OpenAI",
+                "source": "OpenAI on OpenAI How OpenAI uses its own technology.",
+            },
+        ],
+    }
+
+    results = google_videos_api.response(response)
+
+    assert len(results) == 2
+    assert results[0]["length"] == "12:34"
+    assert results[0]["publishedDate"].year == 2026
+    assert results[0]["content"] == ""
+    assert (
+        results[0]["thumbnail"]
+        == "https://img.youtube.com/vi/jUiZg4LQgiY/hqdefault.jpg"
+    )
+    assert results[1]["author"] == ""
+    assert "OpenAI uses its own technology" in results[1]["content"]
+
+
+def test_google_videos_api_parses_serpbase_time_and_thumbnail_fallback():
+    google_videos_api.provider = "serpbase"
+    response = Mock()
+    response.json.return_value = {
+        "status": 0,
+        "videos": [
+            {
+                "title": "AsyncIO Video",
+                "link": "https://www.youtube.com/watch?v=q_yk3oV14hE",
+                "source": "Duration: Posted: Aug 1 2025",
+                "duration": "9 Minutes",
+            },
+            {
+                "title": "Author Only Video",
+                "link": "https://youtu.be/abc123xyz00",
+                "source": "Corey Schafer",
+                "time": "1 week ago",
+            },
+        ],
+    }
+
+    results = google_videos_api.response(response)
+
+    assert len(results) == 2
+    assert results[0]["length"] == "9 Minutes"
+    assert results[0]["publishedDate"].year == 2025
+    assert (
+        results[0]["thumbnail"]
+        == "https://img.youtube.com/vi/q_yk3oV14hE/hqdefault.jpg"
+    )
+    assert results[1]["author"] == "Corey Schafer"
+    assert (
+        results[1]["iframe_src"] == "https://www.youtube-nocookie.com/embed/abc123xyz00"
+    )
+
+
+def test_google_news_api_parses_sparse_serpbase_metadata():
+    google_news_api.provider = "serpbase"
+    response = Mock()
+    response.json.return_value = {
+        "status": 0,
+        "news": [
+            {
+                "title": "Asyncio News",
+                "link": "https://example.com/news",
+                "source": "Example News Posted: Sep 27, 2025",
+            }
+        ],
+    }
+
+    results = google_news_api.response(response)
+
+    assert len(results) == 1
+    assert results[0]["author"] == "Example News"
+    assert results[0]["publishedDate"].year == 2025
+    assert results[0]["content"] == "Example News Posted: Sep 27, 2025"
+
+
+def test_google_api_init_rejects_invalid_provider():
+    google_api.provider = "invalid"
+    google_api.api_key = "test-key"
+
+    try:
+        google_api.init({})
+        assert False
+    except SearxEngineAPIException as exc:
+        assert "Unsupported Google API provider" in str(exc)


### PR DESCRIPTION
## Summary
- add optional `google_api`, `google_images_api`, `google_news_api`, and `google_videos_api` engines
- support configurable API providers through a shared provider layer, with `serpbase` as the default provider and `serper` as an alternative
- add tests and documentation for the new API-backed Google engines
## Details
This change adds a new family of Google API-backed engines without changing the existing `google`, `google_images`, `google_news`, or `google_videos` engines.
The new engines are configured as `inactive: true` by default because they require an API key. Users can enable them explicitly in `settings.yml` and choose the provider with the `provider` setting.
The provider layer normalizes responses from both backends so that the engines keep the same external behavior and result types.
## Testing
- add unit tests for web, images, news, and videos response normalization
- verify the new engines are registered through `settings.yml`
- verify Python 3.10 compatibility with the `tomli` fallback for `tomllib`