### PR TITLE
[fix] gmx: crash when there are no related query suggestions

### DIFF
--- a/searx/engines/gmx.py
+++ b/searx/engines/gmx.py
@@ -80,7 +80,7 @@ def response(resp: 'SXNG_Response') -> EngineResults:
 
     results = resp.json()["results"]
 
-    for suggestion in results["rs"]:
+    for suggestion in results.get("rs", []):
         res.add(res.types.LegacyResult({"suggestion": suggestion["t"]}))
 
     for result in results["hits"]:


### PR DESCRIPTION
Example query:
- `!gmx hello world abcdef`

## AI Disclaimer
- [X] I haven't used any AI for this PR.