### PR TITLE
fix: handle string date values in Startpage news engine

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -345,7 +345,19 @@ def _get_news_result(result):
 
     publishedDate = None
     if result.get("date"):
-        publishedDate = datetime.fromtimestamp(result["date"] / 1000)
+        date_val = result["date"]
+        # Handle both integer and string date values
+        if isinstance(date_val, str):
+            try:
+                date_val = int(date_val)
+            except (ValueError, TypeError):
+                # If it's a non-numeric string, try parsing it directly
+                try:
+                    publishedDate = dateutil.parser.parse(date_val)
+                except (ValueError, TypeError):
+                    pass
+        if isinstance(date_val, (int, float)):
+            publishedDate = datetime.fromtimestamp(date_val / 1000)
 
     thumbnailUrl = None
     if result.get("thumbnailUrl"):


### PR DESCRIPTION
## Fix

The Startpage news engine's `_get_news_result` function assumed the `date` field was always an integer (Unix timestamp in ms). In some cases, Startpage returns the date as a string, causing a `TypeError`.

This PR adds type checking to handle:
- **Integer timestamps** (existing behavior, divided by 1000)
- **String timestamps** (converted to int first)
- **Non-numeric date strings** (parsed with dateutil)

Fixes #5979

## Testing
- Existing tests pass unchanged
- No new dependencies (dateutil is already used by this module)
- The fix is minimal and only affects the error path