### PR TITLE
Fix Result.defaults_from() inverted logic

### DIFF
--- a/searx/result_types/_base.py
+++ b/searx/result_types/_base.py
@@ -32,7 +32,7 @@ import msgspec
 from searx import logger as log
 
 WHITESPACE_REGEX = re.compile('( |\t|\n)+', re.M | re.U)
-UNKNOWN = object()
+UNSET = object()
 
 
 def _normalize_url_fields(result: "Result | LegacyResult"):
@@ -326,12 +326,13 @@ class Result(msgspec.Struct, kw_only=True):
 
     def defaults_from(self, other: "Result"):
         """Fields not set in *self* will be updated from the field values of the
-        *other*.
+        *other*.  If a field is set (exists) but contains an empty string
+        or the value ``None``, it is also considered *not set*.
         """
         for field_name in self.__struct_fields__:
-            self_val = getattr(self, field_name, False)
-            other_val = getattr(other, field_name, False)
-            if self_val:
+            self_val = getattr(self, field_name, UNSET)
+            other_val = getattr(other, field_name, UNSET)
+            if self_val is UNSET and other_val not in (UNSET, "", None):
                 setattr(self, field_name, other_val)
 
 
@@ -440,8 +441,6 @@ class LegacyResult(dict[str, t.Any]):
        Do not use this class in your own implementations!
     """
 
-    UNSET: object = object()
-
     # emulate field types from type class Result
     url: str | None
     template: str
@@ -512,7 +511,7 @@ class LegacyResult(dict[str, t.Any]):
             )
 
     def __getattr__(self, name: str, default: t.Any = UNSET) -> t.Any:
-        if default == self.UNSET and name not in self:
+        if default == UNSET and name not in self:
             raise AttributeError(f"LegacyResult object has no field named: {name}")
         return self[name]
 
@@ -563,9 +562,12 @@ class LegacyResult(dict[str, t.Any]):
             self.engines.add(self.engine)
 
     def defaults_from(self, other: "LegacyResult"):
-        for k, v in other.items():
-            if not self.get(k):
-                self[k] = v
+        # If a field is set (exists) but contains an empty string or the value
+        # ``None``, it is also considered *not set*.
+        for field_name, other_val in other.items():
+            self_val = self.get(field_name, UNSET)
+            if self_val is UNSET and other_val not in ("", UNSET):
+                self[field_name] = other_val
 
     def filter_urls(self, filter_func: "Callable[[Result | LegacyResult, str, str], str | bool]"):
         """See :py:obj:`Result.filter_urls`"""


### PR DESCRIPTION
### What does this PR do?

Fixes one bugs that prevented cross-engine result deduplication from working correctly ~+ added an improvement for better result matching.~

1. **`Result.defaults_from()` had inverted logic**: because of this issue always only one search engine was shown in the engine set.

2. ~**URL hash was too strict for cross-engine dedup**~: ~Two engines returning the same page with minor URL differences (e.g. `www.example.com/page` vs `example.com/page`.  or `www.example.com/page#anchor1` vs `www.example.com/page#anchor2`) want to be count as the same result to improve scoring (which is more important).
The has is still quite unique and should avoid false positives:~

```python
...
url = self.parsed_url
        netloc = url.netloc.removeprefix("www.")
        return hash(
            f"{self.template}"
            + f"|{netloc}|{url.path}|{url.params}|{url.query}"
            + f"|{self.img_src}"
        )
```

### How to test this PR locally?

   - Configure at least two general-search engines
   - Search for a query likely to return overlapping results
   - ~Before fix: each result shows only one engine name~
   - After fix: results found by multiple engines should list multiple engine names

### Related issues

### Code of Conduct

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  AI tools used:
  - **OpenCode (glm-5.1)**: Used to understand the issue and validate the implementation.