### PR TITLE
[fix] yacy: add time_range_support with client-side date filtering

### DIFF
--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -53,14 +53,18 @@ Implementations
 # pylint: disable=fixme
 
 
+import logging
 import random
+from datetime import datetime, timedelta, timezone
 from json import loads
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse, parse_qs
 from dateutil import parser
 
 from httpx import DigestAuth
 
 from searx.utils import html_to_text
+
+logger = logging.getLogger('searx.engines.yacy')
 
 # about
 about = {
@@ -75,6 +79,7 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
+time_range_support = True
 number_of_results = 10
 http_digest_auth_user = ""
 """HTTP digest user for the local YACY instance"""
@@ -100,6 +105,13 @@ base_url: list[str] | str = []
 """The value is an URL or a list of URLs.  In the latter case instance will be
 selected randomly.
 """
+
+_TIME_RANGE_OFFSETS = {
+    'day': timedelta(days=1),
+    'week': timedelta(weeks=1),
+    'month': timedelta(days=31),
+    'year': timedelta(days=365),
+}
 
 
 def init(_):
@@ -138,6 +150,14 @@ def request(query, params):
     if params['language'] != 'all':
         args['lr'] = 'lang_' + params['language'].split('-')[0]
 
+    # add date range if specified
+    time_range = params.get('time_range')
+    if time_range and time_range in _TIME_RANGE_OFFSETS:
+        now = datetime.now(timezone.utc)
+        start = now - _TIME_RANGE_OFFSETS[time_range]
+        args['datestart'] = start.strftime('%Y/%m/%d')
+        args['dateend'] = now.strftime('%Y/%m/%d')
+
     params["url"] = f"{_base_url()}/yacysearch.json?{urlencode(args)}"
 
     if http_digest_auth_user and http_digest_auth_pass:
@@ -159,6 +179,13 @@ def response(resp):
 
     if len(search_results) == 0:
         return []
+
+    # parse date filter bounds from request URL (YaCy ignores them server-side in global mode)
+    date_start = date_end = None
+    qs = parse_qs(urlparse(str(resp.request.url)).query)
+    if 'datestart' in qs and 'dateend' in qs:
+        date_start = datetime.strptime(qs['datestart'][0], '%Y/%m/%d').replace(tzinfo=timezone.utc)
+        date_end = datetime.strptime(qs['dateend'][0], '%Y/%m/%d').replace(tzinfo=timezone.utc)
 
     for result in search_results[0].get('items', []):
         # parse image results
@@ -186,7 +213,18 @@ def response(resp):
         else:
             publishedDate = None
             if 'pubDate' in result:
-                publishedDate = parser.parse(result['pubDate'])
+                try:
+                    publishedDate = parser.parse(result['pubDate'])
+                except Exception:  # pylint: disable=broad-except
+                    pass
+
+            # skip results outside the requested date range
+            if date_start and date_end:
+                if publishedDate is None:
+                    continue
+                pub = publishedDate if publishedDate.tzinfo else publishedDate.replace(tzinfo=timezone.utc)
+                if not (date_start <= pub <= date_end):
+                    continue
 
             # append result
             results.append(

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -53,18 +53,15 @@ Implementations
 # pylint: disable=fixme
 
 
-import logging
 import random
 from datetime import datetime, timedelta, timezone
 from json import loads
-from urllib.parse import urlencode, urlparse, parse_qs
+from urllib.parse import urlencode
 from dateutil import parser
 
 from httpx import DigestAuth
 
 from searx.utils import html_to_text
-
-logger = logging.getLogger('searx.engines.yacy')
 
 # about
 about = {
@@ -150,13 +147,13 @@ def request(query, params):
     if params['language'] != 'all':
         args['lr'] = 'lang_' + params['language'].split('-')[0]
 
-    # add date range if specified
+    # store date filter bounds for client-side filtering in response()
+    # YaCy does not enforce datestart/dateend server-side in global (P2P) mode
     time_range = params.get('time_range')
     if time_range and time_range in _TIME_RANGE_OFFSETS:
         now = datetime.now(timezone.utc)
-        start = now - _TIME_RANGE_OFFSETS[time_range]
-        args['datestart'] = start.strftime('%Y/%m/%d')
-        args['dateend'] = now.strftime('%Y/%m/%d')
+        params['date_start'] = now - _TIME_RANGE_OFFSETS[time_range]
+        params['date_end'] = now
 
     params["url"] = f"{_base_url()}/yacysearch.json?{urlencode(args)}"
 
@@ -180,12 +177,8 @@ def response(resp):
     if len(search_results) == 0:
         return []
 
-    # parse date filter bounds from request URL (YaCy ignores them server-side in global mode)
-    date_start = date_end = None
-    qs = parse_qs(urlparse(str(resp.request.url)).query)
-    if 'datestart' in qs and 'dateend' in qs:
-        date_start = datetime.strptime(qs['datestart'][0], '%Y/%m/%d').replace(tzinfo=timezone.utc)
-        date_end = datetime.strptime(qs['dateend'][0], '%Y/%m/%d').replace(tzinfo=timezone.utc)
+    date_start = resp.search_params.get('date_start')
+    date_end = resp.search_params.get('date_end')
 
     for result in search_results[0].get('items', []):
         # parse image results


### PR DESCRIPTION
### What does this PR do?

YaCy does not enforce datestart/dateend in global (P2P) mode, so results are now filtered client-side based on publishedDate. Adds time_range_support = True so SearXNG does not skip the engine when a time filter is active.

### How to test this PR locally?

1. Run a local YaCy instance on the host machine (port 8090)                                         
2. Configure SearXNG with YaCy as an engine (base_url pointing to your instance, enable_http: true)  
3. Perform a search using only the YaCy engine with no time filter, confirm results appear          
4. Repeat the search with a time filter (e.g. "Last year"), confirm results are filtered to that date range and results without a pubDate are excluded                                        
5. Confirm no results are returned for a time range where YaCy has no indexed content

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  I used Claude Code and tested that the fix indeed works (at least for date crawled)