### PR TITLE
[upd] pypi: Bump lxml from 6.0.4 to 6.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ babel==2.18.0
 flask-babel==4.0.0
 flask==3.1.3
 jinja2==3.1.6
-lxml==6.0.4
+lxml==6.1.0
 pygments==2.20.0
 python-dateutil==2.9.0.post0
 pyyaml==6.0.3


### PR DESCRIPTION
### What does this PR do?

Bump lxml from 6.0.4 to 6.1.0

Release 6.1.0 fixes a possible external entity injection (XXE) vulnerability in ``iterparse()`` and the ``ETCompatXMLParser``.

https://github.com/lxml/lxml/blob/64ed06c1a0c1833bfac99f209f16c3bdfddfde79/CHANGES.txt#L42-L66

### How to test this PR locally?

    make run

### Related issues

- Closes https://github.com/searxng/searxng/issues/6025

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
