### PR TITLE
[fix] engine 'mwmbl': handle empty 'extract' field gracefully

### DIFF
--- a/searx/engines/mwmbl.py
+++ b/searx/engines/mwmbl.py
@@ -39,11 +39,12 @@ def response(resp):
 
     for result in json_results:
         title_parts = [title['value'] for title in result['title']]
+        extract_parts = [extract['value'] for extract in result.get('extract', [])]
         results.append(
             {
                 'url': result['url'],
                 'title': ''.join(title_parts),
-                'content': result['extract'][0]['value'],
+                'content': ''.join(extract_parts),
             }
         )
 


### PR DESCRIPTION
Closes #6034

The mwmbl engine raises `IndexError: list index out of range` when the API returns a result whose `extract` field is an empty list. Iterate over the extract parts and join them, mirroring the existing title handling.

**AI disclosure (per AI_POLICY.rst):** Claude Code was used to draft the patch and PR text; the diagnosis matches the issue reporter's analysis and I confirmed the fix locally against the three relevant inputs (empty extract list, missing extract key, normal multi-part extract).