### PR TITLE
 [fix] wikidata: crashes when querying due to missing escaping of quotation marks

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -146,7 +146,7 @@ class WDAttribute:
         self.name: str = name
 
     def get_select(self):
-        return "(group_concat(distinct ?{name};separator=", ") as ?{name}s)".replace("{name}", self.name)
+        return "(group_concat(distinct ?{name};separator=', ') as ?{name}s)".replace("{name}", self.name)
 
     def get_label(self, language: str):
         return get_label_for_entity(self.name, language)
@@ -222,7 +222,7 @@ class WDArticle(WDAttribute):
 
 class WDLabelAttribute(WDAttribute):
     def get_select(self):
-        return "(group_concat(distinct ?{name}Label;separator=", ") as ?{name}Labels)".replace("{name}", self.name)
+        return "(group_concat(distinct ?{name}Label;separator=', ') as ?{name}Labels)".replace("{name}", self.name)
 
     def get_where(self):
         return "OPTIONAL { ?item wdt:{name} ?{name} . }".replace("{name}", self.name)


### PR DESCRIPTION
### What does this PR do?

Fix outer quotes of select that would otherwise crash the engine.

### How to test this PR locally?

Run any wiki data request.

### Related issues

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
