### PR TITLE
[fix] Startpage engine fails when date field is string (not integer: TypeError)

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -345,7 +345,10 @@ def _get_news_result(result):
 
     publishedDate = None
     if result.get("date"):
-        publishedDate = datetime.fromtimestamp(result["date"] / 1000)
+        try:
+            publishedDate = datetime.fromtimestamp(int(result["date"]) / 1000)
+        except (TypeError, ValueError):
+            pass
 
     thumbnailUrl = None
     if result.get("thumbnailUrl"):


### PR DESCRIPTION
### What does this PR do?

In order to avoid an abort with an error, type- and value- errors are catched, the publishDate cannot then be determined, but the result item remains.

[1] https://github.com/searxng/searxng/pull/5980/changes#r3091479655

Suggested-by: @Bnyro [1]

### Related issues

Replaces the PRs:

- https://github.com/searxng/searxng/pull/5980
- https://github.com/searxng/searxng/pull/6006

Closes: 

- https://github.com/searxng/searxng/issues/5979

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**
