### PR TITLE
[fix] 360search: improve empty results set handling and increase engine timeout

### DIFF
--- a/searx/engines/360search.py
+++ b/searx/engines/360search.py
@@ -84,6 +84,10 @@ def request(query, params):
 
 
 def response(resp):
+    # sometimes 360search returns empty response when called from non-chinese ips
+    if not resp.text or not resp.text.strip():
+        return []
+
     dom = html.fromstring(resp.text)
     results = []
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -302,7 +302,7 @@ engines:
   - name: 360search
     engine: 360search
     shortcut: 360so
-    timeout: 10.0
+    timeout: 20.0
     disabled: true
 
   - name: 360search videos


### PR DESCRIPTION
### What does this PR do?

Improved empty results set handling and increases the engine default timeout to improve reliability

### How to test this PR locally?

use 360so until you get an empty result set

### Related issues

closes #6035 

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI was used for this commit