### PR TITLE
fix: normalise path separators in webutils for Windows compatibility

### DIFF
--- a/searx/webutils.py
+++ b/searx/webutils.py
@@ -190,7 +190,10 @@ def get_static_file_list() -> list[str]:
                 # ignore hidden file
                 continue
             if f.is_file():
-                file_list.append(str(f.relative_to(static_path)))
+                # Use forward slashes so lookups work on Windows too
+                # (os.path / pathlib use backslashes on Windows, but the
+                # template url_for calls always use forward slashes).
+                file_list.append(f.relative_to(static_path).as_posix())
             if f.is_dir():
                 _walk(f)
 
@@ -202,10 +205,14 @@ def get_result_templates(templates_path):
     result_templates = set()
     templates_path_length = len(templates_path) + 1
     for directory, _, files in os.walk(templates_path):
-        if directory.endswith('result_templates'):
+        # endswith check must handle both / and \ as separator (Windows)
+        norm_dir = directory.replace('\\', '/')
+        if norm_dir.endswith('result_templates'):
             for filename in files:
                 f = os.path.join(directory[templates_path_length:], filename)
-                result_templates.add(f)
+                # Normalise to forward slashes so the lookup in get_result_template
+                # succeeds on Windows (os.path.join uses backslashes there).
+                result_templates.add(f.replace('\\', '/'))
     return result_templates
 
 


### PR DESCRIPTION
## Summary

On Windows, `os.path.join()` and `str(pathlib.Path.relative_to())` produce **backslash-separated** paths, while all template `url_for` calls and the `get_result_template` lookup use **forward slashes**. This mismatch caused two silent, hard-to-diagnose failures when running SearXNG natively on Windows.

### Bug 1 — `TemplateNotFound: result_templates/default.html` (500 on every search)

`get_result_templates()` built the lookup set with backslash paths:
```
simple\result_templates\default.html   ← stored in set
simple/result_templates/default.html   ← looked up by get_result_template()
```
The lookup always missed, so Jinja fell back to the bare `result_templates/default.html` path which it cannot find → **500 Internal Server Error on every search request**.

### Bug 2 — All CSS/JS/images return 404 (completely unstyled pages)

`get_static_file_list()` used `str(f.relative_to(static_path))` which on Windows produces:
```
themes\simple\sxng-ltr.min.css   ← stored in _STATIC_FILES
themes/simple/sxng-ltr.min.css   ← looked up by custom_url_for()
```
The lookup always missed, so `url_for('static', filename='sxng-ltr.min.css')` fell back to `/static/sxng-ltr.min.css` (no theme prefix) — a path WhiteNoise cannot find → **all static assets 404, page completely unstyled**.

## Fix

- `get_result_templates()`: normalise directory and file paths to forward slashes with `.replace('\\', '/')`
- `get_static_file_list()`: use `Path.as_posix()` instead of `str(relative_path)` — `as_posix()` always returns forward slashes regardless of platform

## Test

Verified on Windows 11 with Python 3.13: both HTML search results and all static assets (CSS, JS, images) load correctly after the fix.
