### PR TITLE
update_engine_traits.py: add option to update engines selective

### DIFF
--- a/docs/dev/quickstart.rst
+++ b/docs/dev/quickstart.rst
@@ -60,10 +60,28 @@ into the developer environment and start a python based HTTP server by::
 
     $ ./manage dev.env
     ...
-    (dev.env)$ SEARXNG_DEBUG=1 python -m searx.webapp
+    (dev.env)$ SEARXNG_DEBUG=1 searxng-run
 
 Since this is a pure Python solution, you can set breakpoints in your code with
 ``pdb.set_trace()`` and the debugger will wait for you in the terminal prompt.
+
+Any other script or command line provided by SearXNG can also be used in the
+same environment, here are a few examples::
+
+    # tools related to favicons
+    (dev.env)$ python -m searx.favicons
+
+    # tools related to DATA stored in searx/data
+    (dev.env)$ python -m searx.data --help
+
+    # tools related to engines
+    (dev.env)$ python -m searx.enginelib --help
+
+    # to test one of the update scripts
+    (dev.env)$ searxng_extra/update/update_engine_traits.py --help
+
+    # to test the update of the wikidata units
+    (dev.env)$ searxng_extra/update/update_wikidata_units.py
 
 
 .. sidebar:: further read

--- a/searxng_extra/update/update_engine_traits.py
+++ b/searxng_extra/update/update_engine_traits.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Update :py:obj:`searx.enginelib.traits.EngineTraitsMap` and :origin:`searx/languages.py`
+"""Update :py:obj:`searx.enginelib.traits.EngineTraitsMap` and :origin:`searx/sxng_locales.py`
 
 :py:obj:`searx.enginelib.traits.EngineTraitsMap.ENGINE_TRAITS_FILE`:
   Persistence of engines traits, fetched from the engines.
 
-:origin:`searx/languages.py`
+:origin:`searx/sxng_locales.py`
   Is generated  from intersecting each engine's supported traits.
 
 The script :origin:`searxng_extra/update/update_engine_traits.py` is called in
@@ -28,8 +28,8 @@ from searx.engines import load_engines
 from searx.enginelib.traits import EngineTraitsMap
 
 # Output files.
-languages_file = Path(searx_dir) / 'sxng_locales.py'
-languages_file_header = """\
+sxng_locales_file = Path(searx_dir) / 'sxng_locales.py'
+sxng_locales_file_header = """\
 # SPDX-License-Identifier: AGPL-3.0-or-later
 '''List of SearXNG's locale codes used for the search language/region.
 
@@ -42,7 +42,7 @@ languages_file_header = """\
 
 sxng_locales = (
 """
-languages_file_footer = """,
+sxng_locales_file_footer = """,
 )
 '''
 A list of five-digit tuples:
@@ -83,16 +83,16 @@ app = typer.Typer()
 
 @app.command()
 def cli(engines: t.Annotated[list[str] | None, typer.Argument()] = None):
-    """Update ``data/engine_traits.json`` and ``languages.py``.
+    """Update ``data/engine_traits.json`` and ``sxng_locales.py``.
 
     Optionally, if arguments are provided via the command line, these are
     interpreted as the names of the engines that should be updated.  All other
     engines will be left untouched.
     """
 
-    all_eng_names: list[str] = [_["name"] for _ in settings["engines"]]
+    all_eng_names: list[str] = [e["name"] for e in settings["engines"]]
     if engines:
-        unknown: list[str] = [_ for _ in engines if _ not in all_eng_names]
+        unknown: list[str] = [e for e in engines if e not in all_eng_names]
         if unknown:
             print(f"ERROR: unknown engines --> {', '.join(unknown)}")
             raise typer.Exit(42)
@@ -113,14 +113,14 @@ def cli(engines: t.Annotated[list[str] | None, typer.Argument()] = None):
     print("write json file: %s" % traits_map.ENGINE_TRAITS_FILE)
     traits_map.save_data()
     sxng_tag_list = filter_locales(traits_map)
-    write_languages_file(sxng_tag_list)
+    write_sxng_locales_file(sxng_tag_list)
 
 
 def fetch_traits_map() -> EngineTraitsMap:
     """Fetches supported languages for each engine and writes json file with those."""
     network.set_timeout_for_thread(10.0)
 
-    def log(msg):
+    def log(msg: str):
         print(msg)
 
     traits_map = EngineTraitsMap.fetch_traits(log=log)
@@ -128,13 +128,13 @@ def fetch_traits_map() -> EngineTraitsMap:
     return traits_map
 
 
-def filter_locales(traits_map: EngineTraitsMap):
+def filter_locales(traits_map: EngineTraitsMap) -> set[str]:
     """Filter language & region tags by a threshold."""
 
     min_eng_per_region = 18
     min_eng_per_lang = 22
 
-    _ = {}
+    _: dict[str, int] = {}
     for eng in traits_map.values():
         for reg in eng.regions.keys():
             _[reg] = _.get(reg, 0) + 1
@@ -154,7 +154,7 @@ def filter_locales(traits_map: EngineTraitsMap):
 
     languages = set(k for k, v in _.items() if v >= min_eng_per_lang)
 
-    sxng_tag_list = set()
+    sxng_tag_list: set[str] = set()
     sxng_tag_list.update(regions)
     sxng_tag_list.update(lang_from_region)
     sxng_tag_list.update(languages)
@@ -162,9 +162,9 @@ def filter_locales(traits_map: EngineTraitsMap):
     return sxng_tag_list
 
 
-def write_languages_file(sxng_tag_list):
+def write_sxng_locales_file(sxng_tag_list: set[str]):
 
-    language_codes = []
+    language_codes: list[tuple[str, str, str, str, str]] = []
 
     for sxng_tag in sorted(sxng_tag_list):
         sxng_locale: babel.Locale = babel.Locale.parse(sxng_tag, sep='-')
@@ -173,7 +173,7 @@ def write_languages_file(sxng_tag_list):
 
         item = (
             sxng_tag,
-            sxng_locale.get_language_name().title(),  # type: ignore
+            sxng_locale.get_language_name().title(),  # pyright: ignore[reportOptionalMemberAccess]
             sxng_locale.get_territory_name() or '',
             sxng_locale.english_name.split(' (')[0] if sxng_locale.english_name else '',
             UnicodeEscape(flag),
@@ -181,13 +181,13 @@ def write_languages_file(sxng_tag_list):
 
         language_codes.append(item)
 
-    language_codes = tuple(language_codes)
+    _codes = tuple(language_codes)
 
-    with languages_file.open('w', encoding='utf-8') as new_file:
+    with sxng_locales_file.open('w', encoding='utf-8') as new_file:
         file_content = "{header} {language_codes}{footer}".format(
-            header=languages_file_header,
-            language_codes=pformat(language_codes, width=120, indent=4)[1:-1],
-            footer=languages_file_footer,
+            header=sxng_locales_file_header,
+            language_codes=pformat(_codes, width=120, indent=4)[1:-1],
+            footer=sxng_locales_file_footer,
         )
         new_file.write(file_content)
         new_file.close()

--- a/searxng_extra/update/update_engine_traits.py
+++ b/searxng_extra/update/update_engine_traits.py
@@ -12,12 +12,15 @@ The script :origin:`searxng_extra/update/update_engine_traits.py` is called in
 the :origin:`CI Update data ... <.github/workflows/data-update.yml>`
 
 """
-
 # pylint: disable=invalid-name
+
+import typing as t
+
 from unicodedata import lookup
 from pathlib import Path
 from pprint import pformat
 import babel
+import typer
 
 from searx import settings, searx_dir
 from searx import network
@@ -75,23 +78,45 @@ lang2emoji = {
     'he': '\U0001f1ee\U0001f1f1',  # Hebrew
 }
 
+app = typer.Typer()
 
-def main():
 
-    engines_cfg = []
+@app.command()
+def cli(engines: t.Annotated[list[str] | None, typer.Argument()] = None):
+    """Update ``data/engine_traits.json`` and ``languages.py``.
 
+    Optionally, if arguments are provided via the command line, these are
+    interpreted as the names of the engines that should be updated.  All other
+    engines will be left untouched.
+    """
+
+    all_eng_names: list[str] = [_["name"] for _ in settings["engines"]]
+    if engines:
+        unknown: list[str] = [_ for _ in engines if _ not in all_eng_names]
+        if unknown:
+            print(f"ERROR: unknown engines --> {', '.join(unknown)}")
+            raise typer.Exit(42)
+
+    engines_cfg: list[dict[str, t.Any]] = []
     for eng_data in settings["engines"]:
-        eng_data["inactive"] = False
-        engines_cfg.append(eng_data)
+        if not engines or eng_data["name"] in engines:
+            eng_data["inactive"] = False
+            engines_cfg.append(eng_data)
 
     load_engines(engines_cfg)
-    # traits_map = EngineTraitsMap.from_data()
-    traits_map = fetch_traits_map()
+    traits_map: EngineTraitsMap = fetch_traits_map()
+    if engines:
+        _map = EngineTraitsMap.from_data()
+        _map.update(traits_map)
+        traits_map = _map
+
+    print("write json file: %s" % traits_map.ENGINE_TRAITS_FILE)
+    traits_map.save_data()
     sxng_tag_list = filter_locales(traits_map)
     write_languages_file(sxng_tag_list)
 
 
-def fetch_traits_map():
+def fetch_traits_map() -> EngineTraitsMap:
     """Fetches supported languages for each engine and writes json file with those."""
     network.set_timeout_for_thread(10.0)
 
@@ -100,8 +125,6 @@ def fetch_traits_map():
 
     traits_map = EngineTraitsMap.fetch_traits(log=log)
     print("fetched properties from %s engines" % len(traits_map))
-    print("write json file: %s" % traits_map.ENGINE_TRAITS_FILE)
-    traits_map.save_data()
     return traits_map
 
 
@@ -203,4 +226,4 @@ def get_unicode_flag(locale: babel.Locale):
 
 
 if __name__ == "__main__":
-    main()
+    app()


### PR DESCRIPTION
### What does this PR do?

Previously, `update_engine_traits.py` would fetch traits for all engines, which is very slow and by side-effect touches engine data that are unrelated to the engine you're currently working on.

To be faster with developing `update_engine_traits.py` supports now engine arguments.

### How to test this PR locally?

To test, jump into the developer environment and run the script::

    $ ./manage dev.env
    (dev.env)$ ./searxng_extra/update/update_engine_traits.py --help


### Related issues

- https://github.com/searxng/searxng/pull/6076

### Code of Conduct


[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].** (no AI used)

