### PR TITLE
[chore] settings.yml: set broken engines yahoo and karmasearch to inactive

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1203,6 +1203,7 @@ engines:
     categories: [general, web]
     search_type: web
     shortcut: ka
+    inactive: true
 
   - name: karmasearch images
     engine: karmasearch
@@ -1210,18 +1211,21 @@ engines:
     search_type: images
     shortcut: kai
     paging: false
+    inactive: true
 
   - name: karmasearch videos
     engine: karmasearch
     categories: [videos, web]
     search_type: videos
     shortcut: kav
+    inactive: true
 
   - name: karmasearch news
     engine: karmasearch
     categories: [news, web]
     search_type: news
     shortcut: kan
+    inactive: true
 
   - name: kickass
     engine: kickass
@@ -2149,6 +2153,7 @@ engines:
   - name: yahoo news
     engine: yahoo_news
     shortcut: yhn
+    inactive: true
 
   - name: youtube
     shortcut: yt


### PR DESCRIPTION
Both engines stopped working a while ago, and hence both are currently unusable. So it doesn't make sense to keep them enabled.

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
