### PR TITLE
[fix] yandex images: crashes when parsing images without fallback source

### DIFF
--- a/searx/engines/yandex.py
+++ b/searx/engines/yandex.py
@@ -87,7 +87,6 @@ def request(query, params):
 
 def response(resp):
     if search_type == 'web':
-
         catch_bad_response(resp)
 
         dom = html.fromstring(resp.text)
@@ -106,7 +105,6 @@ def response(resp):
         return results
 
     if search_type == 'images':
-
         catch_bad_response(resp)
 
         html_data = html.fromstring(resp.text)
@@ -127,22 +125,25 @@ def response(resp):
         for _, item_data in json_resp['initialState']['serpList']['items']['entities'].items():
             title = item_data['snippet']['title']
             source = item_data['snippet']['url']
-            thumb = item_data['image']
-            fullsize_image = item_data['viewerData']['dups'][0]['url']
-            height = item_data['viewerData']['dups'][0]['h']
-            width = item_data['viewerData']['dups'][0]['w']
-            filesize = item_data['viewerData']['dups'][0]['fileSizeInBytes']
-            humanized_filesize = humanize_bytes(filesize)
+
+            image_source = item_data["viewerData"]["thumb"]
+            for i in item_data['viewerData']['dups'] + item_data['viewerData']['preview']:
+                if i["h"] > image_source["h"]:
+                    image_source = i
+
+            humanized_filesize = None
+            if image_source.get("fileSizeInBytes"):
+                humanized_filesize = humanize_bytes(image_source["fileSizeInBytes"])
 
             results.append(
                 {
                     'title': title,
                     'url': source,
-                    'img_src': fullsize_image,
+                    'img_src': image_source["url"],
                     'filesize': humanized_filesize,
-                    'thumbnail_src': thumb,
+                    'thumbnail_src': item_data["image"],
                     'template': 'images.html',
-                    'resolution': f'{width} x {height}',
+                    'resolution': f'{image_source["w"]} x {image_source["h"]}',
                 }
             )
 


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- Fix that Yandex images crashes when the `dups` field is an empty array.

### How to test this PR locally?
- !ydi tree (if you're not captchaed)

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

