### PR TITLE
[fix] preferences: opening preferences page is very slow (multiple seconds on bad hardware)

### DIFF
--- a/searx/enginelib/traits.py
+++ b/searx/enginelib/traits.py
@@ -116,19 +116,6 @@ class EngineTraits:
             return self.all_locale
         return locales.get_engine_locale(searxng_locale, self.regions, default=default)
 
-    def is_locale_supported(self, searxng_locale: str) -> bool:
-        """A *locale* (SearXNG's internal representation) is considered to be
-        supported by the engine if the *region* or the *language* is supported
-        by the engine.
-
-        For verification the functions :py:func:`EngineTraits.get_region` and
-        :py:func:`EngineTraits.get_language` are used.
-        """
-        if self.data_type == "traits_v1":
-            return bool(self.get_region(searxng_locale) or self.get_language(searxng_locale))
-
-        raise TypeError("engine traits of type %s is unknown" % self.data_type)
-
     def copy(self):
         """Create a copy of the dataclass object."""
         return EngineTraits(**dataclasses.asdict(self))

--- a/searx/templates/simple/preferences/engines.html
+++ b/searx/templates/simple/preferences/engines.html
@@ -23,7 +23,6 @@
         <th class="checkbox-col">{{- _("Allow") -}}</th>{{- '' -}}
         <th class="name">{{- _("Engine name") -}}</th>{{- '' -}}
         <th class="shortcut">{{ _("!bang") -}}</th>{{- '' -}}
-        <th>{{- _("Supports selected language") -}}</th>{{- '' -}}
         <th>{{- _("SafeSearch") -}}</th>{{- '' -}}
         <th>{{- _("Time range") -}}</th>{{- '' -}}
         <th>{{- _("Weight") }}</th>
@@ -69,9 +68,6 @@
               </th>{{- '' -}}
               <td class="shortcut">{{- '' -}}
                 <span class="bang">{{ '!' + shortcuts[search_engine.name] }}</span>{{- '' -}}
-              </td>{{- '' -}}
-              <td>
-                {{- checkbox(None, supports[search_engine.name]['supports_selected_language'], true) -}}
               </td>{{- '' -}}
               <td>
                 {{- checkbox(None, supports[search_engine.name]['safesearch'], true) -}}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -918,9 +918,6 @@ def preferences():
             'rate80': rate80,
             'rate95': rate95,
             'warn_timeout': e.timeout > settings['outgoing']['request_timeout'],
-            'supports_selected_language': e.traits.is_locale_supported(
-                str(sxng_request.preferences.get_value('language') or 'all')
-            ),
             'result_count': result_count,
         }
     # end of stats
@@ -956,15 +953,9 @@ def preferences():
     # supports
     supports = {}
     for _, e in filtered_engines.items():
-        supports_selected_language = e.traits.is_locale_supported(
-            str(sxng_request.preferences.get_value('language') or 'all')
-        )
-        safesearch = e.safesearch
-        time_range_support = e.time_range_support
         supports[e.name] = {
-            'supports_selected_language': supports_selected_language,
-            'safesearch': safesearch,
-            'time_range_support': time_range_support,
+            'safesearch': e.safesearch,
+            'time_range_support': e.time_range_support,
         }
 
     return render(


### PR DESCRIPTION
I've been profiling the `/preferences` endpoint using werkzeug's `ProfilerMiddleware` (i.e. just do `app.wsgi_app = ProfilerMiddleware(app.wsgi_app)`) and look at the outputs in the terminal when doing `make run`.

It turns out that 95%+ of the time spent were inside babel's Locale parsing (> 700ms on my machine). That's because, when opening the settings, we loaded the full engine traits of each engine and checked if it matches the user-defined search language. As we have 250+ engines, and babel is very slow when parsing Locale's, this took a very long time.

By removing this feature that shows whether the selected search language is supported by the engine, the load time went down from 800ms to 50ms on my machine (which is still very slow, but well, that's future work on optimizing).

I'm pretty sure that somebody will complain about losing this feature, but I don't think it's any important to see whether an engine supports your current search language, I don't think anyone really goes to the engines settings and enables all engines that have the "supports search language" checkmark checked... In my eyes, the performance is much more important. (at least I would be very frustrated if I try out a project and it takes multiple seconds to load the settings page...)

<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### How to test this PR locally?
- The difference can be seen by just opening the `/preferences` before and after the change, but it's also possible to statistically see that:
Apply the following patch:
```diff
diff --git a/searx/webapp.py b/searx/webapp.py
index f5e8e5cf3..d2c506ae7 100755
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -3,6 +3,7 @@
 """WebApp"""
 # pylint: disable=use-dict-literal
 
+from werkzeug.middleware.profiler import ProfilerMiddleware
 import json
 import os
 import sys
@@ -1382,6 +1383,7 @@ def static_headers(headers: Headers, _path: str, _url: str) -> None:
         headers[header] = str(value)
 
 
+app.wsgi_app = ProfilerMiddleware(app.wsgi_app)
 app.wsgi_app = ProxyFix(app.wsgi_app)
 app.wsgi_app = WhiteNoise(
     app.wsgi_app,
```
Observe the outputted `cumtime` in the first row of the printed profiling logs before and after the changes in this PR.



[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst
- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

