### PR TITLE
ci: install buildhost tools for docs workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,6 +50,9 @@ jobs:
             python-${{ env.PYTHON_VERSION }}-${{ runner.arch }}-
           path: "./local/"
 
+      - name: Install Ubuntu packages
+        run: sudo -H ./utils/searxng.sh install buildhost
+
       - name: Setup venv
         run: make V=1 install
 


### PR DESCRIPTION
## What changed
- Install the buildhost toolchain in the Documentation workflow before creating the venv and building docs.
- This adds the OS packages documented for docs builds, including Graphviz, so kernel-figure dot diagrams can render in the published docs.

Fixes #6099.

## Tests
- python -c "import pathlib, yaml; ... yaml.safe_load(...)"
- git diff-tree --check --no-commit-id -r a72237784035784ec0adf050b4c7e1973c1d53a1
- Verified the committed workflow file keeps LF line endings.

I did not run a full local docs build because the repository cannot be fully checked out on Windows due to NTFS-invalid :socket paths; this workflow change targets the Linux GitHub Actions runner.