### PR TITLE
[doc] CI: install graphviz for documentation build

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,6 +42,11 @@ jobs:
           persist-credentials: "false"
           fetch-depth: "0"
 
+      - name: Install documentation build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes graphviz
+
       - name: Setup cache Python
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:


### PR DESCRIPTION
## Summary
- install Graphviz in the documentation workflow before building docs
- allows linuxdoc/kernel-figure DOT diagrams, including docs/admin/arch_public.dot, to render as images in published docs

Fixes #6099

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/documentation.yml')"
- git diff --check

I did not run the full docs build locally because this machine does not have Graphviz installed; the workflow change installs the missing tool on the docs builder.