### PR TITLE
[fix] startpage: all requests get blocked with CAPTCHA

### DIFF
--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -134,7 +134,7 @@ time_range_support = True
 safesearch = True
 
 time_range_dict = {"day": "d", "week": "w", "month": "m", "year": "y"}
-safesearch_dict = {0: "1", 1: "0", 2: "0"}
+safesearch_dict = {0: "none", 1: "moderate", 2: "heavy"}
 
 # search-url
 base_url = "https://www.startpage.com"
@@ -251,9 +251,10 @@ def request(query, params):
         "t": "device",
         "sc": get_sc_code(params),
         "with_date": time_range_dict.get(params["time_range"], ""),
-        "abp": "1",
         "abd": "1",
         "abe": "1",
+        "qsr": "all",
+        "qadf": safesearch_dict[params["safesearch"]],
     }
 
     if engine_language:


### PR DESCRIPTION
### What does this PR do?
- Setting the "abp" query parameter causes instant blocks, it's no longer used at Startpage
- The safesearch map changed for both the request form and the cookies. As we were sending invalid values, that also made it easier to detect us
<!-- Explain the motivation and changes in your pull request.  -->

### How to test this PR locally?
- !sp test
- !spi test
- !spn test


[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
