### PR TITLE
[fix] mojeek: access denied because of wrong request parameters

### DIFF
--- a/searx/engines/mojeek.py
+++ b/searx/engines/mojeek.py
@@ -59,8 +59,6 @@ def request(query, params):
     args = {
         "q": query,
         "safe": min(params["safesearch"], 1),
-        language_param: traits.get_language(params["searxng_locale"], traits.custom["language_all"]),
-        region_param: traits.get_region(params["searxng_locale"], traits.custom["region_all"]),
     }
 
     if search_type:
@@ -76,6 +74,10 @@ def request(query, params):
         logger.debug(args["since"])
 
     params["url"] = f"{base_url}/search?{urlencode(args)}"
+    params["cookies"] = {
+        language_param: traits.get_language(params["searxng_locale"], traits.custom["language_all"]),
+        region_param: traits.get_region(params["searxng_locale"], traits.custom["region_all"]),
+    }
 
     return params
 


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- the languages/locales params are now passed as cookies (like the mojeek website does it)
- otherwise we get access denied immediately

### How to test this PR locally?
- !mojeek test


[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
