### PR TITLE
[feat] engines: add flaticon icons engine

### DIFF
--- a/searx/engines/flaticon.py
+++ b/searx/engines/flaticon.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Flaticon_ is a database for icons.
+
+.. _Flaticon: https://www.flaticon.com
+"""
+
+from urllib.parse import urlencode
+
+import typing as t
+
+from searx.result_types import EngineResults
+
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
+    from searx.search.processors import OnlineParams
+
+
+about = {
+    "website": "https://www.flaticon.com",
+    "wikidata_id": "Q105283791",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+base_url = "https://www.flaticon.com"
+
+categories = ["images", "icons"]
+paging = True
+
+
+def request(query: str, params: "OnlineParams") -> None:
+    args = {
+        "word": query,
+    }
+    params["headers"].update(
+        {
+            # important: query term is not URL encoded in the referer string
+            "Referer": f"{base_url}/search?word={query}",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+    )
+    params["url"] = f"{base_url}/ajax/search/{params['pageno']}?{urlencode(args)}"
+
+
+def _fix_url(url: str) -> str:
+    return url.replace(r"\/", "/")
+
+
+def response(resp: "SXNG_Response"):
+    res = EngineResults()
+
+    result: dict[str, str]  # TBH: dict[str, t.Any]
+    for result in resp.json()["items"]:
+        res.add(
+            res.types.LegacyResult(
+                {
+                    "template": "images.html",
+                    "url": _fix_url(result["slug"]),
+                    "thumbnail_src": _fix_url(result["png"]),
+                    "img_src": _fix_url(result["png512"]),
+                    "title": result["name"],
+                    "content": ", ".join([tag["tag"] for tag in result["tags"]]),  # pyright: ignore[reportArgumentType]
+                    "author": result["team_name"],
+                }
+            )
+        )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -886,6 +886,11 @@ engines:
     shortcut: ftm
     disabled: true
 
+  - name: flaticon
+    engine: flaticon
+    shortcut: fli
+    disabled: true
+
   - name: flickr
     categories: images
     shortcut: fl


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- Unfortunately getting the SVG files requires a paid subscription. Tools like https://addons.mozilla.org/en-US/firefox/addon/flaticon-downloader-bymapree/ can bypass the subscription and download them if you have an account, but without an account, there's no way to get the SVG as far as I can tell.

### How to test this PR locally?
- !fli bird

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

