### PR TITLE
[feat] engines: add icons8 image engine

### DIFF
--- a/searx/engines/icons8.py
+++ b/searx/engines/icons8.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Icons8_ is a database for icons.
+
+.. _Icons8: https://icons8.com
+"""
+
+from urllib.parse import urlencode
+
+import typing as t
+
+from searx.result_types import EngineResults, ImageRef
+from searx.network import multi_requests, Request
+
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
+    from searx.search.processors import OnlineParams
+
+
+about = {
+    "website": "https://icons8.com",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+base_url = "https://icons8.com"
+api_url = "https://search-app.icons8.com"
+cdn_url = "https://img.icons8.com"
+
+categories = ["images", "icons"]
+paging = True
+
+icons8_fetch_svg = False
+"""Whether to additionally load the full resolution SVG icon.
+
+.. attention::
+
+   This does one request per icon (!), so be aware that this might be very slow
+   and the engine timeout should be increased.  Multi-requests trigger a flood
+   of requests to the origin; typically, which leads to the SearXNG IP being
+   blocked very quickly.
+"""
+
+results_per_page = 20
+
+
+def request(query: str, params: "OnlineParams") -> None:
+    args = {
+        "amount": results_per_page,
+        "offset": (params["pageno"] - 1) * results_per_page,
+        "term": query,
+    }
+    params["url"] = f"{api_url}/api/iconsets/v7/search?{urlencode(args)}"
+
+
+def _fetch_svgs(ids: list[str]) -> dict[str, str]:
+    responses = multi_requests(
+        [
+            Request.get(
+                f"https://api-icons.icons8.com/siteApi/icons/icon?id={id}&svg=true",
+            )
+            for id in ids
+        ]
+    )
+
+    svgs: dict[str, str] = {}
+    for i, resp in enumerate(responses):
+        if isinstance(resp, Exception):
+            continue
+
+        # the image is a base64 encoded SVG, so we can display it
+        # as data:image
+        b64_svg: str = resp.json()["icon"]["svg"]
+        svgs[ids[i]] = f"data:image/svg+xml;base64,{b64_svg}"
+
+    return svgs
+
+
+# any very big resolution will give us the max-res image
+def _get_image_url(result: dict[str, t.Any], img_format: str, resolution: int = 10000) -> str:
+    return f"{cdn_url}/{result['platform']}/{resolution}/{result['commonName']}.{img_format}"
+
+
+def response(resp: "SXNG_Response"):
+    res = EngineResults()
+    icons = resp.json()["icons"]
+
+    svgs = {}
+    if icons8_fetch_svg:
+        svgs = _fetch_svgs(list(icon["id"] for icon in icons))
+
+    for result in icons:
+        result: dict[str, t.Any]
+
+        extra_formats = [
+            ImageRef(
+                url=_get_image_url(result, "png"),
+                subtype="png",
+            ),
+            ImageRef(
+                url=_get_image_url(result, "jpg"),
+                subtype="jpeg",
+            ),
+        ]
+        if result["id"] in svgs:
+            img_url = thumbnail_url = svgs[result["id"]]
+            img_format = "SVG"
+        else:
+            img_url = extra_formats.pop(0).url
+            img_format = "PNG"
+            thumbnail_url = _get_image_url(result, "png", resolution=512)
+
+        res.add(
+            res.types.Image(
+                url=f"{base_url}/icon/{result['id']}/{result['commonName']}",
+                thumbnail_src=thumbnail_url,
+                img_src=img_url,
+                title=result["name"],
+                content=result.get("subcategory") or "",
+                img_format=img_format,
+                formats=extra_formats,
+            )
+        )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1276,6 +1276,17 @@ engines:
       require_api_key: false
       results: JSON
 
+  - name: icons8
+    engine: icons8
+    shortcut: i8
+    # Uncomment the lines below to do extra requests to fetch
+    # the SVG image files with infinite resolution
+    # otherwise limited-resolution JPEG files are loaded
+    # icons8_fetch_svg: true
+    # results_per_page: 10
+    # timeout: 10
+    disabled: true
+
   - name: il post
     engine: il_post
     shortcut: pst


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- implement https://icons8.com
- there's an option `fetch_svg` which loads the source SVG files - it has the caveat that it requires one request per image though (this bypasses the icons8 subscription plan btw, so it's rather a grayzone :) )

### How to test this PR locally?
- !i8 bird

### Notes
- using multi-request code was inspired by dalf's work in #4827 - without it the engine would be much slower
- multi-request: https://github.com/searxng/searxng/blob/7420706a5074803a78f3c795cf79427746e504e0/searx/network/__init__.py#L101

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
