### PR TITLE
[enh] simplify and clean up preferences

### DIFF
--- a/searx/plugins/oa_doi_rewrite.py
+++ b/searx/plugins/oa_doi_rewrite.py
@@ -19,9 +19,6 @@ if typing.TYPE_CHECKING:
     from searx.plugins import PluginCfg
 
 
-ahmia_blacklist: list = []
-
-
 def filter_url_field(result: "Result|LegacyResult", field_name: str, url_src: str) -> bool | str:
     """Returns bool ``True`` to use URL unchanged (``False`` to ignore URL).
     If URL should be modified, the returned string is the new URL to use."""
@@ -29,11 +26,15 @@ def filter_url_field(result: "Result|LegacyResult", field_name: str, url_src: st
     if field_name != "url":
         return True  # use it unchanged
 
+    resolver_url = get_doi_resolver()
+    if not resolver_url:
+        return True  # use it unchanged
+
     doi = extract_doi(result.parsed_url)
     if doi and len(doi) < 50:
         for suffix in ("/", ".pdf", ".xml", "/full", "/meta", "/abstract"):
             doi = doi.removesuffix(suffix)
-        new_url = get_doi_resolver() + doi
+        new_url = resolver_url + doi
         if "doi" not in result:
             result["doi"] = doi
         log.debug("oa_doi_rewrite: [URL field: %s] %s -> %s", field_name, url_src, new_url)
@@ -53,7 +54,7 @@ class SXNGPlugin(Plugin):
             id=self.id,
             name=gettext("Open Access DOI rewrite"),
             description=gettext("Avoid paywalls by redirecting to open-access versions of publications when available"),
-            preference_section="general",
+            preference_section=None,
         )
 
     def on_result(
@@ -83,7 +84,7 @@ def extract_doi(url):
 
 def get_doi_resolver() -> str:
     doi_resolvers = get_setting("doi_resolvers")
-    selected_resolver = sxng_request.preferences.get_value('doi_resolver')[0]
-    if selected_resolver not in doi_resolvers:
-        selected_resolver = get_setting("default_doi_resolver")
+    selected_resolver = sxng_request.preferences.get_value("doi_resolver")
+    if not selected_resolver or selected_resolver not in doi_resolvers:
+        return ""
     return doi_resolvers[selected_resolver]

--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -457,10 +457,10 @@ class Preferences:
                 get_setting("ui.results_on_new_tab"),
                 locked="results_on_new_tab" in self.cfg.lock,
             ),
-            'doi_resolver': MultipleChoiceSetting(
-                [get_setting("default_doi_resolver")],
+            "doi_resolver": EnumStringSetting(
+                get_setting("default_doi_resolver"),
                 locked="doi_resolver" in self.cfg.lock,
-                choices=DOI_RESOLVERS,
+                choices=["", *DOI_RESOLVERS],
             ),
             'simple_style': EnumStringSetting(
                 get_setting("ui.theme_args.simple_style"),
@@ -536,6 +536,8 @@ class Preferences:
                 self.plugins.parse_cookie(input_data.get('disabled_plugins', ''), input_data.get('enabled_plugins', ''))
             elif user_setting_name == 'tokens':
                 self.tokens.parse(user_setting)
+        if "oa_doi_rewrite" in self.plugins.choices:
+            self.plugins.choices["oa_doi_rewrite"] = bool(self.get_value("doi_resolver"))
 
     def parse_form(self, input_data: dict[str, str]):
         """Parse formular (``<input>``) data from a ``flask.request.form``"""
@@ -564,6 +566,8 @@ class Preferences:
         self.key_value_settings['categories'].parse_form(enabled_categories)  # type: ignore
         self.engines.parse_form(disabled_engines)
         self.plugins.parse_form(disabled_plugins)
+        if "oa_doi_rewrite" in self.plugins.choices:
+            self.plugins.choices["oa_doi_rewrite"] = bool(self.get_value("doi_resolver"))
 
     # cannot be used in case of engines or plugins
     def get_value(self, user_setting_name: str) -> t.Any:

--- a/searx/templates/simple/preferences.html
+++ b/searx/templates/simple/preferences.html
@@ -183,16 +183,16 @@
     {%- if 'favicon_resolver' not in locked_preferences -%}
       {%- include 'simple/preferences/favicon.html' -%}
     {%- endif -%}
+    {%- if 'doi_resolver' not in locked_preferences -%}
+      {%- include 'simple/preferences/doi_resolver.html' -%}
+    {%- endif -%}
     {% if 'safesearch' not in locked_preferences %}
       {%- include 'simple/preferences/safesearch.html' -%}
     {%- endif -%}
-    {%- include 'simple/preferences/tokens.html' -%}
-    {{- plugin_preferences('general') -}}
-
-
-    {%- if 'doi_resolver' not in locked_preferences %}
-      {%- include 'simple/preferences/doi_resolver.html' -%}
+    {%- if engines_with_tokens -%}
+      {%- include 'simple/preferences/tokens.html' -%}
     {%- endif -%}
+    {{- plugin_preferences('general') -}}
     {{- tab_footer() -}}
 
     {# tab: ui #}

--- a/searx/templates/simple/preferences/doi_resolver.html
+++ b/searx/templates/simple/preferences/doi_resolver.html
@@ -1,20 +1,17 @@
-<div class="pref-group">{{- _('Digital Object Identifier (DOI)') -}}</div>
-
-{{- plugin_preferences('general/doi_resolver') -}}
-
 <fieldset>{{- '' -}}
-  <legend id="pref_doi_resolver">{{- _('Open Access DOI resolver') -}}</legend>{{- '' -}}
+  <legend id="pref_doi_resolver">{{- _('DOI Resolver') -}}</legend>{{- '' -}}
   <div class="value">{{- '' -}}
-    <select id='doi_resolver' name='doi_resolver' aria-labelledby="pref_doi_resolver">{{- '' -}}
-      {%- for doi_resolver_name,doi_resolver_url in doi_resolvers.items() -%}
+    <select name="doi_resolver" aria-labelledby="pref_doi_resolver">{{- '' -}}
+      <option value=""> - </option>
+      {%- for doi_resolver_name in doi_resolvers -%}
         <option value="{{ doi_resolver_name }}"
-                {%- if doi_resolver_url == current_doi_resolver %} selected="selected" {%- endif -%}>
-          {{- doi_resolver_name }} - {{ doi_resolver_url -}}
+                {%- if doi_resolver_name == current_doi_resolver %} selected="selected" {%- endif -%}>
+          {{- doi_resolver_name -}}
         </option>
       {%- endfor -%}
     </select>{{- '' -}}
   </div>{{- '' -}}
   <div class="description">
-    {{- _('Select service used by DOI rewrite') -}}
+    {{- _('Avoid paywalls by redirecting to open-access versions of publications when available') -}}
   </div>{{- '' -}}
 </fieldset>{{- '' -}}

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -957,6 +957,7 @@ def preferences():
         # fmt: off
         'preferences.html',
         preferences = True,
+        engines_with_tokens = any(getattr(e, "tokens", None) for e in engines.values()),
         selected_categories = get_selected_categories(sxng_request.preferences, sxng_request.form),
         locales = LOCALE_NAMES,
         current_locale = sxng_request.preferences.get_value("locale"),
@@ -973,7 +974,7 @@ def preferences():
         shortcuts = {y: x for x, y in engine_shortcuts.items()},
         themes = themes,
         plugins_storage = searx.plugins.STORAGE.info,
-        current_doi_resolver = get_doi_resolver(),
+        current_doi_resolver = sxng_request.preferences.get_value("doi_resolver"),
         allowed_plugins = allowed_plugins,
         preferences_url_params = sxng_request.preferences.get_as_url_params(),
         locked_preferences = get_setting("preferences").lock,


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

<!-- Explain the motivation and changes in your pull request.  -->

This PR is a start to begin to clean up the preferences page. I have started with just two small changes:

- The 'engine tokens' field is only shown now if there are any engines with tokens configured. Offering to drop if @return42 is still working on the [preferences implementation](https://github.com/searxng/searxng/issues/4931#issuecomment-2998947896) as it's only a two line change.

- I have made many changes to the preferences of the DOI Resolver. Primarily, I have combined the previous two settings (one dropdown and one toggle) into just a single dropdown similar to the favicon resolver. I am not sure if this goes against the 'spirit' of the plugins but thought it would be better to discuss it here and maybe we will come up with a better alternative.

<img width="1295" height="673" alt="Screenshot" src="https://github.com/user-attachments/assets/d8a1ce27-75a9-400f-a2f4-59beb3bd2b59" />

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

`make run`

Go to /preferences under General:

Search when DOI resolver is disabled when off ('-') and enabled when a resolver is selected.

The tokens block should be hidden unless an engine has tokens in settings.

### Related issues

<!--
Closes: #234
-->

Related: https://github.com/searxng/searxng/issues/4931

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor for occasional suggestions and to ask it about edge cases.