### PR TITLE
[mod] normalize variable name for the max number of results per request

### DIFF
--- a/docs/dev/engines/engine_overview.rst
+++ b/docs/dev/engines/engine_overview.rst
@@ -107,7 +107,7 @@ module:
    ======================= =========== ===========================================
    base_url                string      base-url, can be overwritten to use same
                                        engine on other URL
-   number_of_results       int         maximum number of results per request
+   page_size               int         maximum number of results per request
    language                string      ISO code of language and country like en_US
    api_key                 string      api-key if required by engine
    ======================= =========== ===========================================

--- a/searx/engines/artic.py
+++ b/searx/engines/artic.py
@@ -21,7 +21,7 @@ about = {
 
 categories = ['images']
 paging = True
-nb_per_page = 20
+page_size = 20
 
 search_api = 'https://api.artic.edu/api/v1/artworks/search?'
 image_api = 'https://www.artic.edu/iiif/2/'
@@ -34,7 +34,7 @@ def request(query, params):
             'q': query,
             'page': params['pageno'],
             'fields': 'id,title,artist_display,medium_display,image_id,date_display,dimensions,artist_titles',
-            'limit': nb_per_page,
+            'limit': page_size,
         }
     )
     params['url'] = search_api + args

--- a/searx/engines/base.py
+++ b/searx/engines/base.py
@@ -26,7 +26,7 @@ base_url = (
 
 # engine dependent config
 paging = True
-number_of_results = 10
+page_size = 10
 
 # shortcuts for advanced search
 shortcut_dict = {
@@ -57,12 +57,12 @@ def request(query, params):
         query = re.sub(key, val, query)
 
     # basic search
-    offset = (params['pageno'] - 1) * number_of_results
+    offset = (params['pageno'] - 1) * page_size
 
     string_args = {
         'query': urlencode({'query': query}),
         'offset': offset,
-        'hits': number_of_results,
+        'hits': page_size,
     }
 
     params['url'] = base_url.format(**string_args)

--- a/searx/engines/chefkoch.py
+++ b/searx/engines/chefkoch.py
@@ -16,7 +16,7 @@ about = {
 paging = True
 categories = []
 
-number_of_results = 20
+page_size = 20
 skip_premium = True
 
 
@@ -25,7 +25,7 @@ thumbnail_format = "crop-240x300"
 
 
 def request(query, params):
-    args = {'query': query, 'limit': number_of_results, 'offset': (params['pageno'] - 1) * number_of_results}
+    args = {'query': query, 'limit': page_size, 'offset': (params['pageno'] - 1) * page_size}
     params['url'] = f"{base_url}/v2/search-gateway/recipes?{urlencode(args)}"
     return params
 

--- a/searx/engines/core.py
+++ b/searx/engines/core.py
@@ -56,7 +56,7 @@ the API key in the engine :ref:`core engine config`."""
 
 categories = ["science", "scientific publications"]
 paging = True
-nb_per_page = 10
+page_size = 10
 base_url = "https://api.core.ac.uk/v3/search/works/"
 
 
@@ -77,8 +77,8 @@ def request(query: str, params: "OnlineParams") -> None:
     # API v3 uses different parameters
     search_params = {
         "q": query,
-        "offset": (params["pageno"] - 1) * nb_per_page,
-        "limit": nb_per_page,
+        "offset": (params["pageno"] - 1) * page_size,
+        "limit": page_size,
         "sort": "relevance",
     }
 

--- a/searx/engines/dailymotion.py
+++ b/searx/engines/dailymotion.py
@@ -38,7 +38,7 @@ about = {
 # engine dependent config
 categories = ["videos"]
 paging = True
-number_of_results = 10
+page_size = 10
 
 time_range_support = True
 time_delta_dict = {
@@ -113,7 +113,7 @@ def request(query, params):
         "password_protected": "false",
         "private": "false",
         "sort": "relevance",
-        "limit": number_of_results,
+        "limit": page_size,
         "fields": ",".join(result_fields),
     }
 

--- a/searx/engines/doku.py
+++ b/searx/engines/doku.py
@@ -21,7 +21,6 @@ about = {
 # engine dependent config
 categories = ['general']  # 'images', 'music', 'videos', 'files'
 paging = False
-number_of_results = 5
 
 # search-url
 # Doku is OpenSearch compatible

--- a/searx/engines/flickr.py
+++ b/searx/engines/flickr.py
@@ -20,7 +20,7 @@ about = {
 
 categories = ['images']
 
-nb_per_page = 15
+page_size = 15
 paging = True
 api_key = None
 
@@ -29,7 +29,7 @@ url = (
     'https://api.flickr.com/services/rest/?method=flickr.photos.search'
     + '&api_key={api_key}&{text}&sort=relevance'
     + '&extras=description%2C+owner_name%2C+url_o%2C+url_n%2C+url_z'
-    + '&per_page={nb_per_page}&format=json&nojsoncallback=1&page={page}'
+    + '&per_page={page_size}&format=json&nojsoncallback=1&page={page}'
 )
 photo_url = 'https://www.flickr.com/photos/{userid}/{photoid}'
 
@@ -42,7 +42,7 @@ def build_flickr_url(user_id, photo_id):
 
 def request(query, params):
     params['url'] = url.format(
-        text=urlencode({'text': query}), api_key=api_key, nb_per_page=nb_per_page, page=params['pageno']
+        text=urlencode({'text': query}), api_key=api_key, page_size=page_size, page=params['pageno']
     )
     return params
 

--- a/searx/engines/mediawiki.py
+++ b/searx/engines/mediawiki.py
@@ -51,7 +51,7 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
-number_of_results = 5
+page_size = 5
 
 search_type: str = 'nearmatch'
 """Which type of search to perform.  One of the following values: ``nearmatch``,
@@ -110,7 +110,7 @@ def request(query, params):
         params['language'] = params['language'].split('-')[0]
 
     api_url = f"{base_url.rstrip('/')}/{api_path}?".format(language=params['language'])
-    offset = (params['pageno'] - 1) * number_of_results
+    offset = (params['pageno'] - 1) * page_size
 
     args = {
         'action': 'query',
@@ -118,7 +118,7 @@ def request(query, params):
         'format': 'json',
         'srsearch': query,
         'sroffset': offset,
-        'srlimit': number_of_results,
+        'srlimit': page_size,
         'srwhat': search_type,
         'srprop': srprop,
         'srsort': srsort,

--- a/searx/engines/metacpan.py
+++ b/searx/engines/metacpan.py
@@ -14,7 +14,7 @@ about = {
 }
 
 # engine dependent config
-number_of_results = 20  # Don't put this over 5000
+page_size = 20  # Don't put this over 5000
 categories = ["it", "packages"]
 disabled = True
 shortcut = "cpan"
@@ -43,7 +43,7 @@ query_data_template = {
         {"date": {"order": "desc"}},
     ],
     '_source': ['documentation', "abstract"],
-    'size': number_of_results,
+    'size': page_size,
 }
 search_url = urlunparse(["https", "fastapi.metacpan.org", "/v1/file/_search", "", "", ""])
 
@@ -53,7 +53,7 @@ def request(query, params):
     params["method"] = "POST"
     query_data = query_data_template
     query_data["query"]["multi_match"]["query"] = query
-    query_data["from"] = (params["pageno"] - 1) * number_of_results
+    query_data["from"] = (params["pageno"] - 1) * page_size
     params["json"] = query_data
     return params
 

--- a/searx/engines/openverse.py
+++ b/searx/engines/openverse.py
@@ -21,15 +21,15 @@ about = {
 categories = ['images']
 
 paging = True
-nb_per_page = 20
+page_size = 20
 
 base_url = 'https://api.openverse.org/v1/images/'
-search_string = '?page={page}&page_size={nb_per_page}&format=json&{query}'
+search_string = '?page={page}&page_size={page_size}&format=json&{query}'
 
 
 def request(query, params):
 
-    search_path = search_string.format(query=urlencode({'q': query}), nb_per_page=nb_per_page, page=params['pageno'])
+    search_path = search_string.format(query=urlencode({'q': query}), page_size=page_size, page=params['pageno'])
 
     params['url'] = base_url + search_path
 

--- a/searx/engines/photon.py
+++ b/searx/engines/photon.py
@@ -20,7 +20,7 @@ about = {
 # engine dependent config
 categories = ['map']
 paging = False
-number_of_results = 10
+page_size = 10
 
 # search-url
 base_url = 'https://photon.komoot.io/'
@@ -33,7 +33,7 @@ supported_languages = ['de', 'en', 'fr', 'it']
 
 # do search-request
 def request(query, params):
-    params['url'] = base_url + search_string.format(query=urlencode({'q': query}), limit=number_of_results)
+    params['url'] = base_url + search_string.format(query=urlencode({'q': query}), limit=page_size)
 
     if params['language'] != 'all':
         language = params['language'].split('_')[0]

--- a/searx/engines/pubmed.py
+++ b/searx/engines/pubmed.py
@@ -57,7 +57,7 @@ categories = ["science", "scientific publications"]
 eutils_api = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 
 # engine dependent config
-number_of_results = 10
+page_size = 10
 pubmed_url = "https://www.ncbi.nlm.nih.gov/pubmed/"
 
 
@@ -67,8 +67,8 @@ def request(query: str, params: "OnlineParams") -> None:
         {
             "db": "pubmed",
             "term": query,
-            "retstart": (params["pageno"] - 1) * number_of_results,
-            "hits": number_of_results,
+            "retstart": (params["pageno"] - 1) * page_size,
+            "hits": page_size,
         }
     )
     esearch_url = f"{eutils_api}/esearch.fcgi?{args}"

--- a/searx/engines/radio_browser.py
+++ b/searx/engines/radio_browser.py
@@ -28,7 +28,7 @@ about = {
 paging = True
 categories = ["music", "radio"]
 
-number_of_results = 10
+page_size = 10
 
 station_filters = []  # ['countrycode', 'language']
 """A list of filters to be applied to the search of radio stations.  By default
@@ -100,8 +100,8 @@ def request(query, params):
     args = {
         "name": query,
         "order": "votes",
-        "offset": (params["pageno"] - 1) * number_of_results,
-        "limit": number_of_results,
+        "offset": (params["pageno"] - 1) * page_size,
+        "limit": page_size,
         "hidebroken": "true",
         "reverse": "true",
     }

--- a/searx/engines/springer.py
+++ b/searx/engines/springer.py
@@ -74,7 +74,7 @@ about = {
 categories = ["science", "scientific publications"]
 
 paging = True
-nb_per_page = 10
+page_size = 10
 """Number of results to return in the request, see `Pagination and Limits`_ for
 more details.
 
@@ -109,8 +109,8 @@ def request(query: str, params: "OnlineParams") -> None:
     args = {
         "api_key": api_key,
         "q": query,
-        "s": nb_per_page * (params["pageno"] - 1),
-        "p": nb_per_page,
+        "s": page_size * (params["pageno"] - 1),
+        "p": page_size,
     }
     params["url"] = f"{base_url}?{urlencode(args)}"
     # For example, the ``year:`` filter requires a *Premium Plan* subscription.

--- a/searx/engines/wikicommons.py
+++ b/searx/engines/wikicommons.py
@@ -62,7 +62,7 @@ about = {
 
 categories: list[str] = []
 paging = True
-number_of_results = 10
+page_size = 10
 
 wc_api_url = "https://commons.wikimedia.org/w/api.php"
 wc_search_type: str = ""
@@ -107,8 +107,8 @@ def request(query: str, params: "OnlineParams") -> None:
         "generator": "search",
         "gsrnamespace": "6",  # https://www.mediawiki.org/wiki/Help:Namespaces#Renaming_namespaces
         "gsrprop": "snippet",
-        "gsrlimit": number_of_results,
-        "gsroffset": number_of_results * (params["pageno"] - 1),
+        "gsrlimit": page_size,
+        "gsroffset": page_size * (params["pageno"] - 1),
         "gsrsearch": f"filetype:{filetype} {query}",
         # imageinfo: https://commons.wikimedia.org/w/api.php?action=help&modules=query%2Bimageinfo
         "iiprop": "url|size|mime",

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -75,7 +75,7 @@ about = {
 # engine dependent config
 categories = ['general']
 paging = True
-number_of_results = 10
+page_size = 10
 http_digest_auth_user = ""
 """HTTP digest user for the local YACY instance"""
 http_digest_auth_pass = ""
@@ -125,11 +125,11 @@ def _base_url() -> str:
 
 def request(query, params):
 
-    offset = (params['pageno'] - 1) * number_of_results
+    offset = (params['pageno'] - 1) * page_size
     args = {
         'query': query,
         'startRecord': offset,
-        'maximumRecords': number_of_results,
+        'maximumRecords': page_size,
         'contentdom': search_type,
         'resource': search_mode,
     }

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1391,7 +1391,6 @@ engines:
     engine: metacpan
     shortcut: cpan
     disabled: true
-    number_of_results: 20
 
   # https://docs.searxng.org/dev/engines/offline/search-indexer-engines.html#module-searx.engines.meilisearch
   # - name: meilisearch


### PR DESCRIPTION
No functional changes ... in the past, we have used different names for the variable that specifies the maximum number of hits in the outgoing request.

- ``page_size``
- ``number_of_results``
- ``nb_per_page``

Since *page_size* is the most accurate term and is also used in the XPath engines, all other engines are adjusted accordingly within this patch .. documentation adjusted accordingly.

### How to test this PR locally?

As far as possible, please test the modified engines.

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI used