### PR TITLE
[fix] bing: Allow redirects for bing_images and bing_videos

### DIFF
--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -66,6 +66,10 @@ def request(query, params):
 
     params["url"] = base_url + "?" + urlencode(query_params)
 
+    # in some regions where geoblocking is employed (e.g. China),
+    # www.bing.com redirects to the regional version of Bing
+    params['allow_redirects'] = True
+
     return params
 
 

--- a/searx/engines/bing_videos.py
+++ b/searx/engines/bing_videos.py
@@ -62,6 +62,10 @@ def request(query, params):
 
     params["url"] = base_url + "?" + urlencode(query_params)
 
+    # in some regions where geoblocking is employed (e.g. China),
+    # www.bing.com redirects to the regional version of Bing
+    params['allow_redirects'] = True
+
     return params
 
 


### PR DESCRIPTION
In some regions where geoblocking is employed (e.g. China), www.bing.com redirects to the regional version of Bing. Apply the same workaround as bing.py so image and video search work in those regions.

<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

<!-- Explain the motivation and changes in your pull request.  -->
set `params['allow_redirects'] = True` for bing images and bing videos to make them work in China mainland.

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

### Related issues

<!--
Closes: #234
-->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [ ] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have not used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

This is a minor change.
