### PR TITLE
[fix] json, xpath engine: rename safe_search_support option to safesearch

### DIFF
--- a/searx/engines/json_engine.py
+++ b/searx/engines/json_engine.py
@@ -29,7 +29,7 @@ Time Range:
 
 Safe-Search:
 
-- :py:obj:`safe_search_support`
+- :py:obj:`safesearch`
 - :py:obj:`safe_search_map`
 
 Response:
@@ -103,7 +103,7 @@ Replacements are:
 
 ``{safe_search}``:
   Safe-search :py:obj:`URL parameter <safe_search_map>` if engine
-  :py:obj:`supports safe-search <safe_search_support>`.  The ``{safe_search}``
+  :py:obj:`supports safe-search <safesearch>`.  The ``{safe_search}``
   replacement is taken from the :py:obj:`safes_search_map`.  Filter results::
 
       0: none, 1: moderate, 2:strict
@@ -236,7 +236,7 @@ time_range_map = {
       year: 365
 '''
 
-safe_search_support = False
+safesearch = False
 '''Engine supports safe-search.'''
 
 safe_search_map = {0: '&filter=none', 1: '&filter=moderate', 2: '&filter=strict'}
@@ -286,7 +286,6 @@ def do_query(data, q):  # pylint: disable=invalid-name
     qkey = q[0]
 
     for key, value in iterate(data):
-
         if len(q) == 1:
             if key == qkey:
                 ret.append(value)

--- a/searx/engines/xpath.py
+++ b/searx/engines/xpath.py
@@ -31,7 +31,7 @@ Time Range:
 
 Safe-Search:
 
-- :py:obj:`safe_search_support`
+- :py:obj:`safesearch`
 - :py:obj:`safe_search_map`
 
 Response:
@@ -100,7 +100,7 @@ Replacements are:
 
 ``{safe_search}``:
   Safe-search :py:obj:`URL parameter <safe_search_map>` if engine
-  :py:obj:`supports safe-search <safe_search_support>`.  The ``{safe_search}``
+  :py:obj:`supports safe-search <safesearch>`.  The ``{safe_search}``
   replacement is taken from the :py:obj:`safes_search_map`.  Filter results::
 
       0: none, 1: moderate, 2:strict
@@ -205,7 +205,7 @@ time_range_map = {
       year: 365
 '''
 
-safe_search_support = False
+safesearch = False
 '''Engine supports safe-search.'''
 
 safe_search_map = {0: '&filter=none', 1: '&filter=moderate', 2: '&filter=strict'}
@@ -280,7 +280,6 @@ def response(resp) -> EngineResults:  # pylint: disable=too-many-branches
 
     if results_xpath:
         for result in eval_xpath_list(dom, results_xpath):
-
             url = extract_url(eval_xpath_list(result, url_xpath, min_len=1), search_url)
             title = extract_text(eval_xpath_list(result, title_xpath, min_len=1))
             content = extract_text(eval_xpath_list(result, content_xpath))


### PR DESCRIPTION

### What does this PR do?
- fixes that the `xpath` and `json_engine` documentation claim that safesearch can be enabled by setting `safe_search_support` to True - the current engine option is called `safesearch`

### How to test this PR locally?
- try to enable safesearch on a JSON engine

### Code of Conduct



- [X] **I hereby confirm that this PR conforms with the [AI Policy].**


