### PR TITLE
[fix] disable qwant engine / the rate-limits are just very strict

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1798,6 +1798,7 @@ engines:
     engine: qwant
     shortcut: qw
     categories: [general, web]
+    disabled: true
 
   - name: qwant news
     qwant_categ: news
@@ -1805,6 +1806,7 @@ engines:
     shortcut: qwn
     categories: news
     network: qwant
+    disabled: true
 
   - name: qwant images
     qwant_categ: images
@@ -1812,6 +1814,7 @@ engines:
     shortcut: qwi
     categories: [images, web]
     network: qwant
+    disabled: true
 
   - name: qwant videos
     qwant_categ: videos
@@ -1819,6 +1822,7 @@ engines:
     shortcut: qwv
     categories: [videos, web]
     network: qwant
+    disabled: true
 
   # - name: library
   #   engine: recoll


### PR DESCRIPTION
Qwant is set to inactive by default due to its strict rate-limits

Related:

- https://github.com/searxng/searxng/pull/6127

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

