### PR TITLE
[fix] pexels: fix engine crashes with SearxEngineAccessDeniedException

### DIFF
--- a/searx/engines/pexels.py
+++ b/searx/engines/pexels.py
@@ -9,7 +9,7 @@ from lxml import html
 from searx.result_types import EngineResults
 from searx.utils import eval_xpath_list, gen_useragent
 from searx.enginelib import EngineCache
-from searx.exceptions import SearxEngineAPIException
+from searx.exceptions import SearxEngineAPIException, SearxEngineAccessDeniedException
 from searx.network import get
 
 
@@ -58,6 +58,8 @@ def _get_secret_key():
             # circumvents Cloudflare bot protections
             "User-Agent": gen_useragent(),
             "Referer": base_url,
+            "Sec-GPC": "1",
+            "Connection": "keep-alive",
         },
     )
 
@@ -95,7 +97,7 @@ def request(query, params):
         try:
             secret_key = _get_secret_key()
             CACHE.set(SECRET_KEY_DB_KEY, secret_key)
-        except SearxEngineAPIException as e:
+        except (SearxEngineAPIException, SearxEngineAccessDeniedException) as e:
             logger.debug("failed to extract API key %s" % e)
             secret_key = api_key
 


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
2 changes:
- when we get blocked while trying to extract the secret key, we get a `SearxEngineAccessDeniedException`, so we must also catch these exceptions when falling back to the hardcoded API key
- updated the headers to not get automatically blocked by Cloudflare anymore

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
