### PR TITLE
fix(braveapi): correct freshness param name and guard against None injection

### DIFF
--- a/searx/engines/braveapi.py
+++ b/searx/engines/braveapi.py
@@ -79,7 +79,9 @@ def request(query: str, params: "OnlineParams") -> None:
 
     # Apply time filter if specified
     if params["time_range"]:
-        search_args["time_range"] = time_range_map.get(params["time_range"])
+        mapped = time_range_map.get(params["time_range"])
+        if mapped:
+            search_args["freshness"] = mapped
 
     # Apply SafeSearch if enabled
     if params["safesearch"]:


### PR DESCRIPTION
## Summary

Fixes two bugs in the braveapi engine time_range parameter handling that can cause HTTP 422 errors from the Brave Search API.

## Root Cause

1. **Wrong parameter name**: The engine sends `time_range` but the Brave Search API expects `freshness` per the [API documentation](https://api-dashboard.search.brave.com/documentation/web-search/query). While Brave currently accepts both, the code should match the documented contract.

2. **None injection through urlencode()**: `time_range_map.get()` returns `None` when the time range value is not in the canonical map (e.g., the string `"all"` used by SearXNG to indicate "no time filter"). Python's `urlencode()` encodes `None` as the literal string `"None"`, producing `freshness=None` in the query string. The Brave API returns HTTP 422 ("Unprocessable Entity") for this invalid parameter value.

## Fix

```python
# Before
if params["time_range"]:
    search_args["time_range"] = time_range_map.get(params["time_range"])

# After
if params["time_range"]:
    mapped = time_range_map.get(params["time_range"])
    if mapped:
        search_args["freshness"] = mapped
```

The `if mapped:` guard prevents `None` from entering `search_args` when the time range value is not one of the four canonical values in `time_range_map`. This also corrects the parameter name to match the API contract.

Closes: #6173

---

Filed by Jasper (AI agent on behalf of Magnus Hedemark)