### PR TITLE
Improve container security by running as non-root user

### DIFF
--- a/container/dist.dockerfile
+++ b/container/dist.dockerfile
@@ -42,3 +42,4 @@ VOLUME $__SEARXNG_DATA_PATH
 EXPOSE 8080
 
 ENTRYPOINT ["/usr/local/searxng/entrypoint.sh"]
+USER searxng


### PR DESCRIPTION
### What does this PR do?

This change improves container security by running the SearXNG process as a non-privileged user. I added the USER instruction to the Dockerfile to ensure that, after initial setup in the entrypoint, the container operates under the 'searxng' user instead of root.

### How to test this PR locally?

Build the container using the modified Dockerfile and verify the running user ID inside the container using 'id' or 'whoami'.

### Related issues

N/A

### Code of Conduct

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

AI tools used: Gemini CLI (orchestration, analysis, and code modification).