### PR TITLE
[fix] crash when lock is omitted

### DIFF
--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -147,6 +147,8 @@ def apply_schema(settings: dict[str, t.Any], schema: dict[str, t.Any], path_list
                 # Type Validation at runtime:
                 # https://jcristharif.com/msgspec/structs.html#type-validation
                 cfg_dict = settings.get(key)
+                if cfg_dict is None:
+                    cfg_dict = {}
                 cfg_json = msgspec.json.encode(cfg_dict)
                 settings[key] = msgspec.json.decode(cfg_json, type=value)
             except msgspec.ValidationError as e:


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

When empty, treat the section as {} so msgspec uses defaults instead of null.

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->
     
`make run` with `lock: []` commented out.

### Related issues

Closes https://github.com/searxng/searxng/issues/6178

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

No ai!