### PR TITLE
[feat] engines: add kagi engine (general, news, images, videos)

### DIFF
--- a/searx/engines/kagi.py
+++ b/searx/engines/kagi.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Engine for Kagi API (v1)
+
+Mandatory settings:
+
+- :py:obj:`api_key`
+- :py:obj:`kagi_categ`
+
+Supported features:
+
+- Categories (search, news, images, videos)
+- Paging
+- Safe_search
+- Time_range
+"""
+
+from json import dumps, loads
+from datetime import datetime, date
+from dateutil.relativedelta import relativedelta
+from searx.network import raise_for_httperror
+from searx.utils import parse_duration_string
+
+about = {
+    "website": "https://www.kagi.com/",
+    "wikidata_id": "Q123819301",
+    "official_api_documentation": "https://kagi.com/api/docs/openapi/search",
+    "use_official_api": True,
+    "require_api_key": True,
+    "results": "JSON",
+}
+
+paging = True
+
+time_range_support = True
+
+timeout = 5
+
+api_key = None
+
+kagi_categ = None
+
+api_url = 'https://kagi.com/api/v1/search'
+
+def walk_dict(data, path):
+    v = data
+    for p in path:
+        v = v.get(p)
+        if v is None:
+            return v
+    return v
+
+class MapPath():
+    def __init__(self, path):
+        self._path = path
+
+    def Map(self, d):
+        return walk_dict(d, self._path)
+
+class MapResolutionPath(MapPath):
+    def __init__(self, path, width, height):
+        super().__init__(path)
+        self._width = width
+        self._height = height
+
+    def Map(self, d):
+        v = super().Map(d)
+        if isinstance(v, dict):
+            v = f'{v.get(self._width,"")} x {v.get(self._height,"")}'
+        return v
+
+class MapTimePath(MapPath):
+    def Map(self, d):
+        v = super().Map(d)
+        if isinstance(v, str):
+            return datetime.fromisoformat(v)
+        return v
+
+class MapDurationPath(MapPath):
+    def Map(self, d):
+        v = super().Map(d)
+        if isinstance(v, str):
+            return parse_duration_string(v)
+        return v
+
+categ_maps = {
+    'search': {
+        'result_key': 'search',
+        'maps': {
+            'url': MapPath(['url']),
+            'title': MapPath(['title']),
+            'content': MapPath(['snippet']),
+            'publishedDate': MapTimePath(['time'])
+        }
+    },
+    'news': {
+        'result_key': 'news',
+        'maps': {
+            'url': MapPath(['url']),
+            'title': MapPath(['title']),
+            'content': MapPath(['snippet']),
+            'publishedDate': MapTimePath(['time'])
+        }
+    },
+    'images': {
+        'result_key': 'image',
+        'template': 'images.html',
+        'maps': {
+            'url': MapPath(['image', 'url']),
+            'img_src': MapPath(['image', 'url']),
+            'resolution': MapResolutionPath(['image'],'width','height'),
+            'title': MapPath(['title']),
+            'thumbnail': MapPath(['props', 'thumbnail', 'url']),
+            'content': MapPath(['url']),
+            'publishedDate': MapTimePath(['time'])
+        }
+    },
+    'videos': {
+        'result_key': 'video',
+        'template': 'videos.html',
+        'maps': {
+            'url': MapPath(['url']),
+            'title': MapPath(['title']),
+            'thumbnail': MapPath(['image', 'url']),
+            'content': MapPath(['snippet']),
+            'publishedDate': MapTimePath(['time']),
+            'length': MapDurationPath(['props', 'duration']),
+            'views': MapPath(['props', 'view_count']),
+            'author': MapPath(['props', 'creator_name'])
+        }
+    }
+}
+
+def get_after(tr):
+    tod = date.today()
+    if tr == 'day':
+        return (tod - relativedelta(days=1)).isoformat()
+    elif tr == 'week':
+        return (tod - relativedelta(weeks=1)).isoformat()
+    elif tr == 'month':
+        return (tod - relativedelta(months=1)).isoformat()
+    else:
+        return (tod - relativedelta(years=1)).isoformat()
+
+def request(query, params):
+    if not query:
+        return None
+
+    pageno = params.get('pageno',1)
+
+    if pageno > 10:
+        return None
+
+    req = {
+        'query': query,
+        'page': pageno,
+        'workflow': kagi_categ
+    }
+
+    req['filters'] = { 'safe_search': False if params['safesearch'] == 0 else True }
+
+    if params.get('time_range') is not None:
+        req['filters']['after'] = get_after(params['time_range'])
+
+    params['headers']['Authorization'] = f'Bearer {api_key}'
+    params['url'] = api_url
+    params['method'] = 'POST'
+    params['json'] = req
+
+    return params
+
+def response(resp):
+    raise_for_httperror(resp)
+
+    results = []
+
+    js = loads(resp.text)
+
+    cmap = categ_maps[kagi_categ]
+    rk = cmap['result_key']
+    mp = cmap['maps']
+    tmpl = cmap.get('template', None)
+
+    for rs in js.get('data', {}).get(rk, []):
+        tmp_result = {}
+        for k in mp.keys():
+            tmp_v = mp[k].Map(rs)
+            if tmp_v is not None:
+                tmp_result[k] = tmp_v
+        if tmpl is not None:
+            tmp_result['template'] = tmpl
+        results.append(tmp_result)
+
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1212,6 +1212,34 @@ engines:
     timeout: 3.0
     disabled: true
 
+#  - name: kagi
+#    engine: kagi
+#    categories: [general, web]
+#    shortcut: kg
+#    api_key: ''  # required
+#    kagi_categ: search
+#
+#  - name: kagi.news
+#    engine: kagi
+#    categories: [news, web]
+#    shortcut: kgn
+#    api_key: ''  # required
+#    kagi_categ: news
+#
+#  - name: kagi.images
+#    engine: kagi
+#    categories: [images, web]
+#    shortcut: kgi
+#    api_key: ''  # required
+#    kagi_categ: images
+#
+#  - name: kagi.videos
+#    engine: kagi
+#    categories: [videos, web]
+#    shortcut: kgv
+#    api_key: ''  # required
+#    kagi_categ: videos
+
   - name: karmasearch
     engine: karmasearch
     categories: [general, web]


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

Adds engine for Kagi API (v1)

https://www.kagi.com/

### How to test this PR locally?

Enable in settings with valid api_key

>general
- !kg test
>news
- !kgn test
>images
- !kgi test
>videos
- !kgv test

### Related issues

Closes: #2247

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.