### PR TITLE
[fix] no such table during engine init

### DIFF
--- a/searx/sqlitedb.py
+++ b/searx/sqlitedb.py
@@ -327,7 +327,6 @@ class SQLiteAppl(abc.ABC):
 
         if self._init_done:
             return False
-        self._init_done = True
 
         logger.debug("init DB: %s", self.db_url)
         self.properties.init(conn)
@@ -342,6 +341,7 @@ class SQLiteAppl(abc.ABC):
                 raise sqlite3.DatabaseError("Expected DB schema v%s, DB schema is v%s" % (self.DB_SCHEMA, ver))
             logger.debug("DB_SCHEMA = %s", ver)
 
+        self._init_done = True
         return True
 
     def create_schema(self, conn: sqlite3.Connection):
@@ -368,6 +368,9 @@ class SQLiteProperties(SQLiteAppl):
          PRIMARY KEY (name))
 
     """
+
+    _locks: dict[str, threading.Lock] = {}
+    _locks_lock = threading.Lock()
 
     SQLITE_JOURNAL_MODE: str = "WAL"
 
@@ -406,11 +409,16 @@ CREATE TABLE IF NOT EXISTS properties (
 
         if self._init_done:
             return False
-        self._init_done = True
-        logger.debug("init properties of DB: %s", self.db_url)
-        res = conn.execute(self.SQL_TABLE_EXISTS)
-        if res.fetchone() is None:  # DB schema needs to be be created
-            self.create_schema(conn)
+        with self._locks_lock:
+            db_lock = self._locks.setdefault(self.db_url, threading.Lock())
+        with db_lock:
+            if self._init_done:
+                return False
+            logger.debug("init properties of DB: %s", self.db_url)
+            res = conn.execute(self.SQL_TABLE_EXISTS)
+            if res.fetchone() is None:  # DB schema needs to be be created
+                self.create_schema(conn)
+            self._init_done = True
         return True
 
     def __call__(self, name: str, default: t.Any = None) -> t.Any:


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

<!-- Explain the motivation and changes in your pull request.  -->

Fixes a race condition when the sqlite cache is made for the first time. Many engines can run init in parallel which triggers the cache maintenance which then reads the table before it's created:

```
sqlite3.OperationalError: no such table: properties
```

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

`make container`

Restart several times

Confirm no more race conditions

### Related issues

<!--
Closes: #234
-->

Closes: https://github.com/searxng/searxng/issues/6181

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Opus 4.8 to narrow down where the race is happening