### PR TITLE
[fix] duckduckgo: image requests get blocked

### DIFF
--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -41,7 +41,9 @@ safesearch_cookies = {0: "-2", 1: None, 2: "1"}
 safesearch_args = {0: "1", 1: None, 2: "1"}
 
 search_path_map = {"images": "i", "videos": "v", "news": "news"}
+
 _HTTP_User_Agent: str = gen_useragent()
+send_accept_language_header = False
 
 
 def init(engine_settings: dict[str, t.Any]):

--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -152,7 +152,6 @@ class OnlineProcessor(EngineProcessor):
         # add Accept-Language header
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Language
 
-        headers["Accept-Language"] = "en,en-US;q=0.7,en;q=0.3"
         if self.engine.send_accept_language_header and search_query.locale:
             _l = search_query.locale.language
             _t = search_query.locale.territory or _l


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- for some reason all i.js requests sending the accept language header get blocked, so this removes it

Related:

- https://github.com/searxng/searxng/pull/5758

### How to test this PR locally?
- !ddi test

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
