### PR TITLE
refactor(nvd): use fromisoformat for published  date

### DIFF
--- a/searx/engines/nvd.py
+++ b/searx/engines/nvd.py
@@ -44,7 +44,7 @@ def response(resp) -> EngineResults:
 
         cve_id = item["cve"]["id"]
         description = item["cve"]["descriptions"][0]["value"]
-        date = datetime.strptime(item["cve"]["published"], "%Y-%m-%dT%H:%M:%S.%f")
+        date = datetime.fromisoformat(item["cve"]["published"])
 
         # Extract severity (Low, Medium, High, or Critical) and CVSS score, if available
         info = item["cve"].get("metrics", {}).get("cvssMetricV31", [{}])[0].get("cvssData", {})


### PR DESCRIPTION


### What does this PR do?

Replaces ISO datetime parsing via datetime.strptime with datetime.fromisoformat
where the format is already ISO-like.

### How to test this PR locally?

I ran:

- `python -m py_compile searx/engines/nvd.py`
- `make format`
- `make test.unit`

### Related issues

Closes: #6098

### Code of Conduct

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

AI disclosure: I used ChatGPT to understand the issue and local workflow. I made and verified the final code change myself.

