### PR TITLE
[fix] issue #338 selenium robot tests: fail on browser-side JavaScript errors 

### DIFF
--- a/tests/robot/__main__.py
+++ b/tests/robot/__main__.py
@@ -9,6 +9,8 @@ import traceback
 import pathlib
 import shutil
 
+from time import sleep
+
 from splinter import Browser
 
 import tests as searx_tests
@@ -43,14 +45,61 @@ class SearxRobotLayer:
         del os.environ['SEARXNG_SETTINGS_PATH']
 
 
+def _format_log_entry(entry):
+    """Build a readable one-line message from a BiDi log entry."""
+    level = getattr(entry, 'level', None) or '?'
+    text = getattr(entry, 'text', None) or repr(entry)
+    return '[{0}] {1}'.format(level, text)
+
+
+def _collect_browser_errors(browser):
+    """Register WebDriver BiDi handlers that collect JavaScript errors and
+    error-level console messages emitted by the browser.
+
+    The returned list is filled asynchronously while the test interacts with
+    the page, so it must be inspected only after the test has finished.
+    """
+    errors = []
+
+    script = browser.driver.script
+    script.add_javascript_error_handler(lambda entry: errors.append(_format_log_entry(entry)))
+
+    def on_console_message(entry):
+        if getattr(entry, 'level', None) == 'error':
+            errors.append(_format_log_entry(entry))
+
+    script.add_console_message_handler(on_console_message)
+    return errors
+
+
 def run_robot_tests(tests):
     print('Running {0} tests'.format(len(tests)))
     print(f'{shutil.which("geckodriver")}')
     print(f'{shutil.which("firefox")}')
 
+    failures = []
     for test in tests:
-        with Browser('firefox', headless=True, profile_preferences={'intl.accept_languages': 'en'}) as browser:
+        # 'webSocketUrl' enables the WebDriver BiDi protocol, which lets us
+        # subscribe to the browser's log entries (see _collect_browser_errors).
+        with Browser(
+            'firefox',
+            headless=True,
+            profile_preferences={'intl.accept_languages': 'en'},
+            capabilities={'webSocketUrl': True},
+        ) as browser:
+            errors = _collect_browser_errors(browser)
             test(browser)
+            # give the asynchronous BiDi log events a moment to be delivered
+            sleep(1)
+            if errors:
+                failures.append((test.__name__, errors))
+
+    if failures:
+        report = ['JavaScript errors were detected in the browser console:']
+        for name, errors in failures:
+            report.append('  {0}:'.format(name))
+            report.extend('    - {0}'.format(error) for error in errors)
+        raise AssertionError('\n'.join(report))
 
 
 def main():


### PR DESCRIPTION
### What does this PR do?

Makes the Selenium/Splinter robot tests fail when the browser reports
JavaScript errors, so client-side regressions are caught automatically in CI.

Previously the tests only asserted that certain text/elements were present on
the page; a broken script that still rendered the expected markup would pass
unnoticed. This PR subscribes to the browser console and fails the run if any
JavaScript errors are detected while a test executes.

Changes (all in `tests/robot/__main__.py`):

- Start the Firefox browser with the `webSocketUrl` capability, which enables
  the **WebDriver BiDi** protocol. This is required because Firefox/geckodriver
  does not support the classic `driver.get_log('browser')` API (that is
  Chrome/CDP only). BiDi is the modern, cross-browser, W3C-standard way to read
  the console and is available in the pinned `selenium==4.44.0`.
- Add `_collect_browser_errors(browser)`, which registers two BiDi log handlers
  via `browser.driver.script`:
  - `add_javascript_error_handler` — captures uncaught JavaScript exceptions.
  - `add_console_message_handler` — captures `error`-level console messages.
- Rework `run_robot_tests()` so each test still runs in its own browser, then
  records any errors that were collected. After all tests have run, if any
  errors were captured it raises an `AssertionError` that lists them per test.
  `main()` already converts that into a non-zero exit code, so CI fails.
- Add a short settle (`sleep(1)`) after each test to allow the asynchronous
  BiDi log events to be delivered before the errors are inspected.

### How to test this PR locally?

```sh
make test.robot
```

This downloads geckodriver (via `gecko.driver`) and runs
`python -m tests.robot`, which starts the SearXNG webapp and drives a headless
Firefox. Requires Firefox to be installed locally.

To confirm the new check actually fails on JavaScript errors, temporarily
introduce a JS error in a template/script served by the test instance (for
example, call an undefined function on page load) and re-run `make test.robot`:
the run should now fail and print the offending console messages grouped by
test name.

Notes / edge cases:

- The check fails on both uncaught JS exceptions **and** `error`-level console
  messages. The latter is slightly broader (e.g. a failed resource load logged
  at error level would fail a test); this can be narrowed to JS exceptions only
  if preferred.
- Requires a geckodriver/Firefox new enough to support WebDriver BiDi.

### Related issues

Closes hopefully : #338

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  AI tools used:

  - **Claude Code (Anthropic)** — used to research the existing robot test
    setup, identify that Firefox/geckodriver requires WebDriver BiDi (rather
    than the Chrome-only `get_log` API) for console access,
    in `tests/robot/__main__.py`, and verify it against the repo's `black` and
    `pylint` configuration. All changes were reviewed before submission.
