### PR TITLE
fix: avoid limiter warning when disabled

### DIFF
--- a/searx/botdetection/config.py
+++ b/searx/botdetection/config.py
@@ -72,14 +72,21 @@ class Config:
     UNSET: object = UNSET
 
     @classmethod
-    def from_toml(cls, schema_file: pathlib.Path, cfg_file: pathlib.Path, deprecated: dict[str, str]) -> "Config":
+    def from_toml(
+        cls,
+        schema_file: pathlib.Path,
+        cfg_file: pathlib.Path,
+        deprecated: dict[str, str],
+        warn_missing: bool = True,
+    ) -> "Config":
 
         # init schema
 
         log.debug("load schema file: %s", schema_file)
         cfg = cls(cfg_schema=toml_load(schema_file), deprecated=deprecated)
         if not cfg_file.exists():
-            log.warning("missing config file: %s", cfg_file)
+            if warn_missing:
+                log.warning("missing config file: %s", cfg_file)
             return cfg
 
         # load configuration

--- a/searx/limiter.py
+++ b/searx/limiter.py
@@ -130,7 +130,7 @@ LIMITER_CFG_SCHEMA = Path(__file__).parent / "limiter.toml"
 """Base configuration (schema) of the botdetection."""
 
 
-def get_cfg() -> config.Config:
+def get_cfg(warn_missing: bool = True) -> config.Config:
     """Returns SearXNG's global limiter configuration."""
     global CFG  # pylint: disable=global-statement
 
@@ -138,7 +138,12 @@ def get_cfg() -> config.Config:
         from . import settings_loader  # pylint: disable=import-outside-toplevel
 
         cfg_file = (settings_loader.get_user_cfg_folder() or Path("/etc/searxng")) / "limiter.toml"
-        CFG = config.Config.from_toml(LIMITER_CFG_SCHEMA, cfg_file, searx.compat.LIMITER_CFG_DEPRECATED)
+        CFG = config.Config.from_toml(
+            LIMITER_CFG_SCHEMA,
+            cfg_file,
+            searx.compat.LIMITER_CFG_DEPRECATED,
+            warn_missing=warn_missing,
+        )
         searx.compat.limiter_fix_cfg(CFG, cfg_file)
 
     return CFG
@@ -226,7 +231,7 @@ def initialize(app: flask.Flask, settings):
     # even if the limiter is not activated, the botdetection must be activated
     # (e.g. the self_info plugin uses the botdetection to get client IP)
 
-    cfg = get_cfg()
+    cfg = get_cfg(warn_missing=settings['server']['limiter'] or settings['server']['public_instance'])
     valkey_client = valkeydb.client()
     botdetection.init(cfg, valkey_client)
 

--- a/tests/unit/test_limiter.py
+++ b/tests/unit/test_limiter.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,missing-class-docstring
+
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import searx.limiter
+from searx import settings
+
+from tests import SearxTestCase
+
+
+class LimiterInitializeTest(SearxTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(self._reset_limiter_cfg)
+
+    def _reset_limiter_cfg(self):
+        searx.limiter.CFG = None
+        searx.limiter._INSTALLED = False
+
+    def _settings_with(self, *, limiter_enabled: bool, public_instance: bool = False):
+        test_settings = deepcopy(settings)
+        test_settings['server']['limiter'] = limiter_enabled
+        test_settings['server']['public_instance'] = public_instance
+        return test_settings
+
+    def test_initialize_skips_missing_limiter_warning_when_disabled(self):
+        with TemporaryDirectory() as tempdir:
+            with patch('searx.settings_loader.get_user_cfg_folder', return_value=Path(tempdir)):
+                with patch('searx.limiter.valkeydb.client', return_value=None):
+                    with patch('searx.limiter.botdetection.init') as botdetection_init:
+                        with self.assertNoLogs('searx.botdetection.config', level='WARNING'):
+                            searx.limiter.initialize(self.app, self._settings_with(limiter_enabled=False))
+
+        botdetection_init.assert_called_once()
+
+    def test_initialize_warns_about_missing_limiter_config_when_enabled(self):
+        with TemporaryDirectory() as tempdir:
+            with patch('searx.settings_loader.get_user_cfg_folder', return_value=Path(tempdir)):
+                with patch('searx.limiter.valkeydb.client', return_value=None):
+                    with patch('searx.limiter.botdetection.init'):
+                        with self.assertLogs('searx.botdetection.config', level='WARNING') as logs:
+                            searx.limiter.initialize(self.app, self._settings_with(limiter_enabled=True))
+
+        self.assertIn('missing config file', logs.output[0])


### PR DESCRIPTION
## Summary
- avoid warning about a missing `limiter.toml` when both `server.limiter` and `server.public_instance` are disabled
- keep the warning in place when limiter-related startup paths actually need that config
- add regression coverage for both the disabled and enabled startup cases

## Testing
- ./manage pyenv.cmd python -m unittest tests.unit.test_limiter tests.unit.test_plugin_self_info

Closes #6172