### PR TITLE
[fix] use fromisoformat in NVD engine

### DIFF
--- a/searx/engines/nvd.py
+++ b/searx/engines/nvd.py
@@ -44,7 +44,7 @@ def response(resp) -> EngineResults:
 
         cve_id = item["cve"]["id"]
         description = item["cve"]["descriptions"][0]["value"]
-        date = datetime.strptime(item["cve"]["published"], "%Y-%m-%dT%H:%M:%S.%f")
+        date = datetime.fromisoformat(item["cve"]["published"])
 
         # Extract severity (Low, Medium, High, or Critical) and CVSS score, if available
         info = item["cve"].get("metrics", {}).get("cvssMetricV31", [{}])[0].get("cvssData", {})

--- a/tests/unit/settings/test_nvd.yml
+++ b/tests/unit/settings/test_nvd.yml
@@ -1,0 +1,16 @@
+# This SearXNG setup is used in unit tests
+
+use_default_settings:
+
+  engines:
+    # remove all engines
+    keep_only: []
+
+engines:
+
+  - name: nvd
+    engine: nvd
+    categories: ["it"]
+    shortcut: "nvd"
+    timeout: 9.0
+    disabled: true

--- a/tests/unit/test_engine_nvd.py
+++ b/tests/unit/test_engine_nvd.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,disable=missing-class-docstring
+
+import logging
+from datetime import datetime
+from unittest.mock import Mock
+from parameterized import parameterized
+
+import searx.search
+import searx.engines
+from tests import SearxTestCase
+
+
+class NvdTests(SearxTestCase):
+
+    TEST_SETTINGS = "test_nvd.yml"
+
+    def setUp(self):
+        super().setUp()
+        self.nvd = searx.engines.engines['nvd']
+        self.nvd.logger.setLevel(logging.INFO)
+
+    def tearDown(self):
+        searx.search.load_engines([])
+
+    @parameterized.expand(
+        [
+            ("1999-03-22T05:00:00.000", datetime(1999, 3, 22, 5, 0, 0)),
+            ("1999-03-22T05:00:00", datetime(1999, 3, 22, 5, 0, 0)),
+        ]
+    )
+    def test_published_date_parses_isoformat_variants(self, published, expected):
+        response = Mock()
+        response.json.return_value = {
+            "response": [
+                {
+                    "grid": {
+                        "vulnerabilities": [
+                            {
+                                "cve": {
+                                    "id": "CVE-1999-0001",
+                                    "published": published,
+                                    "descriptions": [{"value": "Test vulnerability"}],
+                                    "metrics": {},
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        results = self.nvd.response(response)
+
+        self.assertEqual(expected, results[0]["publishedDate"])


### PR DESCRIPTION
## Summary
- replace the NVD engine's manual `strptime` call with `datetime.fromisoformat`
- add a focused regression test for published timestamps with and without fractional seconds

## Testing
- `./local/py3/bin/python -m nose2 -v tests.unit.test_engine_nvd`
- `./local/py3/bin/python -m nose2 -v tests.unit.test_engine_tineye`

Closes #6098.

AI disclosure: I used Codex as a coding aid for this patch and test setup, then reviewed the final change and test scope before opening the PR.