### PR TITLE
[fix] online engine processor: accept language headers doesn't get sent for 'all' language

### DIFF
--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -152,10 +152,13 @@ class OnlineProcessor(EngineProcessor):
         # add Accept-Language header
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Language
 
-        if self.engine.send_accept_language_header and search_query.locale:
-            _l = search_query.locale.language
-            _t = search_query.locale.territory or _l
-            headers["Accept-Language"] = f"{_l},{_l}-{_t};q=0.7,en;q=0.3"
+        if self.engine.send_accept_language_header:
+            if search_query.locale:
+                _l = search_query.locale.language
+                _t = search_query.locale.territory or _l
+                headers["Accept-Language"] = f"{_l},{_l}-{_t};q=0.7,en;q=0.3"
+            else:
+                headers["Accept-Language"] = "en-US,en;q=0.9"
         self.logger.debug("HTTP Accept-Language: %s", headers.get("Accept-Language", ""))
 
         return params


### PR DESCRIPTION
### What does this PR do?
- this re-adds the accept language header for the "all" language that was accidentally removed in #6188
- see #6188 
- this also fixes e.g. Qwants "all" language

### Related issues
- #6188 

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No Ai used.
