### PR TITLE
[fix] recursionerror in favicon sqlite init

### DIFF
--- a/searx/sqlitedb.py
+++ b/searx/sqlitedb.py
@@ -331,7 +331,8 @@ class SQLiteAppl(abc.ABC):
         logger.debug("init DB: %s", self.db_url)
         self.properties.init(conn)
 
-        ver = self.properties("DB_SCHEMA")
+        res = conn.execute(self.properties.SQL_GET, ("DB_SCHEMA",)).fetchone()
+        ver = res[0] if res else None
         if ver is None:
             with conn:
                 self.create_schema(conn)
@@ -347,12 +348,13 @@ class SQLiteAppl(abc.ABC):
     def create_schema(self, conn: sqlite3.Connection):
 
         logger.debug("create schema ..")
-        self.properties.set("DB_SCHEMA", self.DB_SCHEMA)
-        self.properties.set("LAST_MAINTENANCE", "")
+        sql_set = self.properties.SQL_SET
         with conn:
+            conn.execute(sql_set, ("DB_SCHEMA", self.DB_SCHEMA))
+            conn.execute(sql_set, ("LAST_MAINTENANCE", ""))
             for table_name, sql in self.DDL_CREATE_TABLES.items():
                 conn.execute(sql)
-                self.properties.set(f"Table {table_name} created", table_name)
+                conn.execute(sql_set, (f"Table {table_name} created", table_name))
 
 
 class SQLiteProperties(SQLiteAppl):


### PR DESCRIPTION
### What does this PR do?

<!-- Explain the motivation and changes in your pull request.  -->

After https://github.com/searxng/searxng/pull/6185, search returns a 500 when `favicon_resolver` is enabled. I only noticed this was a problem when my [CI](https://github.com/privau/searxng/actions/runs/27082206957) wasn't building.

The favicon sqlite db shares the same file as sqliteproperties but they are separate instances. The fix is to use the conn instead of using self.properties which is currently reentering init.

### How to test this PR locally?

Enable `favicon_resolver`, do a search and you shouldn't get 500s anymore.

Tested live on priv.au, [CI](https://github.com/privau/searxng/actions/runs/27084376536) builds and works.

### Related issues

Related: https://github.com/searxng/searxng/issues/6181
Closes: https://github.com/searxng/searxng/issues/6214

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor to see when the recursion is happening