### PR TITLE
[fix] aol engine uses wikidata id for C++

### DIFF
--- a/searx/engines/aol.py
+++ b/searx/engines/aol.py
@@ -40,7 +40,7 @@ if t.TYPE_CHECKING:
 
 about = {
     "website": "https://www.aol.com",
-    "wikidata_id": "Q2407",
+    "wikidata_id": "Q27585",
     "official_api_documentation": None,
     "use_official_api": False,
     "require_api_key": False,


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

Changes the wikidata id to the correct one. An incorrect ID causes the engine description to be messed up.

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

### Related issues

<!--
Closes: #234
-->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
