### PR TITLE
fix(limiter): silence missing limiter.toml warning when limiter is disabled

### DIFF
--- a/searx/limiter.py
+++ b/searx/limiter.py
@@ -221,13 +221,25 @@ def is_installed():
 
 def initialize(app: flask.Flask, settings):
     """Install the limiter"""
-    global _INSTALLED  # pylint: disable=global-statement
+    global CFG, _INSTALLED  # pylint: disable=global-statement
 
-    # even if the limiter is not activated, the botdetection must be activated
-    # (e.g. the self_info plugin uses the botdetection to get client IP)
-
-    cfg = get_cfg()
     valkey_client = valkeydb.client()
+
+    # keep botdetection initialised even when limiter is disabled
+    # (e.g. the self_info plugin uses botdetection to get client IP)
+
+    if settings['server']['limiter'] or settings['server']['public_instance']:
+        cfg = get_cfg()
+    else:
+        # Load just the schema defaults when limiter is disabled.  Avoid the
+        # warning from Config.from_toml() that fires when limiter.toml does
+        # not exist (GitHub issue #6172).
+        cfg = config.Config(
+            cfg_schema=config.toml_load(LIMITER_CFG_SCHEMA),
+            deprecated=searx.compat.LIMITER_CFG_DEPRECATED,
+        )
+        CFG = cfg
+
     botdetection.init(cfg, valkey_client)
 
     if not (settings['server']['limiter'] or settings['server']['public_instance']):


### PR DESCRIPTION
### What does this PR do?

When the limiter is disabled (server.limiter: false), SearXNG still logs a WARNING about the missing limiter.toml file during startup. This warning is confusing because the user intentionally chose not to use the limiter.

The fix moves the get_cfg() call behind the limiter-enabled check. When the limiter is disabled, the config is built from schema defaults only without loading the user's limiter.toml and without emitting the missing-file warning. The CFG global is still set so that later get_cfg() calls (from webapp.py or plugins) return the cached schema-only config.

### How to test this PR locally?

Start SearXNG with SEARXNG_LIMITER=false (or server.limiter: false in settings.yml) and without a limiter.toml file. The WARNING about the missing file should no longer appear in the logs.

Expected behaviour:

- Limiter disabled + no limiter.toml => no warning
- Limiter enabled + no limiter.toml => warning still appears (existing behaviour preserved)
- Limiter enabled + limiter.toml exists => no warning (existing behaviour preserved)

### Related issues

Closes: #6172

---

### AI disclosure

This work was AI-assisted. The tool used was Claude (the assistant running on the OpenClaw agent platform). All code was reviewed and understood before submission. The PR description is fully human-written.
