### PR TITLE
[feat] limiter: add a secret bypass key setting and header

### DIFF
--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -12,6 +12,7 @@
        bind_address: "127.0.0.1"
        secret_key: "ultrasecretkey"           # change this!
        limiter: false
+       limiter_bypass_key: false
        public_instance: false
        image_proxy: false
        method: "POST"
@@ -37,6 +38,11 @@
 ``limiter`` :  ``$SEARXNG_LIMITER``
   Rate limit the number of request on the instance, block some bots.  The
   :ref:`limiter` requires a :ref:`settings valkey` database.
+
+``limiter_bypass_key`` : ``$SEARXNG_LIMITER_BYPASS_KEY``
+  Optional key that bypasses the :ref:`limiter` when sent in the
+  ``X-SearXNG-Limiter-Bypass`` HTTP header.  This bypass is usefull if
+  you want to give unrestricted access to your public instance to certain users.
 
 .. _public_instance:
 

--- a/searx/limiter.py
+++ b/searx/limiter.py
@@ -92,6 +92,8 @@ Implementation
 
 """
 
+import hmac
+
 from ipaddress import ip_address
 import sys
 
@@ -101,6 +103,7 @@ import werkzeug
 
 import searx.compat
 from searx import (
+    get_setting,
     logger,
     valkeydb,
 )
@@ -129,6 +132,9 @@ _INSTALLED = False
 LIMITER_CFG_SCHEMA = Path(__file__).parent / "limiter.toml"
 """Base configuration (schema) of the botdetection."""
 
+BYPASS_HEADER = 'X-SearXNG-Limiter-Bypass'
+"""Header that bypasses limiter checks when it matches the configured key."""
+
 
 def get_cfg() -> config.Config:
     """Returns SearXNG's global limiter configuration."""
@@ -144,8 +150,25 @@ def get_cfg() -> config.Config:
     return CFG
 
 
+def is_bypass_request(request: SXNG_Request) -> bool:
+    """Returns ``True`` when a request carries the configured limiter bypass key."""
+    bypass_key = get_setting('server.limiter_bypass_key')
+    if not bypass_key:
+        return False
+
+    request_key = request.headers.get(BYPASS_HEADER)
+    if not request_key or len(request_key) != len(bypass_key):
+        return False
+
+    return hmac.compare_digest(request_key, bypass_key)
+
+
 def filter_request(request: SXNG_Request) -> werkzeug.Response | None:
     # pylint: disable=too-many-return-statements
+
+    if is_bypass_request(request):
+        logger.warning("PASS limiter bypass key: %s", request.path)
+        return None
 
     cfg = get_cfg()
     real_ip = ip_address(request.remote_addr)

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -95,6 +95,9 @@ server:
   # rate limit the number of request on the instance, block some bots.
   # Is overwritten by ${SEARXNG_LIMITER}
   limiter: false
+  # key for bypassing limiter checks when sent in X-SearXNG-Limiter-Bypass.
+  # Is overwritten by ${SEARXNG_LIMITER_BYPASS_KEY}
+  limiter_bypass_key: false
   # enable features designed only for public instances.
   # Is overwritten by ${SEARXNG_PUBLIC_INSTANCE}
   public_instance: false

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -214,6 +214,7 @@ SCHEMA: dict[str, t.Any] = {
         'port': SettingsValue((int, str), 8888, 'SEARXNG_PORT'),
         'bind_address': SettingsValue(str, '127.0.0.1', 'SEARXNG_BIND_ADDRESS'),
         'limiter': SettingsValue(bool, False, 'SEARXNG_LIMITER'),
+        'limiter_bypass_key': SettingsValue((None, False, str), False, 'SEARXNG_LIMITER_BYPASS_KEY'),
         'public_instance': SettingsValue(bool, False, 'SEARXNG_PUBLIC_INSTANCE'),
         'secret_key': SettingsValue(str, environ_name='SEARXNG_SECRET'),
         'base_url': SettingsValue((False, str), False, 'SEARXNG_BASE_URL'),

--- a/tests/unit/test_limiter.py
+++ b/tests/unit/test_limiter.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,missing-class-docstring,invalid-name
+
+import searx
+import searx.limiter
+
+from tests import SearxTestCase
+
+
+class TestLimiterBypassKey(SearxTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.previous_bypass_key = searx.settings['server']['limiter_bypass_key']
+        self.addCleanup(self._restore_bypass_key)
+
+    def _restore_bypass_key(self):
+        searx.settings['server']['limiter_bypass_key'] = self.previous_bypass_key
+
+    def test_is_bypass_request(self):
+        searx.settings['server']['limiter_bypass_key'] = 'test-bypass-key'
+
+        with self.app.test_request_context(
+            '/search',
+            headers={searx.limiter.BYPASS_HEADER: 'test-bypass-key'},
+        ) as ctx:
+            self.assertTrue(searx.limiter.is_bypass_request(ctx.request))
+
+    def test_filter_request_bypasses_bot_detection(self):
+        searx.settings['server']['limiter_bypass_key'] = 'test-bypass-key'
+
+        headers = {
+            'Accept': '*/*',
+            'User-Agent': 'curl/8.0.0',
+            searx.limiter.BYPASS_HEADER: 'test-bypass-key',
+        }
+
+        with self.app.test_request_context('/search', headers=headers) as ctx:
+            self.assertIsNone(searx.limiter.filter_request(ctx.request))
+
+    def test_filter_request_rejects_invalid_bypass_key(self):
+        searx.settings['server']['limiter_bypass_key'] = 'test-bypass-key'
+
+        headers = {
+            'Accept': '*/*',
+            'User-Agent': 'curl/8.0.0',
+            searx.limiter.BYPASS_HEADER: 'wrong-key',
+        }
+
+        with self.app.test_request_context('/search', headers=headers) as ctx:
+            response = searx.limiter.filter_request(ctx.request)
+            self.assertIsNotNone(response)
+            self.assertEqual(response.status_code, 429)

--- a/tests/unit/test_limiter.py
+++ b/tests/unit/test_limiter.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # pylint: disable=missing-module-docstring,missing-class-docstring,invalid-name
 
+from unittest.mock import patch
+
+from parameterized import parameterized
+
 import searx
 import searx.limiter
 
@@ -9,45 +13,26 @@ from tests import SearxTestCase
 
 class TestLimiterBypassKey(SearxTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.previous_bypass_key = searx.settings['server']['limiter_bypass_key']
-        self.addCleanup(self._restore_bypass_key)
+    @parameterized.expand(
+        [
+            ('disabled', False, 'secret', False),
+            ('missing_header', 'secret', None, False),
+            ('incorrect_key', 'secret', 'wrong!', False),
+            ('correct_key', 'secret', 'secret', True),
+        ]
+    )
+    def test_is_bypass_request(self, _name, bypass_key, request_key, expected):
+        headers = {searx.limiter.BYPASS_HEADER: request_key} if request_key else {}
 
-    def _restore_bypass_key(self):
-        searx.settings['server']['limiter_bypass_key'] = self.previous_bypass_key
+        with patch.dict(searx.settings['server'], {'limiter_bypass_key': bypass_key}):
+            with self.app.test_request_context('/search', headers=headers) as ctx:
+                self.assertEqual(searx.limiter.is_bypass_request(ctx.request), expected)
 
-    def test_is_bypass_request(self):
-        searx.settings['server']['limiter_bypass_key'] = 'test-bypass-key'
+    def test_filter_request_bypasses_limiter(self):
+        headers = {searx.limiter.BYPASS_HEADER: 'secret'}
 
-        with self.app.test_request_context(
-            '/search',
-            headers={searx.limiter.BYPASS_HEADER: 'test-bypass-key'},
-        ) as ctx:
-            self.assertTrue(searx.limiter.is_bypass_request(ctx.request))
-
-    def test_filter_request_bypasses_bot_detection(self):
-        searx.settings['server']['limiter_bypass_key'] = 'test-bypass-key'
-
-        headers = {
-            'Accept': '*/*',
-            'User-Agent': 'curl/8.0.0',
-            searx.limiter.BYPASS_HEADER: 'test-bypass-key',
-        }
-
-        with self.app.test_request_context('/search', headers=headers) as ctx:
-            self.assertIsNone(searx.limiter.filter_request(ctx.request))
-
-    def test_filter_request_rejects_invalid_bypass_key(self):
-        searx.settings['server']['limiter_bypass_key'] = 'test-bypass-key'
-
-        headers = {
-            'Accept': '*/*',
-            'User-Agent': 'curl/8.0.0',
-            searx.limiter.BYPASS_HEADER: 'wrong-key',
-        }
-
-        with self.app.test_request_context('/search', headers=headers) as ctx:
-            response = searx.limiter.filter_request(ctx.request)
-            self.assertIsNotNone(response)
-            self.assertEqual(response.status_code, 429)
+        with patch.dict(searx.settings['server'], {'limiter_bypass_key': 'secret'}):
+            with self.app.test_request_context('/search', headers=headers) as ctx:
+                with patch.object(searx.limiter, 'get_cfg') as get_cfg:
+                    self.assertIsNone(searx.limiter.filter_request(ctx.request))
+                    get_cfg.assert_not_called()

--- a/tests/unit/test_settings_loader.py
+++ b/tests/unit/test_settings_loader.py
@@ -10,6 +10,7 @@ from parameterized import parameterized
 
 from searx.exceptions import SearxSettingsException
 from searx import settings_loader
+from searx.settings_defaults import SCHEMA, apply_schema
 from tests import SearxTestCase
 
 
@@ -128,4 +129,5 @@ class TestUserSettings(SearxTestCase):
             },
         ):
             settings, _msg = settings_loader.load_settings()
+            apply_schema(settings, SCHEMA, [])
             self.assertEqual(settings['server']['limiter_bypass_key'], 'test-bypass-key')

--- a/tests/unit/test_settings_loader.py
+++ b/tests/unit/test_settings_loader.py
@@ -37,6 +37,7 @@ class TestDefaultSettings(SearxTestCase):
         self.assertFalse(settings['general']['debug'])
         self.assertIsInstance(settings['general']['instance_name'], str)
         self.assertEqual(settings['server']['secret_key'], "ultrasecretkey")
+        self.assertFalse(settings['server']['limiter_bypass_key'])
         self.assertIsInstance(settings['server']['port'], int)
         self.assertIsInstance(settings['server']['bind_address'], str)
         self.assertIsInstance(settings['engines'], list)
@@ -117,3 +118,14 @@ class TestUserSettings(SearxTestCase):
             self.assertEqual(settings['server']['secret_key'], "user_settings_secret")
             engine_names = [engine['name'] for engine in settings['engines']]
             self.assertEqual(engine_names, ['wikidata', 'wikibooks', 'wikinews', 'wikiquote'])
+
+    def test_limiter_bypass_key_from_environment(self):
+        with patch.dict(
+            os.environ,
+            {
+                'SEARXNG_SETTINGS_PATH': _settings("user_settings_simple.yml"),
+                'SEARXNG_LIMITER_BYPASS_KEY': 'test-bypass-key',
+            },
+        ):
+            settings, _msg = settings_loader.load_settings()
+            self.assertEqual(settings['server']['limiter_bypass_key'], 'test-bypass-key')

--- a/utils/templates/etc/searxng/settings.yml
+++ b/utils/templates/etc/searxng/settings.yml
@@ -16,6 +16,8 @@ server:
   # Is overwritten by ${SEARXNG_SECRET}
   secret_key: "ultrasecretkey"
   limiter: true
+  # Is overwritten by ${SEARXNG_LIMITER_BYPASS_KEY}
+  limiter_bypass_key: false
   image_proxy: true
   # public URL of the instance, to ensure correct inbound links. Is overwritten
   # by ${SEARXNG_BASE_URL}.


### PR DESCRIPTION
### What does this PR do?

Add a new limiter_bypass_key setting and corresponding SEARXNG_LIMITER_BYPASS_KEY environment variable. 

If the `X-SearXNG-Limiter-Bypass` header is sent with a matching secret, the limiter is fully bypassed. It's especially useful for the owner of a public instance to be able to make their own API requests unrestricted. 

### How to test this PR locally?

- Set `server.limiter_bypass_key` to `my-secret-bypass-key`
- Send an API request like `curl -H 'X-SearXNG-Limiter-Bypass: my-secret-bypass-key' http://localhost:8080/search?q=searxng`: the limiter should be skipped.
- Retry without header or with wrong key: you should hit 429 Too Many Requests

### Code of Conduct

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**
- [x] I hereby confirm that I haven't used any other tools than the ones I mention below.

I have used AI tools for working on the changes in this PR: Codex with GPT 5.5. Asked some questions to Cursor's composer 2.5 here and there to help me better understand the codebase.

Most of the code is written with AI, I understand this doesn't really match the "AI should never be the main author of the PR" close. However the changes are not very large. I have thoroughly reviewed, built and tested it. This PR message is fully written by me. I fully understand all the code written. I spent some time manually testing the changes in a docker build.

Feel free to close the PR if that's not enough though. 