### PR TITLE
[chore] devops: add languages config for helix editor

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,10 @@
+[[language]]
+name = "python"
+language-servers = ["basedpyright", "pylsp"]
+formatter = { command = "black", args = [
+    "--target-version",
+    "py311",
+    "--line-length",
+    "120",
+    "--skip-string-normalization",
+] }


### PR DESCRIPTION
The default Helix configuration for Python is different, so the pylint warnings aren't shown and the formatter re-formats files by accident when you edit an existing file.

Therefore, this commit adds `python` language configuration to ease developing SearXNG with Helix Editor [^1].

[^1]: https://helix-editor.com

### Related issues
- #5056 

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  No AI.
