### PR TITLE
[feat] engines: add rawweb engine (foss, hand-indexed blogs)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1848,6 +1848,27 @@ engines:
     engine: radio_browser
     shortcut: rb
 
+  - name: rawweb
+    engine: json_engine
+    shortcut: rw
+    categories: general
+    paging: true
+    search_url: 'https://api.rawweb.org/api/search?keyword={query}&page={pageno}&lang=*'
+    results_query: data
+    url_query: link
+    title_query: title
+    content_query: content
+    title_html_to_text: true
+    content_html_to_text: true
+    disabled: true
+    inactive: true
+    about:
+      website: https://rawweb.org
+      official_api_documentation:
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
   - name: reddit
     engine: reddit
     shortcut: re


### PR DESCRIPTION
RawWeb is a search engine for personal websites / blog posts. It has its own index and the personal websites were selected by hand. Results are quite good for what it is imo. [^1]

[^1]: https://github.com/0x2E/RawWeb.org

### How to test this PR locally?
- !rw searxng

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.