### PR TITLE
 [chore] helix config: enable pylint and use black via pylsp

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,10 +1,11 @@
 [[language]]
 name = "python"
 language-servers = ["basedpyright", "pylsp"]
-formatter = { command = "black", args = [
-    "--target-version",
-    "py311",
-    "--line-length",
-    "120",
-    "--skip-string-normalization",
-] }
+auto-format = true
+
+[language-server.pylsp.config.pylsp]
+plugins.pylint.enabled = true
+plugins.isort.enabled = true
+plugins.black.enabled = true
+plugins.black.skip_string_normalization = true
+plugins.black.line_length = 120


### PR DESCRIPTION
I didn't know `black` can be called via `pylsp` and that pylint isn't enabled by default, hence a quick fixup for #6230

### Related issues
- #6230 

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
