### PR TITLE
[fix] tiger: crashes on empty result

### DIFF
--- a/searx/engines/tiger.py
+++ b/searx/engines/tiger.py
@@ -134,9 +134,12 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
     if tiger_category == "Websuche":
         for result in eval_xpath_list(doc, "//div[@id='mainContainer']//table/tr"):
+            url = extract_text(eval_xpath(result, ".//a[contains(@class, 'weblink')]/@href"))
+            if not url:
+                continue
             res.add(
                 res.types.MainResult(
-                    url=extract_text(eval_xpath(result, ".//a[contains(@class, 'weblink')]/@href")),
+                    url=url,
                     title=extract_text(eval_xpath(result, ".//a[contains(@class, 'weblink')]")) or "",
                     content=extract_text(eval_xpath(result, ".//*[contains(@class, 'webbodynopic')]")) or "",
                 )


### PR DESCRIPTION
e.g. when searching for "!tiger pottering github" or "!tiger return42" or "!tiger bnyro", it sometimes crashes. not really sure why - the problem is that the HTML doesn't really uses descriptive classes or ids, only Tailwind, so it's very hard to select only the results HTML.



### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
