### PR TITLE
[feat] engines: add searchzee engine (general, news)

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -2836,6 +2836,49 @@ engines:
     shortcut: rehi
     disabled: true
 
+  - name: searchzee
+    engine: json_engine
+    search_url: https://searchzee.com/api/search?q={query}&type=web&offset={pageno}
+    paging: true
+    first_page_num: 0
+    results_query: results
+    url_query: url
+    title_query: title
+    content_query: summary
+    content_html_to_text: true
+    categories: general
+    shortcut: sz
+    disabled: true
+    inactive: true
+    about:
+      website: https://searchzee.com
+      use_official_api: false
+      require_api_key: false
+      results: JSON
+
+  - name: searchzee news
+    engine: json_engine
+    search_url: https://searchzee.com/api/search?q={query}&type=news&offset={pageno}{time_range}
+    paging: true
+    first_page_num: 0
+    time_range_support: true
+    time_range_url: "&freshness={time_range_val}"
+    time_range_map:
+      day: pd
+      week: pw
+      month: pm
+      year: py
+    results_query: results
+    url_query: url
+    title_query: title
+    content_query: summary
+    thumbnail_query: thumbnail
+    content_html_to_text: true
+    categories: news
+    shortcut: sznw
+    disabled: true
+    inactive: true
+
   - name: swisscows
     engine: swisscows
     categories: general


### PR DESCRIPTION
The results seem to be from Brave (i.e. they are exactly the same). But it doesn't have any strict rate-limits, so that's nice.

News support time ranges, but apart from that, unfortunately it doesn't support any advanced features like safesearch or languages.

Possibly this engine is already too complicated for only being a `json_engine`, but since it doesn't require any tricky authentication and only supports general and news, `json_engine` is the quickest way to implement it

### How to test this PR locally?
- set it to active n `settings.yml`
- !sz test
- !sznw test (szn was already taken)

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
