### PR TITLE
[chore] add DeprecationWarning for obsolete engine.about.language property

### DIFF
--- a/searx/enginelib/__init__.py
+++ b/searx/enginelib/__init__.py
@@ -220,6 +220,10 @@ class EngineAbout(msgspec.Struct, kw_only=True):
     is available via a :py:obj:`EngineAbout.wikidata_id`.
     """
 
+    language: str = ""
+    """Deprecated! Migrate your setting from `engine.about.language` to
+    `engine.language`"""
+
 
 class Engine(abc.ABC):  # pylint: disable=too-few-public-methods
     """Class of engine instances build from YAML settings.

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -14,6 +14,7 @@ import sys
 import copy
 import os
 from os.path import realpath, dirname
+import warnings
 
 import types
 import inspect
@@ -184,8 +185,9 @@ def set_loggers(engine: "Engine|types.ModuleType", engine_name: str):
 
 
 def update_engine_attributes(engine: "Engine | types.ModuleType", engine_data: dict[str, t.Any]):
-    # set engine attributes from engine_data
+    # pylint: disable=too-many-branches
 
+    # set engine attributes from engine_data
     kvargs: dict[str, t.Any]
     if isinstance(engine.about, EngineAbout):
         kvargs = {**msgspec.to_builtins(engine.about), **engine_data.get("about", {})}
@@ -198,6 +200,18 @@ def update_engine_attributes(engine: "Engine | types.ModuleType", engine_data: d
         raise TypeError(
             f"engine '{engine_data['name']}' ({engine_data['engine']}) - in the about section --> {exc}"
         ) from exc
+
+    # warn about deprecated engine settings
+
+    if engine.about.language:
+        if hasattr(engine, "language") and not engine.language:
+            engine.language = engine.about.language
+        warnings.warn(
+            f"engine '{engine_data['name']}' ({engine_data['engine']})"
+            f" - migrate engine.about.language to engine.language!",
+            DeprecationWarning,
+            2,
+        )
 
     for param_name, param_value in engine_data.items():
         if param_name == "about":


### PR DESCRIPTION
The old property should still be supported for a transitional period; the reasons for this can be seen from the discussion in [1] / the further procedure is also discussed there.

[1] https://github.com/searxng/searxng/issues/6261

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI used


