### PR TITLE
[fix] engines: chinaso: handle empty upstream results gracefully

### DIFF
--- a/searx/engines/chinaso.py
+++ b/searx/engines/chinaso.py
@@ -156,6 +156,13 @@ def response(resp):
     except Exception as e:
         raise SearxEngineAPIException(f"Invalid response: {e}") from e
 
+    # Upstream returns {'status': 0, 'msg': 'empty result', 'data': {}} when there
+    # are no results; this is a valid empty result rather than an API error.
+    if not isinstance(data, dict) or "data" not in data:
+        raise SearxEngineAPIException("Invalid response")
+    if not data["data"]:
+        return []
+
     parsers = {'news': parse_news, 'images': parse_images, 'videos': parse_videos}
 
     return parsers[chinaso_category](data)


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

handle empty upstream results gracefully

<!-- Explain the motivation and changes in your pull request.  -->

### How to test this PR locally?

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

```bash
# test search with
curl 'http://localhost:2012/search' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  --data-raw 'q=%21chinaso+how+to+install+docker+in+debian&category_none=1&pageno=1&language=auto&time_range=&safesearch=0&format=json'
```
response:

```json
{"query": "how to install docker in debian", "results": [], "answers": [], "corrections": [], "infoboxes": [], "suggestions": [], "unresponsive_engines": []}
```

### Related issues

<!--
Closes: #234
-->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->
- [x] I hereby confirm that this PR conforms with the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst).

This is a minor change, no AI is used here.

