### PR TITLE
[feat] image results: automatically guess mimetype based on path

### DIFF
--- a/searx/result_types/image.py
+++ b/searx/result_types/image.py
@@ -14,6 +14,7 @@ template.
 # pylint: disable=too-few-public-methods
 __all__ = ["Image", "ImageRef"]
 
+import mimetypes
 import types
 import typing as t
 from collections.abc import Callable
@@ -71,7 +72,7 @@ class Image(MainResult, kw_only=True):
     """The resolution of the image (e.g. ``1920 x 1080`` pixel)"""
 
     img_format: str = ""
-    """The format of the image (e.g. ``png``)."""
+    """The format of the image :py:obj:`.MainResult.img_src` (e.g. ``png``)."""
 
     source: str = ""
     """Source of the image."""
@@ -82,6 +83,19 @@ class Image(MainResult, kw_only=True):
 
     formats: list[ImageRef] = []
     """List of links to alternative image formats."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if not self.img_format:
+            # automatically guess the image format based on the path of the image
+            mimetype = mimetypes.guess_type(self.img_src)[0]
+            if mimetype:
+                subtype = mimetype.split("/")[-1]
+                if subtype in MIMESUB:
+                    self.img_format = MIMESUB[subtype]
+                else:
+                    self.img_format = subtype.upper()
 
     def filter_urls(self, filter_func: "Callable[[Result | LegacyResult, str, str], str | bool ]"):
 


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- In most cases the search engine doesn't need to support getting the image type (e.g. `JPEG`), as that information is already contained in the URL path
- i.e., we take the `img_src` or `thumbnail_src` URL path to automatically guess the mimetype of the image using the `mimetypes` stdlib module
- that avoids that we always show "original format" instead of the actual image format

### How to test this PR locally?

Activate for instance the heexy images engine ..

```diff
diff --git a/searx/settings.yml b/searx/settings.yml
index a509d94d9..78195ace4 100644
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1258,7 +1258,6 @@ engines:
     heexy_categ: image
     shortcut: hei
     disabled: true
-    inactive: true
```

and search for `!hei bmw`



### Related issues
- #6153 

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
