### PR TITLE
[feat] engines: add magnific images engine

### DIFF
--- a/searx/engines/magnific.py
+++ b/searx/engines/magnific.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Magnific_ is a database for images.
+
+.. _Magnific: https://www.magnific.com
+"""
+
+from urllib.parse import urlencode
+
+import typing as t
+
+from searx.result_types import EngineResults
+
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
+    from searx.search.processors import OnlineParams
+
+
+about = {
+    "website": "https://www.magnific.com",
+    "wikidata_id": "Q104211654",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+base_url = "https://www.magnific.com"
+
+categories = ["images"]
+paging = True
+
+free_images_only = True
+"""
+Whether to only load images that may be used for free, without a Magnific account.
+"""
+
+
+def request(query: str, params: "OnlineParams") -> None:
+    args = {"term": query, "filters[ai-generated][excluded]": 1, "page": params["pageno"], "locale": "en"}
+    if free_images_only:
+        args["filters[license]"] = "free"
+
+    params["headers"]["Referer"] = f"{base_url}/search"
+    params["url"] = f"{base_url}/api/regular/search?{urlencode(args)}"
+
+
+def response(resp: "SXNG_Response"):
+    res = EngineResults()
+
+    result: dict[str, t.Any]  # TBH: dict[str, t.Any]
+    for result in resp.json()["items"]:
+        res.add(
+            res.types.Image(
+                title=result["name"],
+                url=result["url"],
+                thumbnail_src=result["preview"]["url"],
+                img_src=result["preview"]["url"],
+                resolution=f"{result['preview']['width']}x{result['preview']['height']}",
+            )
+        )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -1525,6 +1525,11 @@ engines:
     disabled: true
     inactive: true
 
+  - name: magnific
+    engine: magnific
+    shortcut: mag
+    disabled: true
+
   - name: marginalia
     engine: marginalia
     shortcut: mar


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- add support for https://magnific.com
- run by the same people as flaticon (#6122)
- unfortunately you need to login to get the full resolution image, but the 600px thumbnail images are not too bad for many use cases

### How to test this PR locally?
- !mag tree

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.