### PR TITLE
fix: use correct iar parameter for DuckDuckGo news search

### DIFF
--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -60,7 +60,7 @@ def fetch_vqd(
 
     logger.debug("fetch_vqd: request value from from duckduckgo.com")
     resp = get(
-        url=f"https://duckduckgo.com/?q={quote_plus(query)}&iar=images&t=h_",
+        url=f"https://duckduckgo.com/?q={quote_plus(query)}&iar={iar_param}&t=h_",
         headers=params["headers"],
         timeout=2,
     )


### PR DESCRIPTION
Fixes #6257: DuckDuckGo news VQD token was fetched with iar=images
instead of iar=news, causing news searches to return general results.