### PR TITLE
fix: use correct iar parameter for DuckDuckGo news search (v2)

### DIFF
--- a/searx/engines/duckduckgo.py
+++ b/searx/engines/duckduckgo.py
@@ -229,7 +229,7 @@ def get_cache() -> EngineCache:
 
 def set_vqd(query: str | int, value: str, params: "OnlineParams") -> None:
     cache = get_cache()
-    key = cache.secret_hash(f"{query}//{params['headers']['User-Agent']}")
+    key = cache.secret_hash(f"{query}//{params['headers']['User-Agent']}//{params.get('iar', '')}")
     cache.set(key=key, value=value, expire=3600)
 
 
@@ -244,7 +244,7 @@ def get_vqd(
     :param params: request parameters
     """
     cache = get_cache()
-    key = cache.secret_hash(f"{query}//{params['headers']['User-Agent']}")
+    key = cache.secret_hash(f"{query}//{params['headers']['User-Agent']}//{params.get('iar', '')}")
     value: str = cache.get(key=key) or ""
     if value:
         logger.debug("get_vqd: re-use cached value: %s", value)

--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -60,7 +60,7 @@ def fetch_vqd(
 
     logger.debug("fetch_vqd: request value from from duckduckgo.com")
     resp = get(
-        url=f"https://duckduckgo.com/?q={quote_plus(query)}&iar=images&t=h_",
+        url=f"https://duckduckgo.com/?q={quote_plus(query)}&iar={iar_param}&t=h_",
         headers=params["headers"],
         timeout=2,
     )

--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -56,6 +56,7 @@ def init(engine_settings: dict[str, t.Any]):
 def fetch_vqd(
     query: str,
     params: "OnlineParams",
+    iar: str = "images",
 ):
 
     logger.debug("fetch_vqd: request value from from duckduckgo.com")
@@ -97,7 +98,8 @@ def request(query: str, params: "OnlineParams") -> None:
     # The vqd value is generated from the query and the UA header. To be able to
     # reuse the vqd value, the UA header must be static.
     headers["User-Agent"] = _HTTP_User_Agent
-    vqd = get_vqd(query=query, params=params) or fetch_vqd(query=query, params=params)
+    params["iar"] = ddg_category
+    vqd = get_vqd(query=query, params=params) or fetch_vqd(query=query, params=params, iar=ddg_category)
 
     headers["Accept"] = "*/*"
     headers["Referer"] = "https://duckduckgo.com/"


### PR DESCRIPTION
Fixes #6257: DuckDuckGo news was returning general results because
the VQD token was always fetched with iar=images.

Changes:
- Added iar parameter to VQD cache key so different DDG categories
  don't share cached tokens
- Pass ddg_category to fetch_vqd for correct iar value
- Used ddg_category variable instead of hardcoded iar=images

I have read the Development Quickstart and run local checks.