### PR TITLE
[fix] google_news: move pub_origin/pub_date from content to metadata …

### DIFF
--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -178,12 +178,22 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
         # The pub_date is mostly a relative string like '3 hours ago', not a
         # real timezone date/time, so we can't use publishedDate.
-        # pub_origin and pub_date go into metadata; content is left empty since
-        # Google News HTML does not provide article snippets.
+        # pub_origin and pub_date go into metadata; content is extracted using a fallback text collector.
 
         pub_date = extract_text(eval_xpath(result, ".//time"))
         pub_origin = extract_text(eval_xpath(result, ".//div[contains(@class, 'vr1PYe')]"))
         metadata = " / ".join([x for x in [pub_origin, pub_date] if x])
+
+        # Fallback snippet extractor: extract text from the result, filter out title and metadata
+        content = ""
+        snippet_parts = []
+        for text in (t.strip() for t in result.itertext() if t.strip()):
+            if text in (title, pub_origin, pub_date):
+                continue
+            if len(text) > 15:
+                snippet_parts.append(text)
+        if snippet_parts:
+            content = " ... ".join(snippet_parts)
 
         thumbnail: str = eval_xpath_getindex(result, ".//figure/img/@src", 0, default="")
         if thumbnail and thumbnail.startswith("/"):
@@ -193,7 +203,7 @@ def response(resp: "SXNG_Response") -> EngineResults:
             res.types.MainResult(
                 url=url,
                 title=title,
-                content="",
+                content=content,
                 metadata=metadata,
                 thumbnail=thumbnail,
             )

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -174,26 +174,21 @@ def response(resp: "SXNG_Response") -> EngineResults:
             logger.error(f"no real-url found: {url}")
             continue
 
-        title = extract_text(eval_xpath(result, "./h4")) or ""
+        # title is in <h4> or (since Google changed DOM) in the <a target='_blank'> link text
+        title = extract_text(eval_xpath(result, "./h4")) or \
+                extract_text(eval_xpath(result, ".//a[@target='_blank']")) or ""
 
         # The pub_date is mostly a relative string like '3 hours ago', not a
         # real timezone date/time, so we can't use publishedDate.
-        # pub_origin and pub_date go into metadata; content is extracted using a fallback text collector.
+        # pub_origin and pub_date go into metadata.
 
         pub_date = extract_text(eval_xpath(result, ".//time"))
         pub_origin = extract_text(eval_xpath(result, ".//div[contains(@class, 'vr1PYe')]"))
         metadata = " / ".join([x for x in [pub_origin, pub_date] if x])
 
-        # Fallback snippet extractor: extract text from the result, filter out title and metadata
-        content = ""
-        snippet_parts = []
-        for text in (t.strip() for t in result.itertext() if t.strip()):
-            if text in (title, pub_origin, pub_date):
-                continue
-            if len(text) > 15:
-                snippet_parts.append(text)
-        if snippet_parts:
-            content = " ... ".join(snippet_parts)
+        # Google News HTML does not provide article snippets.
+        # Use the author name (bInasb) as content if present.
+        content = extract_text(eval_xpath(result, ".//div[contains(@class, 'bInasb')]")) or ""
 
         thumbnail: str = eval_xpath_getindex(result, ".//figure/img/@src", 0, default="")
         if thumbnail and thumbnail.startswith("/"):

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -194,16 +194,12 @@ def response(resp: "SXNG_Response") -> EngineResults:
         # pub_origin and pub_date go into metadata.
 
         pub_date = extract_text(eval_xpath(result, ".//time"))
-        pub_origin = extract_text(
-            eval_xpath(result, ".//div[contains(@class, 'vr1PYe')]")
-        )
+        pub_origin = extract_text(eval_xpath(result, ".//a[contains(@class, 'wEwyrc')]"))
         metadata = " / ".join([x for x in [pub_origin, pub_date] if x])
 
         # Google News HTML does not provide article snippets.
         # Use the author name (bInasb) as content if present.
-        content = (
-            extract_text(eval_xpath(result, ".//div[contains(@class, 'bInasb')]")) or ""
-        )
+        author = extract_text(eval_xpath(result, ".//div[contains(@class, 'uQIVzc')]")) or ""
 
         thumbnail: str = eval_xpath_getindex(
             result, ".//figure/img/@src", 0, default=""
@@ -215,7 +211,7 @@ def response(resp: "SXNG_Response") -> EngineResults:
             res.types.MainResult(
                 url=url,
                 title=title,
-                content=content,
+                author=author,
                 metadata=metadata,
                 thumbnail=thumbnail,
             )

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -176,13 +176,14 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
         title = extract_text(eval_xpath(result, "./h4")) or ""
 
-        # The pub_date is mostly a string like 'yesterday', not a real timezone
-        # date or time.  Therefore we can't use publishedDate and place the
-        # *pub* sting into the content.
+        # The pub_date is mostly a relative string like '3 hours ago', not a
+        # real timezone date/time, so we can't use publishedDate.
+        # pub_origin and pub_date go into metadata; content is left empty since
+        # Google News HTML does not provide article snippets.
 
         pub_date = extract_text(eval_xpath(result, ".//time"))
         pub_origin = extract_text(eval_xpath(result, ".//div[contains(@class, 'vr1PYe')]"))
-        content = " / ".join([x for x in [pub_origin, pub_date] if x])
+        metadata = " / ".join([x for x in [pub_origin, pub_date] if x])
 
         thumbnail: str = eval_xpath_getindex(result, ".//figure/img/@src", 0, default="")
         if thumbnail and thumbnail.startswith("/"):
@@ -192,7 +193,8 @@ def response(resp: "SXNG_Response") -> EngineResults:
             res.types.MainResult(
                 url=url,
                 title=title,
-                content=content,
+                content="",
+                metadata=metadata,
                 thumbnail=thumbnail,
             )
         )

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -143,18 +143,14 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
     for result in eval_xpath_list(dom, "//div[@jslog and @data-n-tid and @jsdata]"):
 
-        url: str = eval_xpath_getindex(
-            result, "./a[@target='_blank']/@href", 0, default=0
-        )
+        url: str = eval_xpath_getindex(result, "./a[@target='_blank']/@href", 0, default=0)
         if not url:
             continue
         if url.startswith("./"):
             url = base_url + url[1:]
 
         # The real URL is often encoded in the "jslog" attribute
-        jslog: str | None = eval_xpath_getindex(
-            result, "./a[@target='_blank']/@jslog", 0, default=None
-        )
+        jslog: str | None = eval_xpath_getindex(result, "./a[@target='_blank']/@jslog", 0, default=None)
 
         # Try to extract the real URL from jslog
         real_url: str | None = None
@@ -166,9 +162,7 @@ def response(resp: "SXNG_Response") -> EngineResults:
                 b64_data: str = parts[1].split(":")[-1].strip()
                 # Pad base64 if necessary
                 b64_data += "=" * (-len(b64_data) % 4)
-                decoded_data: list[str | None] = json.loads(
-                    base64.b64decode(b64_data).decode("utf-8")
-                )
+                decoded_data: list[str | None] = json.loads(base64.b64decode(b64_data).decode("utf-8"))
                 # The URL is typically the last element in the decoded array
                 if (
                     isinstance(decoded_data, list)
@@ -184,9 +178,7 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
         # title is in <h4> or (since Google changed DOM) in the <a target='_blank'> link text
         title = (
-            extract_text(eval_xpath(result, "./h4"))
-            or extract_text(eval_xpath(result, ".//a[@target='_blank']"))
-            or ""
+            extract_text(eval_xpath(result, "./h4")) or extract_text(eval_xpath(result, ".//a[@target='_blank']")) or ""
         )
 
         # The pub_date is mostly a relative string like '3 hours ago', not a
@@ -201,9 +193,7 @@ def response(resp: "SXNG_Response") -> EngineResults:
         # Use the author name (bInasb) as content if present.
         author = extract_text(eval_xpath(result, ".//div[contains(@class, 'uQIVzc')]")) or ""
 
-        thumbnail: str = eval_xpath_getindex(
-            result, ".//figure/img/@src", 0, default=""
-        )
+        thumbnail: str = eval_xpath_getindex(result, ".//figure/img/@src", 0, default="")
         if thumbnail and thumbnail.startswith("/"):
             thumbnail = base_url + thumbnail
 

--- a/searx/engines/google_news.py
+++ b/searx/engines/google_news.py
@@ -39,7 +39,9 @@ from searx.utils import (
     extract_text,
 )
 
-from searx.engines.google import fetch_traits as _fetch_traits  # pylint: disable=unused-import
+from searx.engines.google import (
+    fetch_traits as _fetch_traits,
+)  # pylint: disable=unused-import
 from searx.engines.google import (
     get_google_info,
     detect_google_sorry,
@@ -141,14 +143,18 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
     for result in eval_xpath_list(dom, "//div[@jslog and @data-n-tid and @jsdata]"):
 
-        url: str = eval_xpath_getindex(result, "./a[@target='_blank']/@href", 0, default=0)
+        url: str = eval_xpath_getindex(
+            result, "./a[@target='_blank']/@href", 0, default=0
+        )
         if not url:
             continue
         if url.startswith("./"):
             url = base_url + url[1:]
 
         # The real URL is often encoded in the "jslog" attribute
-        jslog: str | None = eval_xpath_getindex(result, "./a[@target='_blank']/@jslog", 0, default=None)
+        jslog: str | None = eval_xpath_getindex(
+            result, "./a[@target='_blank']/@jslog", 0, default=None
+        )
 
         # Try to extract the real URL from jslog
         real_url: str | None = None
@@ -160,7 +166,9 @@ def response(resp: "SXNG_Response") -> EngineResults:
                 b64_data: str = parts[1].split(":")[-1].strip()
                 # Pad base64 if necessary
                 b64_data += "=" * (-len(b64_data) % 4)
-                decoded_data: list[str | None] = json.loads(base64.b64decode(b64_data).decode("utf-8"))
+                decoded_data: list[str | None] = json.loads(
+                    base64.b64decode(b64_data).decode("utf-8")
+                )
                 # The URL is typically the last element in the decoded array
                 if (
                     isinstance(decoded_data, list)
@@ -175,22 +183,31 @@ def response(resp: "SXNG_Response") -> EngineResults:
             continue
 
         # title is in <h4> or (since Google changed DOM) in the <a target='_blank'> link text
-        title = extract_text(eval_xpath(result, "./h4")) or \
-                extract_text(eval_xpath(result, ".//a[@target='_blank']")) or ""
+        title = (
+            extract_text(eval_xpath(result, "./h4"))
+            or extract_text(eval_xpath(result, ".//a[@target='_blank']"))
+            or ""
+        )
 
         # The pub_date is mostly a relative string like '3 hours ago', not a
         # real timezone date/time, so we can't use publishedDate.
         # pub_origin and pub_date go into metadata.
 
         pub_date = extract_text(eval_xpath(result, ".//time"))
-        pub_origin = extract_text(eval_xpath(result, ".//div[contains(@class, 'vr1PYe')]"))
+        pub_origin = extract_text(
+            eval_xpath(result, ".//div[contains(@class, 'vr1PYe')]")
+        )
         metadata = " / ".join([x for x in [pub_origin, pub_date] if x])
 
         # Google News HTML does not provide article snippets.
         # Use the author name (bInasb) as content if present.
-        content = extract_text(eval_xpath(result, ".//div[contains(@class, 'bInasb')]")) or ""
+        content = (
+            extract_text(eval_xpath(result, ".//div[contains(@class, 'bInasb')]")) or ""
+        )
 
-        thumbnail: str = eval_xpath_getindex(result, ".//figure/img/@src", 0, default="")
+        thumbnail: str = eval_xpath_getindex(
+            result, ".//figure/img/@src", 0, default=""
+        )
         if thumbnail and thumbnail.startswith("/"):
             thumbnail = base_url + thumbnail
 


### PR DESCRIPTION
### What does this PR do?

Moves `pub_origin` and `pub_date` from the content field to metadata in the Google News engine.

This fixes the issue where publication information was being stored in the wrong location.

### How to test this PR locally?

1. Run SearXNG locally.
2. Perform a Google News search.
3. Inspect the search results.
4. Verify that `pub_origin` and `pub_date` are stored in metadata rather than content.
5. Confirm the search results render correctly.

### Related issues

Fixes #6256