### PR TITLE
fix(kagi): safe access unpromised result properties

### DIFF
--- a/searx/engines/kagi.py
+++ b/searx/engines/kagi.py
@@ -139,9 +139,13 @@ def response(resp: "SXNG_Response") -> EngineResults:
 
     if kagi_categ in ("images", "videos"):
         # the JSON key is "image" for "images" and "video" for "videos"
-        json_results = json_data["data"][kagi_categ[:-1]]
+        json_results = json_data["data"].get(kagi_categ[:-1])
     else:
-        json_results = json_data["data"][kagi_categ]
+        json_results = json_data["data"].get(kagi_categ)
+
+    # if no results were found, the response doesn't contain the results field
+    if not json_results:
+        return res
 
     for result in json_results:
         published_date: datetime | None = None

--- a/searx/engines/kagi.py
+++ b/searx/engines/kagi.py
@@ -42,10 +42,10 @@ To enable Kagi, add the following to the ``engines`` seciton of
 .. _Api Portal: https://help.kagi.com/kagi/api/overview.html
 """
 
-
 from datetime import datetime, timedelta
 
 import typing as t
+
 
 from searx.extended_types import SXNG_Response
 from searx.result_types import EngineResults
@@ -76,7 +76,12 @@ kagi_categ: t.Literal["search", "images", "news", "videos"] = "search"
 base_url = "https://kagi.com"
 
 safe_search_map = {0: False, 1: True, 2: True}
-time_range_to_days_map: dict[TimeRangeType, int] = {"day": 1, "week": 7, "month": 30, "year": 365}
+time_range_to_days_map: dict[TimeRangeType, int] = {
+    "day": 1,
+    "week": 7,
+    "month": 30,
+    "year": 365,
+}
 
 api_key = ""
 """Kagi API key. Required for using this engine."""
@@ -147,8 +152,8 @@ def response(resp: "SXNG_Response") -> EngineResults:
             res.add(
                 res.types.MainResult(
                     url=result["url"],
-                    title=html_to_text(result["title"]),
-                    content=html_to_text(result["snippet"]),
+                    title=html_to_text(result.get("title", "no title available")),
+                    content=html_to_text(result.get("snippet", "")),
                     thumbnail=result.get("image", {}).get("url") or "",
                     publishedDate=published_date,
                 )
@@ -157,15 +162,15 @@ def response(resp: "SXNG_Response") -> EngineResults:
             res.add(
                 res.types.Image(
                     url=result["url"],
-                    title=html_to_text(result.get("title")),
+                    title=html_to_text(result.get("title", "no title available")),
                     img_src=result.get("image", {}).get("url"),
-                    resolution=f"{result['image']['width']}x{result['image']['height']}",
+                    resolution=f"{result.get('image', {}).get('width')}x{result.get('image', {}).get('height')}",
                     thumbnail_src=result.get("props", {}).get("thumbnail", {}).get("url"),
                 )
             )
         elif kagi_categ == "videos":
             length: timedelta | None = None
-            if result["props"].get("duration"):
+            if result.get("props", {}).get("duration"):
                 length = parse_duration_string(result["props"]["duration"])
 
             res.add(
@@ -173,11 +178,11 @@ def response(resp: "SXNG_Response") -> EngineResults:
                     {
                         "template": "videos.html",
                         "url": result["url"],
-                        "title": html_to_text(result["title"]),
-                        "content": html_to_text(result["snippet"]),
+                        "title": html_to_text(result.get("title", "no title available")),
+                        "content": html_to_text(result.get("snippet", "")),
                         "thumbnail": result.get("image", {}).get("url"),
                         "publishedDate": published_date,
-                        "author": result["props"].get("creator_name"),
+                        "author": result.get("props", {}).get("creator_name"),
                         "length": length,
                     }
                 )


### PR DESCRIPTION
kagi pr

<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

I was testing the new Kagi engine and found for some queries I was getting a `KeyError` exception from the result parsing.

[Their API documentation](https://kagi.redocly.app/api/docs/openapi/search/search#search/search/t=response&c=200&path=data/search) clarifies that only the `url` and `title` properties are required/guaranteed in the search result object, for example:

<img width="457" height="167" alt="Image" src="https://github.com/user-attachments/assets/1476a83c-ac55-4972-835b-548bbcbd1582" />

This PR ensures we only assumes the `url`  key exists, and we use `.get()` to retrieve values for keys that may not be present.

### How to test this PR locally?

- checkout this branch
- uncomment the kagi part in settings.yml
- set the api key in all api_key fields (let me know if you need to borrow one)
- start the server with `make run`
- start searching kagi, e.g. with `!kagi searx metrics`, `!kagi tabby cat`

### Related issues

- Closes #6252
- #2247 ([comment](https://github.com/searxng/searxng/issues/2247#issuecomment-4692976877))

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used