### PR TITLE
[fix] autocomplete suggestrelevance scores for chromium

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -845,7 +845,10 @@ def autocompleter():
         mimetype = 'application/json'
     else:
         # the suggestion request comes from browser's URL bar
-        suggestions = json.dumps([sug_prefix, results])
+        relevances = {
+            'google:suggestrelevance': [600 - i for i in range(len(results))]
+        }  # chromium only shows 3 suggestions unless we attach relevances
+        suggestions = json.dumps([sug_prefix, results, [], [], relevances])
         mimetype = 'application/x-suggestions+json'
 
     suggestions = escape(suggestions, False)


### PR DESCRIPTION
### What does this PR do?

If SearXNG is set as the default search engine in a Chromium based browser, the url bar only shows 3 autocomplete suggestions max even if there are more.

This PR fixes that by adding `google:suggestrelevance` scores to the autocomplete response when using the browser url bar. This is a seemingly undocumented feature in Chromium. There's also more I found like `google:suggestdetail` which allows for images in the autocomplete, which I am currently working on.

### How to test this PR locally?

`make run`, select an autocomplete method in preferences, add `https://example.com/autocompleter?q=%s` to your default search engine's suggestions url in chromium.

<img width="419" height="545" alt="image" src="https://github.com/user-attachments/assets/0867e2c7-4068-4086-9e68-71090e917e1f" />

Verify more than three results are returned

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

AI was used to help find the undocumented feature