### PR TITLE
Improve thumbnail extraction logic in brave.py

### DIFF
--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -336,7 +336,7 @@ def _parse_search(resp: SXNG_Response) -> EngineResults:
             # Pass upstream CDN credentials to the internal image proxy stack
             _image_proxy_headers={
                 "Referer": "https://search.brave.com/",
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
             }
         )
         res.add(item)

--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -336,8 +336,8 @@ def _parse_search(resp: SXNG_Response) -> EngineResults:
             # Pass upstream CDN credentials to the internal image proxy stack
             _image_proxy_headers={
                 "Referer": "https://search.brave.com/",
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
-            }
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
+            },
         )
         res.add(item)
 

--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -317,7 +317,14 @@ def _parse_search(resp: SXNG_Response) -> EngineResults:
                 pub_date = _extract_published_date(_pub_date)
                 content = content.lstrip(_pub_date).strip("- \n\t")
 
-        thumbnail: str = eval_xpath_getindex(result, ".//a[contains(@class, 'thumbnail')]//img/@src", 0, default="")
+        img_node = eval_xpath_getindex(result, ".//a[contains(@class, 'thumbnail')]//img", 0, default=None)
+        thumbnail: str = ""
+
+        if img_node is not None:
+            thumbnail = img_node.get("data-src") or img_node.get("src", "")
+            # If standard src grabbed a transparent base64 SVG or relative path, force data-src
+            if thumbnail.startswith("data:image/") or thumbnail.startswith("/"):
+                thumbnail = img_node.get("data-src", thumbnail)
 
         item = res.types.LegacyResult(
             template="default.html",
@@ -326,6 +333,11 @@ def _parse_search(resp: SXNG_Response) -> EngineResults:
             content=content,
             publishedDate=pub_date,
             thumbnail=thumbnail,
+            # Pass upstream CDN credentials to the internal image proxy stack
+            _image_proxy_headers={
+                "Referer": "https://search.brave.com/",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+            }
         )
         res.add(item)
 


### PR DESCRIPTION
Refactor thumbnail extraction to handle data-src and src attributes. ISSUE 5900

### What does this PR do?

1. **Lazy-Load DOM Extraction**: Updates the XPath query in `_parse_search()` to capture the `<img>` element object rather than hard-targeting `@src`. Prioritizes `data-src`, with a fallback check to verify standard `src` captures do not resolve to base64 data strings or relative layout indicators.
2. **Upstream CDN Authentication**: Attaches `_image_proxy_headers` containing a valid Brave `Referer` and standard `User-Agent`. This prevents Brave's CDN from dropping connections with an `HTTP 403 Forbidden` when an instance operates with `image_proxy: true`.

### How to test this PR locally?

1. Run `make run` with `image_proxy: false` defined in `settings.yml`.
2. Execute a query that triggers organic site preview thumbnails (e.g. `!brave bmw` or `!brave github`). 
3. Inspect browser Network devtools: Verify preview thumbnails return `HTTP 200 OK` from `imgs.search.brave.com` rather than resolving to 1x1 SVG data placeholders.
4. Flip `image_proxy: true` in `settings.yml`, restart the instance, and verify the same thumbnails route successfully through the local `/image_proxy?url=...` endpoint without throwing upstream `403 Forbidden` exceptions.

### Related issues

Closes: #5900 

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Google gemini pro
* Used as a pair-programming syntax reference to map Brave's lazy-loaded `data-src` DOM hierarchy into `lxml` object-inspection logic.
* Assisted in formatting the safe fallback evaluation block inside `searx/engines/brave.py`.
* All resulting code was manually audited, debugged against live Brave response payloads, and verified in a local containerized harness prior to staging.