### PR TITLE
[fix] engine anaconda - add missing about configuration

### DIFF
--- a/searx/enginelib/__init__.py
+++ b/searx/enginelib/__init__.py
@@ -207,6 +207,7 @@ class EngineAbout(msgspec.Struct, kw_only=True):
 
     use_official_api: bool = False
     """SearXNG engine makes use of the official API or not"""
+
     require_api_key: bool = False
     """API requires a key or not."""
 
@@ -217,8 +218,7 @@ class EngineAbout(msgspec.Struct, kw_only=True):
     """Brief description of the engine and where it gets its data from.
 
     This value should only be set as long as no description of the data source
-    is available via a :py:obj:`EngineAbout.wikidata_id`.
-    """
+    is available via a :py:obj:`EngineAbout.wikidata_id`."""
 
     language: str = ""
     """Deprecated! Migrate your setting from `engine.about.language` to

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -443,6 +443,12 @@ engines:
     timeout: 6.0
     shortcut: conda
     disabled: true
+    about:
+      website: https://anaconda.org/search
+      wikidata_id: Q18209310
+      official_api_documentation: https://api.anaconda.org/search
+      use_official_api: false
+      results: HTML
 
   - name: arch linux wiki
     engine: archlinux


### PR DESCRIPTION
[fix] engine anaconda - add missing about configuration

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI here