### PR TITLE
[feat] bilibili engine: add time range support

### DIFF
--- a/searx/engines/bilibili.py
+++ b/searx/engines/bilibili.py
@@ -8,6 +8,7 @@ import random
 import string
 from urllib.parse import urlencode
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from searx import utils
 
@@ -39,6 +40,32 @@ cookie = {
     "home_feed_column": "4",
 }
 
+_CN_TZ = ZoneInfo("Asia/Shanghai")
+
+# Calendar-day time filter (Asia/Shanghai); dict values are days to subtract from today.
+time_range_support = True
+time_range_dict = {"day": 0, "week": 6, "month": 29, "year": 364}
+
+
+def _pubtime_range(time_range: str) -> tuple[int, int]:
+    """Return ``(pubtime_begin_s, pubtime_end_s)`` for Bilibili's search API.
+
+    Time ranges follow Bilibili's website semantics: they are counted in
+    **calendar days** in China Standard Time (``Asia/Shanghai``), not as
+    sliding 24-hour windows.  For example, ``day`` means from 00:00:00 to
+    23:59:59 of the current local day; ``week`` spans from 00:00:00 on the
+    calendar day six days ago through the end of today, and so on.
+
+    The returned Unix timestamps (seconds) map to Bilibili's
+    ``pubtime_begin_s`` and ``pubtime_end_s`` query parameters.
+    """
+    now = datetime.now(_CN_TZ)
+    pubtime_end_s = int(now.replace(hour=23, minute=59, second=59, microsecond=0).timestamp())
+    begin_day = now - timedelta(days=time_range_dict[time_range])
+    pubtime_begin_s = int(begin_day.replace(hour=0, minute=0, second=0, microsecond=0).timestamp())
+
+    return pubtime_begin_s, pubtime_end_s
+
 
 def request(query, params):
     query_params = {
@@ -49,6 +76,11 @@ def request(query, params):
         "keyword": query,
         "search_type": "video",
     }
+
+    if params.get("time_range") in time_range_dict:
+        pubtime_begin_s, pubtime_end_s = _pubtime_range(params["time_range"])
+        query_params["pubtime_begin_s"] = pubtime_begin_s
+        query_params["pubtime_end_s"] = pubtime_end_s
 
     params["url"] = f"{base_url}?{urlencode(query_params)}"
     params["headers"]["Referer"] = "https://www.bilibili.com/"


### PR DESCRIPTION
### What does this PR do?

Adds time range filtering (`day`, `week`, `month`, `year`) to the Bilibili video engine by passing `pubtime_begin_s` and `pubtime_end_s` to the Bilibili search API.

### How to test this PR locally?

1. Enable the Bilibili engine in `searx/settings.yml`.
2. Start SearXNG and search in the web UI with `!bil <keyword>`.
3. Select a time range filter and confirm results are returned.

### Related issues

<!-- None -->

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

  - **Cursor**: assisted with implementing the code changes in `searx/engines/bilibili.py`.
