### PR TITLE
[fix] resulthunter: images in search results are not clickable

### DIFF
--- a/searx/engines/resulthunter.py
+++ b/searx/engines/resulthunter.py
@@ -101,7 +101,7 @@ def _image_results(doc: "ElementBase") -> EngineResults:
                 res.types.Image(
                     url=extract_text(eval_xpath(result, "./@href")) or "",
                     title=extract_text(eval_xpath(result, "./img/@alt")) or "",
-                    thumbnail_src=extract_text(eval_xpath(result, "./img/@src")) or "",
+                    img_src=extract_text(eval_xpath(result, "./img/@src")) or "",
                 ),
             )
         )


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- otherwise clicking images in the results doesn't allow you to download. I.e., `img_src` must always be set

<!-- Explain the motivation and changes in your pull request.  -->

### How to test this PR locally?
- !resi foo

<!-- Commands to run the tests or instructions to test the changes.  Are there
     any edge cases (environment, language, or other contexts) to take into
     account?  -->

### Related issues
- oversight from #6229 
<!--
Closes: #234
-->

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
