### PR TITLE
[mod] images.html: display all engines that found the result, not only the first one

### DIFF
--- a/searx/templates/simple/result_templates/images.html
+++ b/searx/templates/simple/result_templates/images.html
@@ -60,7 +60,7 @@
       </p>
       <p class="result-filesize">{{ _label(_("Filesize"), result.filesize) }}</p>
       <p class="result-source">{{ _label(_("Source"), result.source) }}</p>
-      <p class="result-engine">{{ _label(_("Engine"), result.engine) }}</p>
+      <p class="result-engines">{{ _label(_("Engines"), ", ".join(result.engines)) }}</p>
       <p class="result-url"><span>{{ _("View source") }}:</span>{{- "" -}}
         <a {{ _target(results_on_new_tab) }} href="{{ result.url }}">{{ result.url }}</a>
       </p>


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- display all image engines that returned the image instead of only the first one
- that makes it behave similar to normal results
<!-- Explain the motivation and changes in your pull request.  -->

### How to test this PR locally?
- search for images, e.g. `!images libretube`
- look at the image details, some should now have multiple engines listed


### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
