### PR TITLE
fix(google engine): raise diagnostic error when page has 0 organic results

### DIFF
--- a/searx/engines/google.py
+++ b/searx/engines/google.py
@@ -24,7 +24,7 @@ import babel.languages
 from lxml import html
 
 from searx.enginelib.traits import EngineTraits
-from searx.exceptions import SearxEngineCaptchaException
+from searx.exceptions import SearxEngineCaptchaException, SearxEngineResponseException
 from searx.locales import get_official_locales, language_tag, region_tag
 from searx.result_types import EngineResults
 from searx.utils import (
@@ -424,6 +424,80 @@ def response(resp: "SXNG_Response"):
     for suggestion in eval_xpath_list(dom, suggestion_xpath):
         # append suggestion
         results.append({"suggestion": extract_text(suggestion)})
+
+    # If no results were parsed despite a successful HTTP response, log
+    # diagnostics and raise an error so the user gets feedback instead of a
+    # silent empty page.  Google can return a 200 OK page without organic
+    # result blocks (e.g. direct answer widgets, knowledge panels, or 'no
+    # results found' messages).
+    #
+    # https://github.com/searxng/searxng/issues/6171
+    if len(results) == 0:
+        _page_text = extract_text(dom)
+        _title_text = extract_text(eval_xpath(dom, '//title'))
+
+        # Try to classify the page content for diagnostic purposes
+        _diag_parts: list[str] = []
+
+        # Look for Google's "no results found" message
+        _no_result_signals = [
+            'did not match any documents',
+            'keine Ergebnisse',
+            'no results',
+            'aucun r\u00e9sultat',
+            'nessun risultato',
+            'geen resultaten',
+            '\u6ca1\u6709\u7b26\u5408\u6761\u4ef6\u7684\u641c\u7d22\u7ed3\u679c',
+        ]
+        for _signal in _no_result_signals:
+            if _signal in _page_text[:800]:
+                _diag_parts.append('no_results_message')
+                break
+
+        # Direct answer widgets (weather, time, calculator, translate, etc.)
+        # are often wrapped in a div with role="heading" or data-attributed
+        # knowledge-panel elements.
+        if eval_xpath(dom, '//*[@data-attrid and contains(@data-attrid, "_answer")]'):
+            _diag_parts.append('direct_answer_widget')
+
+        # Knowledge panels (entities, places, people)
+        if eval_xpath(dom, '//*[@data-attrid and contains(@data-attrid, "_knowledge")]'):
+            _diag_parts.append('knowledge_panel')
+
+        # Top stories carousel (common for newsy queries)
+        if eval_xpath(dom, '//div[contains(@class, "WIdY2d") or contains(@class, "xrnccd")]'):
+            _diag_parts.append('top_stories_carousel')
+
+        # Weather results widget
+        if eval_xpath(dom, '//div[contains(@id, "wob_wc")]'):
+            _diag_parts.append('weather_widget')
+
+        # Math / calculator result
+        if eval_xpath(dom, '//div[contains(@class, "jfenQc")]'):
+            _diag_parts.append('calculator_widget')
+
+        # Did-you-mean / spelling correction
+        if eval_xpath(dom, '//a[contains(@href, "spell=1")]'):
+            _diag_parts.append('spelling_correction')
+
+        _body_pg_len = len(resp.text)
+        _diag_indicators = ", ".join(_diag_parts) if _diag_parts else "none"
+        _diag_msg = (
+            f'Google returned {_body_pg_len} byte page with 0 parsed organic results. '
+            f'Title: "{_title_text}". '
+            f'Page indicators: {_diag_indicators}. '
+            f'Snippet: "{_page_text[:300].strip()}"'
+        )
+        logger.warning(_diag_msg)
+
+        # Raise an API-like exception so the user sees an engine error
+        # message instead of a blank result page.
+        _raised_detail = f"Indicators: {_diag_indicators}. " if _diag_parts else ""
+        raise SearxEngineResponseException(
+            'Google returned a page without organic search results. '
+            + _raised_detail
+            + 'Check the SearXNG logs for details.'
+        )
 
     # return results
     return results


### PR DESCRIPTION
## Problem

Google can return a 200 OK response that contains only non-organic page elements (direct answer widgets, knowledge panels, weather widgets, "no results found" messages, etc.) without any organic result blocks. The engine currently silently returns an empty result set without any diagnostic, leaving users confused — they see an empty search page with no indication of what happened.

Reported in #6171 with a specific example: `!google :de-DE time` — Google returns a direct answer widget (current time in Berlin) but no organic result blocks.

## Root Cause

The `response()` function parses organic results using XPath `//a[@data-ved and not(@class)]`. When Google returns a page without organic results (e.g. direct answer, knowledge panel, weather widget), this XPath yields nothing and the function returns an empty `EngineResults()` without any diagnostic.

## Fix

After the parsing loop, if zero results were produced, the engine now:

1. Inspects the DOM for known indicators of non-organic page types (direct answer widgets, knowledge panels, top stories carousels, weather widgets, calculators, "no results found" messages, spelling corrections)
2. Logs a **warning** with the page size, title, classified indicators, and a text snippet — so operators can diagnose what Google returned
3. Raises `SearxEngineResponseException` with a descriptive message — so the user sees an engine error instead of a blank result page

## Example diagnostic log output

```
WARNING:searx.engines.google:Google returned 5284 byte page with 0 parsed organic results. Title: "time - Google Search". Page indicators: direct_answer_widget. Snippet: "Zeit in Berlin, Deutschland Jetzt ..."
```

## Testing

1. Run a query that triggers a direct answer widget, e.g. `!google :de-DE time`
2. Before the fix: silent empty results, no error shown
3. After the fix: engine error "Google returned a page without organic search results. Indicators: direct_answer_widget. Check the SearXNG logs for details."
4. Other queries that normally return organic results should be unaffected

Closes #6171