### PR TITLE
[fix] neosearch: crashes when result has no url

### DIFF
--- a/searx/engines/neosearch.py
+++ b/searx/engines/neosearch.py
@@ -48,6 +48,9 @@ def response(resp: "SXNG_Response") -> EngineResults:
     for lens in json_resp["lenses"]:
         for category in lens["categories"]:
             for result in category["links"]:
+                if not result["url"]:
+                    continue
+
                 res.add(
                     res.types.MainResult(
                         url=result["url"],


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- certain result pages return results without URLs, leading SearXNG to crash

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.