### PR TITLE
[fix] API docs: remove doc of not existing parameters

### DIFF
--- a/docs/dev/search_api.rst
+++ b/docs/dev/search_api.rst
@@ -4,31 +4,32 @@
 Search API
 ==========
 
-SearXNG supports querying via a simple HTTP API.
-Two endpoints, ``/`` and ``/search``, are supported for both GET and POST methods.
-The GET method expects parameters as URL query parameters, while the POST method expects parameters as form data.
+SearXNG supports querying via a simple HTTP API.  Two endpoints, ``/`` and
+``/search``, are supported for both GET and POST methods.  The ``GET`` method
+expects parameters as URL query parameters, while the POST method expects
+parameters as form data (``application/x-www-form-urlencoded``).
 
 If you want to consume the results as JSON, CSV, or RSS, you need to set the
-``format`` parameter accordingly. Supported formats are defined in ``settings.yml``, under the ``search`` section.
-Requesting an unset format will return a 403 Forbidden error. Be aware that many public instances have these formats disabled.
-
+``format`` parameter accordingly.  Supported formats are defined in
+``settings.yml``, under the :ref:`settings search` section.  Requesting an
+unset format will return a 403 Forbidden error.  Be aware that many public
+instances have these formats disabled.
 
 Endpoints:
 
-``GET /``
-``GET /search``
+.. code::
 
-``POST /``
-``POST /search``
+   GET /
+   GET /search
+   POST /
+   POST /search
 
 example cURL calls:
 
-.. code-block:: bash
+.. code:: bash
 
    curl 'https://searx.example.org/search?q=searxng&format=json'
-
    curl -X POST 'https://searx.example.org/search' -d 'q=searxng&format=csv'
-
    curl -L -X POST -d 'q=searxng&format=json' 'https://searx.example.org/'
 
 Parameters
@@ -53,90 +54,27 @@ Parameters
   Comma separated list, specifies the active search categories (see
   :ref:`configured engines`)
 
-``engines`` : optional
-  Comma separated list, specifies the active search engines (see
-  :ref:`configured engines`).
-
 ``language`` : default from :ref:`settings search`
   Code of the language.
 
 ``pageno`` : default ``1``
   Search page number.
 
-``time_range`` : optional
-  [ ``day``, ``month``, ``year`` ]
-
+``time_range`` : optional : [ ``day``, ``month``, ``year`` ]
   Time range of search for engines which support it.  See if an engine supports
   time range search in the preferences page of an instance.
 
-``format`` : optional
-  [ ``json``, ``csv``, ``rss`` ]
-
+``format`` : optional :  [ ``json``, ``csv``, ``rss`` ]
   Output format of results.  Format needs to be activated in :ref:`settings
   search`.
 
-``results_on_new_tab`` : default ``0``
-  [ ``0``, ``1`` ]
-
-  Open search results on new tab.
-
-``image_proxy`` : default from :ref:`settings server`
-  [  ``True``, ``False`` ]
-
-  Proxy image results through SearXNG.
-
-``autocomplete`` : default from :ref:`settings search`
-  [ ``google``, ``dbpedia``, ``duckduckgo``, ``mwmbl``, ``startpage``,
-  ``privacywall``, ``wikipedia``, ``swisscows``, ``qwant`` ]
-
-  Service which completes words as you type.
-
-``safesearch`` :  default from :ref:`settings search`
-  [ ``0``, ``1``, ``2`` ]
-
+``safesearch`` :  default from :ref:`settings search` : [ ``0``, ``1``, ``2`` ]
   Filter search results of engines which support safe search.  See if an engine
   supports safe search in the preferences page of an instance.
 
-``theme`` : default ``simple``
-  [ ``simple`` ]
-
+``theme`` : default ``simple`` : [ ``simple`` ]
   Theme of instance.
 
   Please note, available themes depend on an instance.  It is possible that an
   instance administrator deleted, created or renamed themes on their instance.
   See the available options in the preferences page of the instance.
-
-``enabled_plugins`` : optional
-  List of enabled plugins.
-
-  :default:
-     ``Hash_plugin``, ``Self_Information``,
-     ``Tracker_URL_remover``, ``Ahmia_blacklist``
-
-  :values:
-     .. enabled by default
-
-     ``Hash_plugin``, ``Self_Information``,
-     ``Tracker_URL_remover``, ``Ahmia_blacklist``,
-
-     .. disabled by default
-
-     ``Hostnames_plugin``, ``Open_Access_DOI_rewrite``,
-     ``Vim-like_hotkeys``, ``Tor_check_plugin``
-
-``disabled_plugins``: optional
-  List of disabled plugins.
-
-  :default:
-     ``Hostnames_plugin``, ``Open_Access_DOI_rewrite``,
-     ``Vim-like_hotkeys``, ``Tor_check_plugin``
-
-  :values:
-     see values from ``enabled_plugins``
-
-``enabled_engines`` : optional : *all* :origin:`engines <searx/engines>`
-  List of enabled engines.
-
-``disabled_engines`` : optional : *all* :origin:`engines <searx/engines>`
-  List of disabled engines.
-


### PR DESCRIPTION
remove doc of not existing parameters TBH: Some of the parameters such as engines or plugins still theoretically exist in SearXNG, but we will no longer support them.  They are usually accessed via search syntax and/or cookies and should not pollute the API / it is these supposed features that hinder SearXNG in further development.

### How to test this PR locally?

build the HTML doc

### Related issues

Closes: https://github.com/searxng/searxng/issues/6003

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI used