### PR TITLE
[fix] docs.live (sphinx-autobuild) - watch .rst, .py, .yml

### DIFF
--- a/utils/lib.sh
+++ b/utils/lib.sh
@@ -776,8 +776,11 @@ docs.live() {
     pyenv.install
     docs.prebuild
     # shellcheck disable=SC2086
-    PATH="${PY_ENV_BIN}:${PATH}" pyenv.cmd sphinx-autobuild \
-        ${SPHINX_VERBOSE} ${SPHINXOPTS} --open-browser --host 0.0.0.0 \
+    SPHINX_AUTOBUILD_DEBUG=1 PATH="${PY_ENV_BIN}:${PATH}" pyenv.cmd sphinx-autobuild \
+        ${SPHINX_VERBOSE} ${SPHINXOPTS} \
+        --watch ./searx \
+        --re-ignore '(^|/)\.#|^(?!.*\.(rst|py|yml)$).*'\
+        --open-browser --host 0.0.0.0 \
         -b html -c ./docs -d "${DOCS_BUILD}/.doctrees" ./docs "${DOCS_DIST}"
     dump_return $?
 }


### PR DESCRIPTION
So far, any change to any file triggered a new build, and changes to the doc-strings (in ./searx) were not taken into account. With this patch, a build is only triggered when files with the specified file extensions change.

The watch has been expanded to ./searx so that changes to doc strings also trigger a new build.

### How to test this PR locally?

Start a live build and modify some files

    make docs.live


### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  ChatGPT helped me come up with the regular expression.