### PR TITLE
[fix] strip engine HTML + unescape entities before escape() in result snippets

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -12,6 +12,8 @@ from timeit import default_timer
 from html import escape
 from io import StringIO
 import typing
+import html
+import re
 
 import urllib
 import urllib.parse
@@ -698,9 +700,9 @@ def search():
     for result in results:
         if output_format == 'html':
             if 'content' in result and result['content']:
-                result['content'] = highlight_content(escape(result['content'][:1024]), search_query.query)
+                result['content'] = highlight_content(escape(re.sub('<[^>]+>', '', html.unescape(result['content'][:1024]))), search_query.query)
             if 'title' in result and result['title']:
-                result['title'] = highlight_content(escape(result['title'] or ''), search_query.query)
+                result['title'] = highlight_content(escape(re.sub('<[^>]+>', '', html.unescape(result['title'] or ''))), search_query.query)
 
         # set result['open_group'] = True when the template changes from the previous result
         # set result['close_group'] = True when the template changes on the next result

--- a/tests/unit/test_webapp.py
+++ b/tests/unit/test_webapp.py
@@ -125,6 +125,50 @@ class ViewsTestCase(SearxTestCase):  # pylint: disable=too-many-public-methods
             result.data,
         )
 
+    def test_search_html_strips_engine_markup_in_snippets(self):
+        # Engines (Brave, Kagi, ...) sometimes return snippets that carry
+        # keyword-emphasis markup, either as raw tags or entity-encoded tags.
+        # Both must be stripped before escape() so they don't leak as literal
+        # ``&lt;strong&gt;`` text in the rendered page, while SearXNG's own
+        # ``<span class="highlight">`` emphasis still applies to the query.
+        tagged_results = [
+            MainResult(
+                title="<strong>highlighted</strong> test title",
+                url="http://tagged.test.xyz",
+                content="<strong>first</strong> test &lt;b&gt;content&lt;/b&gt;",
+                engine="startpage",
+            ),
+        ]
+        for r in tagged_results:
+            r.normalize_result_fields()
+
+        def search_mock(search_self, *args):  # pylint: disable=unused-argument
+            search_self.result_container = Mock(
+                get_ordered_results=lambda: tagged_results,
+                answers={},
+                corrections=set(),
+                suggestions=set(),
+                infoboxes=[],
+                unresponsive_engines=set(),
+                results=tagged_results,
+                results_length=lambda: len(tagged_results),
+                get_timings=lambda: [],
+                redirect_url=None,
+                engine_data={},
+            )
+            search_self.search_query.locale = babel.Locale.parse("en-US", sep='-')
+
+        self.setattr4test(searx.search.Search, 'search', search_mock)
+
+        result = self.client.post('/search', data={'q': 'test'})
+
+        # raw and entity-encoded engine tags must not leak as visible text
+        self.assertNotIn(b'&lt;strong&gt;', result.data)
+        self.assertNotIn(b'&lt;b&gt;', result.data)
+        self.assertNotIn(b'<strong>', result.data)
+        # the query keyword is still highlighted by SearXNG's own spans
+        self.assertIn(b'<span class="highlight">test</span>', result.data)
+
     def test_index_json(self):
         result = self.client.post('/', data={'q': 'test', 'format': 'json'})
         self.assertEqual(result.status_code, 308)


### PR DESCRIPTION
## Summary

Engines (Brave, Kagi, etc.) return snippets with `<strong>` keyword emphasis tags (Brave's API does this via `text_decorations=true`, the default). The current ordering runs `escape()` **first**, turning `<strong>` → `&lt;strong&gt;`. `highlight_content()`'s guard `if content.find("<") != -1: return content` is intended to leave already-HTML alone, but `escape()` has already consumed every literal `<`, so the guard is dead code on this path. The escaped tags then pass through, the template renders `title`/`content` with `|safe` (required so `highlight_content`'s trusted `<span class="highlight">` renders), and `&lt;strong&gt;` shows as visible literal text in results.

## Fix

Strip tags **before** `escape()` so engine markup doesn't leak as `&lt;strong&gt;` literal text, letting SearXNG's own highlight spans handle keyword emphasis cleanly. `html.unescape()` runs before stripping so that any entity-encoded markup in a snippet is normalized to real tags first and caught by the same strip.

## Test

Adds `test_search_html_strips_engine_markup_in_snippets` covering the fix: engine-supplied `<strong>`/`&lt;b&gt;` markup in title/content is stripped before `escape()` so it doesn't leak as literal `&amp;lt;strong&amp;gt;` text, while SearXNG's own highlight spans still apply to the query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)