### PR TITLE
fix(kagi): guard against missing fields in partial API responses

### DIFF
--- a/searx/engines/kagi.py
+++ b/searx/engines/kagi.py
@@ -148,37 +148,42 @@ def response(resp: "SXNG_Response") -> EngineResults:
             res.add(
                 res.types.MainResult(
                     url=result["url"],
-                    title=html.unescape(result["title"]),
-                    content=html.unescape(result["snippet"]),
+                    title=html.unescape(result.get("title", "")),
+                    content=html.unescape(result.get("snippet", "")),
                     thumbnail=result.get("image", {}).get("url") or "",
                     publishedDate=published_date,
                 )
             )
         elif kagi_categ == "images":
+            image = result.get("image", {})
+            width = image.get("width")
+            height = image.get("height")
+            resolution = f"{width}x{height}" if width and height else ""
             res.add(
                 res.types.Image(
                     url=result["url"],
-                    title=html.unescape(result.get("title")),
-                    img_src=result.get("image", {}).get("url"),
-                    resolution=f"{result['image']['width']}x{result['image']['height']}",
+                    title=html.unescape(result.get("title", "")),
+                    img_src=image.get("url", ""),
+                    resolution=resolution,
                     thumbnail_src=result.get("props", {}).get("thumbnail", {}).get("url"),
                 )
             )
         elif kagi_categ == "videos":
+            props = result.get("props", {})
             length: timedelta | None = None
-            if result["props"].get("duration"):
-                length = parse_duration_string(result["props"]["duration"])
+            if props.get("duration"):
+                length = parse_duration_string(props["duration"])
 
             res.add(
                 res.types.LegacyResult(
                     {
                         "template": "videos.html",
                         "url": result["url"],
-                        "title": html.unescape(result["title"]),
-                        "content": html.unescape(result["snippet"]),
+                        "title": html.unescape(result.get("title", "")),
+                        "content": html.unescape(result.get("snippet", "")),
                         "thumbnail": result.get("image", {}).get("url"),
                         "publishedDate": published_date,
-                        "author": result["props"].get("creator_name"),
+                        "author": props.get("creator_name"),
                         "length": length,
                     }
                 )

--- a/tests/unit/settings/test_kagi.yml
+++ b/tests/unit/settings/test_kagi.yml
@@ -1,0 +1,24 @@
+# This SearXNG setup is used in unit tests
+
+use_default_settings:
+
+  engines:
+    # remove all engines
+    keep_only: []
+
+search:
+
+  formats: [html, csv, json, rss]
+
+server:
+
+  secret_key: "user_secret_key"
+
+engines:
+
+  - name: kagi
+    engine: kagi
+    shortcut: kg
+    api_key: "test-api-key"
+    kagi_categ: search
+    disabled: true

--- a/tests/unit/test_engine_kagi.py
+++ b/tests/unit/test_engine_kagi.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,disable=missing-class-docstring
+
+import logging
+from unittest.mock import Mock
+
+import searx.engines
+from tests import SearxTestCase
+
+
+class KagiTests(SearxTestCase):
+
+    TEST_SETTINGS = "test_kagi.yml"
+
+    def setUp(self):
+        super().setUp()
+        self.kagi = searx.engines.engines['kagi']
+        self.kagi.logger.setLevel(logging.INFO)
+
+    def tearDown(self):
+        searx.search.load_engines([])
+
+    def _response(self, json_data, categ="search"):
+        """Build a mocked ``SXNG_Response`` and call ``kagi.response``.
+
+        The kagi engine reads the module-level ``kagi_categ`` global to decide
+        which branch of the response parser runs.  The loaded engine object
+        (``searx.engines.engines['kagi']``) is the module the parser reads from,
+        so the category has to be set on that object, not on the
+        ``searx.engines.kagi`` import path.  ``setattr4test`` resets the value
+        to its previous state during cleanup, so each test can pick the category
+        it exercises without leaking into the next one.
+        """
+        self.setattr4test(self.kagi, "kagi_categ", categ)
+        response = Mock()
+        response.json.return_value = json_data
+        response.status_code = 200
+        return self.kagi.response(response)
+
+    # --- search / news branch ---------------------------------------------
+
+    def test_search_result_with_title_and_snippet(self):
+        results = self._response(
+            {
+                "data": {
+                    "search": [
+                        {
+                            "url": "https://example.com/foo",
+                            "title": "Foo &amp; Bar",
+                            "snippet": "A &lt;snippet&gt; about foo",
+                            "image": {"url": "https://example.com/thumb.png"},
+                        }
+                    ],
+                }
+            },
+            categ="search",
+        )
+        self.assertEqual(1, len(results))
+        result = results[0]
+        self.assertEqual("https://example.com/foo", result.url)
+        self.assertEqual("Foo & Bar", result.title)
+        self.assertEqual("A <snippet> about foo", result.content)
+        self.assertEqual("https://example.com/thumb.png", result.thumbnail)
+
+    def test_search_result_without_snippet(self):
+        # Kagi can omit ``snippet`` on some results; the parser must not raise
+        # (observed in production as ``KeyError: 'snippet'`` /
+        # ``unresponsive_engines: [['kagi', 'parsing error']]``).
+        results = self._response(
+            {
+                "data": {
+                    "search": [
+                        {
+                            "url": "https://example.com/no-snippet",
+                            "title": "No snippet here",
+                        }
+                    ],
+                }
+            },
+            categ="search",
+        )
+        self.assertEqual(1, len(results))
+        self.assertEqual("", results[0].content)
+
+    def test_search_result_without_title(self):
+        results = self._response(
+            {
+                "data": {
+                    "search": [
+                        {
+                            "url": "https://example.com/no-title",
+                            "snippet": "only a snippet",
+                        }
+                    ],
+                }
+            },
+            categ="search",
+        )
+        self.assertEqual(1, len(results))
+        self.assertEqual("", results[0].title)
+        self.assertEqual("only a snippet", results[0].content)
+
+    def test_news_result_without_snippet(self):
+        # the ``news`` branch shares the search/news code path
+        results = self._response(
+            {
+                "data": {
+                    "news": [
+                        {
+                            "url": "https://example.com/news",
+                            "title": "A headline",
+                        }
+                    ],
+                }
+            },
+            categ="news",
+        )
+        self.assertEqual(1, len(results))
+        self.assertEqual("", results[0].content)
+
+    # --- videos branch ----------------------------------------------------
+
+    def test_videos_result_without_snippet(self):
+        results = self._response(
+            {
+                "data": {
+                    "video": [
+                        {
+                            "url": "https://example.com/video",
+                            "title": "A video",
+                            "props": {"duration": "3m12s", "creator_name": "alice"},
+                        }
+                    ],
+                }
+            },
+            categ="videos",
+        )
+        self.assertEqual(1, len(results))
+        result = results[0]
+        self.assertEqual("", result["content"])
+        self.assertEqual("A video", result["title"])
+        self.assertEqual("alice", result["author"])
+
+    def test_videos_result_without_title(self):
+        results = self._response(
+            {
+                "data": {
+                    "video": [
+                        {
+                            "url": "https://example.com/video2",
+                            "snippet": "a snippet",
+                            "props": {},
+                        }
+                    ],
+                }
+            },
+            categ="videos",
+        )
+        self.assertEqual(1, len(results))
+        self.assertEqual("", results[0]["title"])
+
+    def test_videos_result_without_props(self):
+        # ``props`` is used unguarded at the top of the videos branch; a result
+        # that omits it entirely must not raise.
+        results = self._response(
+            {
+                "data": {
+                    "video": [
+                        {
+                            "url": "https://example.com/video3",
+                            "title": "A video",
+                            "snippet": "a snippet",
+                        }
+                    ],
+                }
+            },
+            categ="videos",
+        )
+        self.assertEqual(1, len(results))
+        self.assertIsNone(results[0]["length"])
+        self.assertIsNone(results[0]["author"])
+
+    # --- images branch ----------------------------------------------------
+
+    def test_images_result_with_image_dims(self):
+        results = self._response(
+            {
+                "data": {
+                    "image": [
+                        {
+                            "url": "https://example.com/img.html",
+                            "title": "An image",
+                            "image": {
+                                "url": "https://example.com/img.png",
+                                "width": 1920,
+                                "height": 1080,
+                            },
+                            "props": {
+                                "thumbnail": {"url": "https://example.com/thumb.png"},
+                            },
+                        }
+                    ],
+                }
+            },
+            categ="images",
+        )
+        self.assertEqual(1, len(results))
+        result = results[0]
+        self.assertEqual("1920x1080", result.resolution)
+        self.assertEqual("https://example.com/img.png", result.img_src)
+        self.assertEqual("https://example.com/thumb.png", result.thumbnail_src)
+
+    def test_images_result_without_image(self):
+        # the original code did ``result['image']['width']`` chained; a result
+        # without ``image`` raised ``KeyError: 'image'``.  The fix degrades
+        # ``resolution`` to an empty string instead.
+        results = self._response(
+            {
+                "data": {
+                    "image": [
+                        {
+                            "url": "https://example.com/no-dims.html",
+                            "title": "No dims",
+                        }
+                    ],
+                }
+            },
+            categ="images",
+        )
+        self.assertEqual(1, len(results))
+        self.assertEqual("", results[0].resolution)
+
+    def test_images_result_with_image_but_no_dims(self):
+        results = self._response(
+            {
+                "data": {
+                    "image": [
+                        {
+                            "url": "https://example.com/no-dims2.html",
+                            "title": "Image without dims",
+                            "image": {"url": "https://example.com/img2.png"},
+                        }
+                    ],
+                }
+            },
+            categ="images",
+        )
+        self.assertEqual(1, len(results))
+        self.assertEqual("", results[0].resolution)
+        self.assertEqual("https://example.com/img2.png", results[0].img_src)
+
+    # --- related_search ---------------------------------------------------
+
+    def test_related_search_are_collected(self):
+        results = self._response(
+            {
+                "data": {
+                    "search": [
+                        {"url": "https://example.com/r", "title": "t", "snippet": "s"},
+                    ],
+                    "related_search": [{"title": "kagi alternative"}],
+                }
+            },
+            categ="search",
+        )
+        # one search result + one suggestion
+        self.assertEqual(2, len(results))
+        self.assertEqual("kagi alternative", results[1]["suggestion"])


### PR DESCRIPTION
## What does this PR do?

Replaces unguarded `result["..."]` accesses in `kagi.response()` with `.get(key, default)` so a single partial result row no longer raises `KeyError` and flags the engine as a parsing error.

- search/news: `result["title"]` / `result["snippet"]` → `.get(..., "")`
- images: chained `result["image"]["width"]`/`["height"]` → guard the `image` dict and degrade `resolution` to `""` when it or the dims are missing; `img_src=image.get("url", "")` (a bare `image.get("url")` returns `None` when `image` is absent, which then `TypeError`s in `Image.__post_init__` → `mimetypes.guess_type(None)`)
- videos: `result["title"]` / `result["snippet"]` → `.get(..., "")` and `result["props"]` → `result.get("props", {})`

`url` remains unguarded — a result without a URL is unusable regardless, and Kagi always includes it.

## Why is this change important?

Kagi's API can omit `snippet`, `title`, `image`, or `props` on some results. With unguarded accesses, a single partial row raised `KeyError` and the engine was reported as `unresponsive_engines: [['kagi', 'parsing error']]` — results collected before the failing row survived (a query still returned ~20 results), but the error fired every time a partial row appeared. The observed production hit was `KeyError: 'snippet'` at `kagi.py:152`.

Behavior is identical for well-formed responses; the only change is graceful handling of partial responses.

## How to test this PR locally?

\`\`\`bash
.venv/bin/python -m nose2 -v tests.unit.test_engine_kagi
\`\`\`

Verified fail-before / pass-after:

- **upstream master** + the new test file dropped in: **8 errors** (`KeyError: 'snippet'` / `'title'` / `'image'`, `TypeError: NoneType` from `mimetypes.guess_type`, missing `props`)
- **this branch**: **11/11 ok**

## Author's checklist

- [x] Defensive parsing covers search/news/images/videos branches
- [x] `img_src` default prevents the `None`→`TypeError` path in `Image.__post_init__`
- [x] `url` intentionally left unguarded (truly required field)
- [x] Tests added where no kagi engine test existed upstream
- [x] Well-formed response behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)