### PR TITLE
[fix] results: display internationalized domain names human-friendly

### DIFF
--- a/searx/result_types/_base.py
+++ b/searx/result_types/_base.py
@@ -52,6 +52,12 @@ def _normalize_url_fields(result: "Result | LegacyResult"):
             result.parsed_url = urllib.parse.urlparse(result.url)
 
     if result.parsed_url:
+        # properly format special characters (e.g. "ä", "ö") in IDN domains
+        # e.g. "xn--strung-xxa.de" becomes "störung.de"
+        if result.parsed_url.netloc.startswith("xn--"):
+            netloc = result.parsed_url.netloc.encode().decode("idna")
+            result.parsed_url = result.parsed_url._replace(netloc=netloc)
+
         result.parsed_url = result.parsed_url._replace(
             # if the result has no scheme, use http as default
             scheme=result.parsed_url.scheme or "http",


### PR DESCRIPTION
### What does this PR do?

Some search engines encode domains that contain special characters in the IDN format, i.e. by using Punycode (https://en.wikipedia.org/wiki/Punycode).

This means that domains formatted like that are not human readable and thus very unintuive.

Also, as only some engines use Punycode, this often causes a result to appear multiple times, once with a Punycode domain (e.g. xn--allestrungen-9ib.de), and once with a normal domain (e.g. allestörungen.de).

Always formatting the domains nicely has the caveat that the official sites are harder to distinguish from malicious clones that just swapped out some characters by using Punycode, e.g. replaced `a` with `á`. I don't think that will be much of an issue though - I don't think Punycode results previously stopped users from clicking the link, and I also think that most search engines filter out such bad results or don't even have them indexed.

<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

## How to test the changes?
- Enable a bunch of engines and search for `alle störungen`

Before this PR, some results are duplicated
<img width="647" height="171" alt="image" src="https://github.com/user-attachments/assets/b2825769-952c-4fc1-a3a4-f0cdc2e18ebf" />
<img width="676" height="173" alt="image" src="https://github.com/user-attachments/assets/5bd55e29-c947-4944-9f06-cbaa01bd9349" />

After this PR, they're merged into a single result:
<img width="657" height="154" alt="image" src="https://github.com/user-attachments/assets/1c6e0060-4957-457e-bd90-376b7d852de9" />


### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
