### PR TITLE
[fix] autocomplete: google autocompleter crashes

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -21,6 +21,8 @@ from searx.engines import (
 from searx.network import get as http_get, post as http_post
 from searx.exceptions import SearxEngineResponseException
 from searx.utils import extr, gen_useragent
+from searx.data import ENGINE_TRAITS
+from searx.enginelib.traits import EngineTraits
 
 if t.TYPE_CHECKING:
     from searx.extended_types import SXNG_Response
@@ -133,7 +135,9 @@ def google_complete(query: str, sxng_locale: str) -> list[str]:
 
     """
 
-    google_info: dict[str, t.Any] = google.get_google_info({'searxng_locale': sxng_locale}, engines['google'].traits)
+    data = ENGINE_TRAITS.get("google") or {}
+    traits = EngineTraits(**data)
+    google_info: dict[str, t.Any] = google.get_google_info({'searxng_locale': sxng_locale}, traits)
     url = 'https://{subdomain}/complete/search?{args}'
     args = urlencode(
         {


### PR DESCRIPTION

### What does this PR do?

`engines` only contains active engines. Since `google` was set to inactive, it's no longer part of the , making the engine crash.

With this workaround, we directly load the engine traits from the data
dictionary instead of going the intermediate step with the Google engine.

<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### How to test this PR locally?
- enable and use the google autocompleter

### Related issues
closes #6374


### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
