### PR TITLE
Fix Brave API HTML tags and favicon thumbnail issues

### DIFF
--- a/searx/engines/braveapi.py
+++ b/searx/engines/braveapi.py
@@ -31,6 +31,7 @@ from dateutil import parser
 
 from searx.exceptions import SearxEngineAPIException
 from searx.result_types import EngineResults
+from searx.utils import html_to_text
 
 if t.TYPE_CHECKING:
     from searx.extended_types import SXNG_Response
@@ -75,6 +76,7 @@ def request(query: str, params: "OnlineParams") -> None:
         "q": query,
         "count": results_per_page,
         "offset": (params["pageno"] - 1) * results_per_page,
+        "text_decorations": 0,
     }
 
     # Apply time filter if specified
@@ -113,13 +115,18 @@ def response(resp: "SXNG_Response") -> EngineResults:
     data = resp.json()
 
     for result in data.get("web", {}).get("results", []):
+        thumbnail_obj = result.get("thumbnail")
+        thumbnail = ""
+        if thumbnail_obj and not thumbnail_obj.get("logo", False):
+            thumbnail = thumbnail_obj.get("src", "") or ""
+
         res.add(
             res.types.MainResult(
                 url=result["url"],
-                title=result["title"],
-                content=result.get("description", ""),
+                title=html_to_text(result["title"]),
+                content=html_to_text(result.get("description", "")),
                 publishedDate=_extract_published_date(result.get("age")),
-                thumbnail=result.get("thumbnail", {}).get("src"),
+                thumbnail=thumbnail,
             ),
         )
 


### PR DESCRIPTION
### What does this PR do?

This PR completely resolves issue #6375 with the `braveapi` engine by addressing two issues:

1. **Raw HTML in descriptions/titles**: Adds `"text_decorations": 0` to the query parameters in the request phase to suppress HTML formatting tags at the Brave Search API source. To ensure complete robustness, it also cleans titles and descriptions using `html_to_text()` during response parsing to strip any leftover HTML tags/entities


2. **Site logos/favicons treated as search thumbnails**: Inspects the returned `thumbnail` object metadata and filters out any thumbnails that have `"logo": true` (website logos or favicons rather than result previews). The filtered thumbnail defaults to `""` instead of `None` to align perfectly with the `MainResult` type definitions (which are strictly validated via `msgspec`).

### How to test this PR locally?

1. Verify type-safety using pyright/basedpyright:
   ```bash
   local/py3/bin/basedpyright --level warning searx/engines/braveapi.py