### PR TITLE
Fix Brave API HTML tags and favicon thumbnail issues (#6375)

### DIFF
--- a/searx/engines/braveapi.py
+++ b/searx/engines/braveapi.py
@@ -31,6 +31,7 @@ from dateutil import parser
 
 from searx.exceptions import SearxEngineAPIException
 from searx.result_types import EngineResults
+from searx.utils import html_to_text
 
 if t.TYPE_CHECKING:
     from searx.extended_types import SXNG_Response
@@ -75,6 +76,7 @@ def request(query: str, params: "OnlineParams") -> None:
         "q": query,
         "count": results_per_page,
         "offset": (params["pageno"] - 1) * results_per_page,
+        "text_decorations": False,
     }
 
     # Apply time filter if specified
@@ -112,14 +114,19 @@ def response(resp: "SXNG_Response") -> EngineResults:
     res = EngineResults()
     data = resp.json()
 
-    for result in data.get("web", {}).get("results", []):
+    for result in (data.get("web") or {}).get("results", []):
+        thumbnail_obj = result.get("thumbnail")
+        thumbnail = ""
+        if thumbnail_obj and not thumbnail_obj.get("logo", False):
+            thumbnail = thumbnail_obj.get("src") or ""
+
         res.add(
             res.types.MainResult(
                 url=result["url"],
-                title=result["title"],
-                content=result.get("description", ""),
+                title=html_to_text(result["title"]),
+                content=html_to_text(result.get("description", "")),
                 publishedDate=_extract_published_date(result.get("age")),
-                thumbnail=result.get("thumbnail", {}).get("src"),
+                thumbnail=thumbnail,
             ),
         )
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the Brave API issues reported in #6375.

Changes:
- Remove HTML tags from result titles and descriptions before displaying them.
- Skip thumbnails that are site logos/favicons.
- Handle cases where the API returns `"web": null` without raising an exception.

### Testing

To verify the changes, I tested the Brave API engine locally.

1. Created a Brave Search API key.
2. Added the API key to `settings.yml`:

```yaml
engines:
  - name: braveapi
    engine: braveapi
    api_key: "YOUR-BRAVE-API-KEY"
    inactive: false
```

3. Restarted the SearXNG server:

```bash
env PYTHONPATH=. local/py3/bin/python -m searx.webapp
```

4. Searched for queries such as **"python programming"** and verified that:
   - Titles and descriptions are displayed without HTML tags.
   - Site logos/favicons are not shown as thumbnails.
   - The engine continues to work correctly even when the API returns an unexpected response.

### Related issue

Fixes #6375

### Code of Conduct

- [x] I hereby confirm that this PR conforms with the AI Policy.

### AI Usage

Tool used: Antigravity.

I used Antigravity to help inspect the codebase and understand the reported issue. I reviewed the suggested changes, implemented the fix, tested everything locally with a Brave API key, and verified the final behavior before opening this PR.
Also to write the pr.