### PR TITLE
[fix] utils: parse_duration_string drops seconds for HH:MM:SS

### DIFF
--- a/searx/utils.py
+++ b/searx/utils.py
@@ -793,8 +793,9 @@ def parse_duration_string(duration_str: str) -> timedelta | None:
         return None
 
     try:
-        # prepending ["00"] here inits hours to 0 if they are not provided
-        time_parts = (["00"] + duration_str.split(":"))[:3]
+        # prepending ["00"] here inits hours to 0 if they are not provided;
+        # keep the last three parts so an explicit HH:MM:SS is not truncated
+        time_parts = (["00"] + duration_str.split(":"))[-3:]
         hours, minutes, seconds = map(int, time_parts)
         return timedelta(hours=hours, minutes=minutes, seconds=seconds)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,6 +3,7 @@
 
 import random
 import string
+from datetime import timedelta
 import lxml.etree
 from lxml import html
 from parameterized.parameterized import parameterized
@@ -79,6 +80,19 @@ class TestUtils(SearxTestCase):
         self.assertEqual(utils.ecma_unescape('text%20with%20space'), 'text with space')
         self.assertEqual(utils.ecma_unescape('text using %xx: %F3'), 'text using %xx: ó')
         self.assertEqual(utils.ecma_unescape('text using %u: %u5409, %u4E16%u754c'), 'text using %u: 吉, 世界')
+
+    def test_parse_duration_string(self):
+        # MM:SS
+        self.assertEqual(utils.parse_duration_string('02:34'), timedelta(minutes=2, seconds=34))
+        self.assertEqual(utils.parse_duration_string('0:45'), timedelta(seconds=45))
+        # HH:MM:SS must not drop the seconds nor shift the fields
+        self.assertEqual(utils.parse_duration_string('1:02:03'), timedelta(hours=1, minutes=2, seconds=3))
+        self.assertEqual(utils.parse_duration_string('12:34:56'), timedelta(hours=12, minutes=34, seconds=56))
+        self.assertEqual(utils.parse_duration_string('00:03:30'), timedelta(minutes=3, seconds=30))
+        # invalid / empty input returns None
+        self.assertIsNone(utils.parse_duration_string(''))
+        self.assertIsNone(utils.parse_duration_string('   '))
+        self.assertIsNone(utils.parse_duration_string('not a duration'))
 
     @parameterized.expand(
         [


### PR DESCRIPTION
`parse_duration_string` prepends `"00"` to default the hours, then keeps the **first** three parts:

```python
time_parts = (["00"] + duration_str.split(":"))[:3]
```

For an `MM:SS` value this is correct, but for an explicit `HH:MM:SS` value the split produces four parts after the prepend, and `[:3]` keeps `["00", HH, MM]` — dropping the seconds and shifting hours into the minutes slot. For example `"1:02:03"` was parsed as `0:01:02` (62 s) instead of `1:02:03` (3723 s), so engines that report `HH:MM:SS` durations showed wrong values.

Keeping the **last** three parts (`[-3:]`) fixes the `HH:MM:SS` case while leaving `MM:SS` (and the hours-default behaviour) unchanged. Added `HH:MM:SS` cases to `test_parse_duration_string`, which fail before this change and pass after.

Prepared with AI assistance (Claude) and reviewed/verified by me (`tests/unit/test_utils.py` fails before, passes after).
