### PR TITLE
[fix] public domain image archive: crashes upon response

### DIFF
--- a/searx/engines/public_domain_image_archive.py
+++ b/searx/engines/public_domain_image_archive.py
@@ -140,7 +140,7 @@ def response(resp):
         results.append(
             {
                 'template': 'images.html',
-                'url': _clean_url(f"{about['website']}/images/{result['objectID']}"),
+                'url': _clean_url(f"{pdia_base_url}/images/{result['objectID']}"),
                 'img_src': _clean_url(base_image_url),
                 'thumbnail_src': _clean_url(base_image_url + THUMBNAIL_SUFFIX),
                 'title': f"{result['title'].strip()} by {result['artist']} {result.get('displayYear', '')}",


### PR DESCRIPTION
The code used here has always been "bad" because `about` shouldn't be used as data source, but the engine probably broke when type checks / dataclasses for the about parameter in engines has been added with <https://github.com/searxng/searxng/pull/6258>.

Error log:
```
WARNING searx.engines.public domain im: ErrorContext('searx/engines/public_domain_image_archive.py', 143, '\'url\': _clean_url(f"{about[\'website\']}/images/{result[\'objectID\']}"),', 'TypeError', None, ("'EngineAbout' object is not subscriptable",)) False
ERROR   searx.engines.public domain im: exception : 'EngineAbout' object is not subscriptable
Traceback (most recent call last):
  File "/home/bnyro/Projects/searxng/searx/search/processors/online.py", line 253, in search
    search_results = self._search_basic(query, params)
  File "/home/bnyro/Projects/searxng/searx/search/processors/online.py", line 239, in _search_basic
    return self.engine.response(response)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/bnyro/Projects/searxng/searx/engines/public_domain_image_archive.py", line 143, in response
    'url': _clean_url(f"{about['website']}/images/{result['objectID']}"),
                         ~~~~~^^^^^^^^^^^
TypeError: 'EngineAbout' object is not subscriptable
```


### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
