### PR TITLE
[fix] tiger: remember auth cookie for 2 months, not 1 day

### DIFF
--- a/searx/engines/tiger.py
+++ b/searx/engines/tiger.py
@@ -117,7 +117,7 @@ def _obtain_session_code() -> str:
     if not code:
         raise SearxEngineAPIException("failed to obtain session code")
 
-    CACHE.set("session", code, expire=60 * 24 * 60)  # cookie is valid for two months
+    CACHE.set("session", code, expire=60 * 24 * 60 * 60)  # cookie is valid for two months
     return code
 
 


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- fix the calculation for the cache expiry in for the `tiger` engine, the previous one assumed that `expire` is set in `minutes`, but it's actually set in `seconds`, so it has been off by factor 60.

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.