### PR TITLE
[fix] engine cache: return default value when cache entry expired

### DIFF
--- a/searx/cache.py
+++ b/searx/cache.py
@@ -458,12 +458,22 @@ class ExpireCacheSQLite(sqlitedb.SQLiteAppl, ExpireCache):
         # Before values are taken from the table, a maintenance interval may
         # need to be carried out.
         self.maintenance()
-        sql = f"SELECT value FROM {table} WHERE key = ?"
+        sql = f"SELECT value, expire FROM {table} WHERE key = ?"
         row = self.DB.execute(sql, (key,)).fetchone()
         if row is None:
             return default
 
-        return self.deserialize(row[0])
+        # Check if value is expired. It's possible that it's expired but has not
+        # yet been automatically deleted by the periodic maintenance
+        (value, expire) = row
+        now = time.time()
+        if expire < now:
+            # The record is deleted during the maintenance interval. Deleting
+            # the record at this point offers no advantage, as a SELECT
+            # statement must be executed for every cache.get request anyways.
+            return default
+
+        return self.deserialize(value)
 
     def pairs(self, ctx: str) -> Iterator[tuple[str, typing.Any]]:
         """Iterate over key/value pairs from table given by argument ``ctx``.


### PR DESCRIPTION
It's possible that a cache entry is expired but has not yet been automatically deleted by the periodic maintenance because that, by default, runs only every 2 hours.

We now explicitly check for expiry, and if expired, return the default value.

Related:
- see https://github.com/searxng/searxng/pull/6409#discussion_r3584712601

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.