### PR TITLE
[fix] cache: maintenance period comment duration 2h instead of 1h

### DIFF
--- a/searx/cache.py
+++ b/searx/cache.py
@@ -48,7 +48,7 @@ class ExpireCacheCfg(msgspec.Struct):  # pylint: disable=too-few-public-methods
     MAXHOLD_TIME: int = 60 * 60 * 24 * 7  # 7 days
     """Hold time (default in sec.), after which a value is removed from the cache."""
 
-    MAINTENANCE_PERIOD: int = 60 * 60  # 2h
+    MAINTENANCE_PERIOD: int = 60 * 60  # 1h
     """Maintenance period in seconds / when :py:obj:`MAINTENANCE_MODE` is set to
     ``auto``."""
 

--- a/searx/enginelib/__init__.py
+++ b/searx/enginelib/__init__.py
@@ -47,7 +47,7 @@ ENGINES_CACHE: ExpireCacheSQLite = ExpireCacheSQLite.build_cache(
     ExpireCacheCfg(
         name="ENGINES_CACHE",
         MAXHOLD_TIME=60 * 60 * 24 * 7,  # 7 days
-        MAINTENANCE_PERIOD=60 * 60,  # 2h
+        MAINTENANCE_PERIOD=60 * 60,  # 1h
         MAX_VALUE_LEN=1024 * 1024 * 1024,  # 1MB
     )
 )


### PR DESCRIPTION
discussed in https://github.com/searxng/searxng/pull/6414#discussion_r3594721386

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

