### PR TITLE
[fix] qwant: can't fetch engine traits because `engine.about` is no longer a dict

### DIFF
--- a/searx/engines/qwant.py
+++ b/searx/engines/qwant.py
@@ -318,7 +318,7 @@ def fetch_traits(engine_traits: EngineTraits):
     from searx.utils import extr
 
     resp = get(
-        about["website"],  # pyright: ignore[reportArgumentType]
+        base_url,  # pyright: ignore[reportArgumentType]
         timeout=5,
     )
     if not resp.ok:


### PR DESCRIPTION


### Related issues
see #6411

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
