### PR TITLE
[upd] update to gecko driver v37

### DIFF
--- a/manage
+++ b/manage
@@ -48,7 +48,7 @@ PATH="${PY_ENV}/bin:${REPO_ROOT}/node_modules/.bin:${GOROOT}/bin:${GOPATH}/bin:$
 
 PYOBJECTS="searx"
 PY_SETUP_EXTRAS='[test]'
-GECKODRIVER_VERSION="v0.36.0"
+GECKODRIVER_VERSION="v0.37.0"
 # SPHINXOPTS=
 BLACK_OPTIONS=("--target-version" "py311" "--line-length" "120" "--skip-string-normalization")
 BLACK_TARGETS=("--exclude" "(searx/static|searx/languages.py)" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")


### PR DESCRIPTION
### What does this PR do?

Bump `GECKODRIVER_VERSION` from `v0.36.0` to `v0.37.0`

GHA runners currently ship Firefox 152. Selenium warns geckodriver 0.36.0 may not be compatible and recommends 0.37.0:

<img width="2068" height="120" alt="CleanShot 2026-07-19 at 11 59 50@2x" src="https://github.com/user-attachments/assets/7c2e36d2-cb9d-4446-98b4-db05162ef543" />

### How to test this PR locally?

```
make test.robot
```

Confirm warning is gone.

### Related issues

- #3141
- #3735

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
  
No AI used.