### PR TITLE
[fix] manage: detect correct geckodriver platform

### DIFF
--- a/manage
+++ b/manage
@@ -48,7 +48,7 @@ PATH="${PY_ENV}/bin:${REPO_ROOT}/node_modules/.bin:${GOROOT}/bin:${GOPATH}/bin:$
 
 PYOBJECTS="searx"
 PY_SETUP_EXTRAS='[test]'
-GECKODRIVER_VERSION="v0.36.0"
+GECKODRIVER_VERSION="v0.37.0"
 # SPHINXOPTS=
 BLACK_OPTIONS=("--target-version" "py311" "--line-length" "120" "--skip-string-normalization")
 BLACK_TARGETS=("--exclude" "(searx/static|searx/languages.py)" "--include" 'searxng.msg|\.pyi?$' "searx" "searxng_extra" "tests")

--- a/manage
+++ b/manage
@@ -181,22 +181,48 @@ gecko.driver() {
             build_msg INSTALL "geckodriver already installed"
             return
         fi
-        PLATFORM="$(python -c 'import platform; print(platform.system().lower(), platform.architecture()[0])')"
+        PLATFORM="$(python -c 'import platform; print(platform.system().lower(), platform.machine().lower())')"
+        EXT="tar.gz"
         case "$PLATFORM" in
-            "linux 32bit" | "linux2 32bit") ARCH="linux32" ;;
-            "linux 64bit" | "linux2 64bit") ARCH="linux64" ;;
-            "windows 32 bit") ARCH="win32" ;;
-            "windows 64 bit") ARCH="win64" ;;
-            "mac 64bit") ARCH="macos" ;;
+            "linux x86_64") ARCH="linux64" ;;
+            "linux aarch64") ARCH="linux-aarch64" ;;
+            "darwin x86_64") ARCH="macos" ;;
+            "darwin arm64") ARCH="macos-aarch64" ;;
+            "windows amd64")
+                ARCH="win64"
+                EXT="zip"
+                ;;
+            "windows arm64")
+                ARCH="win-aarch64"
+                EXT="zip"
+                ;;
+            "windows x86")
+                ARCH="win32"
+                EXT="zip"
+                ;;
+            *)
+                err_msg "gecko.driver: unsupported platform: ${PLATFORM}"
+                return 42
+                ;;
         esac
-        GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/geckodriver-$GECKODRIVER_VERSION-$ARCH.tar.gz"
+        GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/geckodriver-$GECKODRIVER_VERSION-$ARCH.$EXT"
 
         build_msg GECKO "Installing ${PY_ENV_BIN}/geckodriver from $GECKODRIVER_URL"
 
         FILE="$(mktemp)"
-        wget -qO "$FILE" -- "$GECKODRIVER_URL" && tar xz -C "${PY_ENV_BIN}" -f "$FILE" geckodriver
+        BIN="geckodriver"
+        if [ "$EXT" = "zip" ]; then
+            BIN="geckodriver.exe"
+            if ! command -v unzip > /dev/null 2>&1; then
+                err_msg "gecko.driver: 'unzip' is required to install geckodriver on Windows"
+                return 42
+            fi
+            wget -qO "$FILE" -- "$GECKODRIVER_URL" && unzip -o -q "$FILE" "$BIN" -d "${PY_ENV_BIN}"
+        else
+            wget -qO "$FILE" -- "$GECKODRIVER_URL" && tar xz -C "${PY_ENV_BIN}" -f "$FILE" "$BIN"
+        fi
         rm -- "$FILE"
-        chmod 755 -- "${PY_ENV_BIN}/geckodriver"
+        chmod -- 755 "${PY_ENV_BIN}/${BIN}"
     )
     dump_return $?
 }


### PR DESCRIPTION
### What does this PR do?

`./manage gecko.driver` identifies platforms incorrectly. It uses `platform.architecture()` which is pointer width, NOT cpu arch, and matches strings that python never returns (eg `mac 64bit` instead of `darwin arm64`/`darwin x86_64`), so wrong geckodriver  gets downloaded or the script constructs an invalid download URL.

This switches platform detection to `platform.system()` and `platform.machine()`, maps platform strings to [Mozilla's published release assets](https://github.com/mozilla/geckodriver/releases) (`macos-aarch64`, `linux-aarch64`, `win-aarch64`, etc)

<img width="1820" height="1026" alt="CleanShot 2026-07-19 at 13 32 34@2x" src="https://github.com/user-attachments/assets/df0d5918-c680-4dd2-aab4-7f2feb283a9c" />

On Windows, it also downloads the correct `.zip` archive and installs `geckodriver.exe`.

Unsupported platforms now fail with a clear error instead of constructing an invalid download URL.

32-bit Linux is dropped (Mozilla discontinued `linux32` builds in geckodriver 0.37.0)

### How to test this PR locally?

```bash
rm -f local/py3/bin/geckodriver

./manage gecko.driver

local/py3/bin/geckodriver -V
file local/py3/bin/geckodriver
```

Depending on platform, this should download:
- Apple Silicon (M1/M2/M3): `macos-aarch64`
- Intel Mac: `macos`
- Linux x86_64: `linux64`
- Linux ARM64: `linux-aarch64`
- Windows AMD64: `win64`
- Windows ARM64: `win-aarch64`
- Windows x86: `win32`

### Related issues

Follow-up to https://github.com/searxng/searxng/pull/6433#discussion_r3610453038

### Code of Conduct

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

OpenAI Codex used for looking up geckodriver release assets / platform strings (it just curled for me). Code written by me.