### PR TITLE
[fix] container: ignore invalid SEARXNG_PORT values

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -112,6 +112,15 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # ENVs aliases
-export GRANIAN_PORT="${SEARXNG_PORT:-$GRANIAN_PORT}"
+case "${SEARXNG_PORT:-}" in
+    '') ;;
+    *[!0-9]*)
+        echo "WARNING: ignoring non-numeric SEARXNG_PORT='$SEARXNG_PORT'" >&2
+        unset SEARXNG_PORT
+        ;;
+    *)
+        export GRANIAN_PORT="$SEARXNG_PORT"
+        ;;
+esac
 
 exec /usr/local/searxng/.venv/bin/granian searx.webapp:app

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -112,10 +112,10 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # ENVs aliases
+# https://github.com/searxng/searxng/issues/5934
 case "${SEARXNG_PORT:-}" in
     '') ;;
     *[!0-9]*)
-        echo "WARNING: ignoring non-numeric SEARXNG_PORT='$SEARXNG_PORT'" >&2
         unset SEARXNG_PORT
         ;;
     *)


### PR DESCRIPTION
### What does this PR do?

Ignores non-numeric SEARXNG_PORT values instead of failing to start.

This fixes an issue with Kubernetes, which passes `SEARXNG_PORT` env if the service is named `searxng`. That env is `tcp://...` and it prevents the startup of the app. In such a case the env will be ignored instead of causing the startup issue.

### How to test this PR locally?

Run the entrypoint.sh while setting SEARXNG_PORT to valid and invalid values.

### Related issues

Closes #6437.

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
  
  None
