### PR TITLE
docs: add NovaNodes MCP Gateway as external integration reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ See LICENSE_ for more details.
 .. _nova-nodes-mcp:
 
 NovaNodes MCP Gateway Integration
-==================================
+=================================
 
 The `NovaNodes MCP Gateway <https://github.com/TheNovaNodes/nova-searxng-mcp>`_ provides a bridge between SearXNG and AI agents using the Model Context Protocol (MCP).
 

--- a/README.rst
+++ b/README.rst
@@ -60,3 +60,37 @@ License
 
 This project is licensed under the GNU Affero General Public License (AGPL-3.0).
 See LICENSE_ for more details.
+
+
+
+.. _nova-nodes-mcp:
+
+NovaNodes MCP Gateway Integration
+==================================
+
+The `NovaNodes MCP Gateway <https://github.com/TheNovaNodes/nova-searxng-mcp>`_ provides a bridge between SearXNG and AI agents using the Model Context Protocol (MCP).
+
+Why use it?
+-----------
+
+* **Private search for AI agents** — route MCP search calls through your own SearXNG instance, no third-party APIs, no tracking
+* **90+ engines** — Bing, Brave, DuckDuckGo, Google, Startpage, Qwant, and more
+* **Zero configuration** — just point SEARXNG_URL to your local SearXNG instance
+* **MCP native** — compatible with Claude Desktop, Continue, and any MCP client
+
+Quick start
+~~~~~~~~~~~
+
+.. code-block:: bash
+
+    pip install nova-searxng-mcp
+    # In your .env: SEARXNG_URL=http://127.0.0.1:8080
+    python -m searxng_gateway.server
+
+See the `repository <https://github.com/TheNovaNodes/nova-searxng-mcp>`_ for full documentation.
+
+Compatible with
+~~~~~~~~~~~~~~~
+
+* `AnythingLLM <https://github.com/Mintplex-Labs/anything-llm>`_ — use SearXNG as private search backend for agent web-browsing
+* `OpenClaw <https://github.com/TheNovaNodes>`_ — multi-agent orchestration with private search and memory


### PR DESCRIPTION
Hi @searxng maintainers,

I'm proposing a documentation addition to the SearXNG repository that introduces our open-source MCP (Model Context Protocol) gateway as an external integration reference for self-hosters building AI agent workflows.

### Why this integration matters

SearXNG is the leading self-hosted metasearch engine for privacy-focused web search. AI agents built on local LLMs need reliable, private search backends — SearXNG fills this gap perfectly. Our gateway connects this capability to the MCP ecosystem, which is the emerging standard for LLM tool access (used by Claude Desktop, Continue, and other clients).

### What we built

nova-searxng-mcp is a lightweight MCP server (streamable HTTP transport) that:

- Routes MCP search_web and deep_research tool calls to a local SearXNG instance
- Supports all 90+ SearXNG engines (Bing, Brave, DuckDuckGo, Google, Startpage, Qwant, and more)
- Integrates with semantic memory for contextual search results across conversation threads
- Runs as a standard Python package

### Installation reference

pip install nova-searxng-mcp
# Configure SEARXNG_URL=http://127.0.0.1:8080 in .env
# Run alongside your existing SearXNG instance
python -m searxng_gateway.server

### The bigger picture

Self-hosters using SearXNG increasingly want to connect their search backend to AI agents without sending queries to third-party APIs. Our gateway makes SearXNG the natural search layer for any MCP-compatible LLM setup.

Repository: https://github.com/TheNovaNodes/nova-searxng-mcp
License: MIT
MCP Transport: Streamable HTTP

Thank you for considering this integration reference. Happy to discuss any feedback or adjust the scope of the documentation contribution.