### PR TITLE
[ci] add ai policy checkbox detection

### DIFF
--- a/.github/scripts/ai_policy.cjs
+++ b/.github/scripts/ai_policy.cjs
@@ -1,0 +1,39 @@
+// Closes issues and prs whose authors/agents don't accept the ai policy
+// https://github.com/searxng/searxng/blob/master/AI_POLICY.rst
+
+module.exports = async ({ github, context }) => {
+  const item = context.payload.pull_request || context.payload.issue;
+  const body = item.body || '';
+  const kind = context.payload.pull_request ? 'pull request' : 'issue';
+
+  // https://github.com/searxng/searxng/pull/6476#discussion_r3683782481
+  const hasBox = /\[[Xx]\].*AI Policy/.test(body);
+  const hasRef = /\[AI Policy\]:\s*https:\/\/github\.com\/searxng\/searxng\/.*AI_POLICY/.test(body);
+  if (hasBox && hasRef) {
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: item.number,
+    body:
+      'Hello! Thank you for your contribution.\n\n' +
+      `Unfortunately your ${kind} was closed as the AI Policy has not been accepted.\n\n` +
+      `Please open a new ${kind} after confirming your contribution aligns with our AI Policy.`,
+  });
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: item.number,
+    labels: ['invalid:slop'],
+  });
+  await github.rest.issues.update({
+    owner,
+    repo,
+    issue_number: item.number,
+    state: 'closed',
+    state_reason: 'not_planned',
+  });
+};

--- a/.github/workflows/ai-policy.yml
+++ b/.github/workflows/ai-policy.yml
@@ -1,0 +1,38 @@
+---
+# yamllint disable rule:line-length
+name: AI Policy
+
+# Closes any new issues and PRs from people (or agents) who don't accept the AI Policy
+
+# yamllint disable-line rule:truthy
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check AI Policy
+    # for issues with an author who has not contributed before
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      contains(fromJSON('["NONE","FIRST_TIMER","FIRST_TIME_CONTRIBUTOR"]'),
+               github.event.issue.author_association ||
+               github.event.pull_request.author_association)
+    runs-on: ubuntu-26.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: "false"
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const script = require('./.github/scripts/ai_policy.cjs');
+            await script({ github, context });


### PR DESCRIPTION
### What does this PR do?

Adds CI to automatically close issues and give them the `invalid:slop` tag.

Only affects new users and authors who haven't contributed yet just to reduce the number false positives e.g. if someone forgets by mistake.

The motivation for this is to reduce the burden on the maintainers responding to low quality work and bad AI actors.

### How to test this PR locally?

Make an issue / pr as a new user.

Examples:
[Checkbox Ticked](https://github.com/vojkovic/searxng/issues/5)
[Checkbox Unticked](https://github.com/vojkovic/searxng/issues/4)

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

Cursor to teach me github script
