### PR TITLE
[feat] autocomplete: add kagi autocompleter

### DIFF
--- a/docs/admin/settings/settings_search.rst
+++ b/docs/admin/settings/settings_search.rst
@@ -41,6 +41,7 @@
   - ``dbpedia``
   - ``duckduckgo``
   - ``google``
+  - ``kagi``
   - ``mwmbl``
   - ``naver``
   - ``privacywall``

--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -157,6 +157,24 @@ def google_complete(query: str, sxng_locale: str) -> list[str]:
     return results
 
 
+def kagi(query: str, sxng_locale: str) -> list[str]:
+    """Autocomplete from Kagi."""
+
+    args: dict[str, str] = {'q': query}
+
+    if '-' in sxng_locale:
+        args['r'] = sxng_locale.split('-')[1].lower()
+
+    resp = get("https://kagisuggest.com/api/autosuggest?" + urlencode(args))
+    results: list[str] = []
+
+    if resp.ok:
+        data = resp.json()
+        if len(data) > 1:
+            results = data[1]
+    return results
+
+
 def mwmbl(query: str, _sxng_locale: str) -> list[str]:
     """Autocomplete from Mwmbl_."""
 
@@ -380,6 +398,7 @@ backends: dict[str, t.Callable[[str, str], list[str]]] = {
     'dbpedia': dbpedia,
     'duckduckgo': duckduckgo,
     'google': google_complete,
+    'kagi': kagi,
     'mwmbl': mwmbl,
     'naver': naver,
     'privacywall': privacywall,

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -41,8 +41,8 @@ search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
   # Existing autocomplete backends: "360search", "baidu", "bing", "brave", "dbpedia", "duckduckgo", "google",
-  # "yandex", "privacywall", "mwmbl", "naver", "seznam", "sogou", "startpage", "swisscows", "quark", "qwant",
-  # "wikipedia" - leave blank to turn it off by default.
+  # "kagi", "yandex", "privacywall", "mwmbl", "naver", "seznam", "sogou", "startpage", "swisscows", "quark",
+  # "qwant", "wikipedia" - leave blank to turn it off by default.
   autocomplete: ""
   # minimun characters to type before autocompleter starts
   autocomplete_min: 4


### PR DESCRIPTION
### What does this PR do?

Adds a Kagi Autocompleter backend.

Used https://kagisuggest.com/api/autosuggest from [here](https://help.kagi.com/kagi/getting-started/setting-default.html#custom_use).

I am hoping it is less monitored than the more public endpoint.


### How to test this PR locally?

Enable kagi autocompleter in preferences

Type something into search bar

Confirm autocompleter results work

### Related issues

none

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor found the r arg for the locale