### PR TITLE
[doc] add a managed hosting option to the installation page

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -10,6 +10,13 @@ Installation
 - :ref:`installation scripts`
 - :ref:`installation basic`
 
+If you would rather not run a server yourself, a managed instance can be
+deployed in one click:
+
+.. image:: https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg
+   :target: https://zenith.hosting/host/searxng
+   :alt: Deploy with Zenith
+
 The :ref:`installation basic` is an excellent illustration of *how a SearXNG
 instance is build up* (see :ref:`architecture uWSGI`).  If you do not have any
 special preferences, it's recommended to use the :ref:`installation container` or the


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?

adds a "Deploy with Zenith" badge to the installation page, under the existing list of
installation methods, for people who would rather not run a server themselves.

Zenith is a managed host that runs open source apps on a one-click deploy, and we share a
cut of revenue with the projects we host. i am happy to explain how that works or to sort
it out for SearXNG: hello@zenith.hosting

docs only, one file, additions only. no code, no dependencies, no behaviour change. happy
to reword it, move it further down the page, or drop it entirely if you would rather not
list third party hosts.

### How to test this PR locally?

docs only, so nothing to run beyond the docs build:

    make docs.html

then open the built Installation page and check the badge renders and both links resolve:
the image at https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg and the target at
https://zenith.hosting/host/searxng

`make docs.live` works too if you want it rebuilt as you edit. the change is a standard
RST `.. image::` directive with `:target:` and `:alt:`, matching the rest of the file.

### Related issues

none, this is a standalone docs addition.

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
