### PR TITLE
[mod] defaults: GET method and ddg autocomplete

### DIFF
--- a/docs/admin/settings/settings_search.rst
+++ b/docs/admin/settings/settings_search.rst
@@ -8,7 +8,7 @@
 
    search:
      safe_search: 0
-     autocomplete: ""
+     autocomplete: "duckduckgo"
      favicon_resolver: ""
      default_lang: ""
      ban_time_on_fail: 5
@@ -32,7 +32,7 @@
   - ``2``: Strict
 
 ``autocomplete``:
-  Existing autocomplete backends, leave blank to turn it off.
+  Existing autocomplete backends, set blank to turn it off.
 
   - ``360search``
   - ``baidu``

--- a/docs/admin/settings/settings_server.rst
+++ b/docs/admin/settings/settings_server.rst
@@ -14,7 +14,7 @@
        limiter: false
        public_instance: false
        image_proxy: false
-       method: "POST"
+       method: "GET"
        default_http_headers:
          X-Content-Type-Options : nosniff
          X-Download-Options : noopen
@@ -58,8 +58,8 @@
 
 ``method`` : ``GET`` | ``POST``
 
-  HTTP method.  By defaults ``POST`` is used / The ``POST`` method has the
-  advantage with some WEB browsers that the history is not easy to read, but
+  HTTP method.  By default, ``GET`` is used / The ``POST`` method has the
+  advantage with some browsers that the history is not saved, but
   there are also various disadvantages that sometimes **severely restrict the
   ease of use for the end user** (e.g. back button to jump back to the previous
   search page and drag & drop of search term to new tabs do not work as

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -41,9 +41,9 @@ search:
   # Filter results. 0: None, 1: Moderate, 2: Strict
   safe_search: 0
   # Existing autocomplete backends: "360search", "baidu", "bing", "brave", "dbpedia", "duckduckgo", "google",
-  # "kagi", "yandex", "privacywall", "mwmbl", "naver", "seznam", "sogou", "startpage", "swisscows", "quark",
-  # "qwant", "wikipedia" - leave blank to turn it off by default.
-  autocomplete: ""
+  # "yandex", "privacywall", "mwmbl", "naver", "seznam", "sogou", "startpage", "swisscows", "quark", "qwant",
+  # "wikipedia" - set blank to turn it off by default.
+  autocomplete: "duckduckgo"
   # minimun characters to type before autocompleter starts
   autocomplete_min: 4
   # backend for the favicon near URL in search results.
@@ -107,11 +107,10 @@ server:
   image_proxy: false
   # 1.0 and 1.1 are supported
   http_protocol_version: "1.0"
-  # POST queries are "more secure!" but are also the source of hard-to-locate
-  # annoyances, which is why GET may be better for end users and their browsers.
+  # POST keeps search queries out of the browsers history, but causes UX issues.
   # see https://github.com/searxng/searxng/pull/3619
   # Is overwritten by ${SEARXNG_METHOD}
-  method: "POST"
+  method: "GET"
   default_http_headers:
     X-Content-Type-Options: nosniff
     X-Download-Options: noopen

--- a/searx/settings_defaults.py
+++ b/searx/settings_defaults.py
@@ -192,7 +192,7 @@ SCHEMA: dict[str, t.Any] = {
     'brand': SettingsBrand,
     'search': {
         'safe_search': SettingsValue((0, 1, 2), 0),
-        'autocomplete': SettingsValue(str, ''),
+        'autocomplete': SettingsValue(str, 'duckduckgo'),
         'autocomplete_min': SettingsValue(int, 4),
         'favicon_resolver': SettingsValue(str, ''),
         'default_lang': SettingsValue(tuple(SXNG_LOCALE_TAGS + ['']), ''),
@@ -219,7 +219,7 @@ SCHEMA: dict[str, t.Any] = {
         'base_url': SettingsValue((False, str), False, 'SEARXNG_BASE_URL'),
         'image_proxy': SettingsValue(bool, False, 'SEARXNG_IMAGE_PROXY'),
         'http_protocol_version': SettingsValue(('1.0', '1.1'), '1.0'),
-        'method': SettingsValue(('POST', 'GET'), 'POST', 'SEARXNG_METHOD'),
+        'method': SettingsValue(('POST', 'GET'), 'GET', 'SEARXNG_METHOD'),
         'default_http_headers': SettingsValue(dict, {}),
     },
     # redis is deprecated ..

--- a/searx/templates/simple/elements/apis.html
+++ b/searx/templates/simple/elements/apis.html
@@ -4,7 +4,7 @@
     <div class="wrapper">
       {%- for output_type in search_formats -%}
         <div class="left">
-          <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
+          <form method="{{ method }}" action="{{ url_for('search') }}">
             <input type="hidden" name="q" value="{{ q|e }}">
             {%- for category in selected_categories -%}
               <input type="hidden" name="category_{{ category }}" value="1">

--- a/searx/templates/simple/elements/corrections.html
+++ b/searx/templates/simple/elements/corrections.html
@@ -2,7 +2,7 @@
       <h4 id="corrections-title">{{ _('Try searching for:') }}</h4>
       {% for correction in corrections %}
       <div class="left">
-	      <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" role="navigation">
+	      <form method="{{ method }}" action="{{ url_for('search') }}" role="navigation">
           {% for category in selected_categories %}
           <input type="hidden" name="category_{{ category }}" value="1">
           {% endfor %}

--- a/searx/templates/simple/elements/infobox.html
+++ b/searx/templates/simple/elements/infobox.html
@@ -31,7 +31,7 @@
         <div>
           <h3><bdi>{{ topic.name }}</bdi></h3>
           {%- for suggestion in topic.suggestions -%}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
+            <form method="{{ method }}" action="{{ url_for('search') }}">
               <input type="hidden" name="q" value="{{ suggestion }}">
               <input type="hidden" name="time_range" value="{{ time_range }}">
               <input type="hidden" name="language" value="{{ current_language }}">

--- a/searx/templates/simple/elements/suggestions.html
+++ b/searx/templates/simple/elements/suggestions.html
@@ -3,7 +3,7 @@
     <summary class="title" id="suggestions-title">{{ _('Suggestions') }}</summary>
     <ul class="wrapper">
       {%- for suggestion in suggestions -%}
-      <li><form method="{{ method or 'POST' }}" action="{{ url_for('search') }}">
+      <li><form method="{{ method }}" action="{{ url_for('search') }}">
           <input type="hidden" name="q" value="{{ suggestion.url }}">
           {%- for category in selected_categories -%}
             <input type="hidden" name="category_{{ category }}" value="1">

--- a/searx/templates/simple/results.html
+++ b/searx/templates/simple/results.html
@@ -75,7 +75,7 @@
     {% if paging %}
     <nav id="pagination" role="navigation">
         {% if pageno > 1 %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="previous_page">
+            <form method="{{ method }}" action="{{ url_for('search') }}" class="previous_page">
                 <div class="{% if rtl %}right{% else %}left{% endif %}">
                   <input type="hidden" name="q" value="{{ q|e }}" >
                   {% for category in selected_categories %}
@@ -93,7 +93,7 @@
             </form>
         {% endif %}
         {%- if results | count > 0 -%}
-          <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="next_page">
+          <form method="{{ method }}" action="{{ url_for('search') }}" class="next_page">
               <div class="{% if rtl %}left{% else %}right{% endif %}">
                 <input type="hidden" name="q" value="{{ q|e }}" >
                 {% for category in selected_categories %}
@@ -119,7 +119,7 @@
 
         <div class="numbered_pagination">
         {% for x in range(pstart, pend) %}
-            <form method="{{ method or 'POST' }}" action="{{ url_for('search') }}" class="page_number">
+            <form method="{{ method }}" action="{{ url_for('search') }}" class="page_number">
                 <input type="hidden" name="q" value="{{ q|e }}" >
                 {% for category in selected_categories %}
                 <input type="hidden" name="category_{{ category }}" value="1" >

--- a/searx/templates/simple/search.html
+++ b/searx/templates/simple/search.html
@@ -1,4 +1,4 @@
-<form id="search" method="{{ method or 'POST' }}" action="{{ url_for('search') }}" role="search">
+<form id="search" method="{{ method }}" action="{{ url_for('search') }}" role="search">
   <div id="search_header">
     <a id="search_logo" href="{{ url_for('index') }}" tabindex="0" title="{{ _('Display the front page') }}">
       <span hidden>SearXNG</span>

--- a/searx/templates/simple/simple_search.html
+++ b/searx/templates/simple/simple_search.html
@@ -1,4 +1,4 @@
-<form id="search" method="{{ method or 'POST' }}" action="{{ url_for('search') }}" role="search">
+<form id="search" method="{{ method }}" action="{{ url_for('search') }}" role="search">
   <div id="search_header">
     <div id="search_view">
       <div class="search_box">

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1195,7 +1195,7 @@ def opensearch():
         method = 'GET'
 
     if method not in ('POST', 'GET'):
-        method = 'POST'
+        method = 'GET'
 
     ret = render('opensearch.xml', opensearch_method=method, autocomplete=autocomplete)
     resp = Response(response=ret, status=200, mimetype="application/opensearchdescription+xml")


### PR DESCRIPTION
### What does this PR do?

Changes the default of `server.method` from `POST` to `GET` and `search.autocomplete` from disabled to `duckduckgo`. 

I originally wanted to use brave but I ran into some issues getting consistent results when testing -> ddg is more reliable and privacy respecting enough to make it a solid enough default. (Brave also doesn't support languages but ddg does). Perhaps we can use kagi once https://github.com/searxng/searxng/pull/6481 is merged, as that has the ability for rich output and language support.

Autocomplete being off by default also means `/opensearch.xml` is often added without the suggestions URL and Firefox will cache a broken setup unless the user picks an autocompleter backend and then adds the engine back.

The motivation for swapping to GET by default is that while POST provides the very minor benefit of keeping search queries out of the user's history, it causes a LOT of UX pain. Due to this, GET has been recommended to the instance maintainers for a while (#3619  - read through that PR's comments for a more complete picture). In the past, we have been divided on this issue, so I think it's time we discuss it again to get everyone's views. 😛 

### How to test this PR locally?

`make run` and confirm preferences default to GET and duckduckgo.

### Related issues

- Closes: https://github.com/searxng/searxng/issues/1889
- https://github.com/searxng/searxng/issues/711
- https://github.com/searxng/searxng/issues/3590
- https://github.com/searxng/searxng/pull/3619
- https://github.com/searxng/searxng/pull/2333
- https://github.com/searxng/searxng/pull/6482
- https://github.com/searxng/searxng/discussions/4262

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor for testing