### PR TITLE
[fix] autocompleter: suggestions contain HTML escape codes

### DIFF
--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -851,7 +851,6 @@ def autocompleter():
         suggestions = json.dumps([sug_prefix, results, [], [], relevances])
         mimetype = 'application/x-suggestions+json'
 
-    suggestions = escape(suggestions, False)
     return Response(suggestions, mimetype=mimetype)
 
 


### PR DESCRIPTION
### What does this PR do?

The results were previously HTML-escaped for some reason. That doesn't really make much sense because they never got unescaped anywhere.

For example, `A&B` gets escaped to `A&amp;B` and never unescaped, so the autocompletion frontend shows `A&amp;B`, which isn't user-friendly at all.

Also, it doesn't make sense to escape the full JSON instead of only escaping the suggestion texts individually because that makes it even more unclear.

### How to test this PR locally?
- enable an autocompleter and search for something with a `&` in it
- discovered when testing https://github.com/searxng/searxng/pull/6481

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
