### PR TITLE
[fix] engines: only print search traceback in debug mode

### DIFF
--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -255,11 +255,11 @@ class OnlineProcessor(EngineProcessor):
         except ssl.SSLError as e:
             # requests timeout (connect or read)
             self.handle_exception(result_container, e, suspend=True)
-            self.logger.error("SSLError {}, verify={}".format(e, searx.network.get_network(self.engine.name).verify))
+            self.logger.debug("SSLError {}, verify={}".format(e, searx.network.get_network(self.engine.name).verify))
         except (httpx.TimeoutException, asyncio.TimeoutError) as e:
             # requests timeout (connect or read)
             self.handle_exception(result_container, e, suspend=True)
-            self.logger.error(
+            self.logger.debug(
                 "HTTP requests timeout (search duration : {0} s, timeout: {1} s) : {2}".format(
                     default_timer() - start_time, timeout_limit, e.__class__.__name__
                 )
@@ -267,7 +267,7 @@ class OnlineProcessor(EngineProcessor):
         except (httpx.HTTPError, httpx.StreamError) as e:
             # other requests exception
             self.handle_exception(result_container, e, suspend=True)
-            self.logger.exception(
+            self.logger.debug(
                 "requests exception (search duration : {0} s, timeout: {1} s) : {2}".format(
                     default_timer() - start_time, timeout_limit, e
                 )
@@ -278,7 +278,7 @@ class OnlineProcessor(EngineProcessor):
             SearxEngineAccessDeniedException,
         ) as e:
             self.handle_exception(result_container, e, suspend=True)
-            self.logger.exception(e.message)
+            self.logger.debug(e.message)
         except Exception as e:  # pylint: disable=broad-except
             self.handle_exception(result_container, e)
-            self.logger.exception("exception : {0}".format(e))
+            self.logger.debug("exception : {0}".format(e))


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- Disable printing the stacktrace when an engine crashes while searching in debug mode (i.e. `SEARXNG_DEBUG` and `general.debug` are `False`).
- On large instances, these tracebacks can cause a log file to fill up quite quickly and be annoying when searching for "real" bugs.
- The engine failure summary is still displayed, e.g. it now looks like
 
<img width="1225" height="62" alt="image" src="https://github.com/user-attachments/assets/b2d8ac26-c8b4-4a85-9cd5-0f22a3bb401c" />

instead of 

<img width="1233" height="418" alt="image" src="https://github.com/user-attachments/assets/ea57d82f-322c-425c-a4cc-ad335294fe72" />

I'm not sure if there's a better way to do this, e.g. I thought about setting `engine.logger.disabled = True` in production mode, but that would also hide engine setup error messages, e.g. if the engine is configured wrongly.

### How to test this PR locally?
- set `SEARXNG_DEBUG=0` in `settings.yml`
- search for something (e.g. with startpage which is captchaed)

### Related issues
- closes  #6477

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
