### PR TITLE
[fix] data: clear the "currencies loaded" flag when the load fails

### DIFF
--- a/searx/data/currencies.py
+++ b/searx/data/currencies.py
@@ -29,7 +29,15 @@ class CurrenciesDB:
         if self.cache.properties("currencies loaded") != "OK":
             # To avoid parallel initializations, the property is set first
             self.cache.properties.set("currencies loaded", "OK")
-            self.load()
+            try:
+                self.load()
+            except Exception:  # pylint: disable=broad-except
+                # The property is set before the rows are written, so a failed
+                # load would leave the cache flagged as loaded while holding no
+                # currency data.  Every later init() would then short-circuit
+                # and the data would stay missing for the lifetime of the DB.
+                self.cache.properties.set("currencies loaded", "")
+                raise
         # F I X M E:
         #     do we need a maintenance .. rember: database is stored
         #     in /tmp and will be rebuild during the reboot anyway

--- a/tests/unit/test_data_currencies.py
+++ b/tests/unit/test_data_currencies.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-class-docstring,invalid-name
+"""Tests for :py:obj:`searx.data.currencies.CurrenciesDB`."""
+
+import tempfile
+import pathlib
+
+from searx.cache import ExpireCacheCfg, ExpireCacheSQLite
+from searx.data.currencies import CurrenciesDB
+
+from tests import SearxTestCase
+
+
+class TestCurrenciesDB(SearxTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        self.addCleanup(self.tmp_dir.cleanup)
+        db_url = str(pathlib.Path(self.tmp_dir.name) / "test_currencies.db")
+        self.cache = ExpireCacheSQLite.build_cache(ExpireCacheCfg(name="TEST_CURRENCIES", db_url=db_url))
+
+        self.db = CurrenciesDB.__new__(CurrenciesDB)
+        self.db.cache = self.cache
+
+    def test_init_loads_currencies(self):
+        self.db.init()
+        self.assertEqual(self.cache.properties("currencies loaded"), "OK")
+        self.assertTrue(self.db.is_iso4217("USD"))
+
+    def test_failed_load_does_not_mark_cache_as_loaded(self):
+        """A load() that raises must not leave the "loaded" flag set: the flag is
+        set before the rows are written, so keeping it would make every later
+        init() a no-op against an empty cache (issue #6500)."""
+
+        def failing_load():
+            raise OSError("cannot read currencies.json")
+
+        self.db.load = failing_load  # pyright: ignore[reportAttributeAccessIssue]
+
+        with self.assertRaises(OSError):
+            self.db.init()
+
+        self.assertNotEqual(self.cache.properties("currencies loaded"), "OK")
+        self.assertFalse(self.db.is_iso4217("USD"))
+
+        # a later init() must still be able to populate the cache
+        del self.db.load
+        self.db.init()
+        self.assertTrue(self.db.is_iso4217("USD"))


### PR DESCRIPTION
### What does this PR do?

`CurrenciesDB.init()` sets the `currencies loaded` property *before* it writes any row:

```python
if self.cache.properties("currencies loaded") != "OK":
    # To avoid parallel initializations, the property is set first
    self.cache.properties.set("currencies loaded", "OK")
    self.load()
```

The ordering is deliberate — it keeps two workers from loading `currencies.json` at the same time — but it is not fail-safe. If `load()` raises (unreadable/corrupt `currencies.json`, a write error on the SQLite cache, a worker killed mid-load), the flag stays set on a cache that holds no currency data. Since `init()` only loads while the flag is unset, **no later call can repair it**: `name_to_iso4217()` and `iso4217_to_name()` keep returning `None` for the lifetime of the DB, and `!cc 100 USD to PLN` answers *No results* — which is what #6500 reports (property `OK`, empty cache, `init()` a no-op, only an explicit `load()` fixes it).

This keeps the flag as the parallel-init guard but clears it again when `load()` raises, so the next `init()` retries.

The added test pins the invariant: with the fix reverted it fails, with the fix in place it passes.

**Related observation, not fixed here:** `TrackerPatternsDB.init()` in `searx/data/tracker_patterns.py` has the identical guard, but a different failure mode that this patch would *not* cover — `iter_clear_list()` returns instead of raising when every `CLEAR_LIST_URL` fails (3s timeout each), so `load()` completes normally having written zero rows while the flag reads `OK`. I see that state on one of my own instances:

```
== /tmp/sxng_cache_DATA_CACHE.db
   prop:  tracker_patterns loaded = 'OK'
   table: data_tracker_patterns      rows=0
```

i.e. the tracker-removal plugin is silently inert there and cannot recover without deleting the DB. Making that one fail-safe means deciding whether an empty rule list should count as "loaded", which is a design call for you rather than something to smuggle into a currency fix — happy to open a separate PR/issue if you want it addressed.

### How to test this PR locally?

```sh
python -m pytest tests/unit/test_data_currencies.py -q
```

`test_failed_load_does_not_mark_cache_as_loaded` makes `load()` raise, asserts the flag is not left at `OK`, and asserts a subsequent `init()` still populates the cache. Reverting the `try/except` in `searx/data/currencies.py` makes exactly that test fail and leaves `test_init_loads_currencies` passing.

Checked on Linux / Python 3.13 in a clean container:

- `pytest tests/unit` → 341 passed
- `black --target-version py311 --line-length 120 --skip-string-normalization` → unchanged
- `pylint --rcfile=.pylintrc searx/data/currencies.py tests/unit/test_data_currencies.py` → 10.00/10

### Related issues

Closes: #6500

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

AI disclosure: written with Claude Code (Claude Opus 5) as an assistant. It was used to trace the failure path through `init()`/`load()`, to draft the patch and the test, and to help word this description; I set the direction (keep the parallel-init guard rather than reorder it, scope the change to `currencies.py`, leave the `tracker_patterns.py` design call to you), reviewed the complete diff, and ran the verification above myself. The production cache state quoted above is from my own SearXNG instance, not generated.
