### PR TITLE
[fix] data: clear the "currencies loaded" flag when the load fails

### DIFF
--- a/searx/data/currencies.py
+++ b/searx/data/currencies.py
@@ -29,7 +29,15 @@ class CurrenciesDB:
         if self.cache.properties("currencies loaded") != "OK":
             # To avoid parallel initializations, the property is set first
             self.cache.properties.set("currencies loaded", "OK")
-            self.load()
+            try:
+                self.load()
+            except Exception:  # pylint: disable=broad-except
+                # The property is set before the rows are written, so a failed
+                # load would leave the cache flagged as loaded while holding no
+                # currency data.  Every later init() would then short-circuit
+                # and the data would stay missing for the lifetime of the DB.
+                self.cache.properties.set("currencies loaded", "")
+                raise
         # F I X M E:
         #     do we need a maintenance .. rember: database is stored
         #     in /tmp and will be rebuild during the reboot anyway

--- a/tests/unit/test_data_currencies.py
+++ b/tests/unit/test_data_currencies.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-class-docstring,invalid-name
+"""Tests for :py:obj:`searx.data.currencies.CurrenciesDB`."""
+
+import tempfile
+import pathlib
+
+from searx.cache import ExpireCacheCfg, ExpireCacheSQLite
+from searx.data.currencies import CurrenciesDB
+
+from tests import SearxTestCase
+
+
+class TestCurrenciesDB(SearxTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        self.addCleanup(self.tmp_dir.cleanup)
+        db_url = str(pathlib.Path(self.tmp_dir.name) / "test_currencies.db")
+        self.cache = ExpireCacheSQLite.build_cache(ExpireCacheCfg(name="TEST_CURRENCIES", db_url=db_url))
+
+        self.db = CurrenciesDB.__new__(CurrenciesDB)
+        self.db.cache = self.cache
+
+    def test_init_loads_currencies(self):
+        self.db.init()
+        self.assertEqual(self.cache.properties("currencies loaded"), "OK")
+        self.assertTrue(self.db.is_iso4217("USD"))
+
+    def test_failed_load_does_not_mark_cache_as_loaded(self):
+        """A load() that raises must not leave the "loaded" flag set: the flag is
+        set before the rows are written, so keeping it would make every later
+        init() a no-op against an empty cache (issue #6500)."""
+
+        def failing_load():
+            raise OSError("cannot read currencies.json")
+
+        self.db.load = failing_load  # pyright: ignore[reportAttributeAccessIssue]
+
+        with self.assertRaises(OSError):
+            self.db.init()
+
+        self.assertNotEqual(self.cache.properties("currencies loaded"), "OK")
+        self.assertFalse(self.db.is_iso4217("USD"))
+
+        # a later init() must still be able to populate the cache
+        del self.db.load
+        self.db.init()
+        self.assertTrue(self.db.is_iso4217("USD"))


### PR DESCRIPTION
### What does this PR do?

`CurrenciesDB.init()` sets the "currencies loaded" flag before it writes any row.
If `load()` fails, the flag stays set on an empty cache, and since `init()` only
loads while the flag is unset, nothing reloads it — currency conversion returns
"No results" from then on.

This clears the flag again when `load()` raises, so the next `init()` retries.
The parallel-init guard still works.

Note: `tracker_patterns.py` has the same guard but fails differently —
`iter_clear_list()` returns instead of raising, so `load()` finishes with zero
rows and the flag stays `OK`. I see exactly that on my own instance. I did not
touch it, that one needs your call.

### How to test this PR locally?

`python -m pytest tests/unit/test_data_currencies.py -q`

Revert the `try/except` and `test_failed_load_does_not_mark_cache_as_loaded`
fails while the other one still passes. Full `tests/unit`: 341 passed, `black`
and `pylint` clean.

### Related issues

Closes: #6500

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**
