### PR TITLE
fix(wikidata): comply with wikimedia user-agent policy and handle sparql init error (#6454)

### DIFF
--- a/searx/engines/wikidata.py
+++ b/searx/engines/wikidata.py
@@ -18,7 +18,8 @@ from babel.dates import format_datetime, format_date, format_time, get_datetime_
 from searx.enginelib import EngineCache
 from searx.data import WIKIDATA_UNITS
 from searx.network import post, get
-from searx.utils import searxng_useragent, get_string_replaces_function
+from searx.version import VERSION_TAG
+from searx.utils import get_string_replaces_function
 from searx.external_urls import get_external_url, get_earth_coordinates_url, area_to_osm_zoom
 from searx.engines.wikipedia import (
     fetch_wikimedia_traits,
@@ -448,9 +449,10 @@ WDAttrList = list[WDAttrType]
 
 def get_headers() -> dict[str, str]:
     # user agent: https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits
+    # Policy: https://meta.wikimedia.org/wiki/User-Agent_policy
     return {
         "Accept": "application/sparql-results+json",
-        "User-Agent": f"wikidata engine - {searxng_useragent()}",
+        "User-Agent": f"SearXNG/{VERSION_TAG} (https://github.com/searxng/searxng; contact@searxng.org) wikidata-engine",
     }
 
 
@@ -863,15 +865,18 @@ def init_wikidata_properties():
                 wikidata_property_names.append("wd:" + attribute.name)
     query = QUERY_PROPERTY_NAMES.replace("%ATTRIBUTES%", " ".join(wikidata_property_names))
     kwargs: dict[str, t.Any] = {"timeout": 20}
-    jsonresponse = send_wikidata_query(query, **kwargs)
-    for result in jsonresponse.get("results", {}).get("bindings", {}):
-        name_field = result.get("name")
-        if not name_field:
-            continue
-        name = name_field["value"]
-        lang = name_field["xml:lang"]
-        entity_id = result["item"]["value"].replace("http://www.wikidata.org/entity/", "")
-        WIKIDATA_PROPERTIES[(entity_id, lang)] = name.capitalize()
+    try:
+        jsonresponse = send_wikidata_query(query, **kwargs)
+        for result in jsonresponse.get("results", {}).get("bindings", {}):
+            name_field = result.get("name")
+            if not name_field:
+                continue
+            name = name_field["value"]
+            lang = name_field["xml:lang"]
+            entity_id = result["item"]["value"].replace("http://www.wikidata.org/entity/", "")
+            WIKIDATA_PROPERTIES[(entity_id, lang)] = name.capitalize()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning("Failed to initialize Wikidata properties from SPARQL endpoint: %s", e)
 
     CACHE.set(key="WIKIDATA_PROPERTIES", value=WIKIDATA_PROPERTIES)
 

--- a/tests/unit/engines/test_wikidata.py
+++ b/tests/unit/engines/test_wikidata.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,missing-class-docstring
+
+import sys
+import unittest
+from unittest import mock
+
+if "pwd" not in sys.modules:
+    sys.modules["pwd"] = mock.MagicMock()
+
+from searx.engines import wikidata
+from searx.version import VERSION_TAG
+from searx.data import WIKIDATA_UNITS
+from tests import SearxTestCase
+
+
+class TestWikidataEngine(SearxTestCase):
+
+    def setUp(self):
+        super().setUp()
+        # Ensure fresh CACHE mock
+        wikidata.CACHE = mock.MagicMock()
+
+    def test_get_headers_wikimedia_compliance(self):
+        headers = wikidata.get_headers()
+        self.assertEqual(headers.get("Accept"), "application/sparql-results+json")
+        expected_ua = f"SearXNG/{VERSION_TAG} (https://github.com/searxng/searxng; contact@searxng.org) wikidata-engine"
+        self.assertEqual(headers.get("User-Agent"), expected_ua)
+
+    def test_init_wikidata_properties_success(self):
+        wikidata.CACHE.get.return_value = None
+        fake_response = {
+            "results": {
+                "bindings": [
+                    {
+                        "item": {"value": "http://www.wikidata.org/entity/P1082"},
+                        "name": {"value": "population", "xml:lang": "en"},
+                    }
+                ]
+            }
+        }
+
+        with mock.patch(
+            "searx.engines.wikidata.send_wikidata_query", return_value=fake_response
+        ):
+            wikidata.init_wikidata_properties()
+
+        # Check unit mappings added
+        for k, v in WIKIDATA_UNITS.items():
+            self.assertEqual(wikidata.WIKIDATA_PROPERTIES[k], v["symbol"])
+
+        # Check property added from query
+        self.assertEqual(
+            wikidata.WIKIDATA_PROPERTIES.get(("P1082", "en")), "Population"
+        )
+        wikidata.CACHE.set.assert_called_once_with(
+            key="WIKIDATA_PROPERTIES", value=wikidata.WIKIDATA_PROPERTIES
+        )
+
+    def test_init_wikidata_properties_network_failure_fallback(self):
+        wikidata.CACHE.get.return_value = None
+
+        with mock.patch(
+            "searx.engines.wikidata.send_wikidata_query",
+            side_effect=Exception("HTTP 403 Forbidden: Wikimedia policy"),
+        ):
+            # Should not raise exception and log a warning
+            wikidata.init_wikidata_properties()
+
+        # Units should still be populated
+        for k, v in WIKIDATA_UNITS.items():
+            self.assertEqual(wikidata.WIKIDATA_PROPERTIES[k], v["symbol"])
+
+        wikidata.CACHE.set.assert_called_once_with(
+            key="WIKIDATA_PROPERTIES", value=wikidata.WIKIDATA_PROPERTIES
+        )
+
+    def test_init_wikidata_properties_cached(self):
+        cached_props = {"P434": "MusicBrainz", "cached_key": "cached_val"}
+        wikidata.CACHE.get.return_value = cached_props
+
+        with mock.patch("searx.engines.wikidata.send_wikidata_query") as mock_query:
+            wikidata.init_wikidata_properties()
+            mock_query.assert_not_called()
+
+        self.assertEqual(wikidata.WIKIDATA_PROPERTIES, cached_props)
+
+    def test_request_headers(self):
+        params = {"searxng_locale": "en-US"}
+        wikidata.traits = mock.MagicMock()
+        wikidata.traits.get_region.return_value = "en"
+        wikidata.traits.get_language.return_value = "en"
+        wikidata.traits.custom = {"wiki_netloc": {}}
+
+        wikidata.request("Alan Turing", params)
+
+        self.assertEqual(params["method"], "POST")
+        self.assertEqual(params["url"], wikidata.SPARQL_ENDPOINT_URL)
+        self.assertIn("headers", params)
+        expected_ua = f"SearXNG/{VERSION_TAG} (https://github.com/searxng/searxng; contact@searxng.org) wikidata-engine"
+        self.assertEqual(params["headers"].get("User-Agent"), expected_ua)
+        self.assertEqual(
+            params["headers"].get("Accept"), "application/sparql-results+json"
+        )
+
+    def test_get_label_for_entity(self):
+        wikidata.WIKIDATA_PROPERTIES = {
+            "P345": "IMDb",
+            ("P1082", "en"): "Population",
+            ("P1082", "fr"): "Population (FR)",
+        }
+        self.assertEqual(wikidata.get_label_for_entity("P345", "en"), "IMDb")
+        self.assertEqual(wikidata.get_label_for_entity("P1082", "en"), "Population")
+        self.assertEqual(
+            wikidata.get_label_for_entity("P1082", "fr-FR"), "Population (FR)"
+        )
+        self.assertEqual(wikidata.get_label_for_entity("P1082", "de"), "Population")
+        self.assertEqual(
+            wikidata.get_label_for_entity("UNKNOWN_PROP", "en"), "UNKNOWN_PROP"
+        )


### PR DESCRIPTION
### Summary
Resolves #6454

This PR fixes the HTTP 403 / unhandled crash occurring during the Wikidata engine initialization when querying query.wikidata.org/sparql.

### Root Cause
1. **User-Agent Policy Violation**: Wikimedia/Wikidata requires a specific User-Agent format containing application name, version, and contact/repository info (<client name>/<version> (<contact information>) <library/framework name>/<version>). Requests missing contact information or using unrecognized generic headers trigger HTTP 403 Forbidden responses.
2. **Unhandled Exception during Property Initialization**: init_wikidata_properties() lacked error handling around send_wikidata_query(), causing engine initialization to throw an uncaught exception during startup when SPARQL requests fail or are rate-limited.

### Changes Made
- **User-Agent Headers**: Updated get_headers() in searx/engines/wikidata.py to use User-Agent: SearXNG/<version> (https://github.com/searxng/searxng; contact@searxng.org) wikidata-engine adhering to Wikimedia User-Agent policy.
- **Graceful Fallback & Exception Handling**: Wrapped send_wikidata_query() within init_wikidata_properties() in a 	ry...except Exception block to log a warning instead of failing engine initialization, while falling back gracefully to standard WIKIDATA_UNITS mappings.
- **Unit Tests**: Added comprehensive test suite in 	ests/unit/engines/test_wikidata.py asserting header compliance, SPARQL error fallback, caching behavior, and entity label resolution.

### Local Test Verification
`
============================= test session starts =============================
platform win32 -- Python 3.12.10, pytest-9.1.1, pluggy-1.6.0
rootdir: C:\Users\Roshan.Sah\.gemini\antigravity\scratch\searxng
collected 6 items

tests\unit\engines\test_wikidata.py ......                               [100%]

============================== 6 passed in 2.46s ==============================
`
