### PR TITLE
[fix] network: bump httpx-socks to 0.13.1 for python-socks 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pygments==2.20.0
 python-dateutil==2.9.0.post0
 pyyaml==6.0.3
 httpx[http2]==0.28.1
-httpx-socks[asyncio]==0.10.0
+httpx-socks[asyncio]==0.13.1
 sniffio==1.3.1
 valkey==6.1.1
 markdown-it-py==4.2.0

--- a/searx/network/client.py
+++ b/searx/network/client.py
@@ -133,7 +133,6 @@ def get_transport_for_socks_proxy(
         username=proxy_username,
         password=proxy_password,
         rdns=rdns,
-        loop=get_loop(),
         verify=_verify,  # pyright: ignore[reportArgumentType]
         http2=http2,
         local_address=local_address,


### PR DESCRIPTION
### What does this PR do?

Upgrade httpx-socks to be compatible with the recently bumped python-socks 3.0.0 with proxy_ssl.
Also drops loop= argument which is apparently unused and fails with the bump.

### How to test this PR locally?

Without PR, issue #6514 can be reproduced (use a socks5h proxy).  After merge/build it works.

### Related issues

Closes: searxng/searxng#6514

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
  
This change was created using grok-4.6.  This PR was authored by me.  I asked questions but did not personally investigate the loop= change, so please evaluate critically.  I did build/test a new image and confirmed that it works.  It can be found at:
registry.rich0.org/public/searxng:latest@sha256:e4bf88d1cf8b1ace91f96af9dfe7a36c1ed4e3db3d30d937cb8416431963ac0d
