### PR TITLE
[feat] support custom Marginalia filters

### DIFF
--- a/searx/engines/marginalia.py
+++ b/searx/engines/marginalia.py
@@ -6,12 +6,37 @@ Lofgren .
 .. _Marginalia Search:
    https://about.marginalia-search.com/
 
+
+.. _marginalia filters:
+
+Marginalia Filters
+=================
+
+Custom filters enable server-side customization of Marginalia search results.
+Filter definitions are written in XML and scoped to an API key.  Filters can
+not be used with the public API key ``public``.  The
+`Marginalia Filter Editor`_ can be used to create custom filters with a GUI.
+Alternatively, filters can be written manually in XML.  To associate a filter
+definition with an API key, upload the XML data to the ``/filter/<NAME>`` API
+endpoint, where ``<NAME>`` is the name for the newly created filter.  For more
+information, see the `Marginalia filters announcement blogpost`_ and the
+official `Marginalia API documentation`_.
+
+.. _Marginalia Filter Editor: https://marginalia-search.com/filters
+.. _Marginalia filters announcement blogpost: https://www.marginalia.nu/log/a_127_index_filtering/
+.. _Marginalia API documentation: https://about.marginalia-search.com/article/api/
+
+
 Configuration
 =============
 
 The engine has the following required settings:
 
 - :py:obj:`api_key`
+
+The engine has the following optional settings:
+
+- :py:obj:`filter_name`
 
 You can configure a Marginalia engine by:
 
@@ -21,6 +46,7 @@ You can configure a Marginalia engine by:
      engine: marginalia
      shortcut: mar
      api_key: ...
+     filter_name: ...
 
 Implementations
 ===============
@@ -29,6 +55,8 @@ Implementations
 
 import typing as t
 from urllib.parse import urlencode
+
+from searx.network import get
 from searx.utils import searxng_useragent
 from searx.result_types import EngineResults
 from searx.extended_types import SXNG_Response
@@ -54,6 +82,8 @@ api_key = None
    https://about.marginalia-search.com/article/api/
 
 """
+filter_name: str | None = None
+"""The name of the custom filter to apply to each search."""
 
 
 class ApiSearchResult(t.TypedDict):
@@ -83,6 +113,25 @@ class ApiSearchResults(t.TypedDict):
     results: list[ApiSearchResult]
 
 
+def _marginalia_headers() -> dict[str, t.Any]:
+    return {
+        "User-Agent": searxng_useragent(),
+        "API-Key": api_key,
+    }
+
+
+def _get_filter_names() -> list[str]:
+
+    resp = get(f"{base_url}/filter", headers=_marginalia_headers())
+    if resp.ok:
+        filter_names = resp.json()
+    else:
+        filter_names = []
+    if not isinstance(filter_names, list):
+        raise TypeError("marginalia api returned invalid filter list format")
+    return filter_names
+
+
 def request(query: str, params: dict[str, t.Any]):
 
     query_params = {
@@ -91,10 +140,11 @@ def request(query: str, params: dict[str, t.Any]):
         "nsfw": min(params["safesearch"], 1),
         "query": query,
     }
+    if filter_name:
+        query_params["filter"] = filter_name
 
     params["url"] = f"{base_url}/search?{urlencode(query_params)}"
-    params["headers"]["User-Agent"] = searxng_useragent()
-    params["headers"]["API-Key"] = api_key
+    params["headers"].update(_marginalia_headers())
 
 
 def response(resp: SXNG_Response):
@@ -114,14 +164,18 @@ def response(resp: SXNG_Response):
     return res
 
 
-def init(engine_settings: dict[str, t.Any]):
+def init(_: dict[str, t.Any]):
 
-    _api_key = engine_settings.get("api_key")
-    if not _api_key:
+    if not api_key:
         logger.error("missing api_key: see https://about.marginalia-search.com/article/api")
         return False
 
-    if _api_key == "public":
+    if api_key == "public":
         logger.error("invalid api_key (%s): see https://about.marginalia-search.com/article/api", api_key)
+    elif filter_name:
+        filter_names: list[str] = _get_filter_names()
+        if filter_name not in filter_names:
+            logger.error(f"invalid value for filter_name: '{filter_name}'")
+            return False
 
     return True


### PR DESCRIPTION
### What does this PR do?

This PR adds support for using custom filters (see [Marginalia API](https://about.marginalia-search.com/article/api/), [Filter Editor](https://marginalia-search.com/filters), and the [official blog post](https://www.marginalia.nu/log/a_127_index_filtering/)) with the Marginalia engine. Custom filters allow users to modify the behavior of Marginalia searches, including removing results known to contain ads or increasing/decreasing the rankings of wikis.

This PR adds the optional `filter_name` key to the Marginalia engine configuration to allow a custom filter to be used with the Marginalia API. During engine initialization, the list of saved filters is queried using the Marginalia API if a valid API key (other than `public`) is used. If the user set a `filter_name` and the name is in the list of custom filter names, the filter is added as part of the search query.

### How to test this PR locally?

1. Create a custom filter using the Marginalia API and verify it was created successfully. The following Bash script creates a custom filter (named `testfilter` by default) that limits all results to `en.wikipedia.org` and verifies that the filter exists:
```bash
#!/usr/bin/env bash

declare MARGINALIA_BASE_URL="${MARGINALIA_BASE_URL:-"https://api2.marginalia-search.com"}"
declare MARGINALIA_FILTER_NAME="${MARGINALIA_FILTER_NAME:-"testfilter"}"
declare MARGINALIA_API_KEY="${MARGINALIA_API_KEY:-}"

check_vars() {
  # Check Marginalia API base URL
  if [[ -z "${MARGINALIA_BASE_URL}" ]]; then
    printf -- '%s\n' "'"'$MARGINALIA_BASE_URL'"'"' is required' >&2
    return 1
  fi
  # Check Marginalia filter name
  if [[ -z "${MARGINALIA_FILTER_NAME}" ]]; then
    printf -- '%s\n' "'"'$MARGINALIA_FILTER_NAME'"'"' is required' >&2
    return 1
  fi
  # Check Marginalia API key
  if [[ -z "${MARGINALIA_API_KEY}" ]]; then
    printf -- '%s\n' "'"'$MARGINALIA_API_KEY'"'"' is required' >&2
    return 1
  elif [[ "${MARGINALIA_API_KEY,,}" == "public" ]]; then
    printf -- '%s\n' "'"'$MARGINALIA_API_KEY'"'"' must not be '"'"'public'"'" >&2
    return 1
  fi
}

create_test_filter() {
  local create_filter_resp_code
  create_filter_resp_code="$(
  curl \
    --silent \
    --show-error \
    --write-out '%{http_code}' \
    --header "Content-Type: text/xml" \
    --header "API-Key: ${MARGINALIA_API_KEY}" \
    --data @- \
    "${MARGINALIA_BASE_URL}/filter/${MARGINALIA_FILTER_NAME}" \
    << 'EOF'
<?xml version="1.0"?>
<!-- testfilter.xml -->
<!-- Custom Marginalia filter definition -->
<filter>
  <!-- Include only results from en.wikipedia.org -->
  <domains-include>
    en.wikipedia.org
  </domains-include>
</filter>
EOF
)" || return 1
  # The API returns HTTP 202 when a filter is created successfully
  [[ "${create_filter_resp_code}" == "202" ]] && return 0
  return 1
}

check_filter_exists() {
  local api_resp_code
  api_resp_code="$(
  curl \
    --silent \
    --show-error \
    --output /dev/null \
    --write-out '%{http_code}' \
    --header "API-Key: ${MARGINALIA_API_KEY}" \
    "${MARGINALIA_BASE_URL}/filter/${MARGINALIA_FILTER_NAME}"
  )" || return 1
  # The API returns HTTP 200 when querying an existing filter definition
  if [[ "${api_resp_code}" != "200" ]]; then
    printf -- '%s\n' "Request returned HTTP '${api_resp_code}'"
    return 1
  fi
  return 0
}

main() {
  if ! check_vars; then
    printf -- '%s\n' 'One or more required environment variables unset or set to an invalid value' >&2
    return 1
  fi
  if ! create_test_filter; then
    printf -- '%s\n' "Failed to create marginalia filter '${MARGINALIA_FILTER_NAME}'" >&2
    return 1
  fi
  if ! check_filter_exists; then
    printf -- '%s\n' "Failed to verify that filter '${MARGINALIA_FILTER_NAME}' exists on remote server" >&2
    return 1
  fi
  printf -- '%s\n' "Created marginalia filter '${MARGINALIA_FILTER_NAME}'" >&2
  return 0
}

main
```
2. Set `api_key` to a valid Marginalia API key (other than `public`) and `filter_name` to the name of your test filter in `settings.yaml`:
```yaml
use_default_settings: true
engines:
  - name: marginalia
    engine: marginalia
    shortcut: mar
    # To get an API key, please follow the instructions at
    # - https://about.marginalia-search.com/article/api/
    api_key: "<YOUR_API_KEY>"
    filter_name: "testfilter"
    inactive: false
```
3. Search SearXNG for `example.com` using the Marginalia engine: `!mar example.com`. Only results from `en.wikipedia.org` should be returned, such as `https:­/­/­en.­wikipedia.­org/­wiki/­Example.­com`.
4. Set `api_key` to a valid Marginalia API key (other than `public`) and `filter_name` to a filter name NOT associated with your API key in `settings.yaml`:
```yaml
use_default_settings: true
engines:
  - name: marginalia
    engine: marginalia
    shortcut: mar
    # To get an API key, please follow the instructions at
    # - https://about.marginalia-search.com/article/api/
    api_key: "<YOUR_API_KEY>"
    filter_name: "missingfilter"
    inactive: false
```
5. SearXNG should now fail to initialize the configured Marginalia engine instance with the invalid filter name.

### Related issues

N/A

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

No AI tools were used for any changes within this PR and no AI tools were used to write this PR.