### PR TITLE
fix(braveapi): use Brave's zero-based page offset

### DIFF
--- a/searx/engines/braveapi.py
+++ b/searx/engines/braveapi.py
@@ -51,6 +51,8 @@ api_key: str = ""
 
 categories = ["general", "web"]
 paging = True
+# Brave's offset is a zero-based page number and is limited to 9.
+max_page = 10
 safesearch = True
 time_range_support = True
 
@@ -75,7 +77,7 @@ def request(query: str, params: "OnlineParams") -> None:
     search_args: dict[str, str | int | None] = {
         "q": query,
         "count": results_per_page,
-        "offset": (params["pageno"] - 1) * results_per_page,
+        "offset": params["pageno"] - 1,
         "text_decorations": False,
     }
 

--- a/tests/unit/engines/test_braveapi.py
+++ b/tests/unit/engines/test_braveapi.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the Brave Search API engine."""
+
+from collections import defaultdict
+from urllib.parse import parse_qs, urlparse
+
+from searx.engines import braveapi
+
+from tests import SearxTestCase
+
+
+class TestBraveAPI(SearxTestCase):
+    """Test Brave Search API request construction."""
+
+    def setUp(self):
+        self._api_key = braveapi.api_key
+        self._results_per_page = braveapi.results_per_page
+        braveapi.api_key = "test-api-key"
+        braveapi.results_per_page = 20
+
+    def tearDown(self):
+        braveapi.api_key = self._api_key
+        braveapi.results_per_page = self._results_per_page
+
+    @staticmethod
+    def _params(pageno):
+        params = defaultdict(dict)
+        params.update(
+            {
+                "pageno": pageno,
+                "time_range": None,
+                "safesearch": 0,
+                "headers": {},
+            }
+        )
+        return params
+
+    def test_request_uses_zero_based_page_offset(self):
+        """Brave expects offset to be the zero-based page number."""
+        offsets = {}
+        for pageno in (1, 2, 10):
+            params = self._params(pageno)
+            braveapi.request("test query", params)
+            offsets[pageno] = int(parse_qs(urlparse(params["url"]).query)["offset"][0])
+
+        self.assertEqual(offsets, {1: 0, 2: 1, 10: 9})
+
+    def test_max_page_matches_brave_api_limit(self):
+        """Brave accepts offsets 0 through 9, i.e. ten SearXNG pages."""
+        self.assertEqual(braveapi.max_page, 10)


### PR DESCRIPTION
## Summary

Fix pagination for the Brave Web Search API engine.

Brave's current API treats `offset` as a zero-based page number and accepts values from 0 through 9. The SearXNG engine currently multiplies the page number by `results_per_page`, so page 2 sends `offset=20` and receives HTTP 422 from Brave.

This change:

- sends `pageno - 1` as the Brave `offset`;
- caps the engine at ten pages, matching Brave's documented offset range;
- adds regression coverage for pages 1, 2, and 10.

## Testing

- `python -m unittest tests.unit.engines.test_braveapi`
- `python -m black --check tests/unit/engines/test_braveapi.py`
- `git diff --check`

The Brave API pagination documentation uses `offset=1` for the second page:
https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
