### PR TITLE
[fix] preferences: cap zlib decompress

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -6,7 +6,7 @@
 import typing as t
 
 from base64 import urlsafe_b64encode, urlsafe_b64decode
-from zlib import compress, decompress
+from zlib import compress, decompressobj
 from urllib.parse import parse_qs, urlencode
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -517,7 +517,7 @@ class Preferences:
 
     def parse_encoded_data(self, input_data: str):
         """parse (base64) preferences from request (``flask.request.form['preferences']``)"""
-        bin_data = decompress(urlsafe_b64decode(input_data))
+        bin_data = decompressobj().decompress(urlsafe_b64decode(input_data), 16 * 1024)
         dict_data = {}
         for x, y in parse_qs(bin_data.decode('ascii'), keep_blank_values=True).items():
             dict_data[x] = y[0]

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -484,14 +484,14 @@ def pre_request():
         if k not in sxng_request.form:
             sxng_request.form[k] = v
 
-    if sxng_request.form.get('preferences'):
-        preferences.parse_encoded_data(sxng_request.form['preferences'])
-    else:
-        try:
+    try:
+        if sxng_request.form.get('preferences'):
+            preferences.parse_encoded_data(sxng_request.form['preferences'])
+        else:
             preferences.parse_dict(sxng_request.form)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.exception(e, exc_info=True)
-            sxng_request.errors.append(gettext('Invalid settings'))
+    except Exception as e:  # pylint: disable=broad-except
+        logger.exception(e, exc_info=True)
+        sxng_request.errors.append(gettext('Invalid settings'))
 
     # language is defined neither in settings nor in preferences
     # use browser headers


### PR DESCRIPTION
### What does this PR do?

Caps the zlib decompression to ~~64KB~~ 16KB. A small blob currently could expand to be like hundreds of MB on one request which would effectively be a DOS attack against an instance. ~~64KB is much more than any real request, honestly it could probably be lower like 16KB but this gives some future room.~~

Also invalid blobs also returned 500 because that path wasn't in a try/except like the cookies are.

### How to test this PR locally?

Request `/?preferences=foobar`, it should not return a 500 anymore.

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
  
Cursor found this during a vulnerability scan
