### PR TITLE
[mod] engines: migrate to setup() from init() for simple tasks

### DIFF
--- a/searx/engines/adobe_stock.py
+++ b/searx/engines/adobe_stock.py
@@ -35,7 +35,7 @@ Implementation
 ==============
 
 """
-
+import typing as t
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
@@ -85,7 +85,7 @@ Additional subcategories:
 # Do we need support for "free_collection" and "include_stock_enterprise"?
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if not categories:
         raise ValueError("adobe_stock engine: categories is unset")
 
@@ -100,9 +100,9 @@ def init(_):
         raise ValueError("adobe_stock engine: adobe_content_types is unset")
 
     if isinstance(adobe_content_types, list):
-        for t in adobe_content_types:
-            if t not in ADOBE_VALID_TYPES:
-                raise ValueError("adobe_stock engine: adobe_content_types: '%s' is invalid" % t)
+        for content_type in adobe_content_types:
+            if content_type not in ADOBE_VALID_TYPES:
+                raise ValueError("adobe_stock engine: adobe_content_types: '%s' is invalid" % content_type)
     else:
         raise ValueError(
             "adobe_stock engine: adobe_content_types must be a list of strings not %s" % type(adobe_content_types)

--- a/searx/engines/baidu.py
+++ b/searx/engines/baidu.py
@@ -49,6 +49,9 @@ CACHE: EngineCache
 
 
 def setup(engine_settings: dict[str, t.Any]) -> bool:
+    if baidu_category not in ('general', 'images', 'it'):
+        raise SearxEngineAPIException(f"Unsupported category: {baidu_category}")
+
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_settings["name"])
     return True
@@ -63,11 +66,6 @@ def get_image_cookies(headers: dict[str, str]) -> dict[str, str]:
     cookies = dict(warmup.cookies.items())
     CACHE.set(key=COOKIE_CACHE_KEY, value=cookies, expire=COOKIE_CACHE_EXPIRATION_SECONDS)
     return cookies
-
-
-def init(_):
-    if baidu_category not in ('general', 'images', 'it'):
-        raise SearxEngineAPIException(f"Unsupported category: {baidu_category}")
 
 
 def request(query, params):

--- a/searx/engines/boardreader.py
+++ b/searx/engines/boardreader.py
@@ -45,7 +45,7 @@ CACHE_SESSION_ID_KEY = "session_id_key"
 KEYWORD_RE = re.compile(r"\[\/?Keyword\]")
 
 
-def init(engine_settings: dict[str, t.Any]) -> bool:
+def setup(engine_settings: dict[str, t.Any]) -> bool:
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_name=engine_settings["name"])
     return True

--- a/searx/engines/braveapi.py
+++ b/searx/engines/braveapi.py
@@ -64,7 +64,7 @@ time_range_map = {"day": "past_day", "week": "past_week", "month": "past_month",
 """Mapping of SearXNG time ranges to Brave API time ranges."""
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     """Initialize the engine."""
     if not api_key:
         raise SearxEngineAPIException("No API key provided")

--- a/searx/engines/chinaso.py
+++ b/searx/engines/chinaso.py
@@ -78,7 +78,7 @@ time_range_dict = {'day': '24h', 'week': '1w', 'month': '1m', 'year': '1y'}
 base_url = "https://www.chinaso.com"
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if chinaso_news_source not in t.get_args(ChinasoNewsSourceType):
         raise ValueError(f"Unsupported news source: {chinaso_news_source}")
 

--- a/searx/engines/command.py
+++ b/searx/engines/command.py
@@ -74,6 +74,7 @@ Implementations
 ===============
 """
 
+import typing as t
 import re
 from os.path import expanduser, isabs, realpath, commonprefix
 from shlex import split as shlex_split
@@ -100,7 +101,7 @@ _command_logger = logger.getChild('command')
 _compiled_parse_regex = {}
 
 
-def init(engine_settings):
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     check_parsing_options(engine_settings)
 
     if 'command' not in engine_settings:

--- a/searx/engines/dogpile.py
+++ b/searx/engines/dogpile.py
@@ -36,7 +36,7 @@ base_url = "https://www.dogpile.com"
 safe_search_map = {0: "none", 1: "moderate", 2: "heavy"}
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if dogpile_categ not in ("search", "images", "videos", "news"):
         raise ValueError("invalid search type: %s" % dogpile_categ)
 

--- a/searx/engines/duckduckgo_extra.py
+++ b/searx/engines/duckduckgo_extra.py
@@ -47,7 +47,7 @@ _HTTP_User_Agent: str = gen_useragent()
 send_accept_language_header = False
 
 
-def init(engine_settings: dict[str, t.Any]):
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
 
     if engine_settings["ddg_category"] not in ["images", "videos", "news"]:
         raise ValueError(f"Unsupported DuckDuckGo category: {engine_settings['ddg_category']}")

--- a/searx/engines/elasticsearch.py
+++ b/searx/engines/elasticsearch.py
@@ -41,6 +41,7 @@ authentication configured to read from ``my-index`` index.
 
 """
 
+import typing as t
 from json import loads, dumps
 from searx.exceptions import SearxEngineAPIException
 from searx.result_types import EngineResults
@@ -68,7 +69,7 @@ show_metadata = False
 page_size = 10
 
 
-def init(engine_settings):
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     if 'query_type' in engine_settings and engine_settings['query_type'] not in _available_query_types:
         raise ValueError('unsupported query type', engine_settings['query_type'])
 

--- a/searx/engines/exaapi.py
+++ b/searx/engines/exaapi.py
@@ -78,7 +78,7 @@ content_max_characters: int = 500
 """Maximum characters for the requested content."""
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if not api_key:
         raise SearxEngineAPIException("No API key provided")
     if not 1 <= results_per_page <= 100:

--- a/searx/engines/fireball.py
+++ b/searx/engines/fireball.py
@@ -47,7 +47,7 @@ CACHE_VALID_DURATION = 30 * 24 * 3600  # one month, same as website
 """Duration how long settings cookies are valid."""
 
 
-def init(engine_settings: dict[str, t.Any]):
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_settings["name"])
 

--- a/searx/engines/gitea.py
+++ b/searx/engines/gitea.py
@@ -38,6 +38,7 @@ Implementation
 
 """
 
+import typing as t
 from urllib.parse import urlencode
 from dateutil import parser
 
@@ -77,7 +78,7 @@ page_size: int = 10
 """Maximum number of results per page (default 10)."""
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if not base_url:
         raise ValueError('gitea engine: base_url is unset')
 

--- a/searx/engines/huggingface.py
+++ b/searx/engines/huggingface.py
@@ -33,6 +33,7 @@ Implementations
 
 """
 
+import typing as t
 from urllib.parse import urlencode
 from datetime import datetime
 
@@ -62,7 +63,7 @@ huggingface_endpoint = 'models'
 """
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if huggingface_endpoint not in ('datasets', 'models', 'spaces'):
         raise SearxEngineAPIException(f"Unsupported Hugging Face endpoint: {huggingface_endpoint}")
 

--- a/searx/engines/invidious.py
+++ b/searx/engines/invidious.py
@@ -8,6 +8,7 @@ No public instance offer a public API now
 
 """
 
+import typing as t
 import time
 import random
 from urllib.parse import quote_plus, urlparse
@@ -34,7 +35,7 @@ time_range_support = True
 base_url: list[str] | str = []
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if not base_url:
         raise ValueError("missing invidious base_url")
 

--- a/searx/engines/kagi.py
+++ b/searx/engines/kagi.py
@@ -87,7 +87,7 @@ api_key = ""
 """Kagi API key. Required for using this engine."""
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if not api_key:
         raise ValueError("api_key is required for using kagi")
 

--- a/searx/engines/luxxle.py
+++ b/searx/engines/luxxle.py
@@ -51,7 +51,7 @@ enable_http2 = False
 safe_search_map = {0: "Off", 1: "Moderate", 2: "Strict"}
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if luxxle_categ not in ("search", "images", "videos", "news"):
         raise ValueError("invalid luxxle category: %s" % luxxle_categ)
 

--- a/searx/engines/marginalia.py
+++ b/searx/engines/marginalia.py
@@ -164,7 +164,7 @@ def response(resp: SXNG_Response):
     return res
 
 
-def init(_: dict[str, t.Any]):
+def setup(_: dict[str, t.Any]) -> bool:
 
     if not api_key:
         logger.error("missing api_key: see https://about.marginalia-search.com/article/api")

--- a/searx/engines/mariadb_server.py
+++ b/searx/engines/mariadb_server.py
@@ -26,6 +26,8 @@ Implementations
 
 """
 
+import typing as t
+
 try:
     import mariadb  # pyright: ignore [reportMissingImports]
 except ImportError:
@@ -60,14 +62,16 @@ paging = True
 _connection = None
 
 
-def init(engine_settings):
-    global _connection  # pylint: disable=global-statement
-
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     if 'query_str' not in engine_settings:
         raise ValueError('query_str cannot be empty')
 
     if not engine_settings['query_str'].lower().startswith('select '):
         raise ValueError('only SELECT query is supported')
+
+
+def init(_):
+    global _connection  # pylint: disable=global-statement
 
     _connection = mariadb.connect(database=database, user=username, password=password, host=host, port=port)
 

--- a/searx/engines/meilisearch.py
+++ b/searx/engines/meilisearch.py
@@ -35,7 +35,7 @@ Here is a simple example to query a Meilisearch instance:
 """
 
 # pylint: disable=global-statement
-
+import typing as t
 from json import dumps
 from searx.result_types import EngineResults
 from searx.extended_types import SXNG_Response
@@ -49,7 +49,7 @@ categories = ['general']
 paging = True
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if index == '':
         raise ValueError('index cannot be empty')
 

--- a/searx/engines/mojeek.py
+++ b/searx/engines/mojeek.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Mojeek (general, images, news)"""
 
+import typing as t
 from datetime import datetime
 from urllib.parse import urlencode
 
@@ -51,7 +52,7 @@ region_param = "arc"
 _delta_kwargs = {"day": "days", "week": "weeks", "month": "months", "year": "years"}
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if search_type not in ("", "images", "news"):
         raise ValueError(f"Invalid search type {search_type}")
 

--- a/searx/engines/mrs.py
+++ b/searx/engines/mrs.py
@@ -19,6 +19,7 @@ Implementation
 ==============
 """
 
+import typing as t
 from urllib.parse import quote_plus
 
 about = {
@@ -37,7 +38,7 @@ matrix_url = "https://matrix.to"
 page_size = 20
 
 
-def init(engine_settings):  # pylint: disable=unused-argument
+def setup(_: dict[str, t.Any]) -> bool | None:
     """The ``base_url`` must be set in the configuration, if ``base_url`` is not
     set, a :py:obj:`ValueError` is raised during initialization.
 

--- a/searx/engines/mysql_server.py
+++ b/searx/engines/mysql_server.py
@@ -25,6 +25,8 @@ Implementations
 
 """
 
+import typing as t
+
 from searx.result_types import EngineResults
 
 try:
@@ -60,14 +62,16 @@ paging = True
 _connection = None
 
 
-def init(engine_settings):
-    global _connection  # pylint: disable=global-statement
-
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     if 'query_str' not in engine_settings:
         raise ValueError('query_str cannot be empty')
 
     if not engine_settings['query_str'].lower().startswith('select '):
         raise ValueError('only SELECT query is supported')
+
+
+def init(_):
+    global _connection  # pylint: disable=global-statement
 
     _connection = mysql.connector.connect(
         database=database,

--- a/searx/engines/naver.py
+++ b/searx/engines/naver.py
@@ -2,6 +2,8 @@
 # pylint: disable=line-too-long
 """Naver for SearXNG"""
 
+import typing as t
+
 from urllib.parse import urlencode
 from lxml import html
 
@@ -67,7 +69,7 @@ naver_category_dict = {
 }
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if naver_category not in ('general', 'images', 'news', 'videos'):
         raise SearxEngineAPIException(f"Unsupported category: {naver_category}")
 

--- a/searx/engines/pexels.py
+++ b/searx/engines/pexels.py
@@ -2,6 +2,7 @@
 """Pexels (images)"""
 
 import re
+import typing as t
 
 from urllib.parse import urlencode
 from lxml import html
@@ -46,9 +47,10 @@ CACHE: EngineCache
 enable_http2 = False
 
 
-def init(engine_settings):
+def setup(engine_settings: dict[str, t.Any]) -> bool:
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_settings["name"])
+    return True
 
 
 def _get_secret_key():

--- a/searx/engines/postgresql.py
+++ b/searx/engines/postgresql.py
@@ -21,6 +21,8 @@ Implementations
 
 """
 
+import typing as t
+
 try:
     import psycopg2  # type: ignore
 except ImportError:
@@ -55,14 +57,16 @@ paging = True
 _connection = None
 
 
-def init(engine_settings):
-    global _connection  # pylint: disable=global-statement
-
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     if 'query_str' not in engine_settings:
         raise ValueError('query_str cannot be empty')
 
     if not engine_settings['query_str'].lower().startswith('select '):
         raise ValueError('only SELECT query is supported')
+
+
+def init(_):
+    global _connection  # pylint: disable=global-statement
 
     _connection = psycopg2.connect(
         database=database,

--- a/searx/engines/privacywall.py
+++ b/searx/engines/privacywall.py
@@ -61,7 +61,7 @@ video_page_map = {
 }
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if privacywall_category not in ("general", "images", "videos"):
         raise ValueError("invalid category: %s" % privacywall_category)
 

--- a/searx/engines/quark.py
+++ b/searx/engines/quark.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Quark (Shenma) search engine for searxng"""
 
+import typing as t
 from urllib.parse import urlencode
 from datetime import datetime
 import re
@@ -43,7 +44,7 @@ def is_alibaba_captcha(html):
     return bool(re.search(CAPTCHA_PATTERN, html))
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if quark_category not in ('general', 'images'):
         raise SearxEngineAPIException(f"Unsupported category: {quark_category}")
 

--- a/searx/engines/resulthunter.py
+++ b/searx/engines/resulthunter.py
@@ -42,7 +42,7 @@ resulthunter_categ = "web"
 """Supported categories are ``web`` and ``images``."""
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if resulthunter_categ not in ("web", "images"):
         raise ValueError("invalid category: %s" % resulthunter_categ)
 

--- a/searx/engines/s1search.py
+++ b/searx/engines/s1search.py
@@ -38,12 +38,10 @@ CACHE: EngineCache
 """Cache to store verification tokens for pagination."""
 
 
-def init(_):
+def setup(engine_settings: dict[str, t.Any]) -> bool:
     if not base_url:
         raise ValueError("base_url must be set")
 
-
-def setup(engine_settings: dict[str, t.Any]) -> bool:
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_settings["name"])
     return True

--- a/searx/engines/solr.py
+++ b/searx/engines/solr.py
@@ -28,7 +28,7 @@ This is an example configuration for searching in the collection
 """
 
 # pylint: disable=global-statement
-
+import typing as t
 from urllib.parse import urlencode
 from searx.exceptions import SearxEngineAPIException
 from searx.result_types import EngineResults
@@ -46,7 +46,7 @@ _search_url = ''
 paging = True
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if collection == '':
         raise ValueError('collection cannot be empty')
 

--- a/searx/engines/soundcloud.py
+++ b/searx/engines/soundcloud.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """SoundCloud is a German audio streaming service."""
 
+import typing as t
 import re
 import datetime
 
@@ -115,9 +116,10 @@ def response(resp):
     return results
 
 
-def init(engine_settings):  # pylint: disable=unused-argument
+def setup(engine_settings: dict[str, t.Any]) -> bool:
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_settings["name"])  # type:ignore
+    return True
 
 
 def get_client_id() -> str | None:

--- a/searx/engines/sqlite.py
+++ b/searx/engines/sqlite.py
@@ -66,7 +66,7 @@ limit = 10
 paging = True
 
 
-def init(engine_settings):
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     if 'query_str' not in engine_settings:
         raise ValueError('query_str cannot be empty')
 

--- a/searx/engines/startpage.py
+++ b/searx/engines/startpage.py
@@ -165,7 +165,7 @@ CACHE: EngineCache
 seconds."""
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     global CACHE  # pylint: disable=global-statement
 
     # hint: all three startpage engines (WEB, Images & News) can/should use the

--- a/searx/engines/startpagina.py
+++ b/searx/engines/startpagina.py
@@ -39,7 +39,7 @@ page_size = 10
 api_url = "https://search.kompas.services"
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if startpagina_categ not in ("web", "images", "videos", "news"):
         raise ValueError("invalid search type: %s" % startpagina_categ)
 

--- a/searx/engines/swisscows.py
+++ b/searx/engines/swisscows.py
@@ -152,7 +152,7 @@ def generate_nonce_and_signature(base_path: str, args: dict[str, t.Any]) -> tupl
 maximum_page_size = {"web": 20, "images": 50, "videos": 10}
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if swisscows_category not in ("web", "images", "videos"):
         raise ValueError("illegal swisscows category: %s" % swisscows_category)
 

--- a/searx/engines/tiger.py
+++ b/searx/engines/tiger.py
@@ -45,12 +45,10 @@ CACHE: EngineCache
 """Cache to store session codes (result of solved CAPTCHA)."""
 
 
-def init(_):
+def setup(engine_settings: dict[str, t.Any]) -> bool:
     if tiger_category not in ("Websuche", "News"):
         raise ValueError("invalid search category: %s" % tiger_category)
 
-
-def setup(engine_settings: dict[str, t.Any]) -> bool:
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_settings["name"])
     return True

--- a/searx/engines/tonline.py
+++ b/searx/engines/tonline.py
@@ -44,7 +44,7 @@ tonline_channel_map = {"images": "flickr", "videos": "yt"}
 language = "de"
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if tonline_categ not in ("web", "images", "videos", "news"):
         raise ValueError("invalid category: %s" % tonline_categ)
 

--- a/searx/engines/torznab.py
+++ b/searx/engines/torznab.py
@@ -83,7 +83,7 @@ show_torrent_files: bool = False
 show_magnet_links: bool = True
 
 
-def init(engine_settings=None):  # pylint: disable=unused-argument
+def setup(_: dict[str, t.Any]) -> bool | None:
     """Initialize the engine."""
     if len(base_url) < 1:
         raise ValueError('missing torznab base_url')

--- a/searx/engines/tubearchivist.py
+++ b/searx/engines/tubearchivist.py
@@ -75,6 +75,7 @@ Implementations
 """
 
 
+import typing as t
 from urllib.parse import urlencode
 from dateutil.parser import parse
 from searx.utils import html_to_text, humanize_number
@@ -115,7 +116,7 @@ def absolute_url(relative_url):
     return f'{base_url.rstrip("/")}{relative_url}'
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if not base_url:
         raise ValueError('tubearchivist engine: base_url is unset')
     if not ta_token:

--- a/searx/engines/tusksearch.py
+++ b/searx/engines/tusksearch.py
@@ -39,7 +39,7 @@ tusk_categ = "web"
 api_url = "https://api.tusksearch.com"
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if tusk_categ not in ("web", "images", "videos", "news"):
         raise ValueError("invalid search type: %s" % tusk_categ)
 

--- a/searx/engines/vuhuv.py
+++ b/searx/engines/vuhuv.py
@@ -38,7 +38,7 @@ vuhuv_category = "general"
 category_map = {"general": 1, "images": 2, "videos": 3}
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     if vuhuv_category not in category_map:
         raise ValueError("invalid category: %s" % vuhuv_category)
 

--- a/searx/engines/wolframalpha_noapi.py
+++ b/searx/engines/wolframalpha_noapi.py
@@ -3,7 +3,7 @@
 Wolfram|Alpha (Science)
 """
 
-
+import typing as t
 from json import loads
 from urllib.parse import urlencode
 
@@ -51,7 +51,7 @@ CACHE: EngineCache
 seconds."""
 
 
-def init(engine_settings):
+def setup(engine_settings: dict[str, t.Any]) -> bool | None:
     global CACHE  # pylint: disable=global-statement
     CACHE = EngineCache(engine_settings["name"])  # type:ignore
 

--- a/searx/engines/yacy.py
+++ b/searx/engines/yacy.py
@@ -52,7 +52,7 @@ Implementations
 """
 # pylint: disable=fixme
 
-
+import typing as t
 import random
 from json import loads
 from urllib.parse import urlencode
@@ -102,7 +102,7 @@ selected randomly.
 """
 
 
-def init(_):
+def setup(_: dict[str, t.Any]) -> bool | None:
     valid_types = [
         'text',
         'image',

--- a/tests/unit/engines/test_command.py
+++ b/tests/unit/engines/test_command.py
@@ -152,7 +152,7 @@ commit '''
             'date': r'Date: .*',
             'message': r'\n\n.*$',
         }
-        git_log_engine.init({"command": git_log_engine.command, "parse_regex": git_log_engine.parse_regex})
+        git_log_engine.setup({"command": git_log_engine.command, "parse_regex": git_log_engine.parse_regex})
         expected_results = [
             {
                 'commit': '35f9a8c81d162a361b826bbcd4a1081a4fbe76a7',


### PR DESCRIPTION
### What does this PR do?

This PR migrates 45 engines to use `setup()` instead of `init()` for simple tasks, as clarified in [#6343](https://github.com/searxng/searxng/pull/6343), these engines were mostly using init() for validating engine_settings and caching, which can be done at startup itself with setup().


> Note - I changed one test for command engine, since it was calling init instead of setup.

### How to test this PR locally?

`make run` and try out the engines that have been migrated. Try intentionally passing wrong engine settings and check if engine is discarded during startup itself.

### Related issues
Closes #6345.

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

 No AI was used