### PR TITLE
[fix] yandex: handle empty anti-bot responses

### DIFF
--- a/searx/engines/yandex.py
+++ b/searx/engines/yandex.py
@@ -4,8 +4,10 @@
 from json import loads
 from urllib.parse import urlencode
 from html import unescape
+from httpx import HTTPError
 from lxml import html
-from searx.exceptions import SearxEngineCaptchaException
+from searx.exceptions import SearxEngineCaptchaException, SearxException
+from searx.network import get
 from searx.utils import humanize_bytes, eval_xpath, eval_xpath_list, extract_text, extr
 
 
@@ -48,9 +50,37 @@ title_xpath = './/h3[@class="b-serp-item__title"]/a[@class="b-serp-item__title-l
 content_xpath = './/div[@class="b-serp-item__content"]//div[@class="b-serp-item__text"]'
 
 
+def _refetch(resp):
+    """Yandex anti-bot sometimes replies with an empty 302 response (no
+    Location header) during short periods of time.  One immediate re-request
+    over a fresh connection usually succeeds, so try this once before giving
+    up."""
+    headers = {k: v for k, v in resp.request.headers.items() if k.lower() not in ('host', 'content-length')}
+    try:
+        retried = get(str(resp.request.url), headers=headers)
+    except (HTTPError, SearxException):
+        return None
+    return retried if retried.status_code == 200 and retried.text.strip() else None
+
+
 def catch_bad_response(resp):
+    """Check the response and return a usable response object or raise.
+
+    Besides the captcha check (via the ``x-yandex-captcha`` header), handle
+    Yandex soft-blocking requests with an empty 302 response.
+    """
     if resp.headers.get('x-yandex-captcha') == 'captcha':
-        raise SearxEngineCaptchaException()
+        raise SearxEngineCaptchaException(suspended_time=300)
+
+    if not resp.text.strip():
+        retried = _refetch(resp)
+        if retried is None:
+            # anti-bot soft-block: suspend briefly instead of crashing
+            # with a parse error on the empty body
+            raise SearxEngineCaptchaException(suspended_time=300, message='CAPTCHA (empty anti-bot response)')
+        return retried
+
+    return resp
 
 
 def request(query, params):
@@ -87,7 +117,7 @@ def request(query, params):
 
 def response(resp):
     if search_type == 'web':
-        catch_bad_response(resp)
+        resp = catch_bad_response(resp)
 
         dom = html.fromstring(resp.text)
 
@@ -105,7 +135,7 @@ def response(resp):
         return results
 
     if search_type == 'images':
-        catch_bad_response(resp)
+        resp = catch_bad_response(resp)
 
         html_data = html.fromstring(resp.text)
         html_sample = unescape(html.tostring(html_data, encoding='unicode'))


### PR DESCRIPTION
### What does this PR do?

The changes fix empty responses that Yandex's anti-bot protection sometimes
returns. Occasionally, instead of answering, it replies with HTTP 302 carrying
an empty body and no Location header, so no search data can be obtained:
status=302, resp.text=''. The original search URL itself keeps working, and
the block is short-lived - after a short while Yandex returns the requested
data again.

The fix covers the suspension timeout after a detected captcha and re-issuing
the same search request once, dropping host/content-length headers while
keeping the original cookies. A single retry is usually enough to get an
answer; if not, the engine takes a short 5-minute suspension instead of
crashing. `catch_bad_response()` now returns a usable response object: when the body is
empty, it returns the result of the re-request. Callers therefore have to use
the returned value (`resp = catch_bad_response(resp)`) - otherwise the
original empty response would be parsed again and the retry would be wasted.
These changes raise the number of successful Yandex responses and
reduce waiting time when a captcha appears. The result was confirmed by
repeated requests against SearXNG on my own local instance.

### How to test this PR locally?

Run an instance and search through the yandex engine until the anti-bot
window hits: before this PR the engine shows "parsing error" with a
`Document is empty` traceback in the logs, after this PR the same search
either returns results (transparent retry) or shows a clean suspension that
recovers automatically after ~5 minutes.

### Related issues

#6058 - similar problem with 360search.

### Code of Conduct

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  The Ox Alpha model (running in the opencode CLI) was used for writing the
  code, investigating how correct responses depend on request headers, and
  for translating this PR into English. I have reviewed every change myself
  and verified the fix on my local instance.