### PR TITLE
[mod] py: clearurls update location

### DIFF
--- a/searx/data/tracker_patterns.py
+++ b/searx/data/tracker_patterns.py
@@ -28,11 +28,11 @@ class TrackerPatternsDB:
 
     ctx_name = "data_tracker_patterns"
 
+    # ClearURL rule lists, the first one that responds HTTP 200 is used
     CLEAR_LIST_URL = [
-        # ClearURL rule lists, the first one that responds HTTP 200 is used
-        "https://rules1.clearurls.xyz/data.minify.json",
+        "https://cdn.jsdelivr.net/gh/clearurls/rules@refs/heads/gh-pages/data.minify.json",
         "https://rules2.clearurls.xyz/data.minify.json",
-        "https://raw.githubusercontent.com/ClearURLs/Rules/refs/heads/master/data.min.json",
+        "https://rules1.clearurls.xyz/data.minify.json",
     ]
 
     class Fields:


### PR DESCRIPTION
### What does this PR do?

We should opt to retrieve the lists through jsDelivr service as our first choice and avoid hitting the GH (GitHub) and GL (GitLab) servers.

### How to test this PR locally?

`make run`

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
