### PR TITLE
[fix] hardening engine: ddg weather - get GEO location from response

### DIFF
--- a/searx/engines/duckduckgo_weather.py
+++ b/searx/engines/duckduckgo_weather.py
@@ -109,7 +109,19 @@ def response(resp: SXNG_Response):
 
     json_data = loads(resp.text[resp.text.find('\n') + 1 : resp.text.rfind('\n') - 2])
 
-    geoloc = weather.GeoLocation.by_query(resp.search_params["query"])
+    location = json_data.get("location")
+    if not location:
+        return res
+
+    metadata = json_data.get("weatherAlerts", {}).get("metadata", {})
+    geoloc = weather.GeoLocation(
+        name=location,
+        latitude=metadata.get("latitude"),
+        longitude=metadata.get("longitude"),
+        elevation=0,
+        country_code=metadata.get("language").split("-")[-1],
+        timezone=json_data.get("location"),
+    )
 
     weather_answer = EngineResults.types.WeatherAnswer(
         current=_weather_data(geoloc, json_data["currentWeather"]),


### PR DESCRIPTION
### What does this PR do?

The previous implementation ran into an error if the search term contained words other than just the location (ValueError was raised).

### How to test this PR locally?

To test engine use search terms like:

    !ddw weather berlin germany


### Code of Conduct


[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI tools used
