### PR TITLE
[fix] engine: meilisearch - AttributeError: no attribute 'about'

### DIFF
--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -187,8 +187,9 @@ def set_loggers(engine: "Engine|types.ModuleType", engine_name: str):
 def update_engine_attributes(engine: "Engine | types.ModuleType", engine_data: dict[str, t.Any]):
     # pylint: disable=too-many-branches
 
-    # set engine attributes from engine_data
+    # set / update engine attributes from engine_data
     kvargs: dict[str, t.Any]
+    engine.about = getattr(engine, "about", EngineAbout())
     if isinstance(engine.about, EngineAbout):
         kvargs = {**msgspec.to_builtins(engine.about), **engine_data.get("about", {})}
     else:


### PR DESCRIPTION
### What does this PR do?

fix engine meilisearch - AttributeError: no attribute 'about'


### How to test this PR locally?

Add engine to settings.yml::

```yaml
  - name: meilisearch
    engine: meilisearch
    shortcut: mes
    base_url: http://localhost:7700 
    index: sites
    enable_http: true
```

and `make run` .. there is no longer a `AttributeError`

### Related issues

- Closes: https://github.com/searxng/searxng/issues/6622

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI used