### PR TITLE
[mod] s1search: update mirrors to the ones that are not cloudflared

### DIFF
--- a/searx/engines/s1search.py
+++ b/searx/engines/s1search.py
@@ -82,7 +82,7 @@ def response(resp: "SXNG_Response") -> EngineResults:
             res.types.MainResult(
                 url=extract_text(eval_xpath(result, ".//a[contains(@class, 'title')]/@href")),
                 title=extract_text(eval_xpath(result, ".//a[contains(@class, 'title')]")),
-                content=extract_text(eval_xpath(result, ".//span[contains(@class, 'description') or @class='']")),
+                content=extract_text(eval_xpath(result, ".//span[contains(@class, 'description') or not(@class)]")),
             )
         )
 

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -3344,30 +3344,20 @@ engines:
       require_api_key: false
       results: JSON
 
-  # - name: webcrawler
-  #   engine: s1search
-  #   shortcut: wc
-  #   base_url: https://www.webcrawler.com
-  #   disabled: true
-
-  # s1search yahoo engines / mirrors
-  # - name: excite
-  #   engine: s1search
-  #   shortcut: exc
-  #   base_url: https://results.excite.com.s1search.co
-  #   disabled: true
-
-  # - name: metacrawler
-  #   engine: s1search
-  #   shortcut: mec
-  #   base_url: https://search.metacrawler.com
-  #   disabled: true
-
-  - name: infospace
+  # s1search engines / mirrors
+  - name: metacrawler
     engine: s1search
-    shortcut: ifs
-    base_url: https://search.infospace.com
+    shortcut: mec
+    base_url: https://search.metacrawler.com
     disabled: true
+    inactive: true
+
+  - name: zoo search
+    engine: s1search
+    shortcut: zoo
+    base_url: https://search.zoo.com
+    disabled: true
+    inactive: true
 
 # Doku engine lets you access to any Doku wiki instance:
 # A public one or a privete/corporate one.


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- update the engines that are based on s1search, as s1search added cloudflare captchas to some of the existing mirrors
- also set them to inactive so that they don't get put behind cloudflare immediately as well

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
