### PR TITLE
Fix nested list bug in Preferences class and add unit test

### DIFF
--- a/searx/preferences.py
+++ b/searx/preferences.py
@@ -458,7 +458,7 @@ class Preferences:
                 locked="results_on_new_tab" in self.cfg.lock,
             ),
             'doi_resolver': MultipleChoiceSetting(
-                [get_setting("default_doi_resolver")],
+                get_setting("default_doi_resolver"),
                 locked="doi_resolver" in self.cfg.lock,
                 choices=DOI_RESOLVERS,
             ),

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -211,3 +211,96 @@ class TestPreferences(SearxTestCase):
         }
         self.preferences.save(response_mock)
         self.assertNotIn(setting_key, cookie_callback)
+
+    def test_preferences_doi_resolver_initialization(self):
+        from searx import get_setting
+        from mock import patch
+
+        # Mock get_setting to return a list for default_doi_resolver,
+        # and other necessary settings as strings or lists.
+        def mocked_get(name):
+            settings_map = {
+                "preferences": Mock(lock={}), # Mock the SettingsPref object with a lock dict
+                "ui.default_theme": "simple",
+                "search.default_lang": "en",
+                "ui.default_locale": "en_US",
+                "search.autocomplete": True,
+                "search.favicon_resolver": "none",
+                "server.image_proxy": True,
+                "server.method": "GET",
+                "search.safe_search": "1",
+                "default_doi_resolver": ["crossref"], # This is the problematic one
+            }
+            return settings_map.get(name)
+
+        with patch('searx.preferences.get_setting', side_effect=mocked_get):
+            # This should FAIL in the current state because Preferences will 
+            # wrap ['crossref'] in another list: [['crossref']]
+            try:
+                self.preferences = Preferences(['simple'], ['general'], {}, searx.plugins.PluginStorage())
+            except ValidationException:
+                self.fail("Preferences initialization raised ValidationException due to double nesting of default_doi_resolver")
+
+    def test_preferences_doi_resolver_initialization(self):
+        from unittest.mock import patch
+        
+        # Mock the DOI_RESOLVERS constant and the get_setting call
+        with patch('searx.preferences.DOI_RESOLVERS', ['crossref']), \
+             patch('searx.preferences.get_setting') as mock_get:
+            
+            # Mock various settings to satisfy the constructor
+            mock_get.side_effect = lambda name: {
+                "preferences": MagicMock(lock={}),
+                "ui.default_theme": "simple",
+                "search.default_lang": "en",
+                "ui.default_locale": "en_US",
+                "search.autocomplete": "True",
+                "search.favicon_resolver": "none",
+                "server.image_proxy": True,
+                "server.method": "GET",
+                "search.safe_search": 1,
+                "default_doi_resolver": ["crossref"], # The setting that was bugged
+                "search.languages": ["en", "de", "fr"],
+                "ui.theme_args.simple_style": "auto",
+                "ui.center_alignment": True,
+                "ui.query_in_title": True,
+            }.get(name)
+
+            # This should succeed with the fix (no nested list)
+            # and fail without the fix (nested list)
+            try:
+                Preferences(['simple'], ['general'], {}, MagicMock())
+            except ValidationException:
+                self.fail("Preferences initialization raised ValidationException for doi_resolver")
+
+    def test_preferences_doi_resolver_initialization(self):
+        from unittest.mock import MagicMock, patch
+        
+        # Mock the DOI_RESOLVERS constant and the get_setting call
+        with patch('searx.preferences.DOI_RESOLVERS', ['crossref']), \
+             patch('searx.preferences.get_setting') as mock_get:
+            
+            # Mock various settings to satisfy the constructor
+            mock_get.side_effect = lambda name: {
+                "preferences": MagicMock(lock={}),
+                "ui.default_theme": "simple",
+                "search.default_lang": "en",
+                "ui.default_locale": "en_US",
+                "search.autocomplete": "True",
+                "search.favicon_resolver": "none",
+                "server.image_proxy": True,
+                "server.method": "GET",
+                "search.safe_search": 1,
+                "default_doi_resolver": ["crossref"], # The setting that was bugged
+                "search.languages": ["en", "de", "fr"],
+                "ui.theme_args.simple_style": "auto",
+                "ui.center_alignment": True,
+                "ui.query_in_title": True,
+            }.get(name)
+
+            # This should succeed with the fix (no nested list)
+            # and fail without the fix (nested list)
+            try:
+                Preferences(['simple'], ['general'], {}, MagicMock())
+            except ValidationException:
+                self.fail("Preferences initialization raised ValidationException for doi_resolver")


### PR DESCRIPTION
### What does this PR do?                                                                                               
                                                                                                   
This PR fixes a bug in `searx.preferences.Preferences` where the `default_doi_resolver` setting  was being incorrectly wrapped in a nested list (e.g., `[['crossref']]`), causing a `ValidationException` during initialization.

I discovered this while debugging a 500 error. I found that `get_setting("default_doi_resolver")` returns a list, and the redundant brackets in `searx/preferences.py` resulted in a nested list structure that the `MultipleChoiceSetting` validator could not accept. I removed these brackets to allow for correct initialization.

I also added a regression test in `tests/unit/test_preferences.py` to ensure this doesn't regress.                                                                                          

### How to test this PR locally?                                                                

Run the following command to execute the new unit test:

```sh
uv run pytest tests/unit/test_preferences.py
```
                                                                                                   
### Code of Conduct                                                                             
                                                                                                   
[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst                       
                                                                                                   
- [x] **I hereby confirm that this PR conforms with the [AI Policy].**                          
                                                                                                   
I used Claude Code to help diagnose the bug and generate a reproduction script. I personally verified the fix by running that script and confirming that the new unit test passes. I have fully understood the code changes and am submitting them as a human-led contribution.