### PR TITLE
[feat] engines: add JS-based s1search engine

### DIFF
--- a/searx/engines/s1search_rampjs.py
+++ b/searx/engines/s1search_rampjs.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""JavaScript-based s1search implementation. See :ref:`s1search engine`.
+
+Works for all s1search sites that contain the ``__RAMPJS__`` JavaScript variable.
+"""
+
+import json
+import typing as t
+from urllib.parse import urlencode
+
+from searx.result_types import EngineResults
+from searx.utils import extr, html_to_text
+
+if t.TYPE_CHECKING:
+    from searx.search.processors import OnlineParams
+    from searx.extended_types import SXNG_Response
+
+about = {
+    "website": "https://s1search.co",
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": "JSON",
+}
+
+categories = ["general"]
+paging = True
+
+base_url = "https://search.answers.com"
+# other working base URLs:
+# - https://search.nation.online
+# - https://search.activebeat.com
+# - https://search.legalboulevard.com
+# - https://search.walletgenius.com
+# - https://search.legalboulevard.com
+
+
+def request(query: str, params: "OnlineParams"):
+    args = {"q": query, "page": params["pageno"]}
+    params["url"] = f"{base_url}/?{urlencode(args)}"
+
+
+def response(resp: "SXNG_Response") -> EngineResults:
+    res = EngineResults()
+
+    data_raw = extr(resp.text, "response: ", " };")
+    data = json.loads(data_raw)
+
+    mainline = [s for s in data["search"]["regions"] if s["name"] == "mainline"][0]
+    for group in mainline["groups"]:
+        for result in group["results"]:
+            if not ("url" in result or "clickUrl" in result):
+                continue
+
+            res.add(
+                res.types.MainResult(
+                    url=result.get("url") or result.get("clickUrl"),
+                    title=html_to_text(result["title"]),
+                    content=html_to_text(result["description"]),
+                )
+            )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -3307,13 +3307,6 @@ engines:
       website: https://minecraft.wiki/
       wikidata_id: Q105533483
 
-  # s1search google engines / mirrors
-  - name: searchtoday
-    engine: s1search
-    shortcut: std
-    base_url: https://info.searchtoday.site
-    disabled: true
-
   - name: sina
     engine: json_engine
     shortcut: sina
@@ -3356,6 +3349,13 @@ engines:
     engine: s1search
     shortcut: zoo
     base_url: https://search.zoo.com
+    disabled: true
+    inactive: true
+
+  # s1search engines / mirrors with rampjs page layout
+  - name: s1search
+    engine: s1search_rampjs
+    shortcut: s1
     disabled: true
     inactive: true
 


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- add a new engine for s1search sites that include the __RAMPJS__ javascript variable
- so that's basically a different response layout for the s1search engine, but with the same results

### How to test this PR locally?
- enable the engine and search !s1 test

### Related issues
- #6629 

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.
