### PR TITLE
[feat] engines: add xprivo (general, news, videos)

### DIFF
--- a/searx/engines/xprivo.py
+++ b/searx/engines/xprivo.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""XPrivo"""
+
+import json
+import typing as t
+
+from searx.result_types import EngineResults
+
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
+    from searx.search.processors import OnlineParams
+
+
+about = {
+    "website": 'https://www.xprivo.com',
+    "wikidata_id": None,
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'JSON',
+}
+
+categories = ["general"]
+paging = True
+time_range_support = True
+
+base_url = "https://www.xprivo.com"
+page_size = 10  # not configurable
+
+api_key = "API_KEY_XPRIVO"
+
+XPrivoSearchType = t.Literal["all", "news", "videos"]
+xprivo_search_type: XPrivoSearchType = "all"
+
+
+def setup(_):
+    if xprivo_search_type not in t.get_args(XPrivoSearchType):
+        raise ValueError("invalid search type: %s" % {xprivo_search_type})
+
+
+def request(query: str, params: "OnlineParams"):
+    params["url"] = f"{base_url}/v1/searchengine/completions"
+    params["headers"].update({"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"})
+
+    params["method"] = "POST"
+    params["json"] = {
+        "query": query,
+        "mode": "classic",
+        "search_type": xprivo_search_type,
+        "time_filter": params["time_range"],
+        "region": "",
+        "offset": (params["pageno"] - 1) * page_size,
+        "source": "",
+    }
+
+
+def response(resp: "SXNG_Response"):
+    res = EngineResults()
+
+    # response is a Server-Side Events (SSE) stream
+    data_raw = resp.text.split("\n", 1)[0].removeprefix("data: ")
+    data = json.loads(data_raw)
+
+    for result in data["results"]:
+        if xprivo_search_type == "videos":
+            res.add(
+                res.types.LegacyResult(
+                    template="videos.html",
+                    url=result["url"],
+                    title=result["title"],
+                    content=result["snippet"],
+                    thumbnail=result.get("og_image"),
+                )
+            )
+        else:
+            res.add(
+                res.types.MainResult(
+                    url=result["url"],
+                    title=result["title"],
+                    content=result["snippet"],
+                    thumbnail=result.get("og_image"),
+                )
+            )
+
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -3196,6 +3196,28 @@ engines:
       description: "Canadian search engine with its own index"
       results: HTML
 
+  - name: xprivo
+    engine: xprivo
+    shortcut: xpr
+    disabled: true
+    inactive: true
+
+  - name: xprivo news
+    engine: xprivo
+    categories: news
+    xprivo_search_type: news
+    shortcut: xprn
+    disabled: true
+    inactive: true
+
+  - name: xprivo videos
+    engine: xprivo
+    categories: videos
+    xprivo_search_type: videos
+    shortcut: xprv
+    disabled: true
+    inactive: true
+
   - name: zapmeta
     engine: xpath
     shortcut: zpm


### PR DESCRIPTION
<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
- add support for xprivo.com
- xprivo has a rate-limit of smth like 20 requests per day without an API key. However, if you use a proxy like the [IPv6 rotating proxy](https://github.com/vojkovic/http-proxy-ipv6-pool-docker) you basically get unlimited requests.

### How to test this PR locally?
- enable the engine
- !xpr test
- !xprn test
- !xprv test

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

no Ai used.
