### PR TITLE
[docs] fix some minor reST markup issues in the doc-string

### DIFF
--- a/searx/enginelib/__init__.py
+++ b/searx/enginelib/__init__.py
@@ -305,7 +305,7 @@ class Engine(abc.ABC):  # pylint: disable=too-few-public-methods
 
     region: str = ""
     """For an engine, when there is ``region: ...`` in the YAML settings the engine
-    does support only this one region::
+    does support only this one region:
 
     .. code:: yaml
 

--- a/searx/engines/marginalia.py
+++ b/searx/engines/marginalia.py
@@ -10,7 +10,7 @@ Lofgren .
 .. _marginalia filters:
 
 Marginalia Filters
-=================
+==================
 
 Custom filters enable server-side customization of Marginalia search results.
 Filter definitions are written in XML and scoped to an API key.  Filters can

--- a/searx/engines/yandex_api.py
+++ b/searx/engines/yandex_api.py
@@ -77,10 +77,10 @@ notifications, but only as a fallback -- a request whose own locale matches
 ``kk``, ``uk``, ``tr`` or ``en``."""
 
 region: str = ""
-"""Optional Yandex `region id`.
+"""Optional Yandex `region id`_.
 Only meaningful together with ``SEARCH_TYPE_RU``.
 
-__ https://aistudio.yandex.ru/docs/en/search-api/reference/regions.html
+.. _region id: https://aistudio.yandex.ru/docs/en/search-api/reference/regions.html
 """
 
 page_size: int = 10


### PR DESCRIPTION

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  No AI used