### PR TITLE
[fix] engines: tusksearch referer header

### DIFF
--- a/searx/engines/tusksearch.py
+++ b/searx/engines/tusksearch.py
@@ -13,7 +13,7 @@ from dateutil import parser
 
 from searx.exceptions import SearxEngineAPIException
 from searx.network import get
-from searx.utils import gen_useragent, html_to_text
+from searx.utils import html_to_text
 from searx.result_types import EngineResults
 
 if t.TYPE_CHECKING:
@@ -52,7 +52,7 @@ def _obtain_x_sid() -> tuple[str, str]:
     The header key is usually called `x-sid-{UUIDv4}`, and the value is
     usually a plain UUIDv4 (but a different one than in the header key).
     """
-    resp = get(f"{api_url}/revcontent/embed.js", headers={"User-Agent": gen_useragent()})
+    resp = get(f"{api_url}/revcontent/embed.js", headers={"Referer": "https://tusksearch.com/"})
     if not resp.ok:
         raise SearxEngineAPIException("failed to obtain request x-sid token")
 
@@ -95,6 +95,7 @@ def request(query: str, params: "OnlineParams") -> None:
             # required - we send a random longitude and latitude instead of the actual user location
             "x-lon": str(round(random.random() * 90, 4)),
             "x-lat": str(round(random.random() * 90, 4)),
+            "Referer": "https://tusksearch.com/",
         }
     )
 


### PR DESCRIPTION

### What does this PR do?

Adds a referer header to bypass tusksearch's botdetection.

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor helped in finding the header