### PR TITLE
[fix] engines: resulthunter search_source arg

### DIFF
--- a/searx/engines/resulthunter.py
+++ b/searx/engines/resulthunter.py
@@ -52,6 +52,7 @@ def request(query: str, params: "OnlineParams") -> None:
         "q": query,
         "search_type": resulthunter_categ,
         "offset": params["pageno"] - 1,
+        "search_source": "other",
     }
 
     # uses Brave's engine traits


### PR DESCRIPTION
### What does this PR do?

Adds search_source arg to the resulthunter engine to bypass bot detection.

The arg can really be set to anything to work but the site uses three: 'header' 'other' 'extension', all returned the same results so I just picked 'other'.

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor helped in finding the arg