### PR TITLE
[fix] engines: update brave images/videos parser and news xpath

### DIFF
--- a/searx/engines/brave.py
+++ b/searx/engines/brave.py
@@ -248,13 +248,13 @@ def extract_json_data(text: str) -> dict[str, t.Any]:
     #    node_ids: [0, 19],
     #    data: [{type:"data",data: .... ["q","goggles_id"],route:1,url:1}}]
     #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    text = text[text.index("<script") : text.index("</script")]
-    if not text:
-        raise ValueError("can't find JS/JSON data in the given text")
+    #    form: null,
+    #    error: null
+    # });
     start = text.index("data: [{")
-    end = text.rindex("}}]")
-    js_obj_str = text[start:end]
-    js_obj_str = "{" + js_obj_str + "}}]}"
+    newline = text.index("\n", start)
+    end = text.rindex("}}]", start, newline)
+    js_obj_str = "{" + text[start:end] + "}}]}"
     # js_obj_str = js_obj_str.replace("\xa0", "")  # remove ASCII for &nbsp;
     # js_obj_str = js_obj_str.replace(r"\u003C", "<").replace(r"\u003c", "<")  # fix broken HTML tags in strings
     json_str = js_obj_str_to_json_str(js_obj_str)
@@ -354,14 +354,14 @@ def _parse_news(resp: SXNG_Response) -> EngineResults:
     res = EngineResults()
     dom = html.fromstring(resp.text)
 
-    for result in eval_xpath_list(dom, "//div[contains(@class, 'results')]//div[@data-type='news']"):
-        url = eval_xpath_getindex(result, ".//a[contains(@class, 'result-header')]/@href", 0, default=None)
+    for result in eval_xpath_list(dom, "//div[@data-type='news']"):
+        url = eval_xpath_getindex(result, ".//a/@href", 0, default=None)
         if url is None:
             continue
 
-        title = eval_xpath_list(result, ".//span[contains(@class, 'snippet-title')]")
-        content = eval_xpath_list(result, ".//p[contains(@class, 'desc')]")
-        thumbnail = eval_xpath_getindex(result, ".//div[contains(@class, 'image-wrapper')]//img/@src", 0, default="")
+        title = eval_xpath_list(result, ".//div[contains(@class, 'title')]")
+        content = eval_xpath_list(result, ".//div[contains(@class, 'description')]")
+        thumbnail = eval_xpath_getindex(result, ".//a[contains(@class, 'thumbnail')]//img/@src", 0, default="")
 
         item = res.types.LegacyResult(
             template="default.html",

--- a/searx/utils.py
+++ b/searx/utils.py
@@ -735,13 +735,13 @@ def js_obj_str_to_json_str(js_obj_str: str) -> str:
             if in_string == "'":
                 p = p.replace('"', r'\"')
             parts[i] = p
-            # deal with the sequence blackslash then quote
-            # since js_obj_str splits on quote, we detect this case:
-            # * the previous part ends with a black slash
-            # * the current part is a single quote
-            # when detected the blackslash is removed on the previous part
+            # drop a trailing \ that was escaping the quote
+            # leave it if it has been escaped twice as a literal i.e. two \ and ' in a row
             if blackslash_just_before and p[:1] == "'":
-                parts[i - 1] = parts[i - 1][:-1]
+                prev = parts[i - 1]
+                num_backslashes = len(prev) - len(prev.rstrip("\\"))
+                if num_backslashes % 2 == 1:
+                    parts[i - 1] = prev[:-1]
 
         elif in_string is None and p in ('"', "'", "`"):
             # we are not in string but p is string delimiter


### PR DESCRIPTION
### What does this PR do?

- Brave changed their format for images/videos engine so there is <script> tag rubbish in front, fixes that so it seeks to the data part
- Updated the news xpath for the new classes 
- When testing, I also found some image results with a literal \ in the title couldn't parse properly which was a bug in js_obj_str_to_json_str treating it as escaped, see first test.

### How to test this PR locally?

- `!brave.images ai` <- this query gave the parsing error before 
- Check videos and news engines work too

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor helped find the parsing error while fuzzing results and found updated xpaths 
