### PR TITLE
[fix] engines: dogpile token

### DIFF
--- a/searx/engines/dogpile.py
+++ b/searx/engines/dogpile.py
@@ -8,6 +8,9 @@ import typing as t
 from datetime import datetime, timezone
 import html
 
+from searx.enginelib import EngineCache
+from searx.exceptions import SearxEngineAPIException
+from searx.network import post
 from searx.utils import format_duration, html_to_text, humanize_number
 from searx.result_types import EngineResults
 
@@ -35,15 +38,36 @@ dogpile_categ = "search"
 base_url = "https://www.dogpile.com"
 safe_search_map = {0: "none", 1: "moderate", 2: "heavy"}
 
+CACHE: EngineCache
+"""Cache for the API token from dogpile"""
+
 
 def setup(_: dict[str, t.Any]) -> bool | None:
     if dogpile_categ not in ("search", "images", "videos", "news"):
         raise ValueError("invalid search type: %s" % dogpile_categ)
+    global CACHE  # pylint: disable=global-statement
+    CACHE = EngineCache("dogpile")  # one token for images/videos/news
+    return True
+
+
+def _obtain_token() -> str:
+    token = CACHE.get("token")
+    if token:
+        return token
+    resp = post(f"{base_url}/api/token/refresh", headers={"Origin": base_url}, cookies={"dp_api_token": "1"})
+    if not resp.ok:
+        raise SearxEngineAPIException("failed to obtain dogpile token")
+    token = resp.json()["token"]
+    CACHE.set("token", token, expire=240)  # 300s ttl
+    return token
 
 
 def request(query: str, params: "OnlineParams"):
     params["url"] = f"{base_url}/api/{dogpile_categ}"
     params["headers"]["Origin"] = base_url
+    params["cookies"]["dp_api_token"] = "1"
+    if dogpile_categ != "search":  # web doesnt need token
+        params["headers"]["x-dogpile-token"] = _obtain_token()
 
     params["method"] = "POST"
     params["json"] = {"q": query, "qadf": safe_search_map[params["safesearch"]], "page": params["pageno"]}


### PR DESCRIPTION
### What does this PR do?

Dogpile returns errors without an api token and a `dp_api_token` cookie. The token is needed for the non-web engines and the cookie is needed for all of them.

This PR requests a token and caches it for 240s so it doesn't need to be requested every time and is also shared across all the engine categories (images/videos/news) and adds the `dp_api_token`.

### How to test this PR locally?

Enable engines and test:

``!dog``
``!dogi``
``!dogv``
``!dogn``

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor helped find the endpoint and cookie