### PR TITLE
[fix] container: build cffi on 32 bit arm

### DIFF
--- a/container/builder.dockerfile
+++ b/container/builder.dockerfile
@@ -6,8 +6,10 @@ ENV UV_NO_MANAGED_PYTHON="true"
 ENV UV_NATIVE_TLS="true"
 
 ARG TIMESTAMP_VENV="0"
+ARG TARGETARCH
 
 RUN --mount=type=cache,id=uv,target=/root/.cache/uv set -eux -o pipefail; \
+    if [ "$TARGETARCH" = "arm" ]; then xbps-install -yS libffi-devel; fi; \
     export SOURCE_DATE_EPOCH="$TIMESTAMP_VENV"; \
     uv venv; \
     uv pip install --requirements ./requirements.txt --requirements ./requirements-server.txt; \


### PR DESCRIPTION
### What does this PR do?

The armv7 container build has been failing this is because while curl_cffi itself has an armv7 wheel the cffi dependency doesn’t

Installs libffi-devel on armv7.


### How to test this PR locally?

```
OVERRIDE_ARCH=armv7 make container.build
docker run --rm --platform linux/arm/v7 -p 8080:8080 localhost/searxng/searxng:latest
```

### Related issues

- https://github.com/searxng/searxng/issues/6596#issuecomment-5541757978

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor helped find that cffi was missing and then to test it