### PR TITLE
[mod] ci: increase container test delay

### DIFF
--- a/utils/lib_sxng_container.sh
+++ b/utils/lib_sxng_container.sh
@@ -198,7 +198,7 @@ container.test() {
         pid_logs=$!
 
         # Wait until container is ready
-        sleep 5
+        sleep 20
 
         curl -vf --max-time 5 "http://localhost:8080/healthz"
 


### PR DESCRIPTION
### What does this PR do?

[Testing under armv7 is having trouble running before the delay ends.](https://github.com/searxng/searxng/actions/runs/33853905129/job/101115050429#step:5:52) Increasing to 20 seconds should help.

### How to test this PR locally?

can't

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
