### PR TITLE
[fix] resulthunter: detect blocked requests instead of returning 0 results

### DIFF
--- a/searx/engines/resulthunter.py
+++ b/searx/engines/resulthunter.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 from lxml import html
 
 from searx import locales
+from searx.exceptions import SearxEngineResponseException
 from searx.result_types import EngineResults
 from searx.utils import eval_xpath_list, eval_xpath, extract_text
 
@@ -110,6 +111,11 @@ def _image_results(doc: "ElementBase") -> EngineResults:
 
 def response(resp: "SXNG_Response") -> EngineResults:
     doc = html.fromstring(resp.text)
+
+    # if the request was wrong (e.g. missing params), the site doesn't contain a result container
+    # and instead shows an "Installation required" page to download the resulthunter browser extension
+    if not eval_xpath(doc, "//div[contains(@class, 'organic-results-container')]"):
+        raise SearxEngineResponseException()
 
     match resulthunter_categ:
         case "web":


### PR DESCRIPTION

### What does this PR do?
- detect if resulthunter blocks a request instead of just returning 0 results
- e.g. detects if something like https://resulthunter.com/search?q=rust&search_type=web&freshness=&search_lang=&country= is shown instead of actual results
- maybe we could also have tried to directly match the "Installation required" page from above, but possibly they sometimes also show other sites or change it in the future, so I think it's better to check for the results layout

### How to test this PR locally?
- !reh test before #6651 is merged (or by undoing the changes from it)
- request should fail because it's blocked

### Related issues
- see https://github.com/searxng/searxng/pull/6651#pullrequestreview-5120658883

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

No AI used.