### PR TITLE
[mod] ci: disable armv7 container test

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -105,8 +105,9 @@ jobs:
             arch: amd64
           - runner: ubuntu-26.04-arm
             arch: arm64
-          - runner: ubuntu-26.04-arm
-            arch: armv7
+            #  FIXME: https://github.com/searxng/searxng/pull/6655#issuecomment-5550293085
+            # - runner: ubuntu-26.04-arm
+            #   arch: armv7
 
     steps:
       - name: Login to GHCR


### PR DESCRIPTION
### What does this PR do?

Disables the armv7 container test temporarily until a fix is provided (see related issues)

### How to test this PR locally?

can't

### Related issues

https://github.com/searxng/searxng/pull/6655#issuecomment-5550293085

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
