### PR TITLE
[mod] engines: remove uses of `enable_http2 = False`

### DIFF
--- a/searx/engines/luxxle.py
+++ b/searx/engines/luxxle.py
@@ -37,16 +37,12 @@ about = {
 }
 
 categories = []
-safeseach = True
+safesearch = True
 
 base_url = "https://luxxle.com"
 
 luxxle_categ = "search"
 """Supported categories: "search", "news", "images", "videos"."""
-
-# otherwise all requests get blocked (http2-fingerprinted probably)
-enable_http2 = False
-
 
 safe_search_map = {0: "Off", 1: "Moderate", 2: "Strict"}
 

--- a/searx/engines/pexels.py
+++ b/searx/engines/pexels.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 from lxml import html
 
 from searx.result_types import EngineResults
-from searx.utils import eval_xpath_list, gen_useragent
+from searx.utils import eval_xpath_list
 from searx.enginelib import EngineCache
 from searx.exceptions import SearxEngineAPIException, SearxEngineAccessDeniedException
 from searx.network import get
@@ -44,8 +44,6 @@ SECRET_KEY_DB_KEY = "secret-key"
 CACHE: EngineCache
 """Cache to store the secret API key for the engine."""
 
-enable_http2 = False
-
 
 def setup(engine_settings: dict[str, t.Any]) -> bool:
     global CACHE  # pylint: disable=global-statement
@@ -56,13 +54,7 @@ def setup(engine_settings: dict[str, t.Any]) -> bool:
 def _get_secret_key():
     resp = get(
         base_url,
-        headers={
-            # circumvents Cloudflare bot protections
-            "User-Agent": gen_useragent(),
-            "Referer": base_url,
-            "Sec-GPC": "1",
-            "Connection": "keep-alive",
-        },
+        headers={"Referer": base_url},
     )
 
     if resp.status_code != 200:
@@ -104,8 +96,6 @@ def request(query, params):
             secret_key = api_key
 
     params["headers"]["secret-key"] = secret_key
-
-    return params
 
 
 def response(resp):

--- a/searx/engines/pixabay.py
+++ b/searx/engines/pixabay.py
@@ -27,9 +27,6 @@ time_range_support = True
 safesearch_map = {0: 'off', 1: '1', 2: '1'}
 time_range_map = {'day': '1d', 'week': '1w', 'month': '1m', 'year': '1y'}
 
-# using http2 returns forbidden errors
-enable_http2 = False
-
 
 def request(query, params):
     args = {
@@ -49,8 +46,6 @@ def request(query, params):
 
     # prevent automatic redirects to first page on pagination
     params['allow_redirects'] = False
-
-    return params
 
 
 def _image_result(result):

--- a/searx/engines/stocksnap.py
+++ b/searx/engines/stocksnap.py
@@ -21,8 +21,6 @@ about = {
     "require_api_key": False,
     "results": "JSON",
 }
-# otherwise all requests get blocked, probably HTTP2 fingerprinting
-enable_http2 = False
 
 base_url = "https://stocksnap.io"
 cdn_url = "https://cdn.stocksnap.io"

--- a/searx/engines/uxwing.py
+++ b/searx/engines/uxwing.py
@@ -17,12 +17,10 @@ about = {
 categories = ['images', 'icons']
 
 base_url = "https://uxwing.com"
-enable_http2 = False
 
 
 def request(query, params):
     params['url'] = f"{base_url}/?s={quote_plus(query)}"
-    return params
 
 
 def response(resp):

--- a/searx/engines/yep.py
+++ b/searx/engines/yep.py
@@ -30,8 +30,6 @@ web_base_url = "https://yep.com"
 safesearch = True
 safesearch_map = {0: "off", 1: "moderate", 2: "strict"}
 
-enable_http2 = False
-
 results_per_page = 20
 
 _IMPORT_RE = re.compile(r"import\"(.*?)\";")
@@ -50,9 +48,6 @@ def request(query: str, params: "OnlineParams") -> None:
         {
             "Referer": f"{web_base_url}/",
             "Origin": web_base_url,
-            "Sec-Fetch-Dest": "empty",
-            "Sec-Fetch-Mode": "cors",
-            "Sec-Fetch-Site": "same-site",
         }
     )
 


### PR DESCRIPTION

<!-- FILL IN THESE FIELDS .. and delete the comments after reading.

     Use Markdown for formatting ->  https://www.markdowntools.io/cheat-sheet
-->

### What does this PR do?
`enable_http2 = False` has only been needed because we were flagged by HTTP2 fingerprinting. Now, since we use curl cffi, we can bypass the fingerpinting, so we can use HTTP2 just fine without getting blocked.


### How to test this PR locally?
- use the engines

### Related issues
- #6620 

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [X] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.
