### PR TITLE
[fix] engines: bing first word results

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -72,43 +72,21 @@ def get_locale_params(engine_region: str | None) -> dict[str, str] | None:
     return {"mkt": engine_region}
 
 
-def override_accept_language(params: "OnlineParams", engine_region: str | None) -> None:
-    """Override the ``Accept-Language`` header.
-
-    The default header built by :py:class:`~searx.search.processors.online.OnlineProcessor`
-    appends ``en;q=0.3`` as a fallback language::
-
-        Accept-Language: de,de-DE;q=0.7,en;q=0.3
-
-    Bing seems to better select the results locale based on the
-    ``Accept-Language`` value header.
-
-    This function is shared with :py:mod:`searx.engines.bing_images`,
-    :py:mod:`searx.engines.bing_news`, and :py:mod:`searx.engines.bing_videos`.
-    """
-
-    if not engine_region or engine_region == "clear":
-        return
-
-    lang = engine_region.split("-")[0]
-    params["headers"]["Accept-Language"] = f"{engine_region},{lang};q=0.9"
-
-
 def request(query: str, params: "OnlineParams"):
     """Assemble a Bing-Web request."""
 
     engine_region = traits.get_region(params["searxng_locale"], traits.all_locale)
-
-    override_accept_language(params, engine_region)
 
     query_params: dict[str, str | int] = {
         "q": query,
         "adlt": _safesearch_map.get(params.get("safesearch", 0), "off"),
     }
 
-    locale_params = get_locale_params(engine_region)
-    if locale_params:
-        query_params.update(locale_params)
+    if engine_region and engine_region != "clear":
+        lang, _, cc = engine_region.partition("-")
+        query_params["setlang"] = lang
+        if cc and cc not in ("us", "cn", "ru"):  # bing just sends junk for these
+            query_params["cc"] = cc
 
     params["url"] = f"{base_url}/search?{urlencode(query_params)}"
 

--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -9,7 +9,6 @@ from lxml import html
 from searx.engines.bing import (  # pylint: disable=unused-import
     fetch_traits,
     get_locale_params,
-    override_accept_language,
 )
 
 # about
@@ -43,8 +42,6 @@ def request(query, params):
     """Assemble a Bing-Image request."""
 
     engine_region = traits.get_region(params["searxng_locale"], traits.all_locale)
-
-    override_accept_language(params, engine_region)
 
     # build URL query
     # - example: https://www.bing.com/images/async?q=foo&async=1&first=1&count=35

--- a/searx/engines/bing_news.py
+++ b/searx/engines/bing_news.py
@@ -12,10 +12,7 @@ from urllib.parse import urlencode
 from lxml import html
 
 from searx.enginelib.traits import EngineTraits
-from searx.engines.bing import (
-    get_locale_params,
-    override_accept_language,
-)
+from searx.engines.bing import get_locale_params
 from searx.utils import eval_xpath, eval_xpath_getindex, eval_xpath_list, extract_text
 
 # about
@@ -53,8 +50,6 @@ def request(query, params):
     """Assemble a Bing-News request."""
 
     engine_region = traits.get_region(params["searxng_locale"], traits.all_locale)
-
-    override_accept_language(params, engine_region)
 
     # build URL query
     # - example: https://www.bing.com/news/infinitescrollajax?q=london&first=1

--- a/searx/engines/bing_videos.py
+++ b/searx/engines/bing_videos.py
@@ -9,7 +9,6 @@ from lxml import html
 from searx.engines.bing import (  # pylint: disable=unused-import
     fetch_traits,
     get_locale_params,
-    override_accept_language,
 )
 from searx.engines.bing_images import time_map
 from searx.utils import eval_xpath, eval_xpath_getindex
@@ -38,8 +37,6 @@ def request(query, params):
     """Assemble a Bing-Video request."""
 
     engine_region = traits.get_region(params["searxng_locale"], traits.all_locale)
-
-    override_accept_language(params, engine_region)
 
     # build URL query
     # - example: https://www.bing.com/videos/asyncv2?q=foo&async=content&first=1&count=35


### PR DESCRIPTION
### What does this PR do?

Fixes the bing web engine, it was just using the first word of the query for the search and return random junk other times. see: https://github.com/vojkovic/searxng/issues/10

Swapped to use bing's setlang and cc params. I found `us`, `cn`, `ru` return complete garbage 100% of the time. I reckon that if you don't have an ip address from there it will just return garbage, so those three are skipped. Also removed accept language override because it didn't change anything anymore.

The other bing engines are unchanged and continue to work.

### How to test this PR locally?

```
!bing searxng
!bing weather :en
!bing wetter berlin :de-DE
```

### Related issues

- Closes: https://github.com/searxng/searxng/issues/4964
- Related: https://github.com/vojkovic/searxng/issues/10

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.

Cursor helped fuzz bing with these params.