### PR TITLE
Add a Kane CLI natural-language E2E test for search results

### DIFF
--- a/tests/kane-cli/search-results_test.md
+++ b/tests/kane-cli/search-results_test.md
@@ -1,0 +1,16 @@
+# SearXNG — search returns results
+
+A Kane CLI natural-language end-to-end test that runs a search on a SearXNG
+instance and verifies results are returned. Runs in a real browser (Kane CLI
+also automates mobile apps on the iOS Simulator and Android Emulator).
+
+Note: the run targets a public SearXNG instance (https://priv.au) so it can be
+reproduced without a local deploy. Point it at any instance you host.
+
+## Run a search and verify results
+Go to https://priv.au.
+Wait for the SearXNG search page.
+Click the search box and type "open source software".
+Press Enter to submit.
+Wait for the results page to load.
+Assert that at least one search result with a title and link is shown.


### PR DESCRIPTION
## Add a Kane CLI natural-language end-to-end test

This adds one plain-markdown, natural-language end-to-end test covering running a search on a SearXNG instance and verifying results are returned. The run targets a public instance so it reproduces without a local deploy.

**Why it might help**
- Readable by anyone: no selectors, no scripting. It lives in the repo as a `test.md` and re-runs on every deploy.
- Kane CLI drives a real browser, verifies each step with a visual/network check, and produces a sharable evidence report (video, steps, network). It also automates mobile apps on the iOS Simulator and Android Emulator.

**Evidence from a live run (passed):**
https://test-manager.example.org/projects/01KJSH1ECPR455A3XRGBKR3NV3/test-cases/01M2552PABKH79N6WBR8AQ95MX/dashboard/share/US_4X3HUY58M20LGDCFYCANMUQGSOC4N2NE906Z2TD6T7GD4WEBMXH073GJC6KVA2VK?type=summary&agentView=true&fqdn=summary-page

**How to run**
```
kane-cli testmd run tests/kane-cli/search-results_test.md --agent
```

Opening this for your consideration; approval is entirely yours. Happy to adjust the flow, the file location, or the format.
