### PR TITLE
[fix] engine: core.ac.uk - don't split a string into a tag list

### DIFF
--- a/searx/engines/core.py
+++ b/searx/engines/core.py
@@ -141,12 +141,13 @@ def response(resp: "SXNG_Response") -> EngineResults:
             if name:
                 authors.add(name)
 
+        tag = result.get("fieldOfStudy")
         res.add(
             res.types.Paper(
                 title=result.get("title"),
                 url=url,
                 content=result.get("fullText", "") or "",
-                tags=result.get("fieldOfStudy", []),
+                tags=[tag] if tag else [],
                 publishedDate=published_date,
                 type=result.get("documentType", "") or "",
                 authors=authors,


### PR DESCRIPTION
Before:

<img width="362" height="30" alt="grafik" src="https://github.com/user-attachments/assets/328b2c32-296d-41d0-b781-5f8f77eadc52" />

After:

<img width="362" height="30" alt="grafik" src="https://github.com/user-attachments/assets/8fe86916-aece-4f35-ad80-3722224a462e" />



### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI