### PR TITLE
[mod] defaults: disable image engines with poor results

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -458,6 +458,7 @@ engines:
     engine: artic
     shortcut: arc
     timeout: 4.0
+    disabled: true
 
   - name: artstation
     engine: artstation
@@ -620,6 +621,7 @@ engines:
     engine: openverse
     categories: images
     shortcut: opv
+    disabled: true
 
   - name: media.ccc.de
     engine: ccc_media
@@ -755,6 +757,7 @@ engines:
     engine: devicons
     shortcut: di
     timeout: 3.0
+    disabled: true
 
   - name: ddg definitions
     engine: duckduckgo_definitions
@@ -1037,6 +1040,7 @@ engines:
     categories: images
     shortcut: fl
     engine: flickr_noapi
+    disabled: true
 
   - name: flickr_api
     # You can use the engine using the official stable API, but you need an API
@@ -1591,6 +1595,7 @@ engines:
     engine: lucide
     shortcut: luc
     timeout: 3.0
+    disabled: true
 
   - name: luxxle
     engine: luxxle
@@ -1902,6 +1907,7 @@ engines:
   - name: pexels
     engine: pexels
     shortcut: pe
+    disabled: true
 
   - name: photon
     engine: photon
@@ -2547,6 +2553,7 @@ engines:
   - name: unsplash
     engine: unsplash
     shortcut: us
+    disabled: true
 
   - name: unobtanium
     engine: xpath


### PR DESCRIPTION
### What does this PR do?

The image search defaults are a bit of a mix of results atm with random stock photos, some broken thumbnails (artic) and svg icons.

Following user feedback, I have set `disabled: true` for these engines: pinterest, flickr, pexels, unsplash, openverse, lucide, devicons, artic, bing images

### Code of Conduct

<!-- ⚠️ Bad AI drivers will be denounced: People who produce bad contributions
     that are clearly AI (slop) will be blocked for all future contributions.
     -->

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  If I have used AI tools for working on the changes in this PR, I will
  attach a list of all AI tools I used and how I used them. I hereby confirm
  that I haven't used any other tools than the ones I mention below.


No ai