### PR TITLE
Add per-engine OpenMetrics outcome counters

### DIFF
--- a/docs/admin/settings/settings_general.rst
+++ b/docs/admin/settings/settings_general.rst
@@ -46,3 +46,11 @@
   e.g. for usage with Prometheus. The ``/metrics`` endpoint is using HTTP Basic Auth,
   where the password is the value of ``open_metrics`` set above. The username used for
   Basic Auth can be randomly chosen as only the password is being validated.
+
+  Per-engine request counters use the ``engine_name`` label. In addition to
+  ``searxng_engines_request_count_total``, SearXNG exports
+  ``searxng_engines_successful_request_count_total`` and
+  ``searxng_engines_error_request_count_total``. A successful request includes a
+  valid response with no results; an error request is one handled by the engine
+  processor's exception path. These counters describe requests sent to upstream
+  engines, not incoming ``/search`` requests.

--- a/searx/metrics/__init__.py
+++ b/searx/metrics/__init__.py
@@ -296,8 +296,7 @@ def openmetrics(engine_stats, engine_reliabilities):
             help_hint="The total amount of failed requests made to this engine",
             data_info=[{'engine_name': engine['name']} for engine in engine_stats['time']],
             data=[
-                counter('engine', engine['name'], 'search', 'count', 'error') or 0
-                for engine in engine_stats['time']
+                counter('engine', engine['name'], 'search', 'count', 'error') or 0 for engine in engine_stats['time']
             ],
         ),
         OpenMetricsFamily(

--- a/searx/metrics/__init__.py
+++ b/searx/metrics/__init__.py
@@ -281,6 +281,26 @@ def openmetrics(engine_stats, engine_reliabilities):
             ],
         ),
         OpenMetricsFamily(
+            key="searxng_engines_successful_request_count_total",
+            type_hint="counter",
+            help_hint="The total amount of successful requests made to this engine",
+            data_info=[{'engine_name': engine['name']} for engine in engine_stats['time']],
+            data=[
+                counter('engine', engine['name'], 'search', 'count', 'successful') or 0
+                for engine in engine_stats['time']
+            ],
+        ),
+        OpenMetricsFamily(
+            key="searxng_engines_error_request_count_total",
+            type_hint="counter",
+            help_hint="The total amount of failed requests made to this engine",
+            data_info=[{'engine_name': engine['name']} for engine in engine_stats['time']],
+            data=[
+                counter('engine', engine['name'], 'search', 'count', 'error') or 0
+                for engine in engine_stats['time']
+            ],
+        ),
+        OpenMetricsFamily(
             key="searxng_engines_reliability_total",
             type_hint="counter",
             help_hint="The overall reliability of the engine",

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# pylint: disable=missing-module-docstring,disable=missing-class-docstring
+
+from searx.metrics import counter_inc, initialize, openmetrics
+from tests import SearxTestCase
+
+
+class OpenMetricsTestCase(SearxTestCase):
+
+    def test_engine_request_counters(self):
+        engine_name = "test-engine"
+        initialize([engine_name])
+        for _ in range(3):
+            counter_inc("engine", engine_name, "search", "count", "successful")
+        for _ in range(2):
+            counter_inc("engine", engine_name, "search", "count", "error")
+
+        metrics = openmetrics(
+            {
+                "time": [
+                    {
+                        "name": engine_name,
+                        "total": 0,
+                        "processing": 0,
+                        "http": 0,
+                        "result_count": 0,
+                    }
+                ]
+            },
+            {engine_name: {"sent_count": 5, "reliability": 60}},
+        )
+
+        self.assertIn(
+            "# TYPE searxng_engines_successful_request_count_total counter\n"
+            'searxng_engines_successful_request_count_total{engine_name="test-engine"} 3\n',
+            metrics,
+        )
+        self.assertIn(
+            "# TYPE searxng_engines_error_request_count_total counter\n"
+            'searxng_engines_error_request_count_total{engine_name="test-engine"} 2\n',
+            metrics,
+        )


### PR DESCRIPTION
### What does this PR do?

I need OpenTelemetry metrics to monitor the availability and success rate of each search engine, as well as the overall success rate. The current metrics expose the total number of requests, but do not expose the successful or failed request counts needed to calculate these rates.

This PR adds per-engine counters for successful and failed requests.

### How to test this PR locally?

I added the two new metrics and covered their OpenMetrics output with unit tests.

I also built the container image using the project's official GitHub Actions workflow. The amd64 image build and container health check completed successfully.

### Related issues

Closes #6695

### Code of Conduct

- **I hereby confirm that this PR conforms with the [AI Policy](https://github.com/searxng/searxng/blob/master/AI_POLICY.rst).**

  If I have used AI tools for working on the changes in this PR, I will attach a list of all AI tools I used and how I used them. I hereby confirm that I haven't used any other tools than the ones I mention below.

  I defined the requirements and reviewed the purpose of the change. I used Codex to help locate the relevant code paths and implement the change.