### PR TITLE
[fix] engine: bing images - remove market place argument mkt

### DIFF
--- a/searx/engines/bing.py
+++ b/searx/engines/bing.py
@@ -62,8 +62,8 @@ def get_locale_params(engine_region: str | None) -> dict[str, str] | None:
 
     The ``mkt`` parameter takes a full ``<language>-<country>`` code.
 
-    This function is shared with :py:mod:`searx.engines.bing_images`,
-    :py:mod:`searx.engines.bing_news`, and :py:mod:`searx.engines.bing_videos`.
+    This function is shared with :py:mod:`searx.engines.bing_news`, and
+    :py:mod:`searx.engines.bing_videos`.
     """
 
     if not engine_region or engine_region == "clear":

--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -1,14 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Bing-Images: description see :py:obj:`searx.engines.bing`."""
 
+import typing as t
 import json
 from urllib.parse import urlencode
 
 from lxml import html
 
 from searx.engines.bing import fetch_traits  # pylint: disable=unused-import
+from searx.result_types import EngineResults
 
-# about
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
+    from searx.search.processors import OnlineParams
+
+
 about = {
     "website": "https://www.bing.com/images",
     "wikidata_id": "Q182496",
@@ -18,7 +24,6 @@ about = {
     "results": "HTML",
 }
 
-# engine dependent config
 categories = ["images", "web"]
 paging = True
 enable_http3 = True
@@ -35,13 +40,13 @@ base_url = "https://www.bing.com"
 """Bing-Image search URL"""
 
 
-def request(query, params):
+def request(query: str, params: "OnlineParams"):
     """Assemble a Bing-Image request."""
 
     engine_region = traits.get_region(params["searxng_locale"], traits.all_locale)
 
-    # build URL query
-    # - example: https://www.bing.com/images/async?q=foo&mmasync=1&first=1&count=35
+    # build URL query / example:
+    # https://www.bing.com/images/async?q=foo&mmasync=1&first=1&count=35
 
     query_params = {
         "q": query,
@@ -65,10 +70,10 @@ def request(query, params):
     params["url"] = base_url + "/images/async?" + urlencode(query_params)
 
 
-def response(resp):
+def response(resp: "SXNG_Response") -> EngineResults:
     """Get response from Bing-Image"""
 
-    results = []
+    res = EngineResults()
 
     dom = html.fromstring(resp.text)
 
@@ -84,17 +89,17 @@ def response(resp):
 
         img_format = " ".join(result.xpath('.//div[@class="imgpt"]/div/span/text()')).strip().split(" · ")
         source = " ".join(result.xpath('.//div[@class="imgpt"]//div[@class="lnkw"]//a/text()')).strip()
-        results.append(
-            {
-                "template": "images.html",
-                "url": metadata["purl"],
-                "thumbnail_src": metadata["turl"],
-                "img_src": metadata["murl"],
-                "content": metadata.get("desc"),
-                "title": title,
-                "source": source,
-                "resolution": img_format[0],
-                "img_format": img_format[1] if len(img_format) >= 2 else None,
-            }
+
+        res.add(
+            res.types.Image(
+                title=title,
+                url=metadata["purl"],
+                thumbnail_src=metadata["turl"],
+                img_src=metadata["murl"],
+                content=metadata.get("desc"),
+                source=source,
+                resolution=img_format[0],
+                img_format=img_format[1] if len(img_format) >= 2 else "",
+            )
         )
-    return results
+    return res

--- a/searx/engines/bing_images.py
+++ b/searx/engines/bing_images.py
@@ -6,10 +6,7 @@ from urllib.parse import urlencode
 
 from lxml import html
 
-from searx.engines.bing import (  # pylint: disable=unused-import
-    fetch_traits,
-    get_locale_params,
-)
+from searx.engines.bing import fetch_traits  # pylint: disable=unused-import
 
 # about
 about = {
@@ -44,18 +41,21 @@ def request(query, params):
     engine_region = traits.get_region(params["searxng_locale"], traits.all_locale)
 
     # build URL query
-    # - example: https://www.bing.com/images/async?q=foo&async=1&first=1&count=35
+    # - example: https://www.bing.com/images/async?q=foo&mmasync=1&first=1&count=35
+
     query_params = {
         "q": query,
-        "async": "1",
+        "mmasync": "1",
         # to simplify the page count lets use the default of 35 images per page
         "first": (int(params.get("pageno", 1)) - 1) * 35 + 1,
         "count": 35,
     }
 
-    locale_params = get_locale_params(engine_region)
-    if locale_params:
-        query_params.update(locale_params)
+    if engine_region and engine_region != "clear":
+        lang, _, cc = engine_region.partition("-")
+        query_params["setlang"] = lang
+        if cc:
+            query_params["cc"] = cc
 
     # time range
     # - example: one year (525600 minutes) 'qft=filterui:age-lt525600'
@@ -79,6 +79,9 @@ def response(resp):
 
         metadata = json.loads(result.xpath('.//a[@class="iusc"]/@m')[0])
         title = " ".join(result.xpath('.//div[@class="infnmpt"]//a/text()')).strip()
+        if not title:
+            title = result.xpath('.//div[@class="infnmpt"]//a/@title')[0]
+
         img_format = " ".join(result.xpath('.//div[@class="imgpt"]/div/span/text()')).strip().split(" · ")
         source = " ".join(result.xpath('.//div[@class="imgpt"]//div[@class="lnkw"]//a/text()')).strip()
         results.append(


### PR DESCRIPTION
### commit ``[fix] engine: bing images - remove market place argument mkt``

The ``mkt`` argument does no longer exists and the ``async`` argument has been renamed to ``mmasync``.

For still unknown reasons (IP based?), some users had to observe that the title was missing [1].  I myself was not able to reproduce this error, however the evaluation of the title was additionally expanded by the attribute value of the ``<a title=".."`` element.

Related:

- [1] https://github.com/searxng/searxng/pull/6690#issuecomment-5636811572

### commit ``[mod] engine: bing images - use internal API & type hints``

Switching to internal APIs such as ``EngineResults`` and adding more type hints.  No functional changes.

### How to test this PR locally?

    !bing_images :en-US tony kroos
    !bing_images :de tony kroos

The language- and region-dependent search works quite well according to my observation. However, if Bing-Images can only deliver few results, for example because the query was restricted in time (last day), then Bing starts to include hits in the result list that are biased by the IP of the request.

Bing Images and the Bing Web API both use the ``cc`` argument; unlike with the Bing Web search, however, I could not detect any problems with the image search when using "us" as the region.

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI used