### PR TITLE
[mod] openverse - use of internal APIs and addition filds

### DIFF
--- a/searx/engines/openverse.py
+++ b/searx/engines/openverse.py
@@ -1,54 +1,64 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+"""Openverse (formerly known as: Creative Commons search engine) [Images]
+
+As of 09/2026: The availability of https://openverse.org/ is poor, and queries
+and image requests often time out. However, these issues also occur when using a
+WEB browser to search on openverse.org or view images.
 """
 
-Openverse (formerly known as: Creative Commons search engine) [Images]
-
-"""
-
-from json import loads
+import typing as t
 from urllib.parse import urlencode
+from dateutil import parser
+
+from searx.result_types import EngineResults
+
+
+if t.TYPE_CHECKING:
+    from searx.extended_types import SXNG_Response
+    from searx.search.processors import OnlineParams
 
 
 about = {
-    "website": 'https://openverse.org/',
+    "website": "https://openverse.org/",
     "wikidata_id": None,
-    "official_api_documentation": 'https://api.openverse.org/v1/',
+    "official_api_documentation": "https://api.openverse.org/v1/",
     "use_official_api": True,
     "require_api_key": False,
-    "results": 'JSON',
+    "results": "JSON",
 }
 
-categories = ['images']
+categories = ["images"]
 
 paging = True
 page_size = 20
 
-base_url = 'https://api.openverse.org/v1/images/'
-search_string = '?page={page}&page_size={page_size}&format=json&{query}'
+base_url = "https://api.openverse.org/v1/images/"
 
 
-def request(query, params):
+def request(query: str, params: "OnlineParams"):
+    args: dict[str, str | int] = {
+        "q": query,
+        "page": params["pageno"],
+        "page_size": page_size,
+        "format": "json",
+    }
+    params["url"] = f"{base_url}?{urlencode(args)}"
 
-    search_path = search_string.format(query=urlencode({'q': query}), page_size=page_size, page=params['pageno'])
 
-    params['url'] = base_url + search_path
+def response(resp: "SXNG_Response") -> EngineResults:
+    res = EngineResults()
+    json_data = resp.json()  # type: ignore
 
-    return params
-
-
-def response(resp):
-    results = []
-
-    json_data = loads(resp.text)
-
-    for result in json_data['results']:
-        results.append(
-            {
-                'url': result['foreign_landing_url'],
-                'title': result['title'],
-                'img_src': result['url'],
-                'template': 'images.html',
-            }
+    for result in json_data["results"]:  # pyright: ignore[reportUnknownVariableType]
+        res.add(
+            res.types.Image(
+                url=result["foreign_landing_url"],
+                title=result["title"],
+                img_src=result["url"],
+                thumbnail_src=result["thumbnail"],
+                resolution=f"{result['width']} x {result['height']}",
+                author=result["creator"],
+                publishedDate=parser.parse(result["indexed_on"]),
+            )
         )
-
-    return results
+    return res

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -620,6 +620,7 @@ engines:
     engine: openverse
     categories: images
     shortcut: opv
+    disabled: true
 
   - name: media.ccc.de
     engine: ccc_media


### PR DESCRIPTION
**additional fields:** add resolution, thumbnail and author to the image result.

**types:** use EngineResults and add type hints from internall APIs

**disabled engine:** as of 09/2026: The availability of https://openverse.org/ is poor, and queries and image requests often time out. However, these issues also occur when using a WEB browser to search on openverse.org or view images.

Related:

- https://github.com/searxng/searxng/pull/6690#issuecomment-5645267130

### How to test this PR locally?

    !opv toni kroos 

### Code of Conduct

[AI Policy]: https://github.com/searxng/searxng/blob/master/AI_POLICY.rst

- [x] **I hereby confirm that this PR conforms with the [AI Policy].**

  no AI used